### PR TITLE
fix(auth): fix Codex OAuth device code flow on Windows with reserved ports

### DIFF
--- a/src/kohakuterrarium/llm/codex_auth.py
+++ b/src/kohakuterrarium/llm/codex_auth.py
@@ -19,6 +19,7 @@ import secrets
 import time
 import webbrowser
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from threading import Thread
@@ -233,7 +234,13 @@ async def _device_code_flow() -> CodexTokens:
     device_auth_id = data["device_auth_id"]
     user_code = data["user_code"]
     interval = int(data.get("interval", 5))
-    expires_in = int(data.get("expires_in", 900))
+    if "expires_at" in data:
+        expires_at_dt = datetime.fromisoformat(data["expires_at"])
+        expires_in = max(
+            60, int(expires_at_dt.astimezone(timezone.utc).timestamp() - time.time())
+        )
+    else:
+        expires_in = int(data.get("expires_in", 900))
 
     print(f"[Device] Or visit: {DEVICE_VERIFY_URL}")
     print(f"  Code: {user_code}")
@@ -279,17 +286,30 @@ async def _device_code_flow() -> CodexTokens:
             if resp.status_code in (403, 400, 428):
                 try:
                     error_data = resp.json()
-                    error = error_data.get("error", "")
+                    raw_error = error_data.get("error", "")
+                    # error field may be a string or a dict {"message": ..., "type": ...}
+                    if isinstance(raw_error, dict):
+                        error = raw_error.get("code", raw_error.get("type", "unknown"))
+                        error_msg = raw_error.get("message", str(raw_error))
+                    else:
+                        error = raw_error
+                        error_msg = error
                 except Exception as e:
                     logger.debug("Failed to parse error response JSON", error=str(e))
                     continue
-                if error in ("authorization_pending", "pending"):
+                if error in (
+                    "authorization_pending",
+                    "pending",
+                    "deviceauth_authorization_unknown",  # user hasn't completed yet
+                ):
                     continue
                 if error == "slow_down":
                     interval += 5  # slow down
                     continue
                 if error in ("expired_token", "access_denied"):
                     raise RuntimeError(f"Device code auth failed: {error}")
+                # Any other unrecognised error is fatal — don't loop until timeout
+                raise RuntimeError(f"Device code auth error: {error_msg}")
 
     raise RuntimeError("Device code auth timed out")
 
@@ -351,33 +371,34 @@ async def oauth_login() -> CodexTokens:
     - Local machine: browser opens, redirect catches it
     - SSH/headless: user visits URL on another device, enters code
     - Remote desktop: either flow may work
+    - Windows reserved port: browser fails fast, device code continues
     """
     # Start both flows as concurrent tasks
     browser_task = asyncio.create_task(_browser_flow_safe())
     device_task = asyncio.create_task(_device_code_flow())
 
-    # Wait for EITHER to complete
-    done, pending = await asyncio.wait(
-        [browser_task, device_task],
-        return_when=asyncio.FIRST_COMPLETED,
-    )
+    tasks = {browser_task, device_task}
+    last_error: Exception | None = None
 
-    # Cancel the other
-    for task in pending:
-        task.cancel()
-        try:
-            await task
-        except (asyncio.CancelledError, Exception):
-            pass
+    while tasks:
+        done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            try:
+                tokens = task.result()
+                # Success — cancel the remaining task if any
+                for remaining in tasks:
+                    remaining.cancel()
+                    try:
+                        await remaining
+                    except (asyncio.CancelledError, Exception):
+                        pass
+                return tokens
+            except Exception as e:
+                logger.warning("Auth flow failed", error=str(e))
+                last_error = e
+                # Other task may still succeed — keep waiting
 
-    # Get the result from whichever succeeded
-    for task in done:
-        try:
-            return task.result()
-        except Exception as e:
-            logger.warning("Auth flow failed", error=str(e))
-
-    raise RuntimeError("All authentication flows failed")
+    raise RuntimeError(f"All authentication flows failed: {last_error}")
 
 
 async def _browser_flow_safe() -> CodexTokens:
@@ -385,11 +406,9 @@ async def _browser_flow_safe() -> CodexTokens:
     try:
         return await _browser_flow()
     except OSError as e:
-        # Port already in use or similar
+        # Port already in use / permission denied (e.g. Windows reserved ports)
         logger.debug("Browser flow unavailable", error=str(e))
-        # Wait forever so device code flow can win
-        await asyncio.Event().wait()
-        raise  # unreachable
+        raise RuntimeError(f"Browser flow unavailable: {e}") from e
 
 
 async def refresh_tokens(tokens: CodexTokens) -> CodexTokens:


### PR DESCRIPTION
## Summary

Fixes `kt login codex` failing immediately with \"All authentication flows failed\" on Windows systems where port 1455 falls in the OS-reserved port range (common with Hyper-V / WSL enabled).

## Changes

**Three bugs fixed in `src/kohakuterrarium/llm/codex_auth.py`:**

- **`_browser_flow_safe` hung instead of failing fast**: when `OSError` was caught (port 1455 reserved/denied), the function called `await asyncio.Event().wait()` and hung forever, so `oauth_login`'s `asyncio.wait(FIRST_COMPLETED)` never got a result from it and kept the device code task alive but never returned. Fixed by raising immediately so the task enters `done` as failed and device code can continue.

- **Device code poll error field was a dict, not a string**: the OpenAI device auth endpoint returns `{"error": {"message": "...", "type": "...", "code": "deviceauth_authorization_unknown"}}` — a nested dict. The existing code did `error in ("authorization_pending", ...)` on a dict, which is always `False`, so every pending response fell through to `continue` and the loop spun for the full 900 s timeout. Fixed by normalising the error field to a string code before matching, and explicitly treating `deviceauth_authorization_unknown` as a continue-polling signal.

- **`expires_at` vs `expires_in` mismatch**: the usercode endpoint returns `expires_at` (ISO 8601 timestamp), not `expires_in` (seconds). The code did `int(data.get("expires_in", 900))` and always used the 900 s fallback. Fixed by parsing `expires_at` when present.

- **`oauth_login` cancelled device code on browser failure**: the original loop cancelled all pending tasks when the first task completed. Replaced with a loop that keeps waiting for remaining tasks if the completed task failed, so browser failure doesn't abort device code.

## Testing

Verified on Windows 11 with Hyper-V enabled (port 1455 in reserved range `1446–1545`):
- `kt login codex` now correctly falls through to device code flow
- Device code polling correctly continues while user has not yet authorised
- Authentication completes successfully after user visits the device URL

- [x] Existing tests pass (`pytest tests/unit/`) — 1716 passed, 14 skipped
- [ ] New tests added (not added — auth flow requires live OAuth endpoints)
- [x] Linting passes (`ruff check src/`)
- [ ] Frontend builds (no frontend changes)

## Related Issues

Discovered during initial setup on Windows with Hyper-V / WSL enabled.