### PR TITLE
fix(ws): send structured error frames before closing on internal errors

### DIFF
--- a/src/kohakuterrarium/api/ws/agents.py
+++ b/src/kohakuterrarium/api/ws/agents.py
@@ -16,6 +16,13 @@ async def agent_chat(websocket: WebSocket, agent_id: str):
     await websocket.accept()
     manager = get_manager()
 
+    if manager._agents.get(agent_id) is None:
+        await websocket.send_json(
+            {"type": "error", "content": f"Agent not found: {agent_id}"}
+        )
+        await websocket.close()
+        return
+
     try:
         while True:
             # Receive message from client
@@ -41,4 +48,8 @@ async def agent_chat(websocket: WebSocket, agent_id: str):
         pass
     except Exception as e:
         logger.debug("WebSocket close error", error=str(e), exc_info=True)
+        try:
+            await websocket.send_json({"type": "error", "content": str(e)})
+        except Exception:
+            pass
         await websocket.close()

--- a/src/kohakuterrarium/api/ws/channels.py
+++ b/src/kohakuterrarium/api/ws/channels.py
@@ -32,4 +32,8 @@ async def channel_stream(websocket: WebSocket, terrarium_id: str):
         pass
     except Exception as e:
         logger.debug("WebSocket close error", error=str(e), exc_info=True)
+        try:
+            await websocket.send_json({"type": "error", "content": str(e)})
+        except Exception:
+            pass
         await websocket.close()

--- a/src/kohakuterrarium/api/ws/chat.py
+++ b/src/kohakuterrarium/api/ws/chat.py
@@ -226,6 +226,10 @@ async def ws_terrarium(websocket: WebSocket, terrarium_id: str):
         pass
     except Exception as e:
         logger.debug("Terrarium WS error", error=str(e), exc_info=True)
+        try:
+            await websocket.send_json({"type": "error", "content": str(e)})
+        except Exception:
+            pass
     finally:
         queue.put_nowait(None)
         fwd_task.cancel()
@@ -300,6 +304,10 @@ async def ws_creature(websocket: WebSocket, agent_id: str):
         pass
     except Exception as e:
         logger.debug("Creature WS error", error=str(e), exc_info=True)
+        try:
+            await websocket.send_json({"type": "error", "content": str(e)})
+        except Exception:
+            pass
     finally:
         queue.put_nowait(None)
         fwd_task.cancel()

--- a/src/kohakuterrarium/api/ws/logs.py
+++ b/src/kohakuterrarium/api/ws/logs.py
@@ -128,6 +128,10 @@ async def tail_logs(websocket: WebSocket):
     except Exception as e:
         logger.debug("log WS error", error=str(e), exc_info=True)
         try:
+            await websocket.send_json({"type": "error", "text": str(e)})
+        except Exception:
+            pass
+        try:
             await websocket.close()
         except Exception as e:
             logger.debug("Failed to close log WS", error=str(e), exc_info=True)

--- a/tests/unit/test_ws_error_frames.py
+++ b/tests/unit/test_ws_error_frames.py
@@ -1,0 +1,132 @@
+"""Unit tests for WebSocket error-frame handling.
+
+Every WebSocket endpoint that closes the connection on an internal
+error should first emit a structured ``{"type": "error", ...}`` frame
+so clients (browser, wscat, anything) can surface a real cause instead
+of a bare ``Disconnected (code: 1000)``.
+
+Covered endpoints:
+  * /ws/agents/{agent_id}/chat           (startup validation)
+  * /ws/terrariums/{terrarium_id}/channels
+  * /ws/terrariums/{terrarium_id}         (existing startup validation)
+  * /ws/creatures/{agent_id}              (existing startup validation)
+  * /ws/logs                              (existing no-log-file path)
+
+These tests use ``TestClient`` + ``app.dependency_overrides[get_manager]``
+in the same style as ``tests/unit/test_api_readonly_endpoints.py``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from kohakuterrarium.api.deps import get_manager
+from kohakuterrarium.api.ws import agents as agents_ws
+from kohakuterrarium.api.ws import channels as channels_ws
+from kohakuterrarium.api.ws import chat as chat_ws
+from kohakuterrarium.api.ws import logs as logs_ws
+
+
+def _build_client(fake_manager) -> TestClient:
+    """FastAPI test app wired with all WS routers and a fake manager."""
+    app = FastAPI()
+    app.include_router(agents_ws.router)
+    app.include_router(channels_ws.router)
+    app.include_router(chat_ws.router)
+    app.dependency_overrides[get_manager] = lambda: fake_manager
+    return TestClient(app)
+
+
+def _assert_error_frame_then_close(ws, *, key: str = "content") -> None:
+    """Verify the next message is an error frame and the server then closes."""
+    msg = ws.receive_json()
+    assert msg["type"] == "error"
+    assert key in msg and msg[key], (
+        f"error frame missing non-empty '{key}' field: {msg!r}"
+    )
+    with pytest.raises(WebSocketDisconnect):
+        ws.receive_json()
+
+
+# ----------------------------------------------------------------------
+# /ws/agents/{agent_id}/chat — startup validation (new behavior)
+# ----------------------------------------------------------------------
+
+
+def test_ws_agents_invalid_id_sends_error_frame_before_close():
+    fake_manager = SimpleNamespace(_agents={})
+    client = _build_client(fake_manager)
+
+    with client.websocket_connect("/ws/agents/nonexistent/chat") as ws:
+        _assert_error_frame_then_close(ws)
+
+
+# ----------------------------------------------------------------------
+# /ws/terrariums/{terrarium_id}/channels — catch-all send_json (new behavior)
+# ----------------------------------------------------------------------
+
+
+class _RaisingChannelStreamManager:
+    """Manager whose ``terrarium_channel_stream`` raises on first iteration."""
+
+    async def terrarium_channel_stream(self, tid, channels=None):
+        raise ValueError(f"Terrarium not found: {tid}")
+        yield  # pragma: no cover — keeps this an async generator
+
+
+def test_ws_channels_stream_error_sends_error_frame_before_close():
+    client = _build_client(_RaisingChannelStreamManager())
+
+    with client.websocket_connect("/ws/terrariums/nope/channels") as ws:
+        _assert_error_frame_then_close(ws)
+
+
+# ----------------------------------------------------------------------
+# /ws/terrariums/{terrarium_id} — existing startup validation (regression)
+# ----------------------------------------------------------------------
+
+
+class _UnknownRuntimeManager:
+    """Manager whose ``_get_runtime`` always reports the terrarium missing."""
+
+    def _get_runtime(self, tid):
+        raise ValueError(f"Terrarium not found: {tid}")
+
+
+def test_ws_terrarium_invalid_id_sends_error_frame_before_close():
+    client = _build_client(_UnknownRuntimeManager())
+
+    with client.websocket_connect("/ws/terrariums/nope") as ws:
+        _assert_error_frame_then_close(ws)
+
+
+# ----------------------------------------------------------------------
+# /ws/creatures/{agent_id} — existing startup validation (regression)
+# ----------------------------------------------------------------------
+
+
+def test_ws_creature_invalid_id_sends_error_frame_before_close():
+    fake_manager = SimpleNamespace(_agents={})
+    client = _build_client(fake_manager)
+
+    with client.websocket_connect("/ws/creatures/nope") as ws:
+        _assert_error_frame_then_close(ws)
+
+
+# ----------------------------------------------------------------------
+# /ws/logs — no log file path (existing) + new error frame on catch-all
+# ----------------------------------------------------------------------
+
+
+def test_ws_logs_no_log_file_sends_error_frame_before_close(monkeypatch):
+    monkeypatch.setattr(logs_ws, "_find_current_process_log", lambda: None)
+
+    app = FastAPI()
+    app.include_router(logs_ws.router)
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws/logs") as ws:
+        _assert_error_frame_then_close(ws, key="text")


### PR DESCRIPTION
## Summary

Several WebSocket endpoints (`agents`, `channels`, `chat:ws_terrarium`, `chat:ws_creature`, `logs`) shared the same error-swallowing anti-pattern: a broad `except Exception: logger.debug(...)` around the main loop / stream, followed by a silent `websocket.close()`. Clients (browser, wscat, anything) saw only `Disconnected (code: 1000, reason: "")` and had no way to distinguish a real server error (e.g. "Agent not found") from a network hiccup.

This is the same pattern #18 fixed one specific trigger of (a `NameError` on `queue`). This PR fixes the swallowing itself across the rest of the endpoints so failure modes become visible to clients.

## Changes

- `src/kohakuterrarium/api/ws/agents.py`
  - Add a startup validation for `agent_id` that mirrors `ws_creature` (returns a structured error frame immediately instead of letting the first `receive_json → manager.agent_chat` trigger an internal `ValueError`).
  - Send an error frame in the catch-all `except Exception` before closing.
- `src/kohakuterrarium/api/ws/channels.py` — send error frame in the catch-all before closing.
- `src/kohakuterrarium/api/ws/chat.py` (`ws_terrarium` and `ws_creature`) — send error frame in the catch-all before the `finally` block's cleanup runs.
- `src/kohakuterrarium/api/ws/logs.py` — send error frame before closing in the catch-all.
- `tests/unit/test_ws_error_frames.py` — **new**: 5 unit tests covering all affected endpoints.

Each `send_json` in the catch-all is wrapped in its own `try/except Exception: pass` because the peer may already have disconnected; if so, the fallback is just the existing close behavior (identical to before this PR).

Error frame shape follows the convention already in use per file: `{"type":"error","content": "..."}` for `agents` / `channels` / `chat` (matching the existing startup-validation frames in `chat.py`); `{"type":"error","text": "..."}` for `logs` (matching the existing `"log file not found"` frame).

## Reproduction (before this patch)

```
wscat -c ws://localhost:8001/ws/agents/totally-fake-id/chat
Connected (press CTRL+C to quit)
> {"message":"hello"}
Disconnected (code: 1000, reason: "")
```

No `<`-prefixed server-to-client frame. Server only logged at DEBUG level (`WebSocket close error error=Agent not found: ...`), so users saw nothing.

## After the fix

```
wscat -c ws://localhost:8001/ws/agents/totally-fake-id/chat
Connected (press CTRL+C to quit)
< {"type":"error","content":"Agent not found: totally-fake-id"}
Disconnected (code: 1000, reason: "")
```

For `agents`, the startup validation means the error arrives immediately on connect (no user message needed). For the others, the frame arrives when the internal exception is raised in the main loop / stream.

## Test plan

- [x] `python -m black src/kohakuterrarium/api/ws/ tests/unit/test_ws_error_frames.py` — no reformat needed.
- [x] `python -m ruff check src/kohakuterrarium/api/ws/ tests/unit/test_ws_error_frames.py` — All checks passed.
- [x] `python -c "from kohakuterrarium.api.ws import agents, chat, channels, logs; print('imports OK')"` — OK.
- [x] `python -m pytest tests/unit/test_ws_error_frames.py -v` — **5 passed** in 1.49s.
- [x] `python -m pytest tests/ -q -k "ws or chat or terrarium" --ignore=tests/integration/test_service_api.py` — passed on the WS-adjacent subset. One unrelated flaky test `TestAPIChannelOps::test_send_to_queue_channel` hits `await ch.receive(timeout=1.0)`; confirmed flaky on `main` via `git stash` rerun. Its code path (`TerrariumAPI.send_to_channel → SubAgentChannel.receive`) does not touch any file modified by this PR.
- [x] Manually verified with `wscat` against `/ws/agents/<fake>/chat` (error frame received) and `/ws/terrariums/<fake>/channels` (error frame received) on this branch vs bare `Disconnected` on `main`.

### New test file

`tests/unit/test_ws_error_frames.py` follows the `TestClient` + `dependency_overrides[get_manager]` pattern already established in `tests/unit/test_api_readonly_endpoints.py`. It covers:

| Test | Endpoint | What it verifies |
|---|---|---|
| `test_ws_agents_invalid_id_sends_error_frame_before_close` | `/ws/agents/{id}/chat` | New startup validation introduced by this PR |
| `test_ws_channels_stream_error_sends_error_frame_before_close` | `/ws/terrariums/{id}/channels` | New `send_json` in the catch-all when the async generator raises |
| `test_ws_terrarium_invalid_id_sends_error_frame_before_close` | `/ws/terrariums/{id}` | Regression guard on existing startup validation |
| `test_ws_creature_invalid_id_sends_error_frame_before_close` | `/ws/creatures/{id}` | Regression guard on existing startup validation |
| `test_ws_logs_no_log_file_sends_error_frame_before_close` | `/ws/logs` | Regression guard on existing no-log-file path |

## Non-goals / follow-ups

- `_forward_queue` in `chat.py` also swallows send failures with a broad `except Exception: logger.debug(...)`, but by the time that task's `send_json` fails the peer is almost always already gone, so emitting an error frame there adds little value. Left as-is.
- `terminal.py` already uses `logger.error` (not `debug`) and does send error frames on startup-validation failures. Its runtime `except Exception` still doesn't send a frame before close, but terminal WS has a different lifecycle (dual read/write tasks over a PTY) and warrants a separate focused PR if maintainers want that unified.
- None of these changes touch the happy path — they only make failure modes visible to clients.

## Related

Follow-up to #18 (same error-swallowing pattern, different endpoint).
