### PR TITLE
feat(llm): add Ollama provider support

### DIFF
--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -78,7 +78,7 @@ kt config llm add                 # interactive preset builder
 kt model default <preset-name>
 ```
 
-**Other providers**: `anthropic`, `openrouter`, `gemini`, etc. are built-in backends. See `kt config provider list` and [Configuration](configuration.md) for details.
+**Other providers**: `anthropic`, `openrouter`, `gemini`, `ollama`, etc. are built-in backends. See `kt config provider list` and [Configuration](configuration.md) for details.
 
 ## 4. Run a creature
 

--- a/docs/zh-TW/guides/getting-started.md
+++ b/docs/zh-TW/guides/getting-started.md
@@ -78,7 +78,7 @@ kt config llm add                 # 互動式預設建立器
 kt model default <preset-name>
 ```
 
-**其他提供者**：`anthropic`、`openrouter`、`gemini` 等都是內建後端。詳情請見 `kt config provider list` 與[設定](configuration.md)。
+**其他提供者**：`anthropic`、`openrouter`、`gemini`、`ollama` 等都是內建後端。詳情請見 `kt config provider list` 與[設定](configuration.md)。
 
 ## 4. 執行一隻生物
 

--- a/src/kohakuterrarium/bootstrap/llm.py
+++ b/src/kohakuterrarium/bootstrap/llm.py
@@ -87,11 +87,14 @@ def _create_from_profile(profile: LLMProfile) -> LLMProvider:
     if not api_key and profile.api_key_env:
         api_key = get_api_key(profile.api_key_env)
     if not api_key:
-        raise ValueError(
-            f"API key not found for profile '{profile.name}'. "
-            f"Use 'kt login {profile.provider or 'openai'}' or set "
-            f"{profile.api_key_env or 'OPENAI_API_KEY'} environment variable."
-        )
+        if profile.provider == "ollama":
+            api_key = "ollama"
+        else:
+            raise ValueError(
+                f"API key not found for profile '{profile.name}'. "
+                f"Use 'kt login {profile.provider or 'openai'}' or set "
+                f"{profile.api_key_env or 'OPENAI_API_KEY'} environment variable."
+            )
 
     provider = OpenAIProvider(
         api_key=api_key,

--- a/src/kohakuterrarium/cli/auth.py
+++ b/src/kohakuterrarium/cli/auth.py
@@ -2,6 +2,8 @@
 
 import asyncio
 
+import httpx
+
 from kohakuterrarium.llm.codex_auth import CodexTokens, oauth_login
 from kohakuterrarium.llm.profiles import get_api_key, load_backends, save_api_key
 
@@ -15,6 +17,8 @@ def login_cli(provider: str) -> int:
         return 1
     if backend.backend_type == "codex":
         return _login_codex()
+    if provider == "ollama":
+        return _login_ollama(backend.base_url)
     return _login_api_key(provider, backend.api_key_env)
 
 
@@ -47,6 +51,50 @@ def _login_api_key(provider: str, env_var: str) -> int:
     print("You can now use presets bound to this provider:")
     print("  kt model list")
     print("  kt run @kt-biome/creatures/swe --llm <model>")
+    return 0
+
+
+def _login_ollama(base_url: str) -> int:
+    """Verify Ollama daemon connectivity and list locally-pulled models.
+
+    Ollama does not require authentication; this command only sanity-checks
+    that the daemon is reachable and prints available models so the user knows
+    what to pass as ``--llm``.
+    """
+    tags_url = base_url.rstrip("/").removesuffix("/v1") + "/api/tags"
+    print(f"Checking Ollama at {base_url} ...")
+    try:
+        response = httpx.get(tags_url, timeout=3.0)
+        response.raise_for_status()
+    except httpx.ConnectError:
+        print("Cannot reach Ollama.")
+        print("  1. Install:         https://ollama.com/download")
+        print("  2. Start daemon:    ollama serve")
+        print("  3. Pull a model:    ollama pull gemma4:latest")
+        return 1
+    except httpx.HTTPError as exc:
+        print(f"Ollama responded with an error: {exc}")
+        return 1
+
+    data = response.json()
+    models = data.get("models", [])
+    if not models:
+        print("Ollama is running, but no models are pulled.")
+        print("  Run: ollama pull gemma4:latest")
+        return 0
+
+    print(f"Ollama is reachable. {len(models)} local model(s):")
+    for entry in models:
+        name = entry.get("name", "?")
+        size_gb = entry.get("size", 0) / (1024**3)
+        print(f"  {name:<40} {size_gb:.1f} GB")
+    print()
+    print(
+        "Built-in presets: qwen3.6-35b-local, qwen3.5-27b-local, "
+        "qwen3.5-9b-local, gemma4-e4b-local, gemma4-26b-local"
+    )
+    print("Aliases: ollama, qwen-local, gemma-local")
+    print("Run:  kt model list")
     return 0
 
 

--- a/src/kohakuterrarium/llm/api_keys.py
+++ b/src/kohakuterrarium/llm/api_keys.py
@@ -23,6 +23,7 @@ PROVIDER_KEY_MAP: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "mimo": "MIMO_API_KEY",
+    "ollama": "OLLAMA_API_KEY",
 }
 
 

--- a/src/kohakuterrarium/llm/presets.py
+++ b/src/kohakuterrarium/llm/presets.py
@@ -539,6 +539,40 @@ PRESETS: dict[str, dict[str, Any]] = {
         "max_context": 262144,
         "extra_body": {"reasoning": {"enabled": True, "effort": "high"}},
     },
+    # Ollama (local models via OpenAI-compat endpoint at http://localhost:11434/v1).
+    # Requires `ollama serve` and `ollama pull <model>`. Tool calls work, but the
+    # OpenAI-compat surface returns a single non-streamed response when tools are
+    # enabled; plain chat streams normally.
+    "qwen3.5-9b-local": {
+        "provider": "ollama",
+        "model": "qwen3.5:latest",
+        "max_context": 131072,
+        "max_output": 8192,
+    },
+    "qwen3.5-27b-local": {
+        "provider": "ollama",
+        "model": "qwen3.5:27b",
+        "max_context": 131072,
+        "max_output": 8192,
+    },
+    "qwen3.6-35b-local": {
+        "provider": "ollama",
+        "model": "qwen3.6:latest",
+        "max_context": 131072,
+        "max_output": 8192,
+    },
+    "gemma4-e4b-local": {
+        "provider": "ollama",
+        "model": "gemma4:latest",
+        "max_context": 131072,
+        "max_output": 8192,
+    },
+    "gemma4-26b-local": {
+        "provider": "ollama",
+        "model": "gemma4:26b",
+        "max_context": 131072,
+        "max_output": 8192,
+    },
 }
 
 # Aliases: short names -> canonical preset names
@@ -587,6 +621,10 @@ ALIASES: dict[str, str] = {
     "magistral": "magistral-medium",
     "devstral": "devstral-2",
     "ministral": "ministral-3-14b",
+    # Ollama (local) — qwen + gemma series only
+    "ollama": "qwen3.6-35b-local",
+    "qwen-local": "qwen3.6-35b-local",
+    "gemma-local": "gemma4-e4b-local",
 }
 
 

--- a/src/kohakuterrarium/llm/profiles.py
+++ b/src/kohakuterrarium/llm/profiles.py
@@ -43,6 +43,7 @@ _BUILTIN_PROVIDER_NAMES = {
     "anthropic",
     "gemini",
     "mimo",
+    "ollama",
 }
 
 # Values that historically appeared under a preset's `provider` field to
@@ -106,6 +107,12 @@ def _built_in_providers() -> dict[str, LLMBackend]:
             base_url="https://api.xiaomimimo.com/v1",
             api_key_env="MIMO_API_KEY",
         ),
+        "ollama": LLMBackend(
+            name="ollama",
+            backend_type="openai",
+            base_url="http://localhost:11434/v1",
+            api_key_env="OLLAMA_API_KEY",
+        ),
     }
 
 
@@ -131,6 +138,8 @@ def _legacy_provider_from_data(data: dict[str, Any]) -> str:
         return "anthropic"
     if "openrouter.ai" in base_url:
         return "openrouter"
+    if "localhost:11434" in base_url or "127.0.0.1:11434" in base_url:
+        return "ollama"
     if "generativelanguage.googleapis.com" in base_url:
         return "gemini"
     if "api.openai.com" in base_url:
@@ -143,6 +152,7 @@ def _legacy_provider_from_data(data: dict[str, Any]) -> str:
         "ANTHROPIC_API_KEY",
         "GEMINI_API_KEY",
         "MIMO_API_KEY",
+        "OLLAMA_API_KEY",
     }:
         reverse = {v: k for k, v in PROVIDER_KEY_MAP.items()}
         return reverse[api_key_env]

--- a/tests/integration/test_ollama.py
+++ b/tests/integration/test_ollama.py
@@ -1,0 +1,120 @@
+"""Integration tests for the Ollama provider.
+
+These tests require a live ``ollama serve`` with at least one pulled model.
+They skip cleanly when the daemon is not reachable, so CI without Ollama is
+unaffected.
+
+To run locally:
+    ollama serve &
+    ollama pull qwen3.6        # or qwen3.5 / gemma4
+    uv run pytest tests/integration/test_ollama.py -v
+"""
+
+import httpx
+import pytest
+
+from kohakuterrarium.bootstrap.llm import _create_from_profile
+from kohakuterrarium.llm.base import ToolSchema
+from kohakuterrarium.llm.message import Message
+from kohakuterrarium.llm.profiles import get_preset
+
+
+def _ollama_running() -> bool:
+    try:
+        httpx.get("http://localhost:11434/api/tags", timeout=1.0)
+        return True
+    except Exception:
+        return False
+
+
+def _pulled_models() -> list[str]:
+    try:
+        resp = httpx.get("http://localhost:11434/api/tags", timeout=1.0)
+        resp.raise_for_status()
+        return [m.get("name", "") for m in resp.json().get("models", [])]
+    except Exception:
+        return []
+
+
+pytestmark = pytest.mark.skipif(
+    not _ollama_running(),
+    reason="Ollama daemon not reachable at http://localhost:11434",
+)
+
+
+def _pick_model() -> str:
+    """Pick any pulled model that matches a built-in Ollama preset, or skip."""
+    models = _pulled_models()
+    for candidate in (
+        "qwen3.6:latest",
+        "qwen3.5:latest",
+        "qwen3.5:27b",
+        "gemma4:latest",
+        "gemma4:26b",
+    ):
+        base = candidate.split(":")[0]
+        for name in models:
+            if name == candidate or name.startswith(base + ":"):
+                return name
+    pytest.skip(f"No compatible model pulled. Have: {models}")
+
+
+class TestOllamaProvider:
+    async def test_plain_chat_streams(self):
+        """Without tools, Ollama should return at least one text chunk."""
+        model_tag = _pick_model()
+        profile = get_preset("qwen3.6-35b-local")
+        assert profile is not None
+        profile.model = model_tag  # use whatever is locally pulled
+
+        provider = _create_from_profile(profile)
+
+        chunks: list[str] = []
+        async for chunk in provider.chat(
+            [Message(role="user", content="Reply with a single word: hello.")],
+            stream=True,
+        ):
+            chunks.append(chunk)
+
+        joined = "".join(chunks)
+        assert joined, "expected non-empty response from Ollama"
+        # Do not hard-assert chunk count — some small models answer in a single
+        # chunk for very short prompts. Just verify we got text back.
+
+    async def test_tool_call_is_extracted(self):
+        """When a tool is offered and the model decides to call it, the
+        provider's ``last_tool_calls`` should be populated.
+
+        Note: Ollama's OpenAI-compat endpoint delivers the tool call in a
+        single non-streamed response — the iteration completes immediately
+        with no content chunks, and the call appears in ``last_tool_calls``.
+        """
+        model_tag = _pick_model()
+        profile = get_preset("qwen3.6-35b-local")
+        assert profile is not None
+        profile.model = model_tag
+
+        provider = _create_from_profile(profile)
+
+        tool = ToolSchema(
+            name="get_current_time",
+            description="Return the current time in ISO 8601 format.",
+            parameters={"type": "object", "properties": {}},
+        )
+
+        async for _chunk in provider.chat(
+            [
+                Message(
+                    role="user",
+                    content="What time is it right now? Call the tool.",
+                )
+            ],
+            stream=True,
+            tools=[tool],
+        ):
+            pass
+
+        # Tool calls may or may not be emitted depending on the model's
+        # willingness. We accept either outcome; the assertion is that the
+        # iteration completes without raising and the attribute is a list.
+        assert isinstance(provider.last_tool_calls, list)

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -234,6 +234,32 @@ class TestBootstrapLLM:
             with pytest.raises(ValueError, match="API key not found"):
                 create_llm_provider(config)
 
+    @patch("kohakuterrarium.bootstrap.llm.OpenAIProvider")
+    def test_ollama_profile_uses_dummy_key(self, mock_openai_cls):
+        """Ollama does not require a real API key — bootstrap should inject a dummy."""
+        import os
+
+        from kohakuterrarium.bootstrap.llm import _create_from_profile
+        from kohakuterrarium.llm.profiles import get_preset
+
+        mock_instance = MagicMock()
+        mock_openai_cls.return_value = mock_instance
+
+        os.environ.pop("OLLAMA_API_KEY", None)
+        profile = get_preset("qwen3.6-35b-local")
+        assert profile is not None
+        assert profile.provider == "ollama"
+
+        with patch("kohakuterrarium.bootstrap.llm.get_api_key", return_value=""):
+            result = _create_from_profile(profile)
+
+        mock_openai_cls.assert_called_once()
+        kwargs = mock_openai_cls.call_args.kwargs
+        assert kwargs["api_key"] == "ollama"
+        assert "11434" in kwargs["base_url"]
+        assert kwargs["model"] == "qwen3.6:latest"
+        assert result is mock_instance
+
 
 # ---------------------------------------------------------------------------
 # bootstrap/tools.py

--- a/tests/unit/test_llm_profiles.py
+++ b/tests/unit/test_llm_profiles.py
@@ -12,6 +12,7 @@ from kohakuterrarium.llm.profiles import (
     get_default_model,
     get_preset,
     list_all,
+    load_backends,
     load_profiles,
     resolve_controller_llm,
     save_profile,
@@ -222,3 +223,52 @@ class TestListAll:
         defaults = [e for e in entries if e.get("is_default")]
         assert len(defaults) >= 1
         assert defaults[0]["name"] == "gpt-5.4"
+
+
+# ── Ollama ────────────────────────────────────────────────────
+
+
+class TestOllama:
+    def test_backend_registered(self, tmp_profiles):
+        backends = load_backends()
+        assert "ollama" in backends
+        ollama = backends["ollama"]
+        assert ollama.backend_type == "openai"
+        assert "11434" in ollama.base_url
+
+    def test_presets_resolve_to_ollama_backend(self, tmp_profiles):
+        for name in (
+            "qwen3.5-9b-local",
+            "qwen3.5-27b-local",
+            "qwen3.6-35b-local",
+            "gemma4-e4b-local",
+            "gemma4-26b-local",
+        ):
+            profile = get_preset(name)
+            assert profile is not None, f"preset {name!r} not found"
+            assert profile.provider == "ollama"
+            assert profile.backend_type == "openai"
+            assert "11434" in profile.base_url
+
+    def test_aliases_resolve(self, tmp_profiles):
+        for alias in ("ollama", "qwen-local", "gemma-local"):
+            profile = get_preset(alias)
+            assert profile is not None, f"alias {alias!r} not resolved"
+            assert profile.provider == "ollama"
+
+    def test_localhost_base_url_inferred_as_ollama(self, tmp_profiles):
+        """Legacy presets with localhost:11434 should reverse-map to ollama."""
+        from kohakuterrarium.llm.profiles import _legacy_provider_from_data
+
+        assert (
+            _legacy_provider_from_data(
+                {"base_url": "http://localhost:11434/v1", "model": "x"}
+            )
+            == "ollama"
+        )
+        assert (
+            _legacy_provider_from_data(
+                {"base_url": "http://127.0.0.1:11434/v1", "model": "x"}
+            )
+            == "ollama"
+        )


### PR DESCRIPTION
## Summary

Add Ollama as a built-in LLM backend so KohakuTerrarium can drive locally-hosted Qwen and Gemma models via Ollama's OpenAI-compat endpoint at `http://localhost:11434/v1`.

- New `ollama` backend registered alongside `openai`, `anthropic`, `gemini`, `mimo`, etc.
- Bootstrap injects a dummy `"ollama"` API key when none is configured (the OpenAI-compat surface accepts any non-empty token).
- 5 presets covering Qwen 3.5 / 3.6 and Gemma 4, all suffixed `-local` to avoid name collisions with existing cloud presets like `qwen3.5-27b`:
  - `qwen3.5-9b-local`, `qwen3.5-27b-local`, `qwen3.6-35b-local`
  - `gemma4-e4b-local`, `gemma4-26b-local`
- Aliases: `ollama` → `qwen3.6-35b-local`, `qwen-local`, `gemma-local`.
- `kt login ollama` is a probe-only command — checks daemon reachability via `/api/tags`, lists locally-pulled models, prints preset/alias hints. No credential prompt.
- Reverse-mapping for legacy presets: any `base_url` containing `localhost:11434` or `127.0.0.1:11434` resolves back to the `ollama` provider.
- Docs updated in both `en` and `zh-TW` getting-started guides.

## Test plan

- [x] `uv run pytest tests/unit/test_bootstrap.py tests/unit/test_llm_profiles.py` — 66 passed
- [x] `uv run black --check` on touched files — clean
- [x] `uv run ruff check` on touched files — clean
- [ ] Live daemon check: `ollama serve && ollama pull qwen3.6 && uv run pytest tests/integration/test_ollama.py -v` (integration test skips cleanly when no daemon is reachable)
- [ ] Manual smoke: `kt login ollama` against a running daemon
- [ ] Manual smoke: `kt run <creature> --llm qwen3.6-35b-local`

## Notes

- Tool-call behavior: Ollama's OpenAI-compat endpoint returns a single non-streamed response when `tools` are enabled (plain chat still streams). The integration test documents this and asserts only that iteration completes without raising.
- `OLLAMA_API_KEY` is wired through `PROVIDER_KEY_MAP` for plumbing consistency, even though Ollama has no auth concept.
