### PR TITLE
fix(ws): pass queue into _handle_terrarium_input to prevent NameError

### DIFF
--- a/src/kohakuterrarium/api/ws/chat.py
+++ b/src/kohakuterrarium/api/ws/chat.py
@@ -142,7 +142,9 @@ async def _send_channel_history(ws: WebSocket, runtime) -> None:
             )
 
 
-async def _handle_terrarium_input(ws: WebSocket, manager, terrarium_id: str) -> None:
+async def _handle_terrarium_input(
+    ws: WebSocket, manager, terrarium_id: str, queue: asyncio.Queue
+) -> None:
     """Handle incoming WebSocket messages for a terrarium."""
     while True:
         data = await ws.receive_json()
@@ -221,7 +223,7 @@ async def ws_terrarium(websocket: WebSocket, terrarium_id: str):
     fwd_task = asyncio.create_task(_forward_queue(queue, websocket))
 
     try:
-        await _handle_terrarium_input(websocket, manager, terrarium_id)
+        await _handle_terrarium_input(websocket, manager, terrarium_id, queue)
     except WebSocketDisconnect:
         pass
     except Exception as e:


### PR DESCRIPTION
## Summary

`_handle_terrarium_input` in `src/kohakuterrarium/api/ws/chat.py` referenced a `queue` variable that only existed in the outer `ws_terrarium` coroutine. Any WebSocket client sending `{"type":"input", ...}` to `/ws/terrariums/{id}` triggered `NameError: name 'queue' is not defined` at `chat.py:159`, which was swallowed by the broad `except Exception` in `ws_terrarium` (logged only at DEBUG) and closed the connection with code 1000 — no response was ever delivered to the user.

The frontend chat store (`src/kohakuterrarium-frontend/src/stores/chat.js:758`) sends exactly this payload for every non-channel terrarium message, so this bug effectively breaks all terrarium chat via the web UI.

## Fix

Pass `queue` as an explicit parameter to `_handle_terrarium_input` and forward it at the single call site in `ws_terrarium`.

## Reproduction (before this patch)

1. `POST /api/terrariums` with any working config (e.g. `examples/terrariums/research_assistant/terrarium.yaml`).
2. `wscat -c ws://<host>/ws/terrariums/<id>`
3. Send `{"type":"input","target":"root","message":"hi"}`
4. Connection closes immediately with close code `1000`. At DEBUG log level the server shows:

    ```
    NameError: name 'queue' is not defined
      File ".../api/ws/chat.py", line 159, in _handle_terrarium_input
        await queue.put(user_evt)
    ```

## After the fix

Same reproduction, but now the WebSocket stays open and starts streaming `idle` / agent-output events as expected.

## Test plan

- [x] `python -m black src/kohakuterrarium/api/ws/chat.py` — no reformat.
- [x] `python -m pytest tests/ -q -k "ws or chat or terrarium"` — 16 passed.
- [x] `python -c "from kohakuterrarium.core.agent import Agent; print('OK')"` — OK.
- [x] Reproduced the crash on `main` with `wscat`; verified this branch keeps the connection open and delivers events after `{"type":"input", ...}`.

## Notes

The bug only affects the terrarium endpoint. The sibling `ws_creature` handler inlines its input loop in the same scope as `queue` and was never broken.
