### PR TITLE
feat(webui): multimodal support and chat UX improvements

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
@@ -92,7 +92,7 @@
       <button class="msg-action-btn" title="Copy" aria-label="Copy message" @click="copyMessage">
         <span class="i-carbon-copy text-xs" />
       </button>
-      <button class="msg-action-btn" title="Edit & rerun" aria-label="Edit and rerun message" @click="$emit('request-edit', message)">
+      <button class="msg-action-btn" title="Edit in composer" aria-label="Edit message in composer" @click="$emit('request-edit', message)">
         <span class="i-carbon-edit text-xs" />
       </button>
     </div>

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
@@ -60,29 +60,39 @@
 
   <!-- User message -->
   <div v-else-if="message.role === 'user'" class="ml-auto max-w-[80%] group relative">
-    <div class="card px-4 py-3 border-l-3" :class="message.queued ? 'border-l-amber dark:border-l-amber/60 opacity-70' : 'border-l-sapphire dark:border-l-sapphire/60'">
-      <div class="text-xs text-warm-400 mb-1 flex items-center gap-1.5">
+    <div class="card px-4 py-3 border-l-3 flex flex-col items-end" :class="message.queued ? 'border-l-amber dark:border-l-amber/60 opacity-70' : 'border-l-sapphire dark:border-l-sapphire/60'">
+      <div class="text-xs text-warm-400 mb-1 flex items-center justify-end gap-1.5 w-full">
         <span>You</span>
         <span v-if="message.queued" class="px-1.5 py-0.5 rounded text-[9px] font-medium bg-amber/15 text-amber leading-none">Queued</span>
       </div>
-      <!-- Edit mode -->
-      <div v-if="editing" class="flex flex-col gap-2">
-        <textarea v-model="editText" class="w-full bg-transparent border border-warm-300 dark:border-warm-600 rounded px-2 py-1 text-body resize-none" :rows="Math.max(2, editText.split('\n').length)" @keydown.meta.enter="confirmEdit" @keydown.ctrl.enter="confirmEdit" @keydown.esc="cancelEdit" />
-        <div class="flex gap-2 justify-end text-xs">
-          <button class="px-2 py-0.5 rounded hover:bg-warm-100 dark:hover:bg-warm-800" @click="cancelEdit">Cancel</button>
-          <button class="px-2 py-0.5 rounded bg-sapphire text-white hover:bg-sapphire-dark" @click="confirmEdit">Save & Rerun</button>
+      <div class="flex flex-col gap-2 w-full">
+        <div v-if="message.attachments?.length" class="flex flex-wrap gap-2 mb-1 justify-end">
+          <a v-for="file in message.attachments" :key="file.id || file.url || file.name" :href="file.url" target="_blank" rel="noreferrer" class="attachment-chip" :class="{ 'attachment-chip-image': file.type === 'image' && file.url }" @click="onAttachmentClick($event, file, message.attachments)">
+            <span v-if="file.type === 'image' && file.url" class="attachment-preview-frame">
+              <img
+                :src="file.url"
+                :alt="file.name"
+                class="attachment-preview-image"
+              />
+            </span>
+            <span v-else :class="attachmentIcon(file)" class="text-sm text-iolite dark:text-iolite-light shrink-0" />
+            <span v-if="file.type !== 'image'" class="attachment-meta">
+              <span class="attachment-name truncate max-w-[12rem]">{{ file.name }}</span>
+              <span v-if="file.size" class="text-warm-400">{{ formatFileSize(file.size) }}</span>
+            </span>
+          </a>
         </div>
-      </div>
-      <div v-else class="text-body whitespace-pre-wrap break-words overflow-wrap-anywhere min-w-0">
-        {{ message.content }}
+        <div v-if="message.content" class="text-body whitespace-pre-wrap break-words overflow-wrap-anywhere min-w-0 w-full">
+          {{ message.content }}
+        </div>
       </div>
     </div>
     <!-- Hover actions for user messages -->
-    <div v-if="!editing && !message.queued && messageIdx != null" class="absolute -bottom-5 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+    <div v-if="!message.queued && message.conversationIndex != null" class="absolute -bottom-5 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
       <button class="msg-action-btn" title="Copy" aria-label="Copy message" @click="copyMessage">
         <span class="i-carbon-copy text-xs" />
       </button>
-      <button class="msg-action-btn" title="Edit & rerun" aria-label="Edit and rerun message" @click="startEdit">
+      <button class="msg-action-btn" title="Edit & rerun" aria-label="Edit and rerun message" @click="$emit('request-edit', message)">
         <span class="i-carbon-edit text-xs" />
       </button>
     </div>
@@ -100,6 +110,21 @@
         <ToolCallBlock :tc="part" :expanded="expandedTools[part.id]" @toggle="toggleTool(part.id)" />
       </div>
     </template>
+    <div
+      v-if="assistantRecovering"
+      class="inline-flex items-center gap-2 rounded-md border border-iolite/15 dark:border-iolite/20 bg-iolite/6 dark:bg-iolite/8 px-3 py-2 text-xs text-warm-500 dark:text-warm-400"
+    >
+      <span class="w-1.5 h-1.5 rounded-full bg-iolite kohaku-pulse shrink-0" />
+      <span>{{ t("chat.recoveringReply") }}</span>
+      <span v-if="message.recoveryAttempt > 0" class="text-[10px] text-warm-400">{{ t("chat.recoveryRetry", { count: message.recoveryAttempt }) }}</span>
+    </div>
+    <div
+      v-else-if="assistantRecoveryFailed"
+      class="inline-flex items-center gap-2 rounded-md border border-amber/15 dark:border-amber/20 bg-amber/6 dark:bg-amber/8 px-3 py-2 text-xs text-warm-500 dark:text-warm-400"
+    >
+      <span class="w-1.5 h-1.5 rounded-full bg-amber shrink-0" />
+      <span>{{ t("chat.recoveryFailed") }}</span>
+    </div>
     <!-- Hover actions -->
     <div v-if="isLastAssistant" class="absolute -bottom-5 left-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
       <button class="msg-action-btn" title="Copy" aria-label="Copy response" @click="copyAssistantText">
@@ -130,10 +155,34 @@
       <span class="text-xs font-semibold" :style="{ color: senderGemColor }">{{ message.sender }}</span>
       <span class="text-[10px] text-warm-400">{{ message.timestamp }}</span>
     </div>
-    <div class="pl-7 text-body">
-      <MarkdownRenderer :content="message.content" />
+    <div class="pl-7 flex flex-col gap-2">
+      <div v-if="message.attachments?.length" class="flex flex-wrap gap-2">
+        <a v-for="file in message.attachments" :key="file.id || file.url || file.name" :href="file.url" target="_blank" rel="noreferrer" class="attachment-chip" :class="{ 'attachment-chip-image': file.type === 'image' && file.url }" @click="onAttachmentClick($event, file, message.attachments)">
+          <img
+            v-if="file.type === 'image' && file.url"
+            :src="file.url"
+            :alt="file.name"
+            class="attachment-preview-image"
+          />
+          <span v-else :class="attachmentIcon(file)" class="text-sm text-iolite dark:text-iolite-light shrink-0" />
+          <span class="attachment-meta">
+            <span class="attachment-name truncate max-w-[16rem]">{{ file.name }}</span>
+            <span v-if="file.size" class="text-warm-400">{{ formatFileSize(file.size) }}</span>
+          </span>
+        </a>
+      </div>
+      <div v-if="message.content" class="text-body">
+        <MarkdownRenderer :content="message.content" />
+      </div>
     </div>
   </div>
+
+  <el-image-viewer
+    v-if="imagePreviewVisible && imagePreviewList.length"
+    :url-list="imagePreviewList"
+    :initial-index="imagePreviewIndex"
+    @close="imagePreviewVisible = false"
+  />
 </template>
 
 <script setup>
@@ -141,6 +190,7 @@ import MarkdownRenderer from "@/components/common/MarkdownRenderer.vue"
 import ToolCallBlock from "@/components/chat/ToolCallBlock.vue"
 import { GEM } from "@/utils/colors"
 import { useChatStore } from "@/stores/chat"
+import { useI18n } from "@/utils/i18n"
 
 const props = defineProps({
   message: { type: Object, required: true },
@@ -150,16 +200,39 @@ const props = defineProps({
   isLastAssistant: { type: Boolean, default: false },
 })
 
+defineEmits(["request-edit"])
+
+const { t } = useI18n()
+
 const expandedTools = reactive({})
-const editing = ref(false)
-const editText = ref("")
 const errorExpanded = ref(false)
+const imagePreviewVisible = ref(false)
+const imagePreviewIndex = ref(0)
+const imagePreviewList = ref([])
 
 const errorFirstLine = computed(() => {
   if (props.message.role !== "error") return ""
   const content = props.message.content || ""
   const firstLine = content.split("\n")[0] || ""
   return firstLine.length > 80 ? firstLine.slice(0, 80) + "…" : firstLine
+})
+
+const assistantRecovering = computed(() => {
+  if (props.message.role !== "assistant") return false
+  if (!props.message.recovering) return false
+  const hasText = Array.isArray(props.message.parts)
+    ? props.message.parts.some((part) => part.type === "text" && part.content)
+    : !!props.message.content
+  return !hasText
+})
+
+const assistantRecoveryFailed = computed(() => {
+  if (props.message.role !== "assistant") return false
+  if (!props.message.recoveryFailed) return false
+  const hasText = Array.isArray(props.message.parts)
+    ? props.message.parts.some((part) => part.type === "text" && part.content)
+    : !!props.message.content
+  return !hasText
 })
 
 function toggleTool(id) {
@@ -186,7 +259,31 @@ const senderGemColor = computed(() => {
   return senderColorCache[name]
 })
 
-// ── Message actions (copy / edit / regenerate) ──
+function formatFileSize(size) {
+  if (!size) return ""
+  if (size >= 1024 * 1024) return `${(size / (1024 * 1024)).toFixed(1)} MB`
+  if (size >= 1024) return `${Math.round(size / 1024)} KB`
+  return `${size} B`
+}
+
+function attachmentIcon(file) {
+  if (file.type === "image") return "i-carbon-image"
+  if (file.type === "video") return "i-carbon-video"
+  if (file.type === "pdf") return "i-carbon-document-pdf"
+  return "i-carbon-document"
+}
+
+function onAttachmentClick(event, file, attachments = []) {
+  if (file.type !== "image" || !file.url) return
+  event.preventDefault()
+  const images = attachments.filter((item) => item.type === "image" && item.url)
+  imagePreviewList.value = images.map((item) => item.url)
+  imagePreviewIndex.value = Math.max(
+    0,
+    images.findIndex((item) => item.url === file.url),
+  )
+  imagePreviewVisible.value = true
+}
 
 const chat = useChatStore()
 
@@ -209,30 +306,84 @@ function copyAssistantText() {
   navigator.clipboard.writeText(text)
 }
 
-function startEdit() {
-  editText.value = props.message.content || ""
-  editing.value = true
-}
-
-function cancelEdit() {
-  editing.value = false
-  editText.value = ""
-}
-
-function confirmEdit() {
-  const newContent = editText.value.trim()
-  if (!newContent) return
-  chat.editMessage(props.messageIdx, newContent)
-  editing.value = false
-  editText.value = ""
-}
-
 function regenerate() {
   chat.regenerateLastResponse()
 }
 </script>
 
 <style scoped>
+.attachment-chip {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 100%;
+  padding: 0.5rem 0.625rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(120, 109, 98, 0.22);
+  background: rgba(255, 255, 255, 0.03);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    transform 0.15s;
+}
+
+.attachment-chip:hover {
+  border-color: rgba(125, 108, 255, 0.35);
+  background: rgba(125, 108, 255, 0.06);
+}
+
+.attachment-chip-image {
+  cursor: zoom-in;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.25rem;
+  width: auto;
+  max-width: 10rem;
+  padding: 0.375rem;
+}
+
+.attachment-chip-image:hover {
+  transform: translateY(-1px);
+}
+
+.attachment-preview-frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 6rem;
+  height: 6rem;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.attachment-preview-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.attachment-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.attachment-chip-image .attachment-meta {
+  display: flex;
+  justify-content: space-between;
+}
+
+.attachment-name {
+  color: inherit;
+}
+
 .msg-action-btn {
   display: inline-flex;
   align-items: center;

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -202,7 +202,7 @@ const resolvedEmptyTitle = computed(() => props.emptyTitle || t("chat.noMessages
 const resolvedEmptySubtitle = computed(() => props.emptySubtitle || t("chat.getStarted"))
 const canSend = computed(() => !!inputText.value.trim() || pendingAttachments.value.length > 0)
 const shouldShowSendButton = computed(() => canSend.value || (!chat.processing && !chat.hasRunningJobs))
-const sendButtonLabel = computed(() => (chat.processing || chat.hasRunningJobs) && canSend.value ? t("chat.sendMessage") : t("chat.stopGeneration"))
+const sendButtonLabel = computed(() => t("chat.sendMessage"))
 
 function getCreatureStatus(name) {
   const creature = props.instance.creatures.find((c) => c.name === name)

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -400,6 +400,21 @@ async function onPaste(event) {
   await appendFiles(files)
 }
 
+function beginEditMessage(message) {
+  if (!message) return
+  const text = typeof message.content === "string"
+    ? message.content
+    : Array.isArray(message.parts)
+      ? message.parts.filter((p) => p.type === "text").map((p) => p.content).join("")
+      : ""
+  inputText.value = text
+  nextTick(() => {
+    if (inputEl.value) {
+      inputEl.value.focus()
+    }
+  })
+}
+
 function send() {
   if (props.readOnly || !canSend.value) return
   chat.send(inputText.value, {

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -67,8 +67,8 @@
               <p class="text-warm-300 dark:text-warm-600 text-xs mt-1">{{ resolvedEmptySubtitle }}</p>
             </div>
           </template>
-          <ChatMessage v-for="(msg, idx) in chat.currentMessages" :key="msg.id" :message="msg" :prev-message="idx > 0 ? chat.currentMessages[idx - 1] : null" :is-first="idx === 0" :message-idx="idx" :is-last-assistant="msg.role === 'assistant' && idx === chat.currentMessages.length - 1" />
-          <div v-if="chat.processing" class="flex items-center gap-2.5 py-2 pl-1">
+          <ChatMessage v-for="(msg, idx) in chat.currentMessages" :key="msg.id" :message="msg" :prev-message="idx > 0 ? chat.currentMessages[idx - 1] : null" :is-first="idx === 0" :message-idx="idx" :is-last-assistant="msg.role === 'assistant' && idx === chat.currentMessages.length - 1" @request-edit="beginEditMessage" />
+          <div v-if="chat.isWorking" class="flex items-center gap-2.5 py-2 pl-1">
             <span class="w-2 h-2 rounded-full bg-amber kohaku-glow" />
             <span class="text-sm text-amber/80 kohaku-pulse">{{ t("chat.processing") }}</span>
           </div>
@@ -77,29 +77,46 @@
 
       <!-- Queued messages: shown above input, not in main chat -->
       <div v-if="!readOnly && chat.queuedMessages.length" class="px-4 pt-2 flex flex-col gap-1.5">
+        <div class="px-3 py-1 text-xs text-warm-400 dark:text-warm-500">
+          {{ t("chat.queueNotice") }}
+        </div>
         <div v-for="qm in chat.queuedMessages" :key="qm.id" class="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-amber/5 dark:bg-amber/5 border border-amber/20 text-sm">
           <span class="i-carbon-time text-amber/60 text-xs flex-shrink-0" />
-          <span class="text-warm-500 dark:text-warm-400 truncate">{{ qm.content }}</span>
+          <span class="text-warm-500 dark:text-warm-400 truncate">{{ qm.content || attachmentSummary(qm.attachments) }}</span>
+          <span v-if="qm.attachments?.length" class="text-[10px] text-warm-400 dark:text-warm-500 flex-shrink-0">{{ attachmentSummary(qm.attachments) }}</span>
           <span class="text-warm-300 dark:text-warm-600 text-xs flex-shrink-0 ml-auto">{{ t("chat.queued") }}</span>
         </div>
       </div>
 
       <!-- Input: sits inside bubble, with subtle top border -->
       <div v-if="!readOnly" class="px-4 pb-4 pt-2 border-t border-t-warm-100 dark:border-t-warm-800">
+        <div v-if="pendingAttachments.length" class="mb-2 flex flex-wrap gap-2">
+          <div v-for="file in pendingAttachments" :key="file.id" class="flex items-center gap-2 max-w-full px-2.5 py-1.5 rounded-lg bg-warm-100 dark:bg-warm-800 border border-warm-200 dark:border-warm-700 text-xs">
+            <span :class="attachmentIcon(file)" class="text-sm text-iolite dark:text-iolite-light shrink-0" />
+            <span v-if="file.type !== 'image'" class="truncate max-w-[12rem] text-warm-700 dark:text-warm-200">{{ file.name }}</span>
+            <span v-if="file.type !== 'image'" class="text-warm-400">{{ formatFileSize(file.size) }}</span>
+            <button class="text-warm-400 hover:text-coral" @click="removeAttachment(file.id)">
+              <span class="i-carbon-close text-xs" />
+            </button>
+          </div>
+        </div>
         <div class="flex gap-2 px-3 py-1.5 rounded-xl bg-warm-50 dark:bg-warm-800 border border-warm-200 dark:border-warm-700 focus-within:border-iolite/40 dark:focus-within:border-iolite-light/30 transition-colors" :class="inputText.includes('\n') ? 'items-end' : 'items-center'">
-          <textarea ref="inputEl" v-model="inputText" rows="1" class="flex-1 bg-transparent border-none outline-none text-sm text-warm-800 dark:text-warm-200 placeholder-warm-400 dark:placeholder-warm-500 resize-none max-h-32 leading-relaxed py-1" style="min-height: 2em" :placeholder="inputPlaceholder" @keydown="onInputKeydown" @input="autoResize" />
-          <!-- Compact/Clear actions -->
+          <input ref="fileInputEl" type="file" class="hidden" accept="image/*,video/*,application/pdf" multiple @change="onFileChange" />
+          <button class="w-7 h-7 flex items-center justify-center rounded-md transition-colors shrink-0 text-warm-400 hover:text-iolite dark:hover:text-iolite-light hover:bg-iolite/10" title="Attach image, video, or PDF" aria-label="Attach image, video, or PDF" @click="pickFiles">
+            <span class="i-carbon-attachment text-xs" />
+          </button>
+          <textarea ref="inputEl" v-model="inputText" rows="1" class="flex-1 bg-transparent border-none outline-none text-sm text-warm-800 dark:text-warm-200 placeholder-warm-400 dark:placeholder-warm-500 resize-none max-h-32 leading-relaxed py-1" style="min-height: 2em" :placeholder="inputPlaceholder" @keydown="onInputKeydown" @input="autoResize" @paste="onPaste" />
           <button class="w-7 h-7 flex items-center justify-center rounded-md transition-colors shrink-0 text-warm-400 hover:text-iolite dark:hover:text-iolite-light hover:bg-iolite/10" :title="t('chat.compactContext')" :aria-label="t('chat.compactContext')" @click="triggerCompact">
             <span class="i-carbon-collapse-all text-xs" />
           </button>
           <button class="w-7 h-7 flex items-center justify-center rounded-md transition-colors shrink-0 text-warm-400 hover:text-coral hover:bg-coral/10" :title="t('chat.clearContext')" :aria-label="t('chat.clearContext')" @click="triggerClear">
             <span class="i-carbon-clean text-xs" />
           </button>
-          <button v-if="chat.processing || chat.hasRunningJobs" class="w-8 h-8 flex items-center justify-center rounded-lg transition-all shrink-0 mb-0.5 bg-coral/90 text-white hover:bg-coral shadow-sm shadow-coral/20" :title="`${t('chat.stopGeneration')} (Esc)`" :aria-label="t('chat.stopGeneration')" @click="chat.interrupt()">
-            <span class="i-carbon-stop-filled text-sm" />
-          </button>
-          <button v-else class="w-8 h-8 flex items-center justify-center rounded-lg transition-all shrink-0 mb-0.5" :class="inputText.trim() ? 'bg-iolite text-white hover:bg-iolite-shadow shadow-sm shadow-iolite/20' : 'text-warm-300 dark:text-warm-600 cursor-not-allowed'" :disabled="!inputText.trim()" :aria-label="t('chat.sendMessage')" @click="send">
+<button v-if="shouldShowSendButton" class="w-8 h-8 flex items-center justify-center rounded-lg transition-all shrink-0 mb-0.5" :class="canSend ? 'bg-iolite text-white hover:bg-iolite-shadow shadow-sm shadow-iolite/20' : 'text-warm-300 dark:text-warm-600 cursor-not-allowed'" :disabled="!canSend" :aria-label="sendButtonLabel" @click="send">
             <span class="i-carbon-send text-sm" />
+          </button>
+          <button v-else class="w-8 h-8 flex items-center justify-center rounded-lg transition-all shrink-0 mb-0.5 shadow-sm" :class="chat.hasCancellingJobs ? 'bg-warm-400 text-white' : 'bg-coral/90 text-white hover:bg-coral shadow-coral/20'" :title="chat.hasCancellingJobs ? t('chat.stopping') : `${t('chat.stopGeneration')} (Esc)`" :aria-label="t('chat.stopGeneration')" :disabled="chat.hasCancellingJobs" @click="chat.interrupt()">
+            <span class="i-carbon-stop-filled text-sm" />
           </button>
         </div>
       </div>
@@ -127,6 +144,8 @@ const { t } = useI18n()
 const inputText = ref("")
 const messagesEl = ref(null)
 const inputEl = ref(null)
+const fileInputEl = ref(null)
+const pendingAttachments = ref([])
 
 function draftKey() {
   const instanceId = props.instance?.id || chat._instanceId || ""
@@ -181,6 +200,9 @@ const inputPlaceholder = computed(() => {
 
 const resolvedEmptyTitle = computed(() => props.emptyTitle || t("chat.noMessagesYet"))
 const resolvedEmptySubtitle = computed(() => props.emptySubtitle || t("chat.getStarted"))
+const canSend = computed(() => !!inputText.value.trim() || pendingAttachments.value.length > 0)
+const shouldShowSendButton = computed(() => canSend.value || (!chat.processing && !chat.hasRunningJobs))
+const sendButtonLabel = computed(() => (chat.processing || chat.hasRunningJobs) && canSend.value ? t("chat.sendMessage") : t("chat.stopGeneration"))
 
 function getCreatureStatus(name) {
   const creature = props.instance.creatures.find((c) => c.name === name)
@@ -314,12 +336,80 @@ watch(inputText, () => {
   persistDraft()
 })
 
+function formatFileSize(size) {
+  if (!size) return ""
+  if (size >= 1024 * 1024) return `${(size / (1024 * 1024)).toFixed(1)} MB`
+  if (size >= 1024) return `${Math.round(size / 1024)} KB`
+  return `${size} B`
+}
+
+function attachmentIcon(file) {
+  if (file.type === "image") return "i-carbon-image"
+  if (file.type === "video") return "i-carbon-video"
+  if (file.type === "pdf") return "i-carbon-document-pdf"
+  return "i-carbon-document"
+}
+
+function attachmentSummary(attachments = []) {
+  if (!attachments.length) return ""
+  return attachments.map((item) => item.name).join(", ")
+}
+
+function pickFiles() {
+  fileInputEl.value?.click()
+}
+
+function removeAttachment(id) {
+  pendingAttachments.value = pendingAttachments.value.filter((item) => item.id !== id)
+}
+
+async function fileToAttachment(file) {
+  const url = await new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
+  const kind = file.type.startsWith("image/") ? "image" : file.type.startsWith("video/") ? "video" : file.type === "application/pdf" ? "pdf" : "file"
+  return {
+    id: `${file.name}-${file.size}-${file.lastModified}`,
+    type: kind,
+    name: file.name,
+    mimeType: file.type,
+    size: file.size,
+    url,
+  }
+}
+
+async function appendFiles(fileList) {
+  const files = Array.from(fileList || []).filter((file) => file.type.startsWith("image/") || file.type.startsWith("video/") || file.type === "application/pdf")
+  if (!files.length) return
+  const next = await Promise.all(files.map((file) => fileToAttachment(file)))
+  const seen = new Set(pendingAttachments.value.map((item) => item.id))
+  pendingAttachments.value = [...pendingAttachments.value, ...next.filter((item) => !seen.has(item.id))]
+}
+
+async function onFileChange(event) {
+  await appendFiles(event.target.files)
+  if (fileInputEl.value) fileInputEl.value.value = ""
+}
+
+async function onPaste(event) {
+  const files = Array.from(event.clipboardData?.files || [])
+  if (!files.length) return
+  await appendFiles(files)
+}
+
 function send() {
-  if (props.readOnly || !inputText.value.trim()) return
-  chat.send(inputText.value)
+  if (props.readOnly || !canSend.value) return
+  chat.send(inputText.value, {
+    attachments: pendingAttachments.value,
+    reasoningEffort: chat.sessionInfo.reasoningEffort || "",
+  })
   inputText.value = ""
+  pendingAttachments.value = []
   persistDraft()
-  isNearBottom.value = true // force scroll after send
+  isNearBottom.value = true
   nextTick(() => {
     if (inputEl.value) inputEl.value.style.height = "auto"
     scrollToBottom()
@@ -383,3 +473,4 @@ function onGlobalKeydown(e) {
 onMounted(() => window.addEventListener("keydown", onGlobalKeydown))
 onUnmounted(() => window.removeEventListener("keydown", onGlobalKeydown))
 </script>
+

--- a/src/kohakuterrarium-frontend/src/components/chrome/ModelSwitcher.vue
+++ b/src/kohakuterrarium-frontend/src/components/chrome/ModelSwitcher.vue
@@ -1,15 +1,22 @@
 <template>
-  <div v-if="isTerrarium" class="flex items-center gap-2 min-w-0">
-    <el-select :model-value="selectedTarget" size="small" class="status-select target-select" :disabled="!instanceId" @change="onPickTarget">
+  <div class="flex items-center gap-2 min-w-0">
+    <el-select v-if="isTerrarium" :model-value="selectedTarget" size="small" class="status-select target-select" :disabled="!instanceId" @change="onPickTarget">
       <el-option v-for="target in targetOptions" :key="target.value" :label="target.label" :value="target.value" />
     </el-select>
-    <el-select :model-value="currentModel" size="small" class="status-select model-select" :disabled="!canPickModel" :loading="loading" placeholder="Search model" filterable default-first-option :reserve-keyword="false" @visible-change="onVisibleChange" @change="onPick">
-      <el-option v-for="m in availableModels" :key="m.name" :label="modelLabel(m)" :value="m.name" :disabled="m.name === currentModel" />
-    </el-select>
+    <div class="flex items-center gap-2 min-w-0">
+      <el-select :model-value="currentModel" size="small" class="status-select model-select" :disabled="!instanceId || !canPickModel" :loading="loading" placeholder="Select model" popper-class="model-switcher-popper" @visible-change="onVisibleChange" @change="onPick">
+        <template #header>
+          <div class="model-search-header" @click.stop @mousedown.stop>
+            <input ref="modelSearchInput" v-model.trim="modelSearch" type="text" class="model-search-field" placeholder="Search / filter" @click.stop @keydown.stop />
+          </div>
+        </template>
+        <el-option v-for="m in filteredModels" :key="m.name" :label="modelLabel(m)" :value="m.name" :disabled="m.available === false" />
+      </el-select>
+      <el-select v-model="reasoningEffort" size="small" class="status-select reasoning-select" :disabled="!supportsReasoningControls" @change="onChangeReasoningEffort">
+        <el-option v-for="option in reasoningOptions" :key="option.value || 'default'" :label="option.label" :value="option.value" />
+      </el-select>
+    </div>
   </div>
-  <el-select v-else :model-value="currentModel" size="small" class="status-select model-select" :disabled="!instanceId" :loading="loading" placeholder="Search model" filterable default-first-option :reserve-keyword="false" @visible-change="onVisibleChange" @change="onPick">
-    <el-option v-for="m in availableModels" :key="m.name" :label="modelLabel(m)" :value="m.name" :disabled="m.name === currentModel" />
-  </el-select>
 
   <!-- Model config dialog (opened by gear button in StatusBar) -->
   <el-dialog v-model="configDialogVisible" title="Model Configuration" width="500px" :close-on-click-modal="true">
@@ -31,7 +38,7 @@
 </template>
 
 <script setup>
-import { computed, ref, onMounted, onUnmounted } from "vue"
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue"
 import { ElMessage } from "element-plus"
 
 import { useChatStore } from "@/stores/chat"
@@ -45,7 +52,17 @@ const instances = useInstancesStore()
 
 const models = ref([])
 const loading = ref(false)
-const availableModels = computed(() => models.value.filter((model) => model.available !== false))
+const modelSearch = ref("")
+const modelSearchInput = ref(null)
+const reasoningEffort = ref("")
+const filteredModels = computed(() => {
+  const q = modelSearch.value.trim().toLowerCase()
+  if (!q) return models.value
+  return models.value.filter((model) => {
+    const haystack = [model.name, model.provider, model.login_provider, model.description].filter(Boolean).join(" ").toLowerCase()
+    return haystack.includes(q)
+  })
+})
 
 // Config dialog state
 const configDialogVisible = ref(false)
@@ -81,6 +98,25 @@ const currentModel = computed(() => {
   }
   return chat.sessionInfo.model || inst?.model || ""
 })
+const currentModelProfile = computed(() => models.value.find((m) => m.name === currentModel.value) || null)
+const reasoningProvider = computed(() => {
+  const name = currentModel.value.toLowerCase()
+  const provider = String(currentModelProfile.value?.provider || currentModelProfile.value?.login_provider || "").toLowerCase()
+  if (name.includes("codex") || provider.includes("codex")) return "codex"
+  if (name.includes("gemini") || provider.includes("gemini") || provider.includes("google")) return "gemini"
+  if (name.includes("claude") || provider.includes("anthropic") || name.startsWith("anthropic/")) return "anthropic"
+  if (name.includes("gpt") || provider.includes("openai")) return "openai"
+  return ""
+})
+const reasoningOptions = computed(() => {
+  const base = [{ label: "Reasoning: default", value: "" }]
+  if (reasoningProvider.value === "codex") return [...base, { label: "Reasoning: minimal", value: "minimal" }, { label: "Reasoning: low", value: "low" }, { label: "Reasoning: medium", value: "medium" }, { label: "Reasoning: high", value: "high" }, { label: "Reasoning: xhigh", value: "xhigh" }]
+  if (reasoningProvider.value === "anthropic") return [...base, { label: "Reasoning: low", value: "low" }, { label: "Reasoning: medium", value: "medium" }, { label: "Reasoning: high", value: "high" }, { label: "Reasoning: max", value: "max" }]
+  if (reasoningProvider.value === "gemini") return [...base, { label: "Reasoning: low", value: "low" }, { label: "Reasoning: high", value: "high" }]
+  if (reasoningProvider.value === "openai") return [...base, { label: "Reasoning: minimal", value: "minimal" }, { label: "Reasoning: low", value: "low" }, { label: "Reasoning: medium", value: "medium" }, { label: "Reasoning: high", value: "high" }, { label: "Reasoning: xhigh", value: "xhigh" }]
+  return base
+})
+const supportsReasoningControls = computed(() => reasoningProvider.value !== "")
 
 async function loadModels() {
   loading.value = true
@@ -94,8 +130,18 @@ async function loadModels() {
   }
 }
 
+function syncReasoningEffort() {
+  reasoningEffort.value = currentModelProfile.value?.reasoning_effort || ""
+}
+
 function onVisibleChange(open) {
-  if (open && models.value.length === 0) loadModels()
+  if (open) {
+    if (models.value.length === 0) loadModels()
+    syncReasoningEffort()
+    nextTick(() => modelSearchInput.value?.focus())
+    return
+  }
+  modelSearch.value = ""
 }
 
 function modelLabel(model) {
@@ -129,10 +175,20 @@ async function onPick(modelName) {
       await agentAPI.switchModel(id, modelName)
       chat.sessionInfo.model = modelName
     }
+    syncReasoningEffort()
     ElMessage.success(`Switched to ${modelName}`)
   } catch (err) {
     ElMessage.error(`Model switch failed: ${err?.message || err}`)
   }
+}
+
+function onChangeReasoningEffort(value) {
+  if (!reasoningOptions.value.some((item) => item.value === value)) {
+    reasoningEffort.value = ""
+    chat.sessionInfo.reasoningEffort = ""
+    return
+  }
+  chat.sessionInfo.reasoningEffort = value || ""
 }
 
 /** Open model config dialog with the current profile's JSON */
@@ -140,7 +196,7 @@ function openModelConfig() {
   configJsonError.value = ""
   if (models.value.length === 0) loadModels()
   const modelName = currentModel.value
-  const fullProfile = availableModels.value.find((m) => m.name === modelName) || models.value.find((m) => m.name === modelName)
+  const fullProfile = models.value.find((m) => m.name === modelName)
   const profile = fullProfile
     ? {
         model: fullProfile.model,
@@ -171,6 +227,8 @@ function saveModelConfig() {
 
 // Listen for gear button event from StatusBar
 let _cleanup = null
+watch(currentModelProfile, () => syncReasoningEffort(), { immediate: true })
+
 onMounted(() => {
   _cleanup = onLayoutEvent(LAYOUT_EVENTS.MODEL_CONFIG_OPEN, () => openModelConfig())
 })
@@ -194,5 +252,29 @@ onUnmounted(() => {
 
 .model-select {
   width: 12rem;
+}
+
+.reasoning-select {
+  width: 8.5rem;
+}
+
+.model-search-header {
+  padding: 0.375rem;
+  border-bottom: 1px solid rgba(120, 109, 98, 0.18);
+}
+
+.model-search-field {
+  width: 100%;
+  height: 28px;
+  padding: 0 0.625rem;
+  border-radius: 8px;
+  border: 1px solid rgba(120, 109, 98, 0.25);
+  background: rgba(120, 109, 98, 0.08);
+  color: inherit;
+  outline: none;
+}
+
+.model-search-field:focus {
+  border-color: rgba(125, 108, 255, 0.55);
 }
 </style>

--- a/src/kohakuterrarium-frontend/src/components/chrome/ModelSwitcher.vue
+++ b/src/kohakuterrarium-frontend/src/components/chrome/ModelSwitcher.vue
@@ -131,7 +131,7 @@ async function loadModels() {
 }
 
 function syncReasoningEffort() {
-  reasoningEffort.value = currentModelProfile.value?.reasoning_effort || ""
+  reasoningEffort.value = currentModelProfile.value?.reasoning_effort || "medium"
 }
 
 function onVisibleChange(open) {

--- a/src/kohakuterrarium-frontend/src/pages/settings.vue
+++ b/src/kohakuterrarium-frontend/src/pages/settings.vue
@@ -51,6 +51,7 @@
               </div>
               <div class="text-[11px] text-warm-400 font-mono flex gap-4">
                 <span v-if="profile.base_url">{{ t("settings.models.baseUrlShort") }}: {{ profile.base_url }}</span>
+                <span v-if="profile.api_key_env">{{ t("settings.models.apiKeyEnvShort") }}: {{ profile.api_key_env }}</span>
                 <span>{{ t("settings.models.contextShort") }}: {{ (profile.max_context / 1000).toFixed(0) }}K</span>
                 <span v-if="profile.temperature != null">{{ t("settings.models.temperatureShort") }}: {{ profile.temperature }}</span>
               </div>
@@ -86,6 +87,14 @@
                   <el-input v-model="form.base_url" size="small" placeholder="https://api.openai.com/v1" />
                 </div>
                 <div>
+                  <label class="text-[11px] text-warm-400 mb-1 block">{{ t("settings.models.apiKeyEnv") }}</label>
+                  <el-input v-model.trim="form.api_key_env" size="small" placeholder="MY_CUSTOM_API_KEY" />
+                </div>
+                <div>
+                  <label class="text-[11px] text-warm-400 mb-1 block">{{ t("settings.models.apiKeyOptional") }}</label>
+                  <el-input v-model="form.api_key" size="small" type="password" show-password :placeholder="t('settings.models.apiKeyPlaceholder')" />
+                </div>
+                <div>
                   <label class="text-[11px] text-warm-400 mb-1 block">{{ t("settings.models.maxContext") }}</label>
                   <el-input-number v-model="form.max_context" size="small" :min="1000" :step="1000" />
                 </div>
@@ -94,6 +103,9 @@
                   <el-input-number v-model="form.temperature" size="small" :min="0" :max="2" :step="0.1" :precision="1" />
                 </div>
               </div>
+              <p v-if="editingProfile" class="text-[11px] text-warm-400 mt-3">
+                {{ t("settings.models.apiKeyEditHint") }}
+              </p>
               <div class="flex gap-2 mt-3">
                 <el-button type="primary" size="small" :disabled="!form.name || !form.model" @click="saveProfile">
                   {{ editingProfile ? t("settings.models.update") : t("settings.models.addProfile") }}
@@ -352,6 +364,8 @@ const form = reactive({
   model: "",
   provider: "openai",
   base_url: "",
+  api_key_env: "",
+  api_key: "",
   max_context: 128000,
   temperature: null,
 })
@@ -371,6 +385,8 @@ function editProfile(profile) {
   form.model = profile.model
   form.provider = profile.provider
   form.base_url = profile.base_url || ""
+  form.api_key_env = profile.api_key_env || ""
+  form.api_key = ""
   form.max_context = profile.max_context || 128000
   form.temperature = profile.temperature
 }
@@ -381,12 +397,18 @@ function resetForm() {
   form.model = ""
   form.provider = "openai"
   form.base_url = ""
+  form.api_key_env = ""
+  form.api_key = ""
   form.max_context = 128000
   form.temperature = null
 }
 
 async function saveProfile() {
   if (!form.name || !form.model) return
+  if (form.api_key && !form.api_key_env) {
+    ElMessage.error(t("settings.models.apiKeyEnvRequired"))
+    return
+  }
   try {
     await settingsAPI.saveProfile({ ...form })
     ElMessage.success(t("settings.models.saved", { name: form.name }))

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -945,7 +945,7 @@ export const useChatStore = defineStore("chat", {
         try {
           await terrariumAPI.sendToChannel(this._instanceId, chName, text, "human", {
             attachments,
-            reasoning_effort: options.reasoningEffort || "",
+            reasoning_effort: options.reasoningEffort || this.sessionInfo.reasoningEffort || "medium",
           })
         } catch (err) {
           console.error("Channel send failed:", err)
@@ -959,7 +959,7 @@ export const useChatStore = defineStore("chat", {
               target,
               message: text,
               attachments,
-              reasoning_effort: options.reasoningEffort || "",
+              reasoning_effort: options.reasoningEffort || this.sessionInfo.reasoningEffort || "medium",
             }),
           )
           this.processing = true

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -4,6 +4,144 @@ import { useInstancesStore } from "@/stores/instances"
 import { useStatusStore } from "@/stores/status"
 import { getHybridPrefSync, setHybridPref } from "@/utils/uiPrefs"
 
+function normalizeAttachments(attachments) {
+  if (!Array.isArray(attachments)) return []
+  return attachments
+    .map((item, index) => {
+      if (!item) return null
+      const type = item.type || item.kind || "file"
+      const mimeType = item.mime_type || item.mimeType || item.mime || ""
+      const url = item.url || item.data_url || item.dataUrl || ""
+      return {
+        id: item.id || `att_${index}`,
+        type,
+        name: item.name || item.filename || `attachment-${index + 1}`,
+        mimeType,
+        size: item.size || 0,
+        url,
+      }
+    })
+    .filter(Boolean)
+}
+
+function parseMessageContent(content) {
+  if (typeof content === "string") return { text: content, attachments: [] }
+  if (!Array.isArray(content)) return { text: "", attachments: [] }
+
+  const text = []
+  const attachments = []
+  for (const part of content) {
+    if (!part) continue
+    if (part.type === "text") {
+      if (part.text) text.push(part.text)
+      continue
+    }
+    if (part.type === "input_text") {
+      if (part.text) text.push(part.text)
+      continue
+    }
+    if (part.type === "image_url" || part.type === "input_image") {
+      const image = part.image_url?.url || part.url || ""
+      attachments.push({
+        type: "image",
+        name: part.name || "image",
+        mimeType: part.mime_type || "",
+        url: image,
+      })
+      continue
+    }
+    if (part.type === "input_file" || part.type === "file") {
+      attachments.push({
+        type: part.mime_type === "application/pdf" ? "pdf" : "file",
+        name: part.filename || part.name || "file",
+        mimeType: part.mime_type || "",
+        url: part.file_data || part.url || "",
+      })
+      continue
+    }
+    if (part.type === "input_video" || part.type === "video") {
+      attachments.push({
+        type: "video",
+        name: part.filename || part.name || "video",
+        mimeType: part.mime_type || "",
+        url: part.video_data || part.url || "",
+      })
+    }
+  }
+  return { text: text.join("\n"), attachments: normalizeAttachments(attachments) }
+}
+
+function attachConversationIndices(uiMessages, rawMessages) {
+  if (!Array.isArray(uiMessages) || !Array.isArray(rawMessages) || !uiMessages.length || !rawMessages.length) {
+    return uiMessages
+  }
+  let rawUserIndex = 0
+  for (const message of uiMessages) {
+    if (message.role !== "user") continue
+    while (rawUserIndex < rawMessages.length && rawMessages[rawUserIndex]?.role !== "user") {
+      rawUserIndex += 1
+    }
+    if (rawUserIndex >= rawMessages.length) break
+    message.conversationIndex = rawUserIndex
+    rawUserIndex += 1
+  }
+  return uiMessages
+}
+
+function cloneMessage(message) {
+  return {
+    ...message,
+    attachments: Array.isArray(message.attachments)
+      ? message.attachments.map((item) => ({ ...item }))
+      : message.attachments,
+    tool_calls: Array.isArray(message.tool_calls)
+      ? message.tool_calls.map((item) => ({ ...item }))
+      : message.tool_calls,
+    parts: Array.isArray(message.parts)
+      ? message.parts.map((part) => ({
+          ...part,
+          args: part.args && typeof part.args === "object" ? { ...part.args } : part.args,
+          tools_used: Array.isArray(part.tools_used) ? [...part.tools_used] : part.tools_used,
+          children: Array.isArray(part.children)
+            ? part.children.map((child) => ({
+                ...child,
+                args:
+                  child.args && typeof child.args === "object"
+                    ? { ...child.args }
+                    : child.args,
+                tools_used: Array.isArray(child.tools_used)
+                  ? [...child.tools_used]
+                  : child.tools_used,
+              }))
+            : part.children,
+        }))
+      : message.parts,
+  }
+}
+
+function refreshTabMessages(store, tabKey) {
+  if (!tabKey) return
+  const messages = store.messagesByTab[tabKey]
+  if (!Array.isArray(messages)) return
+  store.messagesByTab = {
+    ...store.messagesByTab,
+    [tabKey]: messages.map((message) => cloneMessage(message)),
+  }
+}
+
+function mutateTabMessages(store, tabKey, updater) {
+  if (!tabKey) return null
+  const current = store.messagesByTab[tabKey]
+  if (!Array.isArray(current)) return null
+  const draft = current.map((message) => cloneMessage(message))
+  const next = updater(draft) || draft
+  store.messagesByTab = {
+    ...store.messagesByTab,
+    [tabKey]: next,
+  }
+  return next
+}
+
 /**
  * Convert OpenAI-format conversation history to frontend messages.
  */
@@ -16,10 +154,12 @@ export function _convertHistory(messages) {
   for (const msg of messages) {
     if (msg.role === "system" || msg.role === "tool") continue
     if (msg.role === "user") {
+      const parsed = parseMessageContent(msg.content)
       result.push({
         id: "h_" + result.length,
         role: "user",
-        content: msg.content || "",
+        content: parsed.text,
+        attachments: parsed.attachments.length ? parsed.attachments : undefined,
         timestamp: "",
       })
     } else if (msg.role === "assistant") {
@@ -31,10 +171,14 @@ export function _convertHistory(messages) {
         status: "done",
         result: toolResults[tc.id] || "",
       }))
+      // Handle multimodal content: parse array format like user messages
+      const parsed = parseMessageContent(msg.content)
       result.push({
         id: "h_" + result.length,
         role: "assistant",
-        content: msg.content || "",
+        content: parsed.text,
+        attachments: parsed.attachments.length ? parsed.attachments : undefined,
+        parts: [], // Will be filled by event replay or fallback
         timestamp: "",
         tool_calls: tcs.length ? tcs : undefined,
       })
@@ -269,10 +413,12 @@ export function _replayEvents(messages, events) {
     // ── Common types (both formats) ──
     if (t === "user_input") {
       cur = null
+      const parsed = parseMessageContent(evt.content)
       result.push({
         id: "h_" + result.length,
         role: "user",
-        content: evt.content || "",
+        content: parsed.text,
+        attachments: parsed.attachments.length ? parsed.attachments : undefined,
         timestamp: "",
       })
     } else if (t === "processing_start") {
@@ -517,27 +663,52 @@ export function _replayEvents(messages, events) {
     }
   }
 
-  // Only mark sub-agents as interrupted if they have NO job_id tracking
-  // (legacy events without job_id) AND have no result
-  for (const msg of result) {
-    for (const part of msg.parts || []) {
-      if (
-        part.type === "tool" &&
-        part.kind === "subagent" &&
-        part.status === "done" &&
-        !part.result &&
-        !part.jobId
-      ) {
-        part.status = "interrupted"
-      }
-    }
-  }
-
   // Clean up empty parts
   for (const msg of result) {
     if (msg.parts?.length === 0) delete msg.parts
   }
-  return { messages: result, pendingJobs }
+
+  const fallback = attachConversationIndices(_convertHistory(messages), messages)
+  for (let i = 0; i < Math.min(result.length, fallback.length); i++) {
+    const liveMsg = result[i]
+    const finalMsg = fallback[i]
+    if (!liveMsg || !finalMsg || liveMsg.role !== finalMsg.role) continue
+
+    if (liveMsg.role === "assistant") {
+      const hasText = Array.isArray(liveMsg.parts)
+        ? liveMsg.parts.some((part) => part.type === "text" && part.content)
+        : !!liveMsg.content
+      const hasTools = Array.isArray(liveMsg.parts)
+        ? liveMsg.parts.some((part) => part.type === "tool")
+        : Array.isArray(liveMsg.tool_calls) && liveMsg.tool_calls.length > 0
+      const hasAttachments = Array.isArray(liveMsg.attachments) && liveMsg.attachments.length > 0
+      const fallbackHasContent = finalMsg.content || (Array.isArray(finalMsg.attachments) && finalMsg.attachments.length > 0)
+
+      if (!hasText && !hasTools) {
+        // Live message has no visible content — use fallback.
+        // Merge live parts into fallback text so the rendered message
+        // contains both the fallback content AND any live tool/subagent parts.
+        const mergedParts = [
+          // Convert fallback content/attachments into text/attachment parts
+          ...(finalMsg.content ? [{ type: "text", content: finalMsg.content }] : []),
+          ...(finalMsg.attachments?.length ? finalMsg.attachments.map((a) => ({ type: a.type || "file", ...a, partType: "attachment" })) : []),
+          // Preserve any live tool/subagent parts
+          ...(Array.isArray(liveMsg.parts) ? liveMsg.parts : []),
+        ]
+        result[i] = {
+          ...finalMsg,
+          content: finalMsg.content,
+          attachments: finalMsg.attachments,
+          parts: mergedParts.length ? mergedParts : undefined,
+          tool_calls: liveMsg.tool_calls || finalMsg.tool_calls,
+        }
+      }
+    } else if (liveMsg.role === "user" && !liveMsg.content && finalMsg.content) {
+      result[i] = { ...liveMsg, content: finalMsg.content, attachments: finalMsg.attachments }
+    }
+  }
+
+  return { messages: attachConversationIndices(result, messages), pendingJobs }
 }
 
 function _parseArgs(args) {
@@ -580,6 +751,7 @@ export const useChatStore = defineStore("chat", {
       model: "",
       agentName: "",
       compactThreshold: 0,
+      reasoningEffort: "",
     },
     /** Reactive tick counter - incremented every second when jobs are running */
     _jobTick: 0,
@@ -595,6 +767,12 @@ export const useChatStore = defineStore("chat", {
     queuedMessages: [],
     /** @type {number} Monotonic token to ignore stale history/WS callbacks after instance switches */
     _instanceGeneration: 0,
+    /** @type {number | null} Recovery poll timer for empty assistant messages */
+    _recoveryPollTimer: null,
+    /** @type {number} Attempts used by empty-message recovery polling */
+    _recoveryPollAttempts: 0,
+    /** @type {string | null} Tab currently being recovery-polled */
+    _recoveryPollTab: null,
     /** @type {Record<string, number>} Recent user message signatures for cross-tab dedupe */
     _recentUserInputs: {},
   }),
@@ -605,6 +783,7 @@ export const useChatStore = defineStore("chat", {
       return state.messagesByTab[state.activeTab] || []
     },
     hasRunningJobs: (state) => Object.keys(state.runningJobs).length > 0,
+    isWorking: (state) => state.processing || Object.keys(state.runningJobs).length > 0,
     terrariumTarget: (state) => {
       if (state._instanceType !== "terrarium") return null
       const tab = state.activeTab
@@ -634,6 +813,7 @@ export const useChatStore = defineStore("chat", {
         agentName: "",
         compactThreshold: 0,
         maxContext: 0,
+        reasoningEffort: "",
       }
 
       // Reset status store too
@@ -724,8 +904,23 @@ export const useChatStore = defineStore("chat", {
       }
     },
 
-    async send(text) {
-      if (!this.activeTab || !text.trim() || !this._ws) return
+/** Force clear processing state (fallback when backend doesn't respond). */
+    _forceClearState() {
+      this.processing = false
+      // Clear cancelling jobs
+      for (const jobId in this.runningJobs) {
+        const job = this.runningJobs[jobId]
+        if (job.cancelling) {
+          delete this.runningJobs[jobId]
+        }
+      }
+      this._checkJobTimer()
+    },
+
+    async send(text, options = {}) {
+      const trimmed = typeof text === "string" ? text.trim() : ""
+      const attachments = normalizeAttachments(options.attachments)
+      if (!this.activeTab || (!trimmed && attachments.length === 0) || !this._ws) return
 
       const tab = this.activeTab
       const now = Date.now()
@@ -733,12 +928,12 @@ export const useChatStore = defineStore("chat", {
         id: "u_" + now,
         role: "user",
         content: text,
+        attachments: attachments.length ? attachments : undefined,
         timestamp: new Date(now).toISOString(),
       }
 
-      this._recentUserInputs[`${tab}:${text}`] = now
+      this._recentUserInputs[`${tab}:${trimmed}`] = now
       if (this.processing) {
-        // Don't put in main chat — hold in queue, shown above input box
         msg.queued = true
         this.queuedMessages.push(msg)
       } else {
@@ -748,14 +943,25 @@ export const useChatStore = defineStore("chat", {
       if (tab.startsWith("ch:")) {
         const chName = tab.slice(3)
         try {
-          await terrariumAPI.sendToChannel(this._instanceId, chName, text, "human")
+          await terrariumAPI.sendToChannel(this._instanceId, chName, text, "human", {
+            attachments,
+            reasoning_effort: options.reasoningEffort || "",
+          })
         } catch (err) {
           console.error("Channel send failed:", err)
         }
       } else {
         const target = tab
         if (this._ws.readyState === WebSocket.OPEN) {
-          this._ws.send(JSON.stringify({ type: "input", target, message: text }))
+          this._ws.send(
+            JSON.stringify({
+              type: "input",
+              target,
+              message: text,
+              attachments,
+              reasoning_effort: options.reasoningEffort || "",
+            }),
+          )
           this.processing = true
         }
       }
@@ -852,15 +1058,21 @@ export const useChatStore = defineStore("chat", {
 
     async _loadAgentHistory(agentId, tabKey, generation = this._instanceGeneration) {
       try {
-        const { messages, events } = await agentAPI.getHistory(agentId)
+        const data = await agentAPI.getHistory(agentId)
         if (generation !== this._instanceGeneration) return
-        if (events?.length) {
+
+        const events = Array.isArray(data?.events) ? data.events : []
+        const messages = Array.isArray(data?.messages) ? data.messages : []
+
+        if (events.length) {
           const { messages: msgs, pendingJobs } = _replayEvents(messages, events)
           this.messagesByTab[tabKey] = msgs
+          refreshTabMessages(this, tabKey)
           this._restoreTokenUsage(tabKey, events)
           this._restoreRunningState(pendingJobs)
-        } else if (messages?.length) {
+        } else if (messages.length) {
           this.messagesByTab[tabKey] = _convertHistory(messages)
+          refreshTabMessages(this, tabKey)
         }
       } catch {
         /* no history yet */
@@ -914,29 +1126,30 @@ export const useChatStore = defineStore("chat", {
     /** Handle ALL incoming WS messages */
     _onMessage(data) {
       const source = data.source || ""
+      const tabKey = this._resolveSourceTab(source)
 
       if (data.type === "user_input") {
-        this._handleUserInput(source, data)
+        this._handleUserInput(tabKey, data)
       } else if (data.type === "text") {
         // If we get text chunks but processing is false (e.g. reconnect mid-stream),
         // set processing to true so the UI shows "KohakUwUing"
         if (!this.processing) this.processing = true
-        this._appendStreamChunk(source, data.content)
+        this._appendStreamChunk(tabKey, data.content)
       } else if (data.type === "processing_start") {
         this.processing = true
         // Promote queued user messages (agent is now processing them)
-        this._promoteQueuedMessages(source)
+        this._promoteQueuedMessages(tabKey)
       } else if (data.type === "processing_end") {
-        this._finishStream(source)
+        this._finishStream(tabKey)
       } else if (data.type === "idle") {
         this.processing = false
-        this._finishStream(source)
+        this._finishStream(tabKey)
       } else if (data.type === "activity") {
-        this._handleActivity(source, data)
+        this._handleActivity(tabKey, data)
       } else if (data.type === "channel_message") {
         this._handleChannelMessage(data)
       } else if (data.type === "error") {
-        this._addMsg(source, {
+        this._addMsg(tabKey, {
           id: "err_" + Date.now(),
           role: "system",
           content: "Error: " + (data.content || ""),
@@ -944,6 +1157,18 @@ export const useChatStore = defineStore("chat", {
         })
         this.processing = false
       }
+    },
+
+    _resolveSourceTab(source) {
+      if (source && this.messagesByTab[source]) return source
+      if (this.activeTab && this.messagesByTab[this.activeTab] && !this.activeTab.startsWith("ch:")) {
+        return this.activeTab
+      }
+      const agentTabs = this.tabs.filter((tab) => !tab.startsWith("ch:"))
+      if (agentTabs.length === 1 && this.messagesByTab[agentTabs[0]]) {
+        return agentTabs[0]
+      }
+      return source
     },
 
     _handleActivity(source, data) {
@@ -1007,6 +1232,7 @@ export const useChatStore = defineStore("chat", {
             timestamp: new Date().toISOString(),
           })
         }
+        refreshTabMessages(this, source)
         return
       }
 
@@ -1020,6 +1246,7 @@ export const useChatStore = defineStore("chat", {
           existing.summary = data.summary || ""
           existing.messagesCompacted = data.messages_compacted || 0
           existing.status = "done"
+          refreshTabMessages(this, source)
           return
         }
         msgs.push({
@@ -1031,6 +1258,7 @@ export const useChatStore = defineStore("chat", {
           messagesCompacted: data.messages_compacted || 0,
           timestamp: new Date().toISOString(),
         })
+        refreshTabMessages(this, source)
         return
       }
 
@@ -1041,6 +1269,7 @@ export const useChatStore = defineStore("chat", {
           messagesCleared: data.messages_cleared || 0,
           timestamp: new Date().toISOString(),
         })
+        refreshTabMessages(this, source)
         return
       }
 
@@ -1055,6 +1284,7 @@ export const useChatStore = defineStore("chat", {
           timestamp: new Date().toISOString(),
         })
         this.processing = false
+        refreshTabMessages(this, source)
         return
       }
 
@@ -1072,6 +1302,7 @@ export const useChatStore = defineStore("chat", {
           sender,
           timestamp: new Date().toISOString(),
         })
+        refreshTabMessages(this, source)
         return
       }
 
@@ -1108,6 +1339,7 @@ export const useChatStore = defineStore("chat", {
           promotable: !isBg,
         }
         this._ensureJobTimer()
+        refreshTabMessages(this, source)
       } else if (at === "tool_done" || at === "subagent_done") {
         let tc = this._findToolPart(msgs, name, data.job_id)
         if (!tc) {
@@ -1136,6 +1368,7 @@ export const useChatStore = defineStore("chat", {
         if (data.completion_tokens != null) tc.completion_tokens = data.completion_tokens
         delete this.runningJobs[tc.jobId || tc.id]
         this._checkJobTimer()
+        refreshTabMessages(this, source)
       } else if (at === "tool_error" || at === "subagent_error") {
         let tc = this._findToolPart(msgs, name, data.job_id)
         if (!tc) {
@@ -1164,6 +1397,7 @@ export const useChatStore = defineStore("chat", {
         if (data.completion_tokens != null) tc.completion_tokens = data.completion_tokens
         delete this.runningJobs[tc.jobId || tc.id]
         this._checkJobTimer()
+        refreshTabMessages(this, source)
       } else if (at === "subagent_token_update") {
         // Live token usage update from a running sub-agent
         const saName = data.subagent || ""
@@ -1173,6 +1407,7 @@ export const useChatStore = defineStore("chat", {
           if (data.total_tokens) sa.total_tokens = data.total_tokens
           if (data.prompt_tokens) sa.prompt_tokens = data.prompt_tokens
           if (data.completion_tokens) sa.completion_tokens = data.completion_tokens
+          refreshTabMessages(this, source)
         }
       } else if (at?.startsWith("subagent_tool_")) {
         // Sub-agent internal tool activity: find parent by job_id or name
@@ -1194,6 +1429,7 @@ export const useChatStore = defineStore("chat", {
               result: "",
             })
             if (!sa.tools_used.includes(toolName)) sa.tools_used.push(toolName)
+            refreshTabMessages(this, source)
           } else if (subAct === "tool_done" && toolName) {
             const child = [...sa.children]
               .reverse()
@@ -1201,6 +1437,7 @@ export const useChatStore = defineStore("chat", {
             if (child) {
               child.status = "done"
               child.result = data.detail || ""
+              refreshTabMessages(this, source)
             }
           } else if (subAct === "tool_error" && toolName) {
             const child = [...sa.children]
@@ -1209,6 +1446,7 @@ export const useChatStore = defineStore("chat", {
             if (child) {
               child.status = "error"
               child.result = data.detail || ""
+              refreshTabMessages(this, source)
             }
           }
         }
@@ -1217,6 +1455,7 @@ export const useChatStore = defineStore("chat", {
         const promJobId = data.job_id || ""
         if (promJobId && this.runningJobs[promJobId]) {
           this.runningJobs[promJobId].promotable = false
+          refreshTabMessages(this, source)
         }
       }
     },
@@ -1285,22 +1524,119 @@ export const useChatStore = defineStore("chat", {
       }
     },
 
+    _logRecovery(event, detail = {}) {
+      if (!import.meta.env.DEV) return
+      console.debug("[chat-recovery]", event, {
+        instanceId: this._instanceId,
+        activeTab: this.activeTab,
+        attempts: this._recoveryPollAttempts,
+        ...detail,
+      })
+    },
+
+    _stopRecoveryPolling() {
+      if (this._recoveryPollTimer !== null) {
+        clearTimeout(this._recoveryPollTimer)
+        this._recoveryPollTimer = null
+      }
+      this._recoveryPollAttempts = 0
+      this._recoveryPollTab = null
+    },
+
+    _scheduleRecoveryPoll(tab, generation = this._instanceGeneration) {
+      if (!tab || !this._instanceId) return
+      const delays = [200, 350, 600, 1000, 1600, 2500]
+      const attempt = this._recoveryPollAttempts
+      if (attempt >= delays.length) {
+        this._logRecovery("failed", { tab, attempt })
+        mutateTabMessages(this, tab, (messages) => {
+          const last = messages[messages.length - 1]
+          if (last?.role === "assistant") {
+            last.recovering = false
+            last.recoveryFailed = true
+            last.recoveryAttempt = this._recoveryPollAttempts
+          }
+          return messages
+        })
+        this._stopRecoveryPolling()
+        return
+      }
+      this._recoveryPollTab = tab
+      if (this._recoveryPollTimer !== null) clearTimeout(this._recoveryPollTimer)
+      this._recoveryPollTimer = setTimeout(async () => {
+        this._logRecovery("poll", { tab, attempt, delay: delays[attempt] })
+        this._recoveryPollTimer = null
+        if (generation !== this._instanceGeneration) return this._stopRecoveryPolling()
+        if (this.activeTab !== tab) return this._stopRecoveryPolling()
+        const recovered = await this._resyncHistory({ tab, generation })
+        if (recovered) {
+          this._logRecovery("recovered", { tab, attempt })
+          this._stopRecoveryPolling()
+          return
+        }
+        mutateTabMessages(this, tab, (messages) => {
+          const last = messages[messages.length - 1]
+          if (last?.role === "assistant") {
+            last.recovering = true
+            last.recoveryAttempt = this._recoveryPollAttempts + 1
+          }
+          return messages
+        })
+        this._recoveryPollAttempts += 1
+        this._scheduleRecoveryPoll(tab, generation)
+      }, delays[attempt])
+    },
+
+    _startRecoveryPolling(tab) {
+      if (!tab || !this._instanceId) return
+      this._stopRecoveryPolling()
+      this._logRecovery("start", { tab })
+      this._recoveryPollAttempts = 0
+      mutateTabMessages(this, tab, (messages) => {
+        const last = messages[messages.length - 1]
+        if (last?.role === "assistant") {
+          last.recovering = true
+          last.recoveryFailed = false
+          last.recoveryAttempt = 0
+        }
+        return messages
+      })
+      this._scheduleRecoveryPoll(tab, this._instanceGeneration)
+    },
+
     /** Re-fetch conversation history from the backend and rebuild the
      *  local message list. Called after edit/regenerate/rewind so the
      *  frontend matches the backend's truncated conversation. */
-    async _resyncHistory() {
-      if (!this._instanceId) return
+    async _resyncHistory(options = {}) {
+      if (!this._instanceId) return false
+      const tab = options.tab || this.activeTab
+      const generation = options.generation ?? this._instanceGeneration
       try {
         const { agentAPI } = await import("@/utils/api")
         const data = await agentAPI.getHistory(this._instanceId)
-        const tab = this.activeTab
-        if (!tab || !data?.events) return
-        // Rebuild messages from the event history.
-        const events = data.events
-        const { messages } = _replayEvents([], events)
+        if (generation !== this._instanceGeneration) return false
+        if (!tab || !data?.events) return false
+        // Rebuild messages from backend history, preserving final conversation
+        // messages when event replay is incomplete (e.g. providers/paths that
+        // don't emit live text chunks for multimodal turns).
+        const events = Array.isArray(data.events) ? data.events : []
+        const rawMessages = Array.isArray(data.messages) ? data.messages : []
+        const { messages } = _replayEvents(rawMessages, events)
         this.messagesByTab[tab] = messages
+        refreshTabMessages(this, tab)
+        const latest = this.messagesByTab[tab]?.[this.messagesByTab[tab].length - 1]
+        if (!latest || latest.role !== "assistant") return false
+        const hasText = Array.isArray(latest.parts)
+          ? latest.parts.some((p) => p.type === "text" && p.content)
+          : !!latest.content
+        const hasToolOrSubagent = Array.isArray(latest.parts)
+          ? latest.parts.some((p) => p.type === "tool")
+          : Array.isArray(latest.tool_calls) && latest.tool_calls.length > 0
+        const hasAttachments = Array.isArray(latest.attachments) && latest.attachments.length > 0
+        return hasText || hasToolOrSubagent || hasAttachments
       } catch (e) {
         console.warn("Failed to resync history:", e)
+        return false
       }
     },
 
@@ -1374,13 +1710,14 @@ export const useChatStore = defineStore("chat", {
 
     _handleUserInput(source, data) {
       if (!source || !this.messagesByTab[source]) return
-      const signature = `${source}:${data.content || ""}`
+      const parsed = parseMessageContent(data.content)
+      const signature = `${source}:${parsed.text || ""}`
       const now = Date.now()
       const seenAt = this._recentUserInputs[signature] || 0
       if (now - seenAt < 2000) return
       const msgs = this.messagesByTab[source]
       const last = msgs[msgs.length - 1]
-      if (last?.role === "user" && last.content === (data.content || "")) {
+      if (last?.role === "user" && last.content === (parsed.text || "")) {
         this._recentUserInputs[signature] = now
         return
       }
@@ -1388,27 +1725,35 @@ export const useChatStore = defineStore("chat", {
       this._addMsg(source, {
         id: `u_sync_${now}`,
         role: "user",
-        content: data.content || "",
+        content: parsed.text || "",
+        attachments: parsed.attachments.length ? parsed.attachments : undefined,
         timestamp: data.timestamp || new Date((data.ts || now / 1000) * 1000).toISOString(),
       })
     },
 
     _handleChannelMessage(data) {
       const tabKey = `ch:${data.channel}`
+      const parsed = parseMessageContent(data.content)
 
       if (this.messagesByTab[tabKey]) {
-        const existing = this.messagesByTab[tabKey]
-        if (data.message_id && existing.some((m) => m.id === data.message_id)) {
-          return
-        }
-        this.messagesByTab[tabKey].push({
-          id: data.message_id || "ch_" + Date.now(),
-          role: "channel",
-          sender: data.sender,
-          content: data.content,
-          timestamp: data.timestamp,
+        let added = false
+        const next = mutateTabMessages(this, tabKey, (messages) => {
+          if (data.message_id && messages.some((m) => m.id === data.message_id)) {
+            return messages
+          }
+          messages.push({
+            id: data.message_id || "ch_" + Date.now(),
+            role: "channel",
+            sender: data.sender,
+            content: parsed.text,
+            attachments: parsed.attachments.length ? parsed.attachments : undefined,
+            timestamp: data.timestamp,
+          })
+          added = true
+          return messages
         })
-        if (this.activeTab !== tabKey) {
+        if (!next) return
+        if (added && this.activeTab !== tabKey) {
           this.unreadCounts[tabKey] = (this.unreadCounts[tabKey] || 0) + 1
         }
       }
@@ -1431,12 +1776,16 @@ export const useChatStore = defineStore("chat", {
     /** Move queued messages from the hold queue into the main chat. */
     _promoteQueuedMessages(source) {
       if (!this.queuedMessages.length) return
-      const msgs = this.messagesByTab[source]
-      if (!msgs) return
-      for (const msg of this.queuedMessages) {
-        delete msg.queued
-        msgs.push(msg)
-      }
+      const promoted = this.queuedMessages.map((msg) => {
+        const next = cloneMessage(msg)
+        delete next.queued
+        return next
+      })
+      const next = mutateTabMessages(this, source, (messages) => {
+        messages.push(...promoted)
+        return messages
+      })
+      if (!next) return
       this.queuedMessages = []
     },
 
@@ -1457,34 +1806,66 @@ export const useChatStore = defineStore("chat", {
     },
 
     _appendStreamChunk(source, content) {
-      const msgs = this.messagesByTab[source]
-      if (!msgs) return
-      const last = this._ensureAssistantMsg(msgs)
-      const tail = last.parts.length > 0 ? last.parts[last.parts.length - 1] : null
-      if (tail && tail.type === "text" && tail._streaming) {
-        tail.content += content
-      } else {
-        last.parts.push({ type: "text", content, _streaming: true })
-      }
+      mutateTabMessages(this, source, (messages) => {
+        const last = this._ensureAssistantMsg(messages)
+        const tail = last.parts.length > 0 ? last.parts[last.parts.length - 1] : null
+        if (tail && tail.type === "text" && tail._streaming) {
+          tail.content += content
+        } else {
+          last.parts.push({ type: "text", content, _streaming: true })
+        }
+        return messages
+      })
     },
 
     _finishStream(source) {
       this.processing = false
-      const msgs = this.messagesByTab[source]
-      if (msgs) {
-        const last = msgs[msgs.length - 1]
+      const msgs = mutateTabMessages(this, source, (messages) => {
+        const last = messages[messages.length - 1]
         if (last?._streaming) {
           last._streaming = false
           for (const p of last.parts || []) {
             if (p.type === "text") p._streaming = false
           }
         }
+        return messages
+      })
+      if (!msgs) return
+
+      const last = msgs[msgs.length - 1]
+      if (source !== this.activeTab) return
+      if (!last || last.role !== "assistant") return
+
+      const hasText = Array.isArray(last.parts)
+        ? last.parts.some((p) => p.type === "text" && p.content)
+        : !!last.content
+      const hasToolOrSubagent = Array.isArray(last.parts)
+        ? last.parts.some((p) => p.type === "tool")
+        : Array.isArray(last.tool_calls) && last.tool_calls.length > 0
+      const hasAttachments = Array.isArray(last.attachments) && last.attachments.length > 0
+
+      if (hasText || hasToolOrSubagent || hasAttachments) {
+        mutateTabMessages(this, source, (messages) => {
+          const latest = messages[messages.length - 1]
+          if (latest?.role === "assistant") {
+            delete latest.recovering
+            delete latest.recoveryAttempt
+            delete latest.recoveryFailed
+          }
+          return messages
+        })
+        this._stopRecoveryPolling()
+      } else {
+        this._startRecoveryPolling(source)
       }
     },
 
     _addMsg(tabKey, msg) {
       if (!this.messagesByTab[tabKey]) this.messagesByTab[tabKey] = []
-      this.messagesByTab[tabKey].push(msg)
+      mutateTabMessages(this, tabKey, (messages) => {
+        messages.push(cloneMessage(msg))
+        return messages
+      })
     },
 
     // ── Job timer (reactive elapsed tracking) ──
@@ -1515,6 +1896,7 @@ export const useChatStore = defineStore("chat", {
     },
 
     _cleanup() {
+      this._stopRecoveryPolling()
       this.activeTab = null
       this._historyLoaded = false
       this._wsBuffer = []
@@ -1525,6 +1907,10 @@ export const useChatStore = defineStore("chat", {
       if (this._jobTimer !== null) {
         clearInterval(this._jobTimer)
         this._jobTimer = null
+      }
+      if (this._recoveryPollTimer !== null) {
+        clearTimeout(this._recoveryPollTimer)
+        this._recoveryPollTimer = null
       }
     },
 
@@ -1556,3 +1942,6 @@ export const useChatStore = defineStore("chat", {
     },
   },
 })
+
+
+

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from "pinia"
 import { beforeEach, describe, expect, it } from "vitest"
 
+import { agentAPI } from "@/utils/api"
 import { _replayEvents, useChatStore } from "./chat.js"
 
 beforeEach(() => {
@@ -91,6 +92,141 @@ describe("chat store — interrupted task handling", () => {
     expect(tool.status).toBe("interrupted")
     expect(tool.result).toBe("User manually interrupted this job.")
     expect(chat.runningJobs.job_1).toBeUndefined()
+  })
+
+  it("does not infer interrupted for subagents without explicit interruption metadata", () => {
+    const { messages: replayed, pendingJobs } = _replayEvents([], [
+      { type: "processing_start" },
+      { type: "subagent_call", name: "explore", task: "find auth" },
+      { type: "processing_end" },
+    ])
+
+    const tool = replayed[0].parts[0]
+    expect(tool).toMatchObject({
+      type: "tool",
+      kind: "subagent",
+      name: "explore",
+      status: "done",
+      result: "",
+      jobId: "",
+    })
+    expect(pendingJobs).toEqual({})
+  })
+})
+
+describe("chat store — standalone agent history loading", () => {
+  it("rebuilds messages from event-only agent history responses", async () => {
+    const chat = useChatStore()
+    chat._instanceGeneration = 1
+    chat.messagesByTab = { main: [] }
+
+    const originalGetHistory = agentAPI.getHistory
+    agentAPI.getHistory = async () => ({
+      agent_id: "agent_1",
+      events: [
+        { type: "user_input", content: "hello" },
+        { type: "processing_start" },
+        { type: "text", content: "world" },
+        { type: "processing_end" },
+      ],
+    })
+
+    try {
+      await chat._loadAgentHistory("agent_1", "main", 1)
+    } finally {
+      agentAPI.getHistory = originalGetHistory
+    }
+
+    expect(chat.messagesByTab.main).toHaveLength(2)
+    expect(chat.messagesByTab.main[0]).toMatchObject({ role: "user", content: "hello" })
+    expect(chat.messagesByTab.main[1].role).toBe("assistant")
+    expect(chat.messagesByTab.main[1].parts).toEqual([{ type: "text", content: "world", _streaming: false }])
+  })
+})
+
+describe("chat store — standalone agent empty completion recovery", () => {
+  it("resyncs history when a standalone agent finishes with an empty assistant message", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceType = "agent"
+    chat.activeTab = "main"
+    chat.messagesByTab = {
+      main: [
+        {
+          id: "m1",
+          role: "assistant",
+          parts: [],
+          _streaming: true,
+        },
+      ],
+    }
+
+    const calls = []
+    const originalStartRecoveryPolling = chat._startRecoveryPolling
+    chat._startRecoveryPolling = function () {
+      calls.push(chat._instanceId)
+      chat.messagesByTab.main = [
+        { id: "u1", role: "user", content: "这是啥？" },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [{ type: "text", content: "这是 Chrome 新标签页。", _streaming: false }],
+        },
+      ]
+    }
+
+    try {
+      chat._finishStream("main")
+      await Promise.resolve()
+      await Promise.resolve()
+    } finally {
+      chat._startRecoveryPolling = originalStartRecoveryPolling
+    }
+
+    expect(calls).toEqual(["agent_1"])
+    expect(chat.messagesByTab.main).toHaveLength(2)
+    expect(chat.messagesByTab.main[1]).toMatchObject({
+      role: "assistant",
+      parts: [{ type: "text", content: "这是 Chrome 新标签页。", _streaming: false }],
+    })
+  })
+
+  it("does not resync history when the standalone agent already streamed visible text", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceType = "agent"
+    chat.activeTab = "main"
+    chat.messagesByTab = {
+      main: [
+        {
+          id: "m1",
+          role: "assistant",
+          parts: [{ type: "text", content: "partial", _streaming: true }],
+          _streaming: true,
+        },
+      ],
+    }
+
+    const calls = []
+    const originalGetHistory = agentAPI.getHistory
+    agentAPI.getHistory = async (id) => {
+      calls.push(id)
+      return { agent_id: id, events: [] }
+    }
+
+    try {
+      chat._finishStream("main")
+      await Promise.resolve()
+    } finally {
+      agentAPI.getHistory = originalGetHistory
+    }
+
+    expect(calls).toEqual([])
+    expect(chat.messagesByTab.main[0]).toMatchObject({
+      role: "assistant",
+      parts: [{ type: "text", content: "partial", _streaming: false }],
+      _streaming: false,
+    })
   })
 })
 

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -89,7 +89,7 @@ export const terrariumAPI = {
       content,
       sender,
       attachments: options.attachments || [],
-      reasoning_effort: options.reasoning_effort || "",
+      reasoning_effort: options.reasoning_effort || "medium",
     })
     return data
   },

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -84,10 +84,12 @@ export const terrariumAPI = {
     return data
   },
 
-  async sendToChannel(id, channelName, content, sender = "human") {
+  async sendToChannel(id, channelName, content, sender = "human", options = {}) {
     const { data } = await api.post(`/terrariums/${id}/channels/${channelName}/send`, {
       content,
       sender,
+      attachments: options.attachments || [],
+      reasoning_effort: options.reasoning_effort || "",
     })
     return data
   },

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -68,6 +68,8 @@ export default {
   "common.triggers": "Triggers",
   "common.type": "Type",
   "common.view": "View",
+  "chat.recoveringReply": "Finalizing reply…",
+  "chat.recoveryRetry": ({ count }) => `Retry ${count}`,
 
   "home.subtitle": "Build agents that work alone. Compose them into teams that work together.",
   "home.runningInstances": "Running Instances",
@@ -128,6 +130,8 @@ export default {
   "sessions.deleteConfirm": 'Delete session "{name}"?',
   "sessions.deleted": "Session deleted",
   "sessions.deleteFailed": "Failed to delete: {message}",
+  "chat.queueNotice": "New messages will be sent after the current reply finishes.",
+  "chat.recoveryFailed": "Reply sync is taking longer than expected. You can wait a moment or send again.",
 
   "registry.loadingConfigs": "Loading configs...",
   "registry.noConfigsInstalled": "No configs installed.",
@@ -171,6 +175,12 @@ export default {
   "settings.models.modelId": "Model ID *",
   "settings.models.provider": "Provider",
   "settings.models.baseUrlOptional": "Base URL (optional)",
+  "settings.models.apiKeyEnv": "API Key Env",
+  "settings.models.apiKeyOptional": "API Key (optional)",
+  "settings.models.apiKeyPlaceholder": "Leave blank to keep current key",
+  "settings.models.apiKeyEditHint":
+    "Leave the API key blank when editing to keep the currently stored value.",
+  "settings.models.apiKeyEnvRequired": "API Key Env is required when setting an API key",
   "settings.models.maxContext": "Max Context",
   "settings.models.temperature": "Temperature",
   "settings.models.update": "Update",
@@ -180,6 +190,7 @@ export default {
   "settings.models.deleted": 'Profile "{name}" deleted',
   "settings.models.deleteFailed": "Failed to delete",
   "settings.models.baseUrlShort": "url",
+  "settings.models.apiKeyEnvShort": "key",
   "settings.models.contextShort": "ctx",
   "settings.models.temperatureShort": "temp",
   "settings.mcp.description":

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/ja.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/ja.js
@@ -68,6 +68,8 @@ export default {
   "common.triggers": "トリガー",
   "common.type": "種類",
   "common.view": "表示",
+  "chat.recoveringReply": "返信を整えています…",
+  "chat.recoveryRetry": ({ count }) => `${count}回目の再試行`,
 
   "home.subtitle":
     "単独で動くエージェントを作り、それらを組み合わせて協調して動くチームにしましょう。",
@@ -130,6 +132,8 @@ export default {
   "sessions.deleteConfirm": "セッション「{name}」を削除しますか？",
   "sessions.deleted": "セッションを削除しました",
   "sessions.deleteFailed": "削除に失敗しました: {message}",
+  "chat.queueNotice": "新しいメッセージは現在の返信が終わってから送信されます。",
+  "chat.recoveryFailed": "返信の同期に時間がかかっています。少し待つか、もう一度送信してください。",
 
   "registry.loadingConfigs": "設定を読み込み中...",
   "registry.noConfigsInstalled": "インストール済みの設定はありません。",
@@ -173,6 +177,11 @@ export default {
   "settings.models.modelId": "モデル ID *",
   "settings.models.provider": "プロバイダー",
   "settings.models.baseUrlOptional": "Base URL（任意）",
+  "settings.models.apiKeyEnv": "API Key Env",
+  "settings.models.apiKeyOptional": "API キー（任意）",
+  "settings.models.apiKeyPlaceholder": "空欄なら現在のキーを保持します",
+  "settings.models.apiKeyEditHint": "編集中に現在のキーを保持したい場合は、API キーを空欄のままにしてください。",
+  "settings.models.apiKeyEnvRequired": "API キーを設定する場合は API Key Env が必要です",
   "settings.models.maxContext": "最大コンテキスト",
   "settings.models.temperature": "温度",
   "settings.models.update": "更新",
@@ -182,6 +191,7 @@ export default {
   "settings.models.deleted": "プロファイル「{name}」を削除しました",
   "settings.models.deleteFailed": "削除に失敗しました",
   "settings.models.baseUrlShort": "url",
+  "settings.models.apiKeyEnvShort": "key",
   "settings.models.contextShort": "ctx",
   "settings.models.temperatureShort": "temp",
   "settings.mcp.description":

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
@@ -68,6 +68,8 @@ export default {
   "common.triggers": "触发器",
   "common.type": "类型",
   "common.view": "查看",
+  "chat.recoveringReply": "正在整理回复…",
+  "chat.recoveryRetry": ({ count }) => `第 ${count} 次重试`,
 
   "home.subtitle": "打造可独立运作的代理，并将它们组合成能协同工作的团队。",
   "home.runningInstances": "运行中的实例",
@@ -127,6 +129,8 @@ export default {
   "sessions.deleteConfirm": "要删除会话“{name}”吗？",
   "sessions.deleted": "会话已删除",
   "sessions.deleteFailed": "删除失败：{message}",
+  "chat.queueNotice": "新消息会在当前回复完成后发送。",
+  "chat.recoveryFailed": "回复同步比预期更慢。你可以稍等一下，或再次发送。",
 
   "registry.loadingConfigs": "正在加载设置...",
   "registry.noConfigsInstalled": "尚未安装任何设置。",
@@ -169,6 +173,11 @@ export default {
   "settings.models.modelId": "模型 ID *",
   "settings.models.provider": "提供者",
   "settings.models.baseUrlOptional": "Base URL（选填）",
+  "settings.models.apiKeyEnv": "API Key Env",
+  "settings.models.apiKeyOptional": "API 密钥（选填）",
+  "settings.models.apiKeyPlaceholder": "留空则保留当前密钥",
+  "settings.models.apiKeyEditHint": "编辑时若不想覆盖已存储密钥，可将 API 密钥留空。",
+  "settings.models.apiKeyEnvRequired": "设置 API 密钥时必须填写 API Key Env",
   "settings.models.maxContext": "最大上下文",
   "settings.models.temperature": "温度",
   "settings.models.update": "更新",
@@ -178,6 +187,7 @@ export default {
   "settings.models.deleted": "已删除配置文件“{name}”",
   "settings.models.deleteFailed": "删除失败",
   "settings.models.baseUrlShort": "url",
+  "settings.models.apiKeyEnvShort": "key",
   "settings.models.contextShort": "ctx",
   "settings.models.temperatureShort": "temp",
   "settings.mcp.description":

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-TW.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-TW.js
@@ -68,6 +68,8 @@ export default {
   "common.triggers": "觸發器",
   "common.type": "類型",
   "common.view": "檢視",
+  "chat.recoveringReply": "正在整理回覆…",
+  "chat.recoveryRetry": ({ count }) => `第 ${count} 次重試`,
 
   "home.subtitle": "打造可獨立運作的代理，並將它們組合成能協同工作的團隊。",
   "home.runningInstances": "執行中的實例",
@@ -127,6 +129,8 @@ export default {
   "sessions.deleteConfirm": "要刪除工作階段「{name}」嗎？",
   "sessions.deleted": "工作階段已刪除",
   "sessions.deleteFailed": "刪除失敗：{message}",
+  "chat.queueNotice": "新訊息會在目前回覆完成後送出。",
+  "chat.recoveryFailed": "回覆同步比預期更慢。你可以稍等一下，或再次送出。",
 
   "registry.loadingConfigs": "正在載入設定...",
   "registry.noConfigsInstalled": "尚未安裝任何設定。",
@@ -169,6 +173,11 @@ export default {
   "settings.models.modelId": "模型 ID *",
   "settings.models.provider": "提供者",
   "settings.models.baseUrlOptional": "Base URL（選填）",
+  "settings.models.apiKeyEnv": "API Key Env",
+  "settings.models.apiKeyOptional": "API 金鑰（選填）",
+  "settings.models.apiKeyPlaceholder": "留空則保留目前金鑰",
+  "settings.models.apiKeyEditHint": "編輯時若不想覆蓋已儲存金鑰，可將 API 金鑰留空。",
+  "settings.models.apiKeyEnvRequired": "設定 API 金鑰時必須填寫 API Key Env",
   "settings.models.maxContext": "最大上下文",
   "settings.models.temperature": "溫度",
   "settings.models.update": "更新",
@@ -178,6 +187,7 @@ export default {
   "settings.models.deleted": "已刪除設定檔「{name}」",
   "settings.models.deleteFailed": "刪除失敗",
   "settings.models.baseUrlShort": "url",
+  "settings.models.apiKeyEnvShort": "key",
   "settings.models.contextShort": "ctx",
   "settings.models.temperatureShort": "temp",
   "settings.mcp.description":

--- a/src/kohakuterrarium/api/routes/agents.py
+++ b/src/kohakuterrarium/api/routes/agents.py
@@ -199,7 +199,8 @@ async def agent_history(agent_id: str, manager=Depends(get_manager)):
     """Get conversation history + event log for a standalone agent."""
     try:
         history = manager.agent_get_history(agent_id)
-        return {"agent_id": agent_id, "events": history}
+        session = manager._agents.get(agent_id)
+        return {"agent_id": agent_id, "messages": session.agent.conversation_history if session else [], "events": history}
     except ValueError as e:
         raise HTTPException(404, str(e))
 

--- a/src/kohakuterrarium/api/routes/channels.py
+++ b/src/kohakuterrarium/api/routes/channels.py
@@ -4,8 +4,42 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from kohakuterrarium.api.deps import get_manager
 from kohakuterrarium.api.schemas import ChannelSend
+from kohakuterrarium.llm.message import FilePart, ImagePart, TextPart, VideoPart
 
 router = APIRouter()
+
+
+def _build_channel_content(message: str, attachments) -> str | list:
+    parts = []
+    if message:
+        parts.append(TextPart(text=message))
+    for item in attachments or []:
+        att_type = str(getattr(item, "type", "") or "").lower()
+        mime_type = str(getattr(item, "mimeType", "") or "")
+        url = str(getattr(item, "url", "") or "")
+        name = str(getattr(item, "name", "") or "attachment")
+        if not url:
+            continue
+        if att_type == "image" or mime_type.startswith("image/"):
+            parts.append(
+                ImagePart(
+                    url=url,
+                    detail="low",
+                    source_type="attachment",
+                    source_name=name,
+                )
+            )
+        elif att_type == "video" or mime_type.startswith("video/"):
+            parts.append(VideoPart(data=url, mime_type=mime_type or "video/mp4", filename=name))
+        elif mime_type == "application/pdf" or att_type == "pdf":
+            parts.append(FilePart(data=url, mime_type="application/pdf", filename=name))
+        else:
+            parts.append(TextPart(text=f"[{att_type or 'file'} attachment: {name}]"))
+    if not parts:
+        return ""
+    if len(parts) == 1 and isinstance(parts[0], TextPart):
+        return parts[0].text
+    return parts
 
 
 @router.get("")
@@ -27,7 +61,11 @@ async def send_message(
     """Send a message to a channel."""
     try:
         msg_id = await manager.terrarium_channel_send(
-            terrarium_id, channel_name, req.content, req.sender
+            terrarium_id,
+            channel_name,
+            _build_channel_content(req.content, req.attachments),
+            req.sender,
+            reasoning_effort=req.reasoning_effort,
         )
         return {"message_id": msg_id, "status": "sent"}
     except Exception as e:

--- a/src/kohakuterrarium/api/routes/settings.py
+++ b/src/kohakuterrarium/api/routes/settings.py
@@ -196,7 +196,11 @@ async def create_profile(req: ProfileRequest):
     )
     save_profile(profile)
     if api_key_env and req.api_key:
-        save_api_key(api_key_env, req.api_key)
+        provider_key = next(
+            (provider for provider, env_var in PROVIDER_KEY_MAP.items() if env_var == api_key_env),
+            api_key_env,
+        )
+        save_api_key(provider_key, req.api_key)
     return {"status": "saved", "name": req.name}
 
 

--- a/src/kohakuterrarium/api/routes/settings.py
+++ b/src/kohakuterrarium/api/routes/settings.py
@@ -44,6 +44,7 @@ class ProfileRequest(BaseModel):
     provider: str = "openai"
     base_url: str = ""
     api_key_env: str = ""
+    api_key: str = ""
     max_context: int = 128000
     max_output: int = 16384
     temperature: float | None = None
@@ -180,12 +181,13 @@ async def create_profile(req: ProfileRequest):
     """Create or update a custom model profile."""
     if not req.name or not req.model:
         raise HTTPException(400, "Name and model are required")
+    api_key_env = (req.api_key_env or "").strip()
     profile = LLMProfile(
         name=req.name,
         model=req.model,
         provider=req.provider,
         base_url=req.base_url or None,
-        api_key_env=req.api_key_env or None,
+        api_key_env=api_key_env or None,
         max_context=req.max_context,
         max_output=req.max_output,
         temperature=req.temperature,
@@ -193,6 +195,8 @@ async def create_profile(req: ProfileRequest):
         extra_body=req.extra_body,
     )
     save_profile(profile)
+    if api_key_env and req.api_key:
+        save_api_key(api_key_env, req.api_key)
     return {"status": "saved", "name": req.name}
 
 

--- a/src/kohakuterrarium/api/schemas.py
+++ b/src/kohakuterrarium/api/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic request/response models for the HTTP API."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class TerrariumCreate(BaseModel):
@@ -30,11 +30,24 @@ class CreatureAdd(BaseModel):
     send_channels: list[str] = []
 
 
+class AttachmentInput(BaseModel):
+    """Frontend attachment payload for multimodal user input."""
+
+    id: str = ""
+    type: str = "file"
+    name: str = ""
+    mimeType: str = ""
+    size: int = 0
+    url: str = ""
+
+
 class ChannelSend(BaseModel):
     """Request body for sending a message to a channel."""
 
     content: str
     sender: str = "human"
+    attachments: list[AttachmentInput] = Field(default_factory=list)
+    reasoning_effort: str = ""
 
 
 class ChannelAdd(BaseModel):
@@ -70,6 +83,8 @@ class AgentChat(BaseModel):
     """Request body for sending a chat message to an agent."""
 
     message: str
+    attachments: list[AttachmentInput] = Field(default_factory=list)
+    reasoning_effort: str = ""
 
 
 class MessageEdit(BaseModel):

--- a/src/kohakuterrarium/api/ws/chat.py
+++ b/src/kohakuterrarium/api/ws/chat.py
@@ -14,7 +14,13 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from kohakuterrarium.api.deps import get_manager
 from kohakuterrarium.api.events import StreamOutput, get_event_log
-from kohakuterrarium.llm.message import FilePart, ImagePart, TextPart, VideoPart
+from kohakuterrarium.llm.message import (
+    FilePart,
+    ImagePart,
+    TextPart,
+    VideoPart,
+    content_parts_to_dicts,
+)
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -58,10 +64,16 @@ def _build_multimodal_content(message: str, attachments: list[dict] | None):
     return parts
 
 
-def _apply_reasoning_effort(agent, reasoning_effort: str):
-    value = (reasoning_effort or "").strip()
-    if not value:
+def _serialize_content(content):
+    if isinstance(content, list):
+        return content_parts_to_dicts(content)
+    return content
+
+
+def _apply_reasoning_effort(agent, reasoning_effort: str | None):
+    if reasoning_effort is None:
         return None
+    value = reasoning_effort.strip()
     previous = getattr(agent.config, "reasoning_effort", "")
     agent.config.reasoning_effort = value
     llm = getattr(agent, "llm", None)
@@ -70,7 +82,12 @@ def _apply_reasoning_effort(agent, reasoning_effort: str):
             llm.reasoning_effort = value
         extra_body = getattr(llm, "extra_body", None)
         if isinstance(extra_body, dict):
-            llm.extra_body = {**extra_body, "reasoning_effort": value}
+            if value:
+                llm.extra_body = {**extra_body, "reasoning_effort": value}
+            else:
+                new_extra_body = dict(extra_body)
+                new_extra_body.pop("reasoning_effort", None)
+                llm.extra_body = new_extra_body
     return previous
 
 
@@ -140,7 +157,7 @@ def _register_channel_callbacks(
                     "source": "channel",
                     "channel": channel_name,
                     "sender": message.sender,
-                    "content": message.content,
+                    "content": _serialize_content(message.content),
                     "metadata": message.metadata,
                     "message_id": message.message_id,
                     "timestamp": ts,
@@ -173,7 +190,7 @@ async def _send_channel_history(ws: WebSocket, runtime) -> None:
                     "source": "channel",
                     "channel": ch.name,
                     "sender": msg.sender,
-                    "content": msg.content,
+                    "content": _serialize_content(msg.content),
                     "metadata": msg.metadata,
                     "message_id": msg.message_id,
                     "timestamp": ts,
@@ -202,7 +219,7 @@ async def _handle_terrarium_input(ws: WebSocket, manager, terrarium_id: str) -> 
             user_evt = {
                 "type": "user_input",
                 "source": target,
-                "content": content,
+                "content": _serialize_content(content),
                 "ts": time.time(),
             }
             log.append(user_evt)
@@ -335,7 +352,7 @@ async def ws_creature(websocket: WebSocket, agent_id: str):
             user_evt = {
                 "type": "user_input",
                 "source": session.agent.config.name,
-                "content": content,
+                "content": _serialize_content(content),
                 "ts": time.time(),
             }
             log.append(user_evt)

--- a/src/kohakuterrarium/api/ws/chat.py
+++ b/src/kohakuterrarium/api/ws/chat.py
@@ -14,11 +14,64 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from kohakuterrarium.api.deps import get_manager
 from kohakuterrarium.api.events import StreamOutput, get_event_log
+from kohakuterrarium.llm.message import FilePart, ImagePart, TextPart, VideoPart
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 router = APIRouter()
+
+
+def _build_multimodal_content(message: str, attachments: list[dict] | None):
+    parts = []
+    if message:
+        parts.append(TextPart(text=message))
+    for item in attachments or []:
+        att_type = str(item.get("type") or "").lower()
+        mime_type = str(item.get("mimeType") or "")
+        url = str(item.get("url") or "")
+        name = str(item.get("name") or "attachment")
+        if not url:
+            continue
+        if att_type == "image" or mime_type.startswith("image/"):
+            parts.append(
+                ImagePart(
+                    url=url,
+                    detail="low",
+                    source_type="attachment",
+                    source_name=name,
+                )
+            )
+            continue
+        if att_type == "video" or mime_type.startswith("video/"):
+            parts.append(VideoPart(data=url, mime_type=mime_type or "video/mp4", filename=name))
+            continue
+        if mime_type == "application/pdf" or att_type == "pdf":
+            parts.append(FilePart(data=url, mime_type="application/pdf", filename=name))
+            continue
+        label = f"[{att_type or 'file'} attachment: {name}]"
+        parts.append(TextPart(text=label))
+    if not parts:
+        return ""
+    if len(parts) == 1 and isinstance(parts[0], TextPart):
+        return parts[0].text
+    return parts
+
+
+def _apply_reasoning_effort(agent, reasoning_effort: str):
+    value = (reasoning_effort or "").strip()
+    if not value:
+        return None
+    previous = getattr(agent.config, "reasoning_effort", "")
+    agent.config.reasoning_effort = value
+    llm = getattr(agent, "llm", None)
+    if llm is not None:
+        if hasattr(llm, "reasoning_effort"):
+            llm.reasoning_effort = value
+        extra_body = getattr(llm, "extra_body", None)
+        if isinstance(extra_body, dict):
+            llm.extra_body = {**extra_body, "reasoning_effort": value}
+    return previous
 
 
 async def _forward_queue(queue: asyncio.Queue, ws: WebSocket) -> None:
@@ -87,11 +140,8 @@ def _register_channel_callbacks(
                     "source": "channel",
                     "channel": channel_name,
                     "sender": message.sender,
-                    "content": (
-                        message.content
-                        if isinstance(message.content, str)
-                        else str(message.content)
-                    ),
+                    "content": message.content,
+                    "metadata": message.metadata,
                     "message_id": message.message_id,
                     "timestamp": ts,
                     "ts": time.time(),
@@ -123,11 +173,8 @@ async def _send_channel_history(ws: WebSocket, runtime) -> None:
                     "source": "channel",
                     "channel": ch.name,
                     "sender": msg.sender,
-                    "content": (
-                        msg.content
-                        if isinstance(msg.content, str)
-                        else str(msg.content)
-                    ),
+                    "content": msg.content,
+                    "metadata": msg.metadata,
                     "message_id": msg.message_id,
                     "timestamp": ts,
                     "ts": time.time(),
@@ -144,20 +191,28 @@ async def _handle_terrarium_input(ws: WebSocket, manager, terrarium_id: str) -> 
             continue
         target = data.get("target", "root")
         message = data.get("message", "")
-        if not message:
+        attachments = data.get("attachments") or []
+        reasoning_effort = data.get("reasoning_effort", "")
+        if not message and not attachments:
             continue
         try:
             session = manager.terrarium_mount(terrarium_id, target)
+            content = _build_multimodal_content(message, attachments)
             log = get_event_log(f"{terrarium_id}:{target}")
             user_evt = {
                 "type": "user_input",
                 "source": target,
-                "content": message,
+                "content": content,
                 "ts": time.time(),
             }
             log.append(user_evt)
             await queue.put(user_evt)
-            await session.agent.inject_input(message, source="web")
+            previous_effort = _apply_reasoning_effort(session.agent, reasoning_effort)
+            try:
+                await session.agent.inject_input(content, source="web")
+            finally:
+                if previous_effort is not None:
+                    _apply_reasoning_effort(session.agent, previous_effort)
             await ws.send_json({"type": "idle", "source": target, "ts": time.time()})
         except ValueError as e:
             await ws.send_json(
@@ -272,17 +327,25 @@ async def ws_creature(websocket: WebSocket, agent_id: str):
             if data.get("type") != "input":
                 continue
             message = data.get("message", "")
-            if not message:
+            attachments = data.get("attachments") or []
+            reasoning_effort = data.get("reasoning_effort", "")
+            if not message and not attachments:
                 continue
+            content = _build_multimodal_content(message, attachments)
             user_evt = {
                 "type": "user_input",
                 "source": session.agent.config.name,
-                "content": message,
+                "content": content,
                 "ts": time.time(),
             }
             log.append(user_evt)
             await queue.put(user_evt)
-            await session.agent.inject_input(message, source="web")
+            previous_effort = _apply_reasoning_effort(session.agent, reasoning_effort)
+            try:
+                await session.agent.inject_input(content, source="web")
+            finally:
+                if previous_effort is not None:
+                    _apply_reasoning_effort(session.agent, previous_effort)
             await websocket.send_json(
                 {
                     "type": "idle",

--- a/src/kohakuterrarium/core/agent_handlers.py
+++ b/src/kohakuterrarium/core/agent_handlers.py
@@ -23,6 +23,7 @@ from kohakuterrarium.core.events import (
     TriggerEvent,
     create_tool_complete_event,
 )
+from kohakuterrarium.llm.message import content_parts_to_dicts
 from kohakuterrarium.parsing import (
     CommandResultEvent,
     SubAgentCallEvent,
@@ -107,11 +108,10 @@ class AgentHandlersMixin(AgentToolsMixin):
         """
         # Record user input to session store
         if self.session_store is not None and event.type == "user_input":
-            content = (
-                event.get_text_content()
-                if hasattr(event, "is_multimodal") and event.is_multimodal()
-                else (event.content or "")
-            )
+            if hasattr(event, "is_multimodal") and event.is_multimodal():
+                content = content_parts_to_dicts(event.content)
+            else:
+                content = event.content or ""
             self.session_store.append_event(
                 self.config.name, "user_input", {"content": content}
             )

--- a/src/kohakuterrarium/core/events.py
+++ b/src/kohakuterrarium/core/events.py
@@ -141,7 +141,7 @@ class EventType:
 
 
 def create_user_input_event(
-    content: str,
+    content: EventContent,
     source: str = "cli",
     **extra_context: Any,
 ) -> TriggerEvent:

--- a/src/kohakuterrarium/llm/message.py
+++ b/src/kohakuterrarium/llm/message.py
@@ -70,8 +70,48 @@ class ImagePart:
         return "[image]"
 
 
+@dataclass
+class FilePart:
+    """Generic file content part for multimodal messages."""
+
+    data: str
+    mime_type: str
+    filename: str | None = None
+    type: Literal["input_file"] = "input_file"
+
+    def to_dict(self) -> dict[str, Any]:
+        result = {
+            "type": "input_file",
+            "file_data": self.data,
+            "mime_type": self.mime_type,
+        }
+        if self.filename:
+            result["filename"] = self.filename
+        return result
+
+
+@dataclass
+class VideoPart:
+    """Video content part for Gemini-style multimodal input."""
+
+    data: str
+    mime_type: str
+    filename: str | None = None
+    type: Literal["input_video"] = "input_video"
+
+    def to_dict(self) -> dict[str, Any]:
+        result = {
+            "type": "input_video",
+            "video_data": self.data,
+            "mime_type": self.mime_type,
+        }
+        if self.filename:
+            result["filename"] = self.filename
+        return result
+
+
 # Union type for content parts
-ContentPart = TextPart | ImagePart
+ContentPart = TextPart | ImagePart | FilePart | VideoPart
 
 
 def content_parts_to_dicts(parts: list[ContentPart]) -> list[dict[str, Any]]:
@@ -148,6 +188,22 @@ class Message:
                         ImagePart(
                             url=img_data.get("url", ""),
                             detail=img_data.get("detail", "low"),
+                        )
+                    )
+                elif item.get("type") == "input_file" or item.get("type") == "file":
+                    parts.append(
+                        FilePart(
+                            data=item.get("file_data", "") or item.get("url", ""),
+                            mime_type=item.get("mime_type", ""),
+                            filename=item.get("filename") or item.get("name"),
+                        )
+                    )
+                elif item.get("type") == "input_video" or item.get("type") == "video":
+                    parts.append(
+                        VideoPart(
+                            data=item.get("video_data", "") or item.get("url", ""),
+                            mime_type=item.get("mime_type", ""),
+                            filename=item.get("filename") or item.get("name"),
                         )
                     )
             content = parts

--- a/src/kohakuterrarium/llm/openai.py
+++ b/src/kohakuterrarium/llm/openai.py
@@ -9,6 +9,8 @@ from typing import Any, AsyncIterator
 
 from openai import AsyncOpenAI
 
+from kohakuterrarium.llm.message import FilePart, ImagePart, VideoPart
+
 from kohakuterrarium.llm.base import (
     BaseLLMProvider,
     ChatResponse,
@@ -23,6 +25,82 @@ logger = get_logger(__name__)
 # Default API endpoints
 OPENAI_BASE_URL = "https://api.openai.com/v1"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+
+def _normalize_reasoning_effort(model: str, base_url: str, effort: str) -> tuple[str, dict[str, Any]]:
+    value = (effort or "").strip().lower()
+    if not value:
+        return "", {}
+    model_name = (model or "").lower()
+    url = (base_url or "").lower()
+    is_gemini = "gemini" in model_name or "generativelanguage.googleapis.com" in url or "google/" in model_name
+    is_anthropic = model_name.startswith("anthropic/") or "claude" in model_name
+    is_openai = ("gpt" in model_name or "codex" in model_name) and not is_gemini
+
+    if is_gemini:
+        mapped = "HIGH" if value == "high" else "LOW"
+        return "", {"google": {"thinking_config": {"thinking_level": mapped}}}
+    if is_anthropic:
+        allowed = {"low", "medium", "high", "max"}
+        mapped = value if value in allowed else "medium"
+        return "", {"reasoning": {"enabled": True, "effort": mapped}}
+    if is_openai:
+        allowed = {"minimal", "low", "medium", "high", "xhigh"}
+        mapped = value if value in allowed else "medium"
+        return "", {"reasoning": {"enabled": True, "effort": mapped}}
+    return value, {"reasoning_effort": value}
+
+
+def _prepare_messages_for_provider(messages: list[dict[str, Any]], model: str, base_url: str) -> list[dict[str, Any]]:
+    model_name = (model or "").lower()
+    url = (base_url or "").lower()
+    is_gemini = "gemini" in model_name or "generativelanguage.googleapis.com" in url or "google/" in model_name
+    if not is_gemini:
+        normalized = []
+        for msg in messages:
+            content = msg.get("content")
+            if not isinstance(content, list):
+                normalized.append(msg)
+                continue
+            next_content = []
+            for part in content:
+                if isinstance(part, dict) and part.get("type") in {"input_file", "input_video"}:
+                    mime = part.get("mime_type", "")
+                    name = part.get("filename") or part.get("name") or "attachment"
+                    label = f"[{part.get('type', 'file')} attachment: {name}{f' ({mime})' if mime else ''}]"
+                    next_content.append({"type": "text", "text": label})
+                else:
+                    next_content.append(part)
+            normalized.append({**msg, "content": next_content})
+        return normalized
+
+    normalized = []
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            normalized.append(msg)
+            continue
+        next_content = []
+        for part in content:
+            if not isinstance(part, dict):
+                next_content.append(part)
+                continue
+            part_type = part.get("type")
+            if part_type == "image_url":
+                next_content.append(part)
+            elif part_type == "input_file" and part.get("mime_type") == "application/pdf":
+                next_content.append(part)
+            elif part_type == "input_video":
+                next_content.append(part)
+            elif part_type == "input_file":
+                name = part.get("filename") or part.get("name") or "file"
+                mime = part.get("mime_type", "")
+                next_content.append({"type": "text", "text": f"[file attachment: {name}{f' ({mime})' if mime else ''}]"})
+            else:
+                next_content.append(part)
+        normalized.append({**msg, "content": next_content})
+    return normalized
 
 
 class OpenAIProvider(BaseLLMProvider):
@@ -90,6 +168,7 @@ class OpenAIProvider(BaseLLMProvider):
             )
 
         self.extra_body = extra_body or {}
+        self.base_url = base_url
         self._last_usage: dict[str, int] = {}
         self.prompt_cache_key: str | None = None
 
@@ -126,6 +205,7 @@ class OpenAIProvider(BaseLLMProvider):
         self._last_tool_calls = []
 
         api_tools = [t.to_api_format() for t in tools] if tools else None
+        messages = _prepare_messages_for_provider(messages, kwargs.get("model", self.config.model), self.base_url)
 
         create_kwargs: dict[str, Any] = {
             "model": kwargs.get("model", self.config.model),
@@ -150,10 +230,15 @@ class OpenAIProvider(BaseLLMProvider):
         if api_tools:
             create_kwargs["tools"] = api_tools
 
-        # extra_body: merged into the request body by the SDK
         merged_extra = {**self.extra_body}
         if "extra_body" in kwargs:
             merged_extra.update(kwargs["extra_body"])
+        _, reasoning_extra = _normalize_reasoning_effort(
+            kwargs.get("model", self.config.model),
+            self.base_url,
+            str(merged_extra.pop("reasoning_effort", "") or merged_extra.get("reasoning_effort", "")),
+        )
+        merged_extra.update(reasoning_extra)
         if merged_extra:
             create_kwargs["extra_body"] = merged_extra
 
@@ -244,6 +329,7 @@ class OpenAIProvider(BaseLLMProvider):
     ) -> ChatResponse:
         """Non-streaming chat completion via the OpenAI SDK."""
         self._last_tool_calls = []
+        messages = _prepare_messages_for_provider(messages, kwargs.get("model", self.config.model), self.base_url)
 
         create_kwargs: dict[str, Any] = {
             "model": kwargs.get("model", self.config.model),
@@ -261,6 +347,12 @@ class OpenAIProvider(BaseLLMProvider):
         merged_extra = {**self.extra_body}
         if "extra_body" in kwargs:
             merged_extra.update(kwargs["extra_body"])
+        _, reasoning_extra = _normalize_reasoning_effort(
+            kwargs.get("model", self.config.model),
+            self.base_url,
+            str(merged_extra.pop("reasoning_effort", "") or merged_extra.get("reasoning_effort", "")),
+        )
+        merged_extra.update(reasoning_extra)
         if merged_extra:
             create_kwargs["extra_body"] = merged_extra
 

--- a/src/kohakuterrarium/llm/profiles.py
+++ b/src/kohakuterrarium/llm/profiles.py
@@ -305,6 +305,22 @@ def _is_available(login_provider: str) -> bool:
     return False
 
 
+def _profile_is_available(profile_or_data: dict[str, Any] | LLMProfile) -> bool:
+    """Check if credentials exist for a specific profile or preset."""
+    if isinstance(profile_or_data, LLMProfile):
+        provider = profile_or_data.provider
+        api_key_env = profile_or_data.api_key_env
+    else:
+        provider = profile_or_data.get("provider", "")
+        api_key_env = profile_or_data.get("api_key_env", "")
+
+    if provider == "codex-oauth":
+        return _is_available("codex")
+    if api_key_env:
+        return bool(get_api_key(api_key_env))
+    return _is_available(_login_provider_for(profile_or_data))
+
+
 def list_all() -> list[dict[str, Any]]:
     """List all profiles and presets with availability info."""
     result = []
@@ -318,7 +334,7 @@ def list_all() -> list[dict[str, Any]]:
                 "model": profile.model,
                 "provider": profile.provider,
                 "login_provider": login,
-                "available": _is_available(login),
+                "available": _profile_is_available(profile),
                 "source": "user",
                 "max_context": profile.max_context,
                 "max_output": profile.max_output,
@@ -340,7 +356,7 @@ def list_all() -> list[dict[str, Any]]:
                     "model": data.get("model", ""),
                     "provider": data.get("provider", ""),
                     "login_provider": login,
-                    "available": _is_available(login),
+                    "available": _profile_is_available(data),
                     "source": "preset",
                     "max_context": data.get("max_context", 0),
                     "max_output": data.get("max_output", 0),

--- a/src/kohakuterrarium/serving/manager.py
+++ b/src/kohakuterrarium/serving/manager.py
@@ -476,7 +476,12 @@ class KohakuManager:
         }
 
     async def terrarium_channel_send(
-        self, terrarium_id: str, channel: str, content: str, sender: str = "human"
+        self,
+        terrarium_id: str,
+        channel: str,
+        content: str | list | dict,
+        sender: str = "human",
+        reasoning_effort: str = "",
     ) -> str:
         """Send a message to a shared terrarium channel. Returns message_id."""
         runtime = self._get_runtime(terrarium_id)
@@ -484,7 +489,8 @@ class KohakuManager:
         if ch is None:
             available = runtime.environment.shared_channels.list_channels()
             raise ValueError(f"Channel '{channel}' not found. Available: {available}")
-        msg = ChannelMessage(sender=sender, content=content)
+        metadata = {"reasoning_effort": reasoning_effort} if reasoning_effort else {}
+        msg = ChannelMessage(sender=sender, content=content, metadata=metadata)
         await ch.send(msg)
         return msg.message_id
 

--- a/tests/unit/test_llm_profiles.py
+++ b/tests/unit/test_llm_profiles.py
@@ -42,9 +42,9 @@ class TestPresets:
 
     def test_aliases_point_to_valid_presets(self):
         for alias, target in ALIASES.items():
-            assert (
-                target in PRESETS
-            ), f"alias '{alias}' points to missing preset '{target}'"
+            assert target in PRESETS, (
+                f"alias '{alias}' points to missing preset '{target}'"
+            )
 
     def test_get_preset_by_name(self):
         p = get_preset("gpt-5.4")
@@ -222,3 +222,40 @@ class TestListAll:
         defaults = [e for e in entries if e.get("is_default")]
         assert len(defaults) >= 1
         assert defaults[0]["name"] == "gpt-5.4"
+
+    def test_custom_profile_with_api_key_env_is_available(self, tmp_profiles):
+        save_profile(
+            LLMProfile(
+                name="custom",
+                provider="openai",
+                model="m",
+                api_key_env="MY_CUSTOM_API_KEY",
+            )
+        )
+
+        with patch(
+            "kohakuterrarium.llm.profiles.get_api_key",
+            side_effect=lambda name: "secret" if name == "MY_CUSTOM_API_KEY" else "",
+        ):
+            entries = list_all()
+
+        custom = next(e for e in entries if e["name"] == "custom")
+        assert custom["available"] is True
+
+    def test_custom_profile_without_api_key_env_value_is_unavailable(
+        self, tmp_profiles
+    ):
+        save_profile(
+            LLMProfile(
+                name="custom",
+                provider="openai",
+                model="m",
+                api_key_env="MY_CUSTOM_API_KEY",
+            )
+        )
+
+        with patch("kohakuterrarium.llm.profiles.get_api_key", return_value=""):
+            entries = list_all()
+
+        custom = next(e for e in entries if e["name"] == "custom")
+        assert custom["available"] is False


### PR DESCRIPTION
## Summary

- add multimodal chat support for image/video/PDF attachments in the WebUI
- support pasting images into the chat input and render attachments instead of showing raw base64/data URLs as message text
- add chat editing UX wiring and attachment-aware chat state handling
- add reasoning effort controls in the model switcher with frontend chat tests
- add profile API key configuration in settings with backend/profile support and tests

## Included areas

- chat input attachments, paste handling, and attachment rendering
- multimodal message parsing across frontend store, websocket, and API layers
- reasoning effort selector in WebUI
- profile API key config UI and server-side profile persistence

## Validation

- Frontend tests: 10 files, 67 tests passed
- Frontend build: passed
- Python tests: `pytest tests/unit/test_llm_profiles.py` (27 passed)

## Notes

- Vite build emits existing non-blocking warnings about large chunks and mixed dynamic/static imports for `src/kohakuterrarium-frontend/src/utils/api.js`
- Vitest emits the existing jsdom canvas warning (`HTMLCanvasElement.getContext()` not implemented without the `canvas` package)
