### PR TITLE
fix: update setup instructions and handle optional TUI dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ KohakuTerrarium is a Python framework that enables building any kind of agent sy
 - Practical dependencies allowed (pydantic, httpx, rich, etc.)
 
 ### Development Setup
+- Create virtual environment first: `uv venv` then activate (`.venv/bin/activate` or `.venv\Scripts\Activate.ps1`)
 - Use `uv pip install -e .` for editable install
 - **Never use `sys.path.insert` hacks** in examples or tests - always rely on proper package install
 - Examples and tests should import from `kohakuterrarium.*` directly

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Pipeline:                        Hub-and-spoke:
 ```bash
 git clone https://github.com/KohakuBlueLeaf/KohakuTerrarium.git
 cd KohakuTerrarium
+
+# Create and activate virtual environment
+uv venv
+# Linux/macOS:
+source .venv/bin/activate
+# Windows PowerShell:
+# .venv\Scripts\Activate.ps1
+
 uv pip install -e .
 
 export OPENROUTER_API_KEY=your_key_here

--- a/src/kohakuterrarium/builtins/__init__.py
+++ b/src/kohakuterrarium/builtins/__init__.py
@@ -12,12 +12,12 @@ Contains:
 from kohakuterrarium.builtins.inputs import (
     CLIInput,
     NonBlockingCLIInput,
-    TUIInput,
     create_builtin_input,
     get_builtin_input,
     is_builtin_input,
     list_builtin_inputs,
 )
+from kohakuterrarium.builtins.inputs import TUIInput  # may be None if textual not installed
 from kohakuterrarium.builtins.outputs import (
     ConsoleTTS,
     DummyTTS,
@@ -25,12 +25,12 @@ from kohakuterrarium.builtins.outputs import (
     StdoutOutput,
     TTSConfig,
     TTSModule,
-    TUIOutput,
     create_builtin_output,
     get_builtin_output,
     is_builtin_output,
     list_builtin_outputs,
 )
+from kohakuterrarium.builtins.outputs import TUIOutput  # may be None if textual not installed
 from kohakuterrarium.builtins.subagents import (
     BUILTIN_SUBAGENTS,
     get_builtin_subagent_config,

--- a/src/kohakuterrarium/builtins/inputs/__init__.py
+++ b/src/kohakuterrarium/builtins/inputs/__init__.py
@@ -82,10 +82,13 @@ def create_builtin_input(name: str, options: dict[str, Any] | None = None) -> An
     raise ValueError(f"Unknown builtin input type: {name}")
 
 
-# Register TUI input
-from kohakuterrarium.builtins.tui.input import TUIInput
+# Register TUI input (optional dependency: textual)
+try:
+    from kohakuterrarium.builtins.tui.input import TUIInput
 
-register_builtin_input("tui", TUIInput)
+    register_builtin_input("tui", TUIInput)
+except ImportError:
+    TUIInput = None  # type: ignore[assignment,misc]
 
 # Try to register whisper (optional dependency)
 try:

--- a/src/kohakuterrarium/builtins/outputs/__init__.py
+++ b/src/kohakuterrarium/builtins/outputs/__init__.py
@@ -87,10 +87,13 @@ def create_builtin_output(name: str, options: dict[str, Any] | None = None) -> A
     raise ValueError(f"Unknown builtin output type: {name}")
 
 
-# Register TUI output
-from kohakuterrarium.builtins.tui.output import TUIOutput
+# Register TUI output (optional dependency: textual)
+try:
+    from kohakuterrarium.builtins.tui.output import TUIOutput
 
-register_builtin_output("tui", TUIOutput)
+    register_builtin_output("tui", TUIOutput)
+except ImportError:
+    TUIOutput = None  # type: ignore[assignment,misc]
 
 
 __all__ = [


### PR DESCRIPTION
This pull request improves the handling of optional dependencies for TUI (Textual User Interface) components and clarifies the development setup instructions. The most important changes include making TUI input/output imports robust to missing dependencies, updating the public API to reflect these changes, and improving documentation for setting up the development environment.

**Optional TUI dependency handling:**

* Updated `src/kohakuterrarium/builtins/inputs/__init__.py` and `src/kohakuterrarium/builtins/outputs/__init__.py` to import `TUIInput` and `TUIOutput` only if the `textual` package is installed; otherwise, these are set to `None` to avoid import errors. [[1]](diffhunk://#diff-46536e2f6cc9c95c142cbfdde639a49d9988864390f47ac71f698018b3e90251L85-R91) [[2]](diffhunk://#diff-e2882679566ff8519a3acd5afb910757e88ff5d259c270bed450afff5830c445L90-R96)
* Modified `src/kohakuterrarium/builtins/__init__.py` to re-export `TUIInput` and `TUIOutput` safely, reflecting their optional nature in the public API.

**Development documentation improvements:**

* Updated `README.md` and `CLAUDE.md` to include clear instructions for creating and activating a virtual environment before installing dependencies, improving onboarding for new contributors. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R104-R111) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R38)