### PR TITLE
feat(tools): add file_move, file_delete, mkdir builtin tools

### DIFF
--- a/src/kohakuterrarium/builtin_skills/tools/bash.md
+++ b/src/kohakuterrarium/builtin_skills/tools/bash.md
@@ -17,6 +17,9 @@ Do NOT use bash for operations that have dedicated tools:
 - File writing: use `write` (NOT `echo >`, `cat <<EOF`)
 - File finding: use `glob` (NOT `find`, `ls`)
 - Content search: use `grep` (NOT `grep`, `rg` via bash)
+- Moving / renaming: use `file_move` (NOT `mv`)
+- Deleting: use `file_delete` (NOT `rm`)
+- Creating directories: use `mkdir` tool (NOT `mkdir -p` via bash)
 
 Using dedicated tools gives structured output and enables safety guards.
 

--- a/src/kohakuterrarium/builtin_skills/tools/file_delete.md
+++ b/src/kohakuterrarium/builtin_skills/tools/file_delete.md
@@ -1,0 +1,79 @@
+---
+name: file_delete
+description: Delete a file (must read first) or directory (requires recursive=true)
+category: builtin
+tags: [file, io, delete, remove]
+---
+
+# file_delete
+
+Delete a file or directory. Structured replacement for `bash rm`.
+
+## SAFETY
+
+- **Path boundary**: the target must be inside the agent's working directory
+  (same warn/block policy as the other file tools).
+- **Read-before-delete for files**: you must have read the file first (and
+  it must be unchanged since) before deleting it. This mirrors the
+  read-before-write guard — the model should know what content it is
+  destroying. Symlinks are exempt (the target is not inspected).
+- **Directories are opt-in**: deleting a directory requires
+  `recursive=true`. Without it, the call is rejected with a clear error.
+- **Read state is cleared**: any `file_read_state` record for the deleted
+  path (or paths under a deleted directory) is removed on success.
+
+## Arguments
+
+| Arg | Type | Description |
+|-----|------|-------------|
+| path | string | Path to delete (required) |
+| recursive | bool | Required for directories. Deletes the tree rooted at `path`. Default: false |
+
+## WHEN TO USE
+
+- Removing a stale file you just inspected with `read`
+- Removing an empty scratch directory
+- Tearing down a generated directory tree (with `recursive=true`)
+
+## Examples
+
+Delete a file you just read:
+```
+tool call: file_delete(
+  path: src/old_module.py
+)
+```
+
+Delete a directory tree:
+```
+tool call: file_delete(
+  path: build/
+  recursive: true
+)
+```
+
+## Output
+
+```
+Deleted file /path/to/file
+```
+```
+Deleted directory /path/to/dir
+```
+```
+Deleted symlink /path/to/link
+```
+
+## LIMITATIONS
+
+- Symlinks are unlinked, not resolved — the link is removed but its target
+  is left alone.
+- For directories, `recursive=true` uses `shutil.rmtree` and follows normal
+  filesystem semantics (it stops on permission errors).
+
+## TIPS
+
+- If you really need to force-delete without reading, use `bash rm` and
+  accept the safety trade-off (see `info(bash)`). Prefer this tool.
+- To empty but keep a directory, delete its contents with `glob` + this
+  tool, or combine `file_delete` + `mkdir`.

--- a/src/kohakuterrarium/builtin_skills/tools/file_move.md
+++ b/src/kohakuterrarium/builtin_skills/tools/file_move.md
@@ -1,0 +1,86 @@
+---
+name: file_move
+description: Move or rename a file/directory (set overwrite=true to replace destination)
+category: builtin
+tags: [file, io, move, rename]
+---
+
+# file_move
+
+Move or rename a file or directory. Structured replacement for `bash mv`.
+
+## SAFETY
+
+- **Path boundary**: both `src` and `dst` must be inside the agent's working
+  directory (the same warn/block policy as the other file tools).
+- **Overwrite requires read**: if `dst` exists and is a file, you must have
+  read it first (and it must be unchanged since) before `overwrite=true`
+  will proceed. This prevents silently clobbering tracked content.
+- **No self-move**: `src` and `dst` resolving to the same path is rejected.
+- **Read state migrates**: a file's `read` record is transferred from `src`
+  to `dst` on success, so you can keep editing without re-reading. For
+  directory moves, read records under `src` are cleared (re-read as needed).
+
+## Arguments
+
+| Arg | Type | Description |
+|-----|------|-------------|
+| src | string | Source path (required). Accepts `source` as alias. |
+| dst | string | Destination path (required). Accepts `destination` as alias. |
+| overwrite | bool | Replace `dst` if it already exists (default: false) |
+
+## WHEN TO USE
+
+- Renaming a file or directory
+- Moving a file into another directory
+- Reorganizing project layout
+
+## Examples
+
+Rename a file:
+```
+tool call: file_move(
+  src: src/old_name.py
+  dst: src/new_name.py
+)
+```
+
+Move into a directory:
+```
+tool call: file_move(
+  src: src/utils/helper.py
+  dst: src/helpers/helper.py
+)
+```
+
+Replace an existing file (you must have `read` it first):
+```
+tool call: file_move(
+  src: draft.md
+  dst: README.md
+  overwrite: true
+)
+```
+
+## Output
+
+```
+Moved file /path/to/src -> /path/to/dst
+```
+or
+```
+Moved directory /path/to/src -> /path/to/dst
+```
+
+## LIMITATIONS
+
+- Cross-device moves fall back to copy + delete via `shutil.move`.
+- Symlinks are moved as-is (the link, not the target).
+- `dst`'s parent directory is created automatically if missing.
+
+## TIPS
+
+- To move something *out* of the working directory, the path guard will
+  warn you once; retry to proceed.
+- Use `file_move` instead of `bash mv` — you get path-guard coverage and
+  read-state migration for free.

--- a/src/kohakuterrarium/builtin_skills/tools/mkdir.md
+++ b/src/kohakuterrarium/builtin_skills/tools/mkdir.md
@@ -1,0 +1,73 @@
+---
+name: mkdir
+description: Create a directory (parents and existing dirs OK by default)
+category: builtin
+tags: [file, io, directory, mkdir]
+---
+
+# mkdir
+
+Create a directory. Structured replacement for `bash mkdir -p`.
+
+## SAFETY
+
+- **Path boundary**: the target must be inside the agent's working directory
+  (same warn/block policy as the other file tools).
+- **Path type check**: if `path` already exists and is *not* a directory,
+  the call is rejected rather than replacing the existing file.
+
+## Arguments
+
+| Arg | Type | Description |
+|-----|------|-------------|
+| path | string | Directory path to create (required) |
+| parents | bool | Create missing intermediate directories (default: true) |
+| error_if_exists | bool | Error out instead of succeeding silently when the dir already exists (default: false) |
+
+## Behavior
+
+- By default, behaves like `mkdir -p`: creates parents, treats an existing
+  directory as success.
+- Set `parents=false` to require the parent directory to already exist
+  (strict `mkdir` behavior).
+- Set `error_if_exists=true` if you want to know whether you created the
+  directory fresh — useful as a "claim" check when generating unique paths.
+
+## WHEN TO USE
+
+- Creating output directories before writing files
+- Scaffolding project structure
+- Ensuring a nested path exists before a series of `write` calls
+
+## Examples
+
+Create a nested path (the common case):
+```
+tool call: mkdir(
+  path: build/artifacts/logs
+)
+```
+
+Strict create (parent must exist, fail if dir exists):
+```
+tool call: mkdir(
+  path: build/artifacts
+  parents: false
+  error_if_exists: true
+)
+```
+
+## Output
+
+```
+Created directory /abs/path/to/dir
+```
+```
+Directory already exists: /abs/path/to/dir
+```
+
+## LIMITATIONS
+
+- Does not create files — use `write` for that.
+- Mode/permission bits are taken from the process umask; this tool does
+  not expose a `mode` argument.

--- a/src/kohakuterrarium/builtins/tools/__init__.py
+++ b/src/kohakuterrarium/builtins/tools/__init__.py
@@ -20,12 +20,15 @@ from kohakuterrarium.builtins.tool_catalog import (
 from kohakuterrarium.builtins.tools.ask_user import AskUserTool
 from kohakuterrarium.builtins.tools.bash import BashTool, PythonTool
 from kohakuterrarium.builtins.tools.edit import EditTool
+from kohakuterrarium.builtins.tools.file_delete import FileDeleteTool
+from kohakuterrarium.builtins.tools.file_move import FileMoveTool
 from kohakuterrarium.builtins.tools.glob import GlobTool
 from kohakuterrarium.builtins.tools.multi_edit import MultiEditTool
 from kohakuterrarium.builtins.tools.grep import GrepTool
 from kohakuterrarium.builtins.tools.info import InfoTool
 from kohakuterrarium.builtins.tools.json_read import JsonReadTool
 from kohakuterrarium.builtins.tools.json_write import JsonWriteTool
+from kohakuterrarium.builtins.tools.mkdir import MkdirTool
 from kohakuterrarium.builtins.tools.read import ReadTool
 from kohakuterrarium.builtins.tools.scratchpad_tool import ScratchpadTool
 from kohakuterrarium.builtins.tools.search_memory import SearchMemoryTool
@@ -58,7 +61,10 @@ __all__ = [
     "SendMessageTool",
     "WriteTool",
     "EditTool",
+    "FileDeleteTool",
+    "FileMoveTool",
     "GlobTool",
+    "MkdirTool",
     "MultiEditTool",
     "GrepTool",
     "InfoTool",

--- a/src/kohakuterrarium/builtins/tools/file_delete.py
+++ b/src/kohakuterrarium/builtins/tools/file_delete.py
@@ -1,0 +1,155 @@
+"""
+file_delete tool - remove files and (optionally) directories.
+
+Structured alternative to ``bash rm``. Applies the same philosophy as
+``write`` / ``edit``: the model must have *read* a file before destroying
+it, so it knows what content is being lost. Directory deletion is opt-in
+via ``recursive=true``.
+"""
+
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+from kohakuterrarium.builtins.tools.registry import register_builtin
+from kohakuterrarium.modules.tool.base import (
+    BaseTool,
+    ExecutionMode,
+    ToolResult,
+)
+from kohakuterrarium.utils.file_guard import check_read_before_write
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _lexical_abs_path(path_str: str, context: Any) -> Path:
+    """Absolute path anchored to the agent's working dir *without* following
+    symlinks. ``resolve_tool_path`` uses ``Path.resolve`` which would collapse
+    a symlink to its target — unsafe for delete, where we must remove the
+    link itself, not the thing it points to.
+    """
+    p = Path(path_str).expanduser()
+    if not p.is_absolute() and context is not None:
+        p = Path(context.working_dir) / p
+    return Path(os.path.abspath(p))
+
+
+def _clear_read_state(context: Any, target: Path) -> None:
+    """Drop any file_read_state records under *target*."""
+    if context is None or context.file_read_state is None:
+        return
+    state = context.file_read_state
+    resolved = str(target.resolve()) if target.exists() else str(target)
+    prefix = resolved + os.sep
+    to_remove = [
+        path
+        for path in list(state._records.keys())  # type: ignore[attr-defined]
+        if path == resolved or path.startswith(prefix)
+    ]
+    for path in to_remove:
+        state._records.pop(path, None)  # type: ignore[attr-defined]
+
+
+@register_builtin("file_delete")
+class FileDeleteTool(BaseTool):
+    """
+    Delete a file or directory.
+
+    Files require read-before-delete. Directories require ``recursive=true``
+    to prevent accidental tree removal.
+    """
+
+    needs_context = True
+
+    @property
+    def tool_name(self) -> str:
+        return "file_delete"
+
+    @property
+    def description(self) -> str:
+        return "Delete a file (must read first) or directory (requires recursive=true)"
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _execute(self, args: dict[str, Any], **kwargs: Any) -> ToolResult:
+        context = kwargs.get("context")
+
+        path_arg = args.get("path", "")
+        recursive = bool(args.get("recursive", False))
+
+        if not path_arg:
+            return ToolResult(error="No path provided")
+
+        # Use lexical resolution so symlinks are deleted as-is (not followed).
+        target = _lexical_abs_path(path_arg, context)
+
+        if context and context.path_guard:
+            msg = context.path_guard.check(str(target))
+            if msg:
+                return ToolResult(error=msg)
+
+        is_symlink = target.is_symlink()
+        if not target.exists() and not is_symlink:
+            return ToolResult(error=f"Path not found: {path_arg}")
+
+        # Symlinks: unlink directly. Read-before-delete does not apply —
+        # the link's content is just a path string, and deleting the link
+        # does not touch the file it points to.
+        if is_symlink:
+            try:
+                await asyncio.to_thread(os.unlink, str(target))
+            except PermissionError:
+                return ToolResult(error=f"Permission denied: {path_arg}")
+            except Exception as e:
+                logger.error("file_delete failed", error=str(e))
+                return ToolResult(error=str(e))
+            _clear_read_state(context, target)
+            logger.debug("Symlink deleted", target=str(target))
+            return ToolResult(output=f"Deleted symlink {target}", exit_code=0)
+
+        if target.is_file():
+            msg = check_read_before_write(
+                context.file_read_state if context else None, str(target)
+            )
+            if msg:
+                return ToolResult(
+                    error=msg.replace("write to", "delete").replace(
+                        "writing", "deleting"
+                    )
+                )
+            try:
+                await asyncio.to_thread(os.unlink, str(target))
+            except PermissionError:
+                return ToolResult(error=f"Permission denied: {path_arg}")
+            except Exception as e:
+                logger.error("file_delete failed", error=str(e))
+                return ToolResult(error=str(e))
+            _clear_read_state(context, target)
+            logger.debug("File deleted", target=str(target))
+            return ToolResult(output=f"Deleted file {target}", exit_code=0)
+
+        if target.is_dir():
+            if not recursive:
+                return ToolResult(
+                    error=(
+                        f"{path_arg} is a directory. Set recursive=true to "
+                        "delete it and all its contents."
+                    )
+                )
+            try:
+                await asyncio.to_thread(shutil.rmtree, str(target))
+            except PermissionError:
+                return ToolResult(error=f"Permission denied: {path_arg}")
+            except Exception as e:
+                logger.error("file_delete failed", error=str(e))
+                return ToolResult(error=str(e))
+            _clear_read_state(context, target)
+            logger.debug("Directory deleted", target=str(target))
+            return ToolResult(output=f"Deleted directory {target}", exit_code=0)
+
+        return ToolResult(error=f"Unsupported path type: {path_arg}")

--- a/src/kohakuterrarium/builtins/tools/file_move.py
+++ b/src/kohakuterrarium/builtins/tools/file_move.py
@@ -1,0 +1,161 @@
+"""
+file_move tool - move or rename files and directories.
+
+Structured alternative to ``bash mv``. Applies the same safety guards as
+``write`` / ``edit``:
+
+- Path boundary guard on both source and destination.
+- Read-before-move on destination when it already exists and ``overwrite`` is
+  set (so the model cannot silently clobber tracked content).
+- ``file_read_state`` is migrated from source to destination on success.
+"""
+
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+from kohakuterrarium.builtins.tools.registry import register_builtin
+from kohakuterrarium.modules.tool.base import (
+    BaseTool,
+    ExecutionMode,
+    ToolResult,
+)
+from kohakuterrarium.utils.file_guard import check_read_before_write
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _lexical_abs_path(path_str: str, context: Any) -> Path:
+    """Absolute path anchored to the agent's working dir *without* following
+    symlinks. Matches ``bash mv`` semantics where a symlink src is moved as
+    the link itself, not followed to its target.
+    """
+    p = Path(path_str).expanduser()
+    if not p.is_absolute() and context is not None:
+        p = Path(context.working_dir) / p
+    return Path(os.path.abspath(p))
+
+
+def _migrate_read_state(context: Any, src: Path, dst: Path) -> None:
+    """Move or clear file_read_state records affected by a move.
+
+    Files: migrate the single record from src -> dst if present.
+    Directories: clear every record whose path sits under src. We do not
+    rewrite them to dst because the model should re-read after a bulk move.
+    """
+    if context is None or context.file_read_state is None:
+        return
+    state = context.file_read_state
+    src_key = str(src)
+    if dst.is_dir():
+        prefix = src_key + os.sep
+        to_remove = [
+            path
+            for path in list(state._records.keys())  # type: ignore[attr-defined]
+            if path == src_key or path.startswith(prefix)
+        ]
+        for path in to_remove:
+            state._records.pop(path, None)  # type: ignore[attr-defined]
+        return
+    record = state.get(src_key)
+    if record is None:
+        return
+    state._records.pop(src_key, None)  # type: ignore[attr-defined]
+    state.record_read(
+        str(dst),
+        mtime_ns=record.mtime_ns,
+        partial=record.partial,
+        timestamp=record.timestamp,
+    )
+
+
+@register_builtin("file_move")
+class FileMoveTool(BaseTool):
+    """
+    Move or rename a file or directory.
+
+    Cross-device moves fall back to copy + delete transparently via
+    ``shutil.move``.
+    """
+
+    needs_context = True
+
+    @property
+    def tool_name(self) -> str:
+        return "file_move"
+
+    @property
+    def description(self) -> str:
+        return "Move or rename a file/directory (set overwrite=true to replace destination)"
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _execute(self, args: dict[str, Any], **kwargs: Any) -> ToolResult:
+        context = kwargs.get("context")
+
+        src_arg = args.get("src", "") or args.get("source", "")
+        dst_arg = args.get("dst", "") or args.get("destination", "")
+        overwrite = bool(args.get("overwrite", False))
+
+        if not src_arg:
+            return ToolResult(error="No src provided")
+        if not dst_arg:
+            return ToolResult(error="No dst provided")
+
+        src = _lexical_abs_path(src_arg, context)
+        dst = _lexical_abs_path(dst_arg, context)
+
+        if context and context.path_guard:
+            for path in (src, dst):
+                msg = context.path_guard.check(str(path))
+                if msg:
+                    return ToolResult(error=msg)
+
+        if not src.exists() and not src.is_symlink():
+            return ToolResult(error=f"Source not found: {src_arg}")
+
+        if src == dst:
+            return ToolResult(error="src and dst resolve to the same path")
+
+        if dst.exists() or dst.is_symlink():
+            if not overwrite:
+                return ToolResult(
+                    error=(
+                        f"Destination already exists: {dst_arg}. "
+                        "Set overwrite=true to replace it, or choose a different dst."
+                    )
+                )
+            if dst.is_file() and not dst.is_symlink():
+                msg = check_read_before_write(
+                    context.file_read_state if context else None, str(dst)
+                )
+                if msg:
+                    return ToolResult(error=msg)
+
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(shutil.move, str(src), str(dst))
+        except PermissionError:
+            return ToolResult(error=f"Permission denied moving {src_arg} -> {dst_arg}")
+        except Exception as e:
+            logger.error("file_move failed", error=str(e))
+            return ToolResult(error=str(e))
+
+        _migrate_read_state(context, src, dst)
+
+        if dst.is_symlink():
+            kind = "symlink"
+        elif dst.is_dir():
+            kind = "directory"
+        else:
+            kind = "file"
+        logger.debug("File moved", src=str(src), dst=str(dst), kind=kind)
+        return ToolResult(
+            output=f"Moved {kind} {src} -> {dst}",
+            exit_code=0,
+        )

--- a/src/kohakuterrarium/builtins/tools/mkdir.py
+++ b/src/kohakuterrarium/builtins/tools/mkdir.py
@@ -1,0 +1,93 @@
+"""
+mkdir tool - create directories.
+
+Structured alternative to ``bash mkdir``. Defaults match the pattern used
+elsewhere in the codebase (``Path.mkdir(parents=True, exist_ok=True)``):
+intermediate directories are created automatically, and an existing
+directory is reported (not an error) unless ``error_if_exists=true`` is set.
+"""
+
+import asyncio
+from typing import Any
+
+from kohakuterrarium.builtins.tools.registry import register_builtin
+from kohakuterrarium.modules.tool.base import (
+    BaseTool,
+    ExecutionMode,
+    ToolResult,
+    resolve_tool_path,
+)
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@register_builtin("mkdir")
+class MkdirTool(BaseTool):
+    """
+    Create a directory.
+
+    Parent directories are created by default. Existing directories are
+    treated as success unless ``error_if_exists=true``.
+    """
+
+    needs_context = True
+
+    @property
+    def tool_name(self) -> str:
+        return "mkdir"
+
+    @property
+    def description(self) -> str:
+        return "Create a directory (parents and existing dirs OK by default)"
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _execute(self, args: dict[str, Any], **kwargs: Any) -> ToolResult:
+        context = kwargs.get("context")
+
+        path_arg = args.get("path", "")
+        parents = bool(args.get("parents", True))
+        error_if_exists = bool(args.get("error_if_exists", False))
+
+        if not path_arg:
+            return ToolResult(error="No path provided")
+
+        target = resolve_tool_path(path_arg, context)
+
+        if context and context.path_guard:
+            msg = context.path_guard.check(str(target))
+            if msg:
+                return ToolResult(error=msg)
+
+        if target.exists():
+            if target.is_dir():
+                if error_if_exists:
+                    return ToolResult(error=f"Directory already exists: {path_arg}")
+                return ToolResult(
+                    output=f"Directory already exists: {target}",
+                    exit_code=0,
+                )
+            return ToolResult(error=f"Path exists and is not a directory: {path_arg}")
+
+        try:
+            await asyncio.to_thread(
+                target.mkdir, parents=parents, exist_ok=not error_if_exists
+            )
+        except FileNotFoundError:
+            return ToolResult(
+                error=(
+                    f"Parent directory missing for {path_arg}. "
+                    "Set parents=true (the default) to create it."
+                )
+            )
+        except PermissionError:
+            return ToolResult(error=f"Permission denied: {path_arg}")
+        except Exception as e:
+            logger.error("mkdir failed", error=str(e))
+            return ToolResult(error=str(e))
+
+        logger.debug("Directory created", target=str(target))
+        return ToolResult(output=f"Created directory {target}", exit_code=0)

--- a/tests/unit/test_file_fs_tools.py
+++ b/tests/unit/test_file_fs_tools.py
@@ -1,0 +1,482 @@
+"""
+Unit tests for the filesystem-manipulation tools: file_move, file_delete, mkdir.
+
+These tools are structured replacements for ``bash mv``, ``bash rm`` and
+``bash mkdir -p``. They apply the same path-boundary and read-state guards
+as ``write`` / ``edit``, so these tests focus on:
+
+- Happy paths (file + directory cases)
+- Guard enforcement (read-before-write/delete, path boundary)
+- Read-state bookkeeping on move/delete
+"""
+
+import os
+from pathlib import Path
+
+from kohakuterrarium.builtins.tool_catalog import (
+    get_builtin_tool,
+    list_builtin_tools,
+)
+from kohakuterrarium.builtins.tools.file_delete import FileDeleteTool
+from kohakuterrarium.builtins.tools.file_move import FileMoveTool
+from kohakuterrarium.builtins.tools.mkdir import MkdirTool
+from kohakuterrarium.builtins.tools.read import ReadTool
+from kohakuterrarium.modules.tool.base import ToolContext
+from kohakuterrarium.utils.file_guard import FileReadState, PathBoundaryGuard
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_context(working_dir: Path) -> ToolContext:
+    return ToolContext(
+        agent_name="test_agent",
+        session=None,
+        working_dir=working_dir,
+        file_read_state=FileReadState(),
+        path_guard=PathBoundaryGuard(cwd=str(working_dir), mode="warn"),
+    )
+
+
+async def _read(target: Path, context: ToolContext) -> None:
+    result = await ReadTool().execute({"path": str(target)}, context=context)
+    assert result.success, f"Read failed: {result.error}"
+
+
+# =============================================================================
+# Registration
+# =============================================================================
+
+
+class TestRegistration:
+    """The new tools must be available through the builtin catalog."""
+
+    def test_all_registered(self):
+        names = list_builtin_tools()
+        assert "file_move" in names
+        assert "file_delete" in names
+        assert "mkdir" in names
+
+    def test_get_builtin_returns_instances(self):
+        assert get_builtin_tool("file_move") is not None
+        assert get_builtin_tool("file_delete") is not None
+        assert get_builtin_tool("mkdir") is not None
+
+
+# =============================================================================
+# file_move
+# =============================================================================
+
+
+class TestFileMove:
+    async def test_rename_file(self, tmp_path: Path):
+        src = tmp_path / "old.py"
+        src.write_text("print('hi')\n")
+        dst = tmp_path / "new.py"
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute({"src": str(src), "dst": str(dst)}, context=context)
+        assert result.success, f"file_move failed: {result.error}"
+        assert not src.exists()
+        assert dst.read_text() == "print('hi')\n"
+
+    async def test_move_into_nested_parent_creates_dirs(self, tmp_path: Path):
+        src = tmp_path / "file.txt"
+        src.write_text("content")
+        dst = tmp_path / "nested" / "deeper" / "file.txt"
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute({"src": str(src), "dst": str(dst)}, context=context)
+        assert result.success, f"file_move failed: {result.error}"
+        assert dst.exists()
+        assert dst.read_text() == "content"
+
+    async def test_refuses_existing_dst_without_overwrite(self, tmp_path: Path):
+        src = tmp_path / "src.txt"
+        src.write_text("src")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("dst")
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute({"src": str(src), "dst": str(dst)}, context=context)
+        assert not result.success
+        assert "already exists" in result.error
+        # Neither side should have changed
+        assert src.read_text() == "src"
+        assert dst.read_text() == "dst"
+
+    async def test_overwrite_requires_read_of_dst(self, tmp_path: Path):
+        """overwrite=true still enforces read-before-write on the destination."""
+        src = tmp_path / "src.txt"
+        src.write_text("src")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("dst")
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute(
+            {"src": str(src), "dst": str(dst), "overwrite": True},
+            context=context,
+        )
+        assert not result.success
+        assert "has not been read yet" in result.error
+        # No partial state: both files still as they were
+        assert dst.read_text() == "dst"
+        assert src.read_text() == "src"
+
+    async def test_overwrite_succeeds_after_reading_dst(self, tmp_path: Path):
+        src = tmp_path / "src.txt"
+        src.write_text("src")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("dst")
+
+        context = _make_context(tmp_path)
+        await _read(dst, context)
+
+        tool = FileMoveTool()
+        result = await tool.execute(
+            {"src": str(src), "dst": str(dst), "overwrite": True},
+            context=context,
+        )
+        assert result.success, f"file_move failed: {result.error}"
+        assert dst.read_text() == "src"
+        assert not src.exists()
+
+    async def test_rejects_self_move(self, tmp_path: Path):
+        src = tmp_path / "file.txt"
+        src.write_text("content")
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute({"src": str(src), "dst": str(src)}, context=context)
+        assert not result.success
+        assert "same path" in result.error
+        assert src.read_text() == "content"
+
+    async def test_rejects_missing_src(self, tmp_path: Path):
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute(
+            {"src": str(tmp_path / "missing"), "dst": str(tmp_path / "dst")},
+            context=context,
+        )
+        assert not result.success
+        assert "not found" in result.error
+
+    async def test_rejects_missing_args(self, tmp_path: Path):
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        r1 = await tool.execute({"dst": str(tmp_path / "d")}, context=context)
+        assert not r1.success
+        assert "src" in r1.error
+
+        r2 = await tool.execute({"src": str(tmp_path / "s")}, context=context)
+        assert not r2.success
+        assert "dst" in r2.error
+
+    async def test_source_alias(self, tmp_path: Path):
+        """``source`` / ``destination`` aliases should work."""
+        src = tmp_path / "a.txt"
+        src.write_text("x")
+        dst = tmp_path / "b.txt"
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute(
+            {"source": str(src), "destination": str(dst)},
+            context=context,
+        )
+        assert result.success, f"file_move failed: {result.error}"
+        assert dst.read_text() == "x"
+
+    async def test_move_directory(self, tmp_path: Path):
+        src = tmp_path / "pkg"
+        src.mkdir()
+        (src / "a.py").write_text("a")
+        dst = tmp_path / "renamed"
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute({"src": str(src), "dst": str(dst)}, context=context)
+        assert result.success, f"file_move failed: {result.error}"
+        assert not src.exists()
+        assert (dst / "a.py").read_text() == "a"
+
+    async def test_read_state_follows_file(self, tmp_path: Path):
+        src = tmp_path / "old.py"
+        src.write_text("hello\n")
+        dst = tmp_path / "new.py"
+
+        context = _make_context(tmp_path)
+        await _read(src, context)
+        src_record_before = context.file_read_state.get(str(src))
+        assert src_record_before is not None
+
+        tool = FileMoveTool()
+        result = await tool.execute({"src": str(src), "dst": str(dst)}, context=context)
+        assert result.success, f"file_move failed: {result.error}"
+
+        # src record is gone, dst record exists
+        assert context.file_read_state.get(str(src)) is None
+        dst_record = context.file_read_state.get(str(dst))
+        assert dst_record is not None
+        assert dst_record.mtime_ns == src_record_before.mtime_ns
+
+    async def test_read_state_cleared_for_directory_move(self, tmp_path: Path):
+        src = tmp_path / "pkg"
+        src.mkdir()
+        inside = src / "a.py"
+        inside.write_text("a")
+        dst = tmp_path / "renamed"
+
+        context = _make_context(tmp_path)
+        await _read(inside, context)
+        assert context.file_read_state.get(str(inside)) is not None
+
+        tool = FileMoveTool()
+        result = await tool.execute({"src": str(src), "dst": str(dst)}, context=context)
+        assert result.success, f"file_move failed: {result.error}"
+
+        # The old record under the old path must be dropped
+        assert context.file_read_state.get(str(inside)) is None
+
+    async def test_outside_cwd_blocked_first_attempt(self, tmp_path: Path):
+        src = tmp_path / "file.txt"
+        src.write_text("x")
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        # Pick an arbitrary outside path (we will never actually move)
+        outside = Path("/tmp") / "definitely_outside_cwd_xyz.txt"
+        result = await tool.execute(
+            {"src": str(src), "dst": str(outside)},
+            context=context,
+        )
+        assert not result.success
+        assert "outside the working directory" in result.error
+        assert src.read_text() == "x"
+
+    async def test_symlink_moved_as_link(self, tmp_path: Path):
+        """Moving a symlink must rename the link, not follow to its target."""
+        target = tmp_path / "real.txt"
+        target.write_text("real content")
+        link_src = tmp_path / "link_old"
+        link_dst = tmp_path / "link_new"
+        os.symlink(target, link_src)
+
+        context = _make_context(tmp_path)
+        tool = FileMoveTool()
+
+        result = await tool.execute(
+            {"src": str(link_src), "dst": str(link_dst)}, context=context
+        )
+        assert result.success, f"file_move failed: {result.error}"
+        assert not link_src.exists()
+        assert link_dst.is_symlink()
+        # Target file is untouched
+        assert target.read_text() == "real content"
+
+
+# =============================================================================
+# file_delete
+# =============================================================================
+
+
+class TestFileDelete:
+    async def test_delete_file_requires_read(self, tmp_path: Path):
+        target = tmp_path / "file.txt"
+        target.write_text("content")
+
+        context = _make_context(tmp_path)
+        tool = FileDeleteTool()
+
+        result = await tool.execute({"path": str(target)}, context=context)
+        assert not result.success
+        assert "has not been read yet" in result.error
+        assert target.exists()
+
+    async def test_delete_file_after_read(self, tmp_path: Path):
+        target = tmp_path / "file.txt"
+        target.write_text("content")
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        tool = FileDeleteTool()
+        result = await tool.execute({"path": str(target)}, context=context)
+        assert result.success, f"delete failed: {result.error}"
+        assert not target.exists()
+        # Read-state was cleared
+        assert context.file_read_state.get(str(target)) is None
+
+    async def test_delete_file_detects_stale_read(self, tmp_path: Path):
+        target = tmp_path / "file.txt"
+        target.write_text("original")
+
+        context = _make_context(tmp_path)
+        await _read(target, context)
+
+        # External modification bumps the mtime
+        target.write_text("modified")
+        record = context.file_read_state.get(str(target))
+        atime_ns = os.stat(target).st_atime_ns
+        os.utime(target, ns=(atime_ns, record.mtime_ns + 1_000_000_000))
+
+        tool = FileDeleteTool()
+        result = await tool.execute({"path": str(target)}, context=context)
+        assert not result.success
+        assert "modified since last read" in result.error
+        assert target.exists()
+
+    async def test_delete_directory_requires_recursive(self, tmp_path: Path):
+        target = tmp_path / "dir"
+        target.mkdir()
+        (target / "a.py").write_text("a")
+
+        context = _make_context(tmp_path)
+        tool = FileDeleteTool()
+
+        result = await tool.execute({"path": str(target)}, context=context)
+        assert not result.success
+        assert "recursive=true" in result.error
+        assert target.exists()
+
+    async def test_delete_directory_recursive(self, tmp_path: Path):
+        target = tmp_path / "dir"
+        target.mkdir()
+        inside = target / "a.py"
+        inside.write_text("a")
+
+        context = _make_context(tmp_path)
+        await _read(inside, context)
+
+        tool = FileDeleteTool()
+        result = await tool.execute(
+            {"path": str(target), "recursive": True}, context=context
+        )
+        assert result.success, f"delete failed: {result.error}"
+        assert not target.exists()
+        # Read state under the deleted tree was cleared
+        assert context.file_read_state.get(str(inside)) is None
+
+    async def test_rejects_missing_path_arg(self, tmp_path: Path):
+        context = _make_context(tmp_path)
+        tool = FileDeleteTool()
+
+        result = await tool.execute({}, context=context)
+        assert not result.success
+        assert "No path" in result.error
+
+    async def test_rejects_nonexistent_path(self, tmp_path: Path):
+        context = _make_context(tmp_path)
+        tool = FileDeleteTool()
+
+        result = await tool.execute(
+            {"path": str(tmp_path / "missing")}, context=context
+        )
+        assert not result.success
+        assert "not found" in result.error
+
+    async def test_delete_symlink_without_read(self, tmp_path: Path):
+        """Symlinks are exempt from the read-before-delete guard."""
+        target = tmp_path / "target.txt"
+        target.write_text("content")
+        link = tmp_path / "link.txt"
+        os.symlink(target, link)
+
+        context = _make_context(tmp_path)
+        tool = FileDeleteTool()
+
+        result = await tool.execute({"path": str(link)}, context=context)
+        assert result.success, f"delete failed: {result.error}"
+        assert not link.is_symlink()
+        # The target must remain intact
+        assert target.read_text() == "content"
+
+
+# =============================================================================
+# mkdir
+# =============================================================================
+
+
+class TestMkdir:
+    async def test_creates_nested_dir(self, tmp_path: Path):
+        target = tmp_path / "a" / "b" / "c"
+
+        context = _make_context(tmp_path)
+        tool = MkdirTool()
+
+        result = await tool.execute({"path": str(target)}, context=context)
+        assert result.success, f"mkdir failed: {result.error}"
+        assert target.is_dir()
+
+    async def test_existing_dir_succeeds(self, tmp_path: Path):
+        target = tmp_path / "dir"
+        target.mkdir()
+
+        context = _make_context(tmp_path)
+        tool = MkdirTool()
+
+        result = await tool.execute({"path": str(target)}, context=context)
+        assert result.success
+        assert "already exists" in result.output
+
+    async def test_error_if_exists_rejects_existing_dir(self, tmp_path: Path):
+        target = tmp_path / "dir"
+        target.mkdir()
+
+        context = _make_context(tmp_path)
+        tool = MkdirTool()
+
+        result = await tool.execute(
+            {"path": str(target), "error_if_exists": True}, context=context
+        )
+        assert not result.success
+        assert "already exists" in result.error
+
+    async def test_rejects_existing_file(self, tmp_path: Path):
+        target = tmp_path / "file.txt"
+        target.write_text("content")
+
+        context = _make_context(tmp_path)
+        tool = MkdirTool()
+
+        result = await tool.execute({"path": str(target)}, context=context)
+        assert not result.success
+        assert "not a directory" in result.error
+        assert target.is_file()
+
+    async def test_parents_false_requires_existing_parent(self, tmp_path: Path):
+        target = tmp_path / "missing_parent" / "child"
+
+        context = _make_context(tmp_path)
+        tool = MkdirTool()
+
+        result = await tool.execute(
+            {"path": str(target), "parents": False}, context=context
+        )
+        assert not result.success
+        assert "Parent directory missing" in result.error
+        assert not target.exists()
+
+    async def test_rejects_missing_path_arg(self, tmp_path: Path):
+        context = _make_context(tmp_path)
+        tool = MkdirTool()
+
+        result = await tool.execute({}, context=context)
+        assert not result.success
+        assert "No path" in result.error


### PR DESCRIPTION
## Summary

Close a gap where structured filesystem operations fell back to `bash mv` / `bash rm` / `bash mkdir`, which contradicts the project's own stated principle that *"dedicated tools give structured output and enables safety guards"* (`builtin_skills/tools/bash.md`).

This PR adds three new builtin tools:

- **`file_move`** — move or rename a file/directory. Path-guarded on both `src` and `dst`; `overwrite=true` requires the destination to have been `read` first (so tracked content cannot be silently clobbered); `file_read_state` is migrated from `src` to `dst` on success.
- **`file_delete`** — delete a file or directory. Files require read-before-delete (same spirit as the write/edit guard — you must know what you are destroying); directories require explicit `recursive=true`; symlinks are unlinked without touching their target.
- **`mkdir`** — create a directory with `mkdir -p` semantics by default, with `parents=false` / `error_if_exists=true` opt-ins.

Both `file_move` and `file_delete` use **lexical path resolution** (no symlink following) so symlinks are moved/unlinked as the link itself, matching `bash mv`/`bash rm` semantics and preventing accidental target clobbering.

The `builtin_skills/tools/bash.md` "Prefer Dedicated Tools" list is extended accordingly.

## Files

- `src/kohakuterrarium/builtins/tools/file_move.py`
- `src/kohakuterrarium/builtins/tools/file_delete.py`
- `src/kohakuterrarium/builtins/tools/mkdir.py`
- `src/kohakuterrarium/builtins/tools/__init__.py` — register the three tools
- `src/kohakuterrarium/builtin_skills/tools/{file_move,file_delete,mkdir}.md` — skill manifests
- `src/kohakuterrarium/builtin_skills/tools/bash.md` — extend the "Prefer Dedicated Tools" list
- `tests/unit/test_file_fs_tools.py` — 30 new unit tests

## Test plan

- [x] `pytest tests/unit/test_file_fs_tools.py` — 30/30 pass (registration, happy paths for files/dirs/symlinks, guard enforcement for missing read / stale mtime / path boundary / overwrite / recursive, read-state migration on move, read-state cleared on delete)
- [x] Full unit suite: `pytest tests/unit/` — 1926 passed, 11 pre-existing skips, no regressions
- [x] `black` formatted, `ruff check` clean