### PR TITLE
fix(cli): persist submissions to FileHistory so Up/Down can recall them

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/composer.py
+++ b/src/kohakuterrarium/builtins/cli_rich/composer.py
@@ -150,7 +150,10 @@ class Composer:
                 buf.delete_before_cursor()
                 buf.insert_text("\n")
                 return
-            buf.reset()
+            # append_to_history=True persists the submission to FileHistory
+            # so Up/Down can recall it next session. Default bindings handle
+            # the arrow keys themselves (auto_up/auto_down).
+            buf.reset(append_to_history=True)
             if self._on_submit:
                 self._on_submit(text)
 

--- a/tests/unit/test_run_cli.py
+++ b/tests/unit/test_run_cli.py
@@ -1,5 +1,7 @@
 import types
 
+from prompt_toolkit.history import FileHistory
+
 
 class _DummyVault:
     def __init__(self, *args, **kwargs):
@@ -223,3 +225,71 @@ def test_explicit_mode_without_custom_io_does_not_warn(monkeypatch, tmp_path, ca
     rc = run_cli.run_agent_cli(str(config_dir), log_level="INFO", io_mode="plain")
     assert rc == 0
     assert "Warning:" not in capsys.readouterr().out
+
+
+def test_rich_cli_enter_persists_submission_to_history(tmp_path, monkeypatch):
+    """Issue #28: submissions must be appended to FileHistory so Up/Down can
+    recall them later. The previous `_enter` handler called `buf.reset()`
+    without `append_to_history=True`, so nothing was ever persisted."""
+    from kohakuterrarium.builtins.cli_rich import composer as composer_mod
+
+    monkeypatch.setattr(composer_mod, "HISTORY_DIR", tmp_path)
+
+    submitted: list[str] = []
+    composer = composer_mod.Composer(
+        creature_name="test-creature",
+        on_submit=submitted.append,
+    )
+
+    buf = composer.text_area.buffer
+    buf.text = "first command"
+
+    enter_binding = next(
+        b for b in composer.key_bindings.bindings if b.handler.__name__ == "_enter"
+    )
+
+    class _Event:
+        def __init__(self, current_buffer):
+            self.current_buffer = current_buffer
+
+    enter_binding.handler(_Event(buf))
+
+    # Submission was forwarded and buffer cleared
+    assert submitted == ["first command"]
+    assert buf.text == ""
+
+    # And — the critical assertion — it was persisted to history on disk
+    history_file = tmp_path / "test-creature.txt"
+    assert history_file.exists()
+    persisted = FileHistory(str(history_file)).load_history_strings()
+    assert list(persisted) == ["first command"]
+
+
+async def test_rich_cli_enter_does_not_persist_line_continuation(tmp_path, monkeypatch):
+    """A trailing backslash extends the input to a new line — that partial
+    draft must NOT be appended to history. (Async because prompt_toolkit's
+    Buffer.insert_text schedules a completer task on the running loop.)"""
+    from kohakuterrarium.builtins.cli_rich import composer as composer_mod
+
+    monkeypatch.setattr(composer_mod, "HISTORY_DIR", tmp_path)
+
+    composer = composer_mod.Composer(creature_name="test-creature")
+    buf = composer.text_area.buffer
+    buf.text = "line1\\"
+    buf.cursor_position = len(buf.text)
+
+    enter_binding = next(
+        b for b in composer.key_bindings.bindings if b.handler.__name__ == "_enter"
+    )
+
+    class _Event:
+        def __init__(self, current_buffer):
+            self.current_buffer = current_buffer
+
+    enter_binding.handler(_Event(buf))
+
+    # Backslash dropped, newline inserted — draft lives on, nothing in history
+    assert buf.text == "line1\n"
+    history_file = tmp_path / "test-creature.txt"
+    if history_file.exists():
+        assert list(FileHistory(str(history_file)).load_history_strings()) == []


### PR DESCRIPTION
## Summary

- The rich CLI's `_enter` handler called `buf.reset()` without `append_to_history=True`, so submitted text was never persisted to the on-disk `FileHistory`
- With an empty history, prompt_toolkit's default `Up`/`Down` bindings (`auto_up`/`auto_down`) had nothing to walk through — giving the impression that arrow-key recall was broken
- Single-line fix: `buf.reset()` → `buf.reset(append_to_history=True)` in `src/kohakuterrarium/builtins/cli_rich/composer.py`

Fixes https://github.com/Kohaku-Lab/KohakuTerrarium/issues/28

## Test plan

- [x] `pytest tests/unit/test_run_cli.py` passes (11/11)
- [x] New `test_rich_cli_enter_persists_submission_to_history` — presses Enter and asserts the text lands in `FileHistory` on disk
- [x] New `test_rich_cli_enter_does_not_persist_line_continuation` — backslash line continuations must not leak drafts into history
- [x] Manual: `kt run <creature>`, submit a message, quit, run again, press ↑ → previous message recalled