### PR TITLE
fix(ws): pass queue into _handle_terrarium_input to prevent NameError

### DIFF
--- a/src/kohakuterrarium/api/ws/chat.py
+++ b/src/kohakuterrarium/api/ws/chat.py
@@ -142,7 +142,9 @@ async def _send_channel_history(ws: WebSocket, runtime) -> None:
             )
 
 
-async def _handle_terrarium_input(ws: WebSocket, manager, terrarium_id: str) -> None:
+async def _handle_terrarium_input(
+    ws: WebSocket, manager, terrarium_id: str, queue: asyncio.Queue
+) -> None:
     """Handle incoming WebSocket messages for a terrarium."""
     while True:
         data = await ws.receive_json()
@@ -221,7 +223,7 @@ async def ws_terrarium(websocket: WebSocket, terrarium_id: str):
     fwd_task = asyncio.create_task(_forward_queue(queue, websocket))
 
     try:
-        await _handle_terrarium_input(websocket, manager, terrarium_id)
+        await _handle_terrarium_input(websocket, manager, terrarium_id, queue)
     except WebSocketDisconnect:
         pass
     except Exception as e:


### PR DESCRIPTION
## Summary

`_handle_terrarium_input` in `src/kohakuterrarium/api/ws/chat.py` referenced a `queue` variable that only existed in the outer `ws_terrarium` coroutine. Any WebSocket client sending `{"type":"input", ...}` to `/ws/terrariums/{id}` triggered `NameError: name 'queue' is not defined` at `chat.py:159`, which was silently swallowed by the broad `except Exception` in `ws_terrarium` (only logged at DEBUG) and closed the connection with code 1000 — so the user saw no response at all.

The frontend chat store (`src/kohakuterrarium-frontend/src/stores/chat.js:758`) sends exactly this payload for every non-channel terrarium message, so this effectively broke all terrarium chat via the web UI.

## Changes

- `src/kohakuterrarium/api/ws/chat.py`: Add `queue: asyncio.Queue` as an explicit parameter to `_handle_terrarium_input`, and pass `queue` at the single call site inside `ws_terrarium`.

## Testing

### Reproduction (before this patch)

1. `POST /api/terrariums` with any working config (e.g. `examples/terrariums/research_assistant/terrarium.yaml`).
2. Connect with `wscat -c ws://{host}/ws/terrariums/{id}`.
3. Send `{"type":"input","target":"root","message":"hi"}`.
4. The connection closes immediately with close code `1000`. At DEBUG log level the server shows:

```
NameError: name 'queue' is not defined
  File ".../api/ws/chat.py", line 159, in _handle_terrarium_input
    await queue.put(user_evt)
```



### After the fix

Same reproduction, but the WebSocket stays open and starts streaming `idle` / agent-output events as expected.

### Checks

- [x] Existing tests pass (`python -m pytest tests/ -q -k "ws or chat or terrarium"` → **16 passed**).
- [ ] New tests added — no new tests added; the `_handle_terrarium_input` input path was not previously exercised by a unit test. Happy to add one if preferred.
- [x] Linting passes (`python -m ruff check src/kohakuterrarium/api/ws/chat.py`, and `python -m black src/kohakuterrarium/api/ws/chat.py` leaves the file unchanged).
- [ ] Frontend builds — N/A, backend-only change.

## Related Issues

None that I found in the issue tracker. Happy to open one retroactively if the maintainers prefer that flow.

## Notes

- The sibling `ws_creature` handler is not affected: its input loop is inlined inside `ws_creature`, so `queue` is visible in-scope there.
- This supersedes #17 (opened from a different account by mistake).