### PR TITLE
fix: Briefcase MSI desktop app silent exit on launch

### DIFF
--- a/src/kohakuterrarium/__briefcase__.py
+++ b/src/kohakuterrarium/__briefcase__.py
@@ -7,9 +7,9 @@ KohakuTerrarium desktop app (FastAPI server + pywebview window).
 
 def main():
     """Launch the KohakuTerrarium desktop app."""
-    from kohakuterrarium.serving.web import run_desktop_app
+    from kohakuterrarium.serving.web import _run_desktop_app_blocking
 
-    run_desktop_app()
+    _run_desktop_app_blocking()
 
 
 if __name__ == "__main__":

--- a/src/kohakuterrarium/__main__.py
+++ b/src/kohakuterrarium/__main__.py
@@ -1,8 +1,17 @@
-"""KohakuTerrarium CLI entry point."""
+"""KohakuTerrarium entry point.
+
+When executed as ``python -m kohakuterrarium``, this module decides which path
+to take:
+
+* **Briefcase bundle** — the stub launcher sets no CLI args and
+  ``BRIEFCASE_MAIN_MODULE`` is absent, so we detect the bundle via the
+  embedded Python ``python3XX._pth`` marker and call ``__briefcase__.main()``
+  directly.
+* **Normal CLI** — falls through to ``cli.main()`` as usual.
+"""
 
 import sys
-
-from kohakuterrarium.cli import main
+from pathlib import Path
 
 
 def _configure_utf8_stdio() -> None:
@@ -19,6 +28,24 @@ def _configure_utf8_stdio() -> None:
             pass
 
 
+def _is_briefcase_bundle() -> bool:
+    """Detect whether we are running inside a Briefcase-packaged app.
+
+    Briefcase Windows bundles use an embedded Python distribution which places
+    a ``python3XX._pth`` file next to the stub exe.  Normal Python installs
+    never have a ``._pth`` file beside ``sys.executable``.
+    """
+    exe_dir = Path(sys.executable).resolve().parent
+    return any(exe_dir.glob("python3*._pth"))
+
+
 if __name__ == "__main__":
     _configure_utf8_stdio()
-    sys.exit(main())
+    if _is_briefcase_bundle() and len(sys.argv) <= 1:
+        from kohakuterrarium.__briefcase__ import main
+
+        main()
+    else:
+        from kohakuterrarium.cli import main
+
+        sys.exit(main())


### PR DESCRIPTION
## Summary

- MSI-installed `KohakuTerrarium.exe` exits immediately on launch (exit code 0, no window, no error)
- Root cause: Briefcase stub ignores `pyproject.toml`'s `startup_module`, falls back to `__main__.py` → `cli.main()`, which calls the detached subprocess launcher (`run_desktop_app()`) — both parent and child processes die
- Fix: detect Briefcase bundle in `__main__.py` via `python3*._pth` marker and route to `__briefcase__.main()` with the in-process blocking launcher

## Problem

The Briefcase Windows stub binary does not read `startup_module` from `pyproject.toml`. Instead it reads the `BRIEFCASE_MAIN_MODULE` environment variable, which is never set. It falls back to `runpy._run_module_as_main("kohakuterrarium")` → `__main__.py` → `cli.main()`.

With no CLI arguments (double-click), `cli.main()` hits the `if not args.command` branch and calls `run_desktop_app()`, which spawns a detached subprocess via `subprocess.Popen([sys.executable, "-m", ...])` and returns immediately:

- **Parent**: `main()` returns → .NET stub calls `ExitProcess(0)` → gone
- **Child**: `sys.executable` = `KohakuTerrarium.exe` (stub), doesn't understand `-m` → args fed to argparse → "invalid choice" → exits

Both processes dead. No window ever created.

## Fix

**`__main__.py`** — Added `_is_briefcase_bundle()` that checks for `python3*._pth` files next to `sys.executable` (always present in Briefcase's embedded Python, never in normal installs). When detected with no CLI args, routes to `__briefcase__.main()` directly.

**`__briefcase__.py`** — `run_desktop_app()` → `_run_desktop_app_blocking()`. Runs uvicorn in a daemon thread + pywebview on main thread, all in-process. Blocks until window closes.

## Why `BRIEFCASE_MAIN_MODULE` cannot be set at build time

The stub reads `BRIEFCASE_MAIN_MODULE` via C `_wgetenv()` **before** `Py_Initialize()`. Verified by:
1. Hex dump shows the env var reference at 0x46D0, before all `PreInitializing Python runtime` strings
2. Adding `import os; os.environ.setdefault(...)` to `python313._pth` — the `import` line **never executed** (marker file not created), confirming the stub skips `._pth` import processing
3. Any Python-level `os.environ` change is too late — C runtime reads the env var before Python boots

Remaining options (all rejected):
- **WiX `<Environment>`** in MSI: works but pollutes user's system environment
- **Binary-patch the stub exe**: fragile, breaks on briefcase upgrades
- **Fix in briefcase upstream**: the correct long-term solution (briefcase should embed `startup_module` from `pyproject.toml` into the stub or set the env var during build), but requires an upstream PR to the briefcase project

**Conclusion:** The cleanest practical fix is detecting the briefcase environment in `__main__.py` and routing to `__briefcase__.py` before the CLI path is reached.

## Files changed

| File | Change |
|------|--------|
| `src/kohakuterrarium/__main__.py` | Add bundle detection via `python3*._pth`; route to `__briefcase__.main()` |
| `src/kohakuterrarium/__briefcase__.py` | `run_desktop_app()` → `_run_desktop_app_blocking()` |

## Test plan

- [x] Briefcase MSI build: double-click launches, pywebview window visible, `127.0.0.1:8001` HTTP 200
- [x] Normal terminal: `kt run`, `kt app`, `kt web` behave as before
- [x] `black --check` / `ruff check`: pass
- [x] `pytest`: 1644 passed, no new failures