### PR TITLE
feat: add multi_edit tool for atomic multi-site edits

### DIFF
--- a/src/kohakuterrarium/builtin_skills/tools/multi_edit.md
+++ b/src/kohakuterrarium/builtin_skills/tools/multi_edit.md
@@ -1,0 +1,92 @@
+---
+name: multi_edit
+description: Apply multiple search/replace edits to one file atomically (path, edits). Use info(multi_edit) first.
+category: builtin
+tags: [file, io, edit, batch, refactor]
+---
+
+# multi_edit
+
+Apply an ordered list of search/replace edits to a single file in one atomic
+operation. All edits succeed or none do.
+
+## SAFETY
+
+- **You MUST read the file before editing it.** The tool will error if you haven't.
+- If the file was modified since your last read, you must re-read it.
+- Binary files cannot be edited.
+- All edits are applied in memory first; the file on disk is written back only
+  after every edit succeeds. On any failure the file is left untouched.
+
+## When to use
+
+- Renaming a symbol across multiple call sites in the same file.
+- Coordinated multi-site refactors where partial application would leave the
+  file broken.
+- Any time you would otherwise call `edit` two or more times on the same file.
+
+For a single edit, prefer `edit` — it has a simpler interface.
+
+## Arguments
+
+| Arg | Type | Description |
+|-----|------|-------------|
+| path | @@arg | Path to file (required) |
+| edits | @@arg | Ordered list of `{old, new, replace_all?}` objects (required) |
+
+### Per-edit fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| old | string | Exact text to find (required, non-empty) |
+| new | string | Replacement text (required, may be empty) |
+| replace_all | bool | Replace every occurrence in this step (default: false) |
+
+## Semantics
+
+- Edits are applied **sequentially**: edit N sees the file as modified by
+  edits 0..N-1. Write each `old` to match the state *after* the previous edits.
+- If `old` appears more than once and `replace_all` is false, that edit fails
+  (same rule as the `edit` tool). Add more context or set `replace_all: true`.
+- If any edit fails, the whole call fails and the file is not written.
+
+## Example
+
+```
+tool call: multi_edit(
+  path: src/foo.py
+  edits: [
+    {"old": "class OldName", "new": "class NewName"},
+    {"old": "OldName(", "new": "NewName(", "replace_all": true},
+    {"old": "# TODO: rename", "new": ""}
+  ]
+)
+```
+
+## Output
+
+Success:
+
+```
+Edited /abs/path/src/foo.py
+  3/3 edits applied
+  replacements: 1, 7, 1
+```
+
+Failure (file unchanged):
+
+```
+multi_edit failed: edit[2] did not apply (file unchanged)
+  edit[0] ok: 1 replacement(s)
+  edit[1] ok: 7 replacement(s)
+  edit[2] ERROR: 'old' not found in file after prior edits. ...
+```
+
+## TIPS
+
+- Order matters. If edit A changes the text that edit B's `old` depends on,
+  put A after B or update B's `old` to match the post-A state.
+- For independent non-overlapping edits, any order works — but keep them in
+  top-to-bottom file order for readability.
+- If you find yourself repeating the same `old`/`new` with `replace_all: false`
+  over and over, you probably want a single edit with `replace_all: true`.

--- a/src/kohakuterrarium/builtins/tools/README.md
+++ b/src/kohakuterrarium/builtins/tools/README.md
@@ -15,6 +15,7 @@ re-exports the public API from `builtins.tool_catalog`.
 | `read.py` | `ReadTool`: read file contents with optional line range |
 | `write.py` | `WriteTool`: create or overwrite files |
 | `edit.py` | `EditTool`: edit files using unified diff format |
+| `multi_edit.py` | `MultiEditTool`: apply multiple search/replace edits to one file atomically |
 | `glob.py` | `GlobTool`: find files by glob pattern |
 | `grep.py` | `GrepTool`: search file contents with regex and type filtering |
 | `tree.py` | `TreeTool`: list directory structure (.gitignore-aware, line-limited) |

--- a/src/kohakuterrarium/builtins/tools/__init__.py
+++ b/src/kohakuterrarium/builtins/tools/__init__.py
@@ -25,6 +25,7 @@ from kohakuterrarium.builtins.tools.grep import GrepTool
 from kohakuterrarium.builtins.tools.info import InfoTool
 from kohakuterrarium.builtins.tools.json_read import JsonReadTool
 from kohakuterrarium.builtins.tools.json_write import JsonWriteTool
+from kohakuterrarium.builtins.tools.multi_edit import MultiEditTool
 from kohakuterrarium.builtins.tools.create_trigger import CreateTriggerTool
 from kohakuterrarium.builtins.tools.list_triggers import ListTriggersTool
 from kohakuterrarium.builtins.tools.read import ReadTool
@@ -65,6 +66,7 @@ __all__ = [
     "InfoTool",
     "JsonReadTool",
     "JsonWriteTool",
+    "MultiEditTool",
     "CreateTriggerTool",
     "ListTriggersTool",
     "StopTaskTool",

--- a/src/kohakuterrarium/builtins/tools/multi_edit.py
+++ b/src/kohakuterrarium/builtins/tools/multi_edit.py
@@ -1,0 +1,212 @@
+"""
+Multi-edit tool - apply multiple search/replace edits to one file atomically.
+
+All edits are applied sequentially in memory; the file is written back only
+if every edit succeeds. On any failure, the file on disk is left untouched
+and the tool reports exactly which edit failed.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import aiofiles
+
+from kohakuterrarium.builtins.tools.edit import EditTool
+from kohakuterrarium.builtins.tools.registry import register_builtin
+from kohakuterrarium.modules.tool.base import (
+    BaseTool,
+    ExecutionMode,
+    ToolResult,
+    resolve_tool_path,
+)
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class EditStep:
+    """One step in a multi_edit sequence."""
+
+    old: str
+    new: str
+    replace_all: bool = False
+
+
+@dataclass
+class EditOutcome:
+    """Result of applying a single EditStep."""
+
+    index: int
+    ok: bool
+    replacements: int = 0
+    error: str | None = None
+
+
+def _parse_edits(raw: Any) -> tuple[list[EditStep] | None, str | None]:
+    """Parse and validate the ``edits`` argument."""
+    if not isinstance(raw, list) or not raw:
+        return None, "edits must be a non-empty list of {old, new, replace_all?}"
+    steps: list[EditStep] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            return None, f"edits[{i}] must be an object"
+        old = item.get("old", "")
+        new = item.get("new", "")
+        if not isinstance(old, str) or not isinstance(new, str):
+            return None, f"edits[{i}].old and .new must be strings"
+        if old == "":
+            return None, f"edits[{i}].old is empty; provide exact text to find"
+        steps.append(
+            EditStep(
+                old=old,
+                new=new,
+                replace_all=bool(item.get("replace_all", False)),
+            )
+        )
+    return steps, None
+
+
+def _apply_one(
+    content: str, step: EditStep, idx: int
+) -> tuple[str | None, EditOutcome]:
+    """Apply one EditStep to in-memory content. Returns (new_content, outcome)."""
+    count = content.count(step.old)
+    if count == 0:
+        return None, EditOutcome(
+            index=idx,
+            ok=False,
+            error=(
+                "'old' not found in file after prior edits. "
+                "An earlier edit may have rewritten this text - re-read the file."
+            ),
+        )
+    if count > 1 and not step.replace_all:
+        return None, EditOutcome(
+            index=idx,
+            ok=False,
+            error=(
+                f"'old' matches {count} locations; pass replace_all=true "
+                "or add more surrounding context to make it unique."
+            ),
+        )
+    if step.replace_all:
+        new_content = content.replace(step.old, step.new)
+        replaced = count
+    else:
+        new_content = content.replace(step.old, step.new, 1)
+        replaced = 1
+    return new_content, EditOutcome(index=idx, ok=True, replacements=replaced)
+
+
+def _format_success(path: Path, outcomes: list[EditOutcome]) -> str:
+    total = len(outcomes)
+    reps = ", ".join(str(o.replacements) for o in outcomes)
+    return f"Edited {path}\n  {total}/{total} edits applied\n  replacements: {reps}"
+
+
+def _format_failure(outcomes: list[EditOutcome], total: int, failed_at: int) -> str:
+    lines = [f"multi_edit failed: edit[{failed_at}] did not apply (file unchanged)"]
+    for o in outcomes:
+        if o.ok:
+            lines.append(f"  edit[{o.index}] ok: {o.replacements} replacement(s)")
+        else:
+            lines.append(f"  edit[{o.index}] ERROR: {o.error}")
+    skipped = total - len(outcomes)
+    if skipped > 0:
+        lines.append(f"  {skipped} later edit(s) skipped")
+    return "\n".join(lines)
+
+
+@register_builtin("multi_edit")
+class MultiEditTool(BaseTool):
+    """Apply an ordered list of search/replace edits to one file atomically.
+
+    All edits are applied sequentially to an in-memory copy. The file on disk
+    is only written once every edit has succeeded. On any failure the file is
+    left untouched and the tool reports which edit failed.
+    """
+
+    needs_context = True
+    require_manual_read = True
+
+    @property
+    def tool_name(self) -> str:
+        return "multi_edit"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Apply multiple search/replace edits to one file atomically "
+            "(path, edits=[{old,new,replace_all?},...]). Use info(multi_edit) first."
+        )
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _execute(self, args: dict[str, Any], **kwargs: Any) -> ToolResult:
+        context = kwargs.get("context")
+        path = args.get("path", "")
+        if not path:
+            return ToolResult(
+                error="No path provided. Usage: multi_edit(path=..., edits=[...])"
+            )
+
+        steps, parse_err = _parse_edits(args.get("edits"))
+        if parse_err:
+            return ToolResult(error=parse_err)
+        assert steps is not None
+
+        file_path = resolve_tool_path(path, context)
+
+        # Reuse edit tool's guard stack (binary / path_guard / read-before-write).
+        guard_host = EditTool()
+        guard = guard_host._check_guards(file_path, context)
+        if guard:
+            return guard
+
+        if not file_path.exists():
+            return ToolResult(error=f"File not found: {path}")
+        if not file_path.is_file():
+            return ToolResult(error=f"Not a file: {path}")
+
+        try:
+            async with aiofiles.open(file_path, "r", encoding="utf-8") as f:
+                content = await f.read()
+            original = content
+
+            outcomes: list[EditOutcome] = []
+            for i, step in enumerate(steps):
+                new_content, outcome = _apply_one(content, step, i)
+                outcomes.append(outcome)
+                if not outcome.ok:
+                    return ToolResult(
+                        error=_format_failure(outcomes, len(steps), failed_at=i)
+                    )
+                assert new_content is not None
+                content = new_content
+
+            if content == original:
+                return ToolResult(
+                    output="No changes made (all edits produced identical content)",
+                    exit_code=0,
+                )
+
+            async with aiofiles.open(file_path, "w", encoding="utf-8") as f:
+                await f.write(content)
+
+            guard_host._update_read_state(file_path, context)
+            logger.debug(
+                "multi_edit applied",
+                file_path=str(file_path),
+                edits=len(steps),
+            )
+            return ToolResult(output=_format_success(file_path, outcomes), exit_code=0)
+
+        except PermissionError:
+            return ToolResult(error=f"Permission denied: {path}")
+        except Exception as e:
+            logger.error("multi_edit failed", error=str(e))
+            return ToolResult(error=str(e))

--- a/tests/unit/test_multi_edit.py
+++ b/tests/unit/test_multi_edit.py
@@ -1,0 +1,319 @@
+"""
+Unit tests for the multi_edit tool.
+
+Covers:
+- Single and multiple sequential edits
+- Atomicity on mid-sequence failure (file unchanged)
+- replace_all behavior and ambiguity rejection
+- Read-before-write guard
+- Argument validation
+- Diagnostic messages
+"""
+
+from pathlib import Path
+
+from kohakuterrarium.builtins.tools.multi_edit import MultiEditTool
+from kohakuterrarium.builtins.tools.read import ReadTool
+from kohakuterrarium.modules.tool.base import ToolContext
+from kohakuterrarium.utils.file_guard import FileReadState, PathBoundaryGuard
+
+
+def _make_context(working_dir: Path) -> ToolContext:
+    return ToolContext(
+        agent_name="test_agent",
+        session=None,
+        working_dir=working_dir,
+        file_read_state=FileReadState(),
+        path_guard=PathBoundaryGuard(cwd=str(working_dir), mode="warn"),
+    )
+
+
+async def _read(target: Path, context: ToolContext) -> None:
+    result = await ReadTool().execute({"path": str(target)}, context=context)
+    assert result.success, f"read failed: {result.error}"
+
+
+class TestMultiEditHappyPath:
+    async def test_single_edit(self, tmp_path: Path):
+        target = tmp_path / "code.py"
+        target.write_text("def hello():\n    return 'world'\n")
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [{"old": "return 'world'", "new": "return 'universe'"}],
+            },
+            context=context,
+        )
+        assert result.success, f"multi_edit failed: {result.error}"
+        assert "universe" in target.read_text()
+        assert "world" not in target.read_text()
+        assert "1/1 edits applied" in result.output
+
+    async def test_sequential_dependent_edits(self, tmp_path: Path):
+        """Edit N should see the file as modified by edits 0..N-1."""
+        target = tmp_path / "code.py"
+        target.write_text("class OldName:\n    pass\n")
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        # After edit[0], the file contains "class NewName". Edit[1] depends on that.
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [
+                    {"old": "class OldName", "new": "class NewName"},
+                    {
+                        "old": "class NewName:\n    pass",
+                        "new": "class NewName:\n    x = 1",
+                    },
+                ],
+            },
+            context=context,
+        )
+        assert result.success, f"multi_edit failed: {result.error}"
+        content = target.read_text()
+        assert "class NewName" in content
+        assert "x = 1" in content
+        assert "2/2 edits applied" in result.output
+
+    async def test_replace_all_per_step(self, tmp_path: Path):
+        target = tmp_path / "code.py"
+        target.write_text("foo = 1\nfoo = 2\nfoo = 3\nbar = 4\n")
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [
+                    {"old": "foo", "new": "baz", "replace_all": True},
+                    {"old": "bar = 4", "new": "bar = 40"},
+                ],
+            },
+            context=context,
+        )
+        assert result.success, f"multi_edit failed: {result.error}"
+        content = target.read_text()
+        assert content.count("baz") == 3
+        assert "foo" not in content
+        assert "bar = 40" in content
+        assert "replacements: 3, 1" in result.output
+
+    async def test_empty_new_is_allowed(self, tmp_path: Path):
+        target = tmp_path / "code.py"
+        target.write_text("# TODO: remove\nreal_code()\n")
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [{"old": "# TODO: remove\n", "new": ""}],
+            },
+            context=context,
+        )
+        assert result.success, f"multi_edit failed: {result.error}"
+        assert target.read_text() == "real_code()\n"
+
+
+class TestMultiEditAtomicity:
+    async def test_mid_sequence_failure_leaves_file_unchanged(self, tmp_path: Path):
+        """If any edit fails, the file on disk must not be modified."""
+        target = tmp_path / "code.py"
+        original = "alpha = 1\nbeta = 2\ngamma = 3\n"
+        target.write_text(original)
+        original_bytes = target.read_bytes()
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [
+                    {"old": "alpha = 1", "new": "alpha = 10"},  # ok
+                    {"old": "beta = 2", "new": "beta = 20"},  # ok
+                    {"old": "does_not_exist", "new": "whatever"},  # FAIL
+                    {"old": "gamma = 3", "new": "gamma = 30"},  # skipped
+                ],
+            },
+            context=context,
+        )
+        assert not result.success
+        # File must be byte-identical to the original.
+        assert target.read_bytes() == original_bytes
+        # Diagnostic must identify the failing edit index.
+        assert "edit[2]" in result.error
+        assert "did not apply" in result.error
+        # Prior successes should be reported.
+        assert "edit[0] ok" in result.error
+        assert "edit[1] ok" in result.error
+        # And later edits reported as skipped.
+        assert "1 later edit(s) skipped" in result.error
+
+    async def test_first_edit_failure_also_atomic(self, tmp_path: Path):
+        target = tmp_path / "code.py"
+        original = "hello\n"
+        target.write_text(original)
+        original_bytes = target.read_bytes()
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [
+                    {"old": "nope", "new": "x"},
+                    {"old": "hello", "new": "world"},
+                ],
+            },
+            context=context,
+        )
+        assert not result.success
+        assert target.read_bytes() == original_bytes
+        assert "edit[0]" in result.error
+
+
+class TestMultiEditAmbiguity:
+    async def test_multiple_matches_without_replace_all_fails(self, tmp_path: Path):
+        target = tmp_path / "code.py"
+        original = "foo = 1\nfoo = 2\n"
+        target.write_text(original)
+        original_bytes = target.read_bytes()
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [{"old": "foo", "new": "bar"}],
+            },
+            context=context,
+        )
+        assert not result.success
+        assert target.read_bytes() == original_bytes
+        assert "matches 2 locations" in result.error
+
+
+class TestMultiEditGuards:
+    async def test_blocks_when_file_not_read(self, tmp_path: Path):
+        target = tmp_path / "code.py"
+        target.write_text("hello\n")
+
+        context = _make_context(tmp_path)
+        # Intentionally skip reading the file.
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [{"old": "hello", "new": "goodbye"}],
+            },
+            context=context,
+        )
+        assert not result.success
+        assert "has not been read yet" in result.error
+        assert target.read_text() == "hello\n"
+
+    async def test_missing_file(self, tmp_path: Path):
+        missing = tmp_path / "nope.py"
+        context = _make_context(tmp_path)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(missing),
+                "edits": [{"old": "a", "new": "b"}],
+            },
+            context=context,
+        )
+        assert not result.success
+        assert "File not found" in result.error
+
+
+class TestMultiEditArgValidation:
+    async def test_missing_path(self, tmp_path: Path):
+        context = _make_context(tmp_path)
+        result = await MultiEditTool().execute(
+            {"edits": [{"old": "a", "new": "b"}]},
+            context=context,
+        )
+        assert not result.success
+        assert "No path provided" in result.error
+
+    async def test_missing_edits(self, tmp_path: Path):
+        context = _make_context(tmp_path)
+        result = await MultiEditTool().execute(
+            {"path": str(tmp_path / "x.py")},
+            context=context,
+        )
+        assert not result.success
+        assert "edits must be a non-empty list" in result.error
+
+    async def test_empty_edits_list(self, tmp_path: Path):
+        context = _make_context(tmp_path)
+        result = await MultiEditTool().execute(
+            {"path": str(tmp_path / "x.py"), "edits": []},
+            context=context,
+        )
+        assert not result.success
+        assert "edits must be a non-empty list" in result.error
+
+    async def test_empty_old_rejected(self, tmp_path: Path):
+        target = tmp_path / "code.py"
+        target.write_text("hello\n")
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [{"old": "", "new": "x"}],
+            },
+            context=context,
+        )
+        assert not result.success
+        assert "empty" in result.error
+
+    async def test_non_string_old_rejected(self, tmp_path: Path):
+        target = tmp_path / "code.py"
+        target.write_text("hello\n")
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [{"old": 123, "new": "x"}],
+            },
+            context=context,
+        )
+        assert not result.success
+        assert "must be strings" in result.error
+
+
+class TestMultiEditNoOp:
+    async def test_all_edits_identity(self, tmp_path: Path):
+        """If every edit is a no-op (old == new), result is reported cleanly."""
+        target = tmp_path / "code.py"
+        target.write_text("hello\n")
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        result = await MultiEditTool().execute(
+            {
+                "path": str(target),
+                "edits": [{"old": "hello", "new": "hello"}],
+            },
+            context=context,
+        )
+        assert result.success, f"unexpected failure: {result.error}"
+        assert "No changes made" in result.output
+        assert target.read_text() == "hello\n"


### PR DESCRIPTION
## Summary

Adds a new built-in tool `multi_edit` that applies an ordered list of
search/replace edits to a single file atomically. Reduces round-trips for
multi-site refactors and removes the partial-write failure mode of chained
`edit` calls.

## Changes

- New tool: `src/kohakuterrarium/builtins/tools/multi_edit.py` (`MultiEditTool`)
  - Sequential application: edit N sees edits 0..N-1
  - Atomic write: file on disk is only touched once every edit succeeds
  - Precise diagnostics: failing edit index, prior successes, skipped count
  - Reuses `EditTool`'s guard stack (binary / path_guard / read-before-write)
- Registered in `builtins/tools/__init__.py`
- Skill doc: `builtin_skills/tools/multi_edit.md` (loaded via `##info multi_edit##`)
- README row in `builtins/tools/README.md`
- Tests: `tests/unit/test_multi_edit.py` (15 tests, 6 groups)

## Testing

- [x] New tests pass: `pytest tests/unit/test_multi_edit.py -q` — 15 passed
- [x] Adjacent tool tests still pass: `pytest tests/unit/test_tool_guards.py tests/unit/test_native_tools.py tests/unit/test_tool_format.py -q` — 67 passed
- [x] `black` formatted
- [x] `ruff check` clean
- [ ] Frontend builds — N/A (backend-only change)

Test coverage:
- Happy paths: single edit, sequential dependent edits, per-step `replace_all`, empty `new` (deletion)
- Atomicity: mid-sequence failure and first-edit failure both leave file byte-identical; diagnostics include failing index, prior successes, skipped count
- Ambiguity: multi-match without `replace_all` rejected, file unchanged
- Guards: read-before-write blocks, missing file errors cleanly
- Arg validation: missing path, missing/empty edits list, empty `old`, non-string `old`
- No-op: all-identity edits return cleanly without writing

## Related Issues

Fixes #7