### PR TITLE
feat(tools): implement missing `think` builtin

### DIFF
--- a/src/kohakuterrarium/builtin_skills/tools/think.md
+++ b/src/kohakuterrarium/builtin_skills/tools/think.md
@@ -1,0 +1,113 @@
+---
+name: think
+description: Record a reasoning step (no-op); preserves thought in the event log
+category: builtin
+tags: [reasoning, planning, event-log]
+---
+
+# think
+
+Record a deliberate reasoning step without any side effects. The tool is a
+no-op: it does not touch the filesystem, network, or any external state. Its
+only job is to emit a `tool_call` / `tool_result` pair into the session event
+log so that the reasoning is:
+
+- Preserved across context compaction (compact summaries are derived from the
+  event log, not from raw stream text)
+- Preserved across session resume (the `.kohakutr` file replays events)
+- Visible to observers (TUI, web dashboard, `kt resume`) as a discrete step
+  rather than blended into free-form streaming text
+
+## WHEN TO USE
+
+- Pausing to plan before a sequence of risky or expensive operations
+- Working through a tricky diagnosis out loud, step by step
+- Recording a decision or tradeoff so future you (after compaction) can still
+  see the reasoning
+- Splitting a long chain of thought into named checkpoints so a reviewer can
+  follow the agent's thinking
+- Keeping structured reasoning separate from user-visible output, especially
+  in agents where the controller is wired to `output_to: external`
+
+## WHEN NOT TO USE
+
+- As a substitute for actually doing the work -- a `think` call that is never
+  followed by concrete tool calls is noise
+- For short in-line asides that would fit naturally in streaming text
+- For information you want the user to see -- `think` output is not routed to
+  external outputs; it only lives in the event log
+
+## HOW TO USE
+
+```
+tool call: think(
+Plain text containing the full thought.
+Can span multiple lines.
+)
+```
+
+The body becomes the `thought` argument. Passing `thought=...` explicitly also
+works.
+
+## Arguments
+
+| Arg | Type | Description |
+|-----|------|-------------|
+| thought | content | The reasoning to record (required; falls back to the body) |
+
+## Examples
+
+Plan before a multi-step refactor:
+
+```
+tool call: think(
+Plan:
+1. Grep for all call sites of parse_config
+2. Confirm the signature change is backward compatible
+3. Update callers in two passes: tests first, then src
+4. Run the full suite before committing
+)
+```
+
+Record a tradeoff:
+
+```
+tool call: think(
+Picking recursion over iteration here -- the tree depth is bounded at ~8
+in practice, so stack overflow is not a concern, and the recursive form
+mirrors the AST structure 1:1. Iterative would need an explicit work stack.
+)
+```
+
+Checkpoint partway through a long task:
+
+```
+tool call: think(
+Progress so far: migrations reverted cleanly, schema is back on v12.
+Next: rerun the failing integration test to confirm the fix.
+)
+```
+
+## Output Format
+
+The tool echoes the thought back as its result. The result is otherwise
+ignored by the framework -- its purpose is event-log preservation, not
+downstream data flow.
+
+## LIMITATIONS
+
+- Pure no-op: does not change any state, does not call any LLM, does not
+  contact the network
+- Not routed to external outputs -- do not use `think` to communicate with
+  the user
+- If the `thought` is empty, the tool returns an error (prevents accidental
+  empty-call spam)
+
+## TIPS
+
+- Prefer one `think` per coherent reasoning step; many tiny thinks fragment
+  the event log
+- Lead with a short label (`Plan:`, `Tradeoff:`, `Progress:`) so the event
+  log is scannable
+- Combine with `scratchpad` when the plan needs to be retrieved later --
+  `think` writes to the log, `scratchpad` writes to working memory

--- a/src/kohakuterrarium/builtins/tools/__init__.py
+++ b/src/kohakuterrarium/builtins/tools/__init__.py
@@ -31,6 +31,7 @@ from kohakuterrarium.builtins.tools.scratchpad_tool import ScratchpadTool
 from kohakuterrarium.builtins.tools.search_memory import SearchMemoryTool
 from kohakuterrarium.builtins.tools.send_message import SendMessageTool
 from kohakuterrarium.builtins.tools.stop_task import StopTaskTool
+from kohakuterrarium.builtins.tools.think import ThinkTool
 from kohakuterrarium.builtins.tools.tree import TreeTool
 from kohakuterrarium.builtins.tools.web_fetch import WebFetchTool
 from kohakuterrarium.builtins.tools.web_search import WebSearchTool
@@ -65,6 +66,7 @@ __all__ = [
     "JsonReadTool",
     "JsonWriteTool",
     "StopTaskTool",
+    "ThinkTool",
     "TreeTool",
     "WebFetchTool",
     "WebSearchTool",

--- a/src/kohakuterrarium/builtins/tools/think.py
+++ b/src/kohakuterrarium/builtins/tools/think.py
@@ -1,0 +1,45 @@
+"""Think tool - preserve reasoning as a tool event in the session log.
+
+The tool is a deliberate no-op at runtime: it takes a `thought` argument
+and echoes it back as the tool result. Its value is purely procedural --
+writing the reasoning into the append-only event log so it survives
+context compaction and session resume, and gives the controller a
+structured place to deliberate without emitting user-visible output.
+"""
+
+from typing import Any
+
+from kohakuterrarium.builtins.tools.registry import register_builtin
+from kohakuterrarium.modules.tool.base import BaseTool, ExecutionMode, ToolResult
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@register_builtin("think")
+class ThinkTool(BaseTool):
+    """Record a reasoning step as a tool event. No side effects."""
+
+    @property
+    def tool_name(self) -> str:
+        return "think"
+
+    @property
+    def description(self) -> str:
+        return "Record a reasoning step (no-op); preserves thought in the event log"
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _execute(self, args: dict[str, Any]) -> ToolResult:
+        """Echo the thought back so it lands in the tool_result event."""
+        thought = args.get("thought") or args.get("body") or args.get("content") or ""
+        if isinstance(thought, str):
+            thought = thought.strip()
+
+        if not thought:
+            return ToolResult(error="thought is required", exit_code=1)
+
+        logger.debug("Think tool recorded thought", length=len(thought))
+        return ToolResult(output=thought, exit_code=0)

--- a/tests/unit/test_think_tool.py
+++ b/tests/unit/test_think_tool.py
@@ -1,0 +1,141 @@
+"""Unit tests for the ``think`` builtin tool.
+
+Covers:
+- Direct registration via @register_builtin decorator
+- tool_name / description / execution_mode properties
+- Happy path: thought echoed back as ToolResult.output
+- Fallback arg keys (body, content)
+- Empty / whitespace-only thought yields an error ToolResult
+- Catalog lookup round-trips to a fresh ThinkTool instance
+- Skill manifest (builtin_skills/tools/think.md) is present and wired up via
+  get_full_documentation()
+"""
+
+from kohakuterrarium.builtin_skills import get_builtin_tool_doc
+from kohakuterrarium.builtins.tool_catalog import get_builtin_tool, is_builtin_tool
+from kohakuterrarium.builtins.tools.think import ThinkTool
+from kohakuterrarium.modules.tool.base import ExecutionMode
+
+
+class TestThinkToolProperties:
+    """Static properties the framework relies on for prompt aggregation."""
+
+    def test_tool_name(self):
+        tool = ThinkTool()
+        assert tool.tool_name == "think"
+
+    def test_description_is_non_empty(self):
+        tool = ThinkTool()
+        assert tool.description
+        assert isinstance(tool.description, str)
+
+    def test_execution_mode_is_direct(self):
+        tool = ThinkTool()
+        assert tool.execution_mode is ExecutionMode.DIRECT
+
+    def test_does_not_need_context(self):
+        assert ThinkTool.needs_context is False
+
+
+class TestThinkToolRegistration:
+    """Catalog lookup and is_builtin checks."""
+
+    def test_registered_in_catalog(self):
+        assert is_builtin_tool("think") is True
+
+    def test_get_builtin_returns_think_tool(self):
+        instance = get_builtin_tool("think")
+        assert instance is not None
+        assert isinstance(instance, ThinkTool)
+
+
+class TestThinkToolExecution:
+    """Execution behaviour: echo the thought, reject empties."""
+
+    async def test_echoes_thought_arg(self):
+        tool = ThinkTool()
+        result = await tool.execute({"thought": "Plan: do the thing."})
+        assert result.success
+        assert result.exit_code == 0
+        assert result.output == "Plan: do the thing."
+
+    async def test_falls_back_to_body_arg(self):
+        tool = ThinkTool()
+        result = await tool.execute({"body": "Body-style content."})
+        assert result.success
+        assert result.output == "Body-style content."
+
+    async def test_falls_back_to_content_arg(self):
+        tool = ThinkTool()
+        result = await tool.execute({"content": "Content-style content."})
+        assert result.success
+        assert result.output == "Content-style content."
+
+    async def test_prefers_thought_over_body(self):
+        tool = ThinkTool()
+        result = await tool.execute(
+            {"thought": "primary", "body": "secondary", "content": "tertiary"}
+        )
+        assert result.success
+        assert result.output == "primary"
+
+    async def test_strips_surrounding_whitespace(self):
+        tool = ThinkTool()
+        result = await tool.execute({"thought": "  indented thought \n"})
+        assert result.success
+        assert result.output == "indented thought"
+
+    async def test_preserves_multiline_body(self):
+        tool = ThinkTool()
+        thought = "Line one.\nLine two.\nLine three."
+        result = await tool.execute({"thought": thought})
+        assert result.success
+        assert result.output == thought
+
+    async def test_empty_thought_returns_error(self):
+        tool = ThinkTool()
+        result = await tool.execute({"thought": ""})
+        assert not result.success
+        assert result.error is not None
+        assert result.exit_code == 1
+
+    async def test_whitespace_only_thought_returns_error(self):
+        tool = ThinkTool()
+        result = await tool.execute({"thought": "   \n\t  "})
+        assert not result.success
+        assert "required" in result.error.lower()
+
+    async def test_no_args_returns_error(self):
+        tool = ThinkTool()
+        result = await tool.execute({})
+        assert not result.success
+        assert result.error is not None
+
+    async def test_non_string_thought_does_not_raise(self):
+        """Non-string ``thought`` should fail cleanly rather than raise.
+
+        If an upstream parser ever hands us a non-string value, the tool
+        must still behave like a tool (return a ``ToolResult``), not blow
+        up with an uncaught TypeError mid-stream.
+        """
+        tool = ThinkTool()
+        result = await tool.execute({"thought": 123})
+        # Either rejected as empty-ish or accepted. Must not raise.
+        assert result is not None
+
+
+class TestThinkToolDocumentation:
+    """Skill manifest is present and wired to ``info``/``get_full_documentation``."""
+
+    def test_builtin_skill_manifest_exists(self):
+        doc = get_builtin_tool_doc("think")
+        assert doc is not None
+        assert "# think" in doc
+
+    def test_get_full_documentation_returns_skill_manifest(self):
+        tool = ThinkTool()
+        doc = tool.get_full_documentation()
+        assert "# think" in doc
+        # Must include the key sections promised to users
+        assert "WHEN TO USE" in doc
+        assert "Arguments" in doc


### PR DESCRIPTION
## Summary

Closes the gap where `think` is documented as a builtin tool and referenced by 13+ example configs, but had no implementation. `bootstrap/tools.py:54-57` only warn-logs unknown builtins, so affected configs silently ran without the tool — worse, if a controller emits `##think##...##think##` (the syntax implied by docs + example prompts), the executor lookup fails and a tool-not-found error lands in the controller context instead of the intended reasoning checkpoint.

## What's added

- **`src/kohakuterrarium/builtins/tools/think.py`** — `ThinkTool`, `ExecutionMode.DIRECT`, no side effects. Accepts `thought` (with `body` / `content` fallbacks to match the arg conventions of `ask_user` and `tree`) and echoes it back so the `tool_call` / `tool_result` pair persists in the `.kohakutr` event log — surviving context compaction and `kt resume`.
- **`src/kohakuterrarium/builtin_skills/tools/think.md`** — skill manifest following the `scratchpad.md` structure (WHEN / HOW / Arguments / Examples / LIMITATIONS / TIPS); loaded on demand by `##info think##`.
- **`src/kohakuterrarium/builtins/tools/__init__.py`** — import + `__all__` entry so `@register_builtin("think")` fires at package import time.
- **`tests/unit/test_think_tool.py`** — 18 tests: catalog registration round-trip, property checks, execution happy-path, three arg-key fallbacks, whitespace stripping, multiline preservation, empty / whitespace-only / missing rejection, non-string defensive handling, and skill-manifest wiring via `get_full_documentation()`.

## Configs that become actually runnable as documented

- `examples/agent-apps/planner_agent`, `monitor_agent`, `discord_bot`, `conversational`
- `examples/terrariums/code_review_team/creatures/{developer, reviewer, tester}`
- `examples/terrariums/novel_terrarium/creatures/{brainstorm, planner, writer}`
- `examples/terrariums/research_assistant/creatures/{coordinator, searcher, analyst}`
- `builtin_skills/subagents/plan.md` (references `think` in its toolset)

## Observable behavior after the fix

1. Startup "Unknown built-in tool" warning for `think` goes away across all affected configs.
2. `prompt/aggregator.py` auto-emits `- think: Record a reasoning step (no-op); preserves thought in the event log` into the controller's tool list.
3. `##info think##` returns the full skill manifest.
4. A `##think##` call starts non-blocking via `asyncio.create_task` like every other tool, completes near-instantly (pure no-op), and emits `tool_call` + `tool_result` events captured by `session/output.py:187,197`.
5. TUI / web dashboard render it as a discrete tool block rather than blended streaming text.
6. Reasoning survives context compaction (event log is the source of truth) and `kt resume` (tool_call / tool_result pair is replayed).

## Test plan

- [x] `ruff check` on all new/edited files — clean
- [x] `black` — applied
- [x] New test file: `pytest tests/unit/test_think_tool.py -v` — **18/18 passed**
- [x] Full unit suite: `pytest tests/unit/` — **1908 passed, 11 skipped**, no regressions