### PR TITLE
feat(cli): /model arrow-key selector with type-to-filter search

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/app.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app.py
@@ -34,12 +34,17 @@ from typing import Any
 from prompt_toolkit.application import Application
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.key_binding.key_bindings import (
+    ConditionalKeyBindings,
+    merge_key_bindings,
+)
 from prompt_toolkit.layout import (
     ConditionalContainer,
     HSplit,
     Layout,
     Window,
 )
+from prompt_toolkit.layout.containers import FloatContainer
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.output import ColorDepth
@@ -58,15 +63,9 @@ from kohakuterrarium.builtins.cli_rich.runtime import (
     make_output,
     spawn,
 )
+from kohakuterrarium.builtins.cli_rich.selector import SelectorOverlay
+from kohakuterrarium.builtins.cli_rich.slash import SlashHandler
 from kohakuterrarium.builtins.cli_rich.theme import COLOR_BANNER
-from kohakuterrarium.builtins.user_commands import (
-    get_builtin_user_command,
-    list_builtin_user_commands,
-)
-from kohakuterrarium.modules.user_command.base import (
-    UserCommandContext,
-    parse_slash_command,
-)
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -80,9 +79,10 @@ class RichCLIApp:
     def __init__(self, agent: Any):
         self.agent = agent
         self.live_region = LiveRegion()
+        self.selector = SelectorOverlay()
+        self.slash = SlashHandler(self)
         self._exit_requested = False
         self._processing = False
-        self._command_registry: dict = {}
         self._pending_task: asyncio.Task | None = None
 
         # Console used only for committing to scrollback (via run_in_terminal).
@@ -215,12 +215,19 @@ class RichCLIApp:
             always_hide_cursor=True,
         )
 
-        root_container = HSplit(
+        base_container = HSplit(
             [
                 status_container,
                 input_frame,
                 footer_window,
             ]
+        )
+
+        # FloatContainer lets SelectorOverlay paint a modal popup above
+        # the normal layout without spawning a second Application.
+        root_container = FloatContainer(
+            content=base_container,
+            floats=self.selector.build_floats(),
         )
 
         layout = Layout(
@@ -231,12 +238,38 @@ class RichCLIApp:
             {
                 "input.frame": "ansicyan",
                 "input.frame.label": "ansicyan bold",
+                # Selector overlay — same blue as the TUI SelectionModal.
+                "selector.frame": "#0F52BA",
+                "selector.frame.label": "#0F52BA bold",
+                "selector.frame.confirm": "#D4920A",
+                "selector.frame.confirm.label": "#D4920A bold",
+                "selector.title": "bold",
+                "selector.hint": "#888888",
+                "selector.row": "",
+                "selector.row.highlight": "bg:#0F52BA #ffffff bold",
+                "selector.row.extra": "#888888",
+                "selector.row.extra.highlight": "bg:#0F52BA #d0d0d0",
             }
+        )
+
+        # Gate the composer's key bindings so they yield while the
+        # overlay is open — otherwise composer's global Enter/Esc
+        # handlers would fire alongside the overlay's.
+        selector_visible = Condition(lambda: self.selector.visible)
+        app_kb = merge_key_bindings(
+            [
+                ConditionalKeyBindings(
+                    self.selector.key_bindings, filter=selector_visible
+                ),
+                ConditionalKeyBindings(
+                    self.composer.key_bindings, filter=~selector_visible
+                ),
+            ]
         )
 
         return Application(
             layout=layout,
-            key_bindings=self.composer.key_bindings,
+            key_bindings=app_kb,
             full_screen=False,
             mouse_support=False,
             erase_when_done=False,
@@ -293,7 +326,7 @@ class RichCLIApp:
 
         # Slash command path
         if text.startswith("/"):
-            self._pending_task = spawn(self._handle_slash(text))
+            self._pending_task = spawn(self.slash.handle(text))
             return
 
         # Send to agent (in a background task so the UI stays responsive)
@@ -316,43 +349,10 @@ class RichCLIApp:
     # ── Slash command dispatch ──
 
     def _wire_command_registry(self) -> None:
-        registry: dict = {}
-        for name in list_builtin_user_commands():
-            cmd = get_builtin_user_command(name)
-            if cmd:
-                registry[name] = cmd
+        """Populate the builtin command registry + wire composer autocomplete."""
+        registry = self.slash.wire_builtins()
         self.composer.set_command_registry(registry)
         self.composer.set_command_context(agent=self.agent)
-        self._command_registry = registry
-
-    async def _handle_slash(self, text: str) -> None:
-        name, args = parse_slash_command(text)
-        cmd = self._command_registry.get(name) or get_builtin_user_command(name)
-        if cmd is None:
-            self._commit_text(f"[red]Unknown command:[/red] /{name}")
-            return
-
-        ctx = UserCommandContext(
-            agent=self.agent,
-            session=getattr(self.agent, "session", None),
-            input_module=getattr(self.agent, "input", None),
-            extra={"command_registry": self._command_registry},
-        )
-        try:
-            result = await cmd.execute(args, ctx)
-        except Exception as e:
-            self._commit_text(f"[red]Command error:[/red] {e}")
-            return
-
-        if result.error:
-            self._commit_text(f"[red]{result.error}[/red]")
-        if result.output:
-            self._commit_text(result.output)
-
-        if name in ("exit", "quit"):
-            self._exit_requested = True
-            if self.app:
-                self.app.exit()
 
     # ── Output module callbacks (called by RichCLIOutput) ──
 

--- a/src/kohakuterrarium/builtins/cli_rich/app.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app.py
@@ -63,7 +63,7 @@ from kohakuterrarium.builtins.cli_rich.runtime import (
     make_output,
     spawn,
 )
-from kohakuterrarium.builtins.cli_rich.selector import SelectorOverlay
+from kohakuterrarium.builtins.cli_rich.selector import SELECTOR_STYLES, SelectorOverlay
 from kohakuterrarium.builtins.cli_rich.slash import SlashHandler
 from kohakuterrarium.builtins.cli_rich.theme import COLOR_BANNER
 from kohakuterrarium.utils.logging import get_logger
@@ -238,17 +238,7 @@ class RichCLIApp:
             {
                 "input.frame": "ansicyan",
                 "input.frame.label": "ansicyan bold",
-                # Selector overlay — same blue as the TUI SelectionModal.
-                "selector.frame": "#0F52BA",
-                "selector.frame.label": "#0F52BA bold",
-                "selector.frame.confirm": "#D4920A",
-                "selector.frame.confirm.label": "#D4920A bold",
-                "selector.title": "bold",
-                "selector.hint": "#888888",
-                "selector.row": "",
-                "selector.row.highlight": "bg:#0F52BA #ffffff bold",
-                "selector.row.extra": "#888888",
-                "selector.row.extra.highlight": "bg:#0F52BA #d0d0d0",
+                **SELECTOR_STYLES,
             }
         )
 

--- a/src/kohakuterrarium/builtins/cli_rich/app.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app.py
@@ -215,16 +215,22 @@ class RichCLIApp:
             always_hide_cursor=True,
         )
 
-        base_container = HSplit(
-            [
-                status_container,
-                input_frame,
-                footer_window,
-            ]
+        # Reserve rows above the composer while the overlay is open.
+        # In non-full-screen mode the app only occupies content rows, so
+        # a Float at top=0 needs the HSplit to grow to hold it —
+        # without this the terminal-bottom case falls back to
+        # prompt_toolkit's "Window too small…".
+        overlay_spacer = Window(
+            height=self._overlay_spacer_height, always_hide_cursor=True
         )
 
-        # FloatContainer lets SelectorOverlay paint a modal popup above
-        # the normal layout without spawning a second Application.
+        base_container = HSplit(
+            [overlay_spacer, status_container, input_frame, footer_window]
+        )
+
+        # FloatContainer paints the overlay modal above the HSplit
+        # without spawning a second Application; Floats are top=0
+        # anchored so they land inside the spacer.
         root_container = FloatContainer(
             content=base_container,
             floats=self.selector.build_floats(),
@@ -272,6 +278,10 @@ class RichCLIApp:
         )
 
     # ── FormattedTextControl callbacks ──
+
+    def _overlay_spacer_height(self) -> Dimension:
+        """Exact spacer height (0 when hidden). Re-evaluated per paint."""
+        return Dimension.exact(self.selector.current_height())
 
     def _status_text(self):
         width = self._terminal_width()

--- a/src/kohakuterrarium/builtins/cli_rich/selector.py
+++ b/src/kohakuterrarium/builtins/cli_rich/selector.py
@@ -10,8 +10,14 @@ Async API: ``show_select(title, options, current)`` returns the picked
 value (or ``None`` on cancel); ``show_confirm(message)`` returns bool.
 Both use an ``asyncio.Future`` set from within the key handlers.
 
-Single-instance: the overlay supports one pending interaction at a time.
-Callers serialize through the app's ``_handle_slash`` task.
+Select mode supports live type-to-filter: any printable key appends
+to the query, Backspace removes, Ctrl+U clears. Filtering is a
+case-insensitive substring match across label / value / model /
+provider — highlight clamps to the filtered view so Enter always
+picks a visible row.
+
+Single-instance: the overlay supports one pending interaction at a
+time. Callers serialize through the app's ``_handle_slash`` task.
 """
 
 import asyncio
@@ -21,11 +27,58 @@ from prompt_toolkit.application import Application
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import StyleAndTextTuples
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout import HSplit, Window
 from prompt_toolkit.layout.containers import ConditionalContainer, Float
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.widgets import Frame
+
+# Column widths (characters). Tuned for typical model lists — long
+# labels/models get ellipsized via ``_fit``; the overall Float still
+# sizes up to max= in its Dimension if the terminal is wide enough.
+_COL_LABEL = 16
+_COL_MODEL = 26
+_COL_PROVIDER = 12
+_COL_CONTEXT = 6
+
+
+# Pointer-led highlight: calm in the terminal, no full-width reverse bar.
+SELECTOR_STYLES: dict[str, str] = {
+    "selector.frame": "#5B8DEF",
+    "selector.frame.label": "#5B8DEF bold",
+    "selector.frame.confirm": "#D4920A",
+    "selector.frame.confirm.label": "#D4920A bold",
+    "selector.title": "#ffffff bold",
+    "selector.count": "#666666",
+    "selector.search.label": "#888888",
+    "selector.search.arrow": "#E85B9F",
+    "selector.search.query": "#ffffff bold",
+    "selector.search.cursor": "#E85B9F",
+    "selector.search.placeholder": "#555555 italic",
+    "selector.pointer": "#3a3a3a",
+    "selector.pointer.highlight": "#E85B9F bold",
+    "selector.row.label": "#b8b8b8",
+    "selector.row.label.highlight": "#ffffff bold",
+    "selector.row.extra": "#6a6a6a",
+    "selector.row.extra.highlight": "#a8a8a8",
+    "selector.row.current": "#D4AF37 bold",
+    "selector.empty": "#777777 italic",
+    "selector.hint": "#666666",
+}
+
+
+def _fit(text: str, width: int, align: str = "left") -> str:
+    """Pad or truncate ``text`` to exactly ``width`` chars.
+
+    Truncation replaces the tail with an ellipsis so the row stays
+    aligned with its neighbours.
+    """
+    if len(text) > width:
+        if width <= 1:
+            return text[:width]
+        return text[: width - 1] + "…"
+    return text.ljust(width) if align == "left" else text.rjust(width)
 
 
 class SelectorOverlay:
@@ -46,6 +99,8 @@ class SelectorOverlay:
         self._title: str = ""
         self._message: str = ""
         self._options: list[dict[str, Any]] = []
+        self._query: str = ""
+        self._filtered: list[dict[str, Any]] = []
         self._highlight: int = 0
         self._future: asyncio.Future[Any] | None = None
         self._saved_focus: Any | None = None
@@ -57,8 +112,8 @@ class SelectorOverlay:
         )
         self._select_window = Window(
             content=self._select_control,
-            width=Dimension(min=40, max=80, preferred=64),
-            height=Dimension(min=3),
+            width=Dimension(min=52, max=96, preferred=76),
+            height=Dimension(min=5),
             dont_extend_height=True,
             wrap_lines=False,
             always_hide_cursor=True,
@@ -155,6 +210,8 @@ class SelectorOverlay:
         self._mode = self.SELECT
         self._title = title or "Select"
         self._options = list(options)
+        self._query = ""
+        self._filtered = list(options)
         self._highlight = self._initial_highlight(options, current)
         self._future = asyncio.get_event_loop().create_future()
 
@@ -205,6 +262,8 @@ class SelectorOverlay:
         self._title = ""
         self._message = ""
         self._options = []
+        self._query = ""
+        self._filtered = []
         self._highlight = 0
         self._future = None
 
@@ -237,116 +296,201 @@ class SelectorOverlay:
         self._saved_focus = None
         app.invalidate()
 
+    # ── Filtering ──
+
+    @staticmethod
+    def _option_matches(opt: dict[str, Any], query: str) -> bool:
+        """Case-insensitive substring match across the visible fields."""
+        if not query:
+            return True
+        q = query.lower()
+        for key in ("label", "value", "model", "provider"):
+            val = opt.get(key)
+            if val and q in str(val).lower():
+                return True
+        return False
+
+    def _apply_filter(self) -> None:
+        """Rebuild ``_filtered`` from ``_options`` + ``_query`` and clamp."""
+        self._filtered = [
+            opt for opt in self._options if self._option_matches(opt, self._query)
+        ]
+        if not self._filtered:
+            self._highlight = 0
+            return
+        if self._highlight >= len(self._filtered):
+            self._highlight = len(self._filtered) - 1
+        if self._highlight < 0:
+            self._highlight = 0
+
     # ── Rendering ──
 
     def _render_select(self) -> StyleAndTextTuples:
         lines: StyleAndTextTuples = []
+        self._render_title(lines)
+        self._render_search(lines)
+        self._render_options(lines)
+        self._render_hint(lines)
+        return lines
+
+    def _render_title(self, lines: StyleAndTextTuples) -> None:
         title = self._title or "Select"
-        lines.append(("class:selector.title", f"{title}\n\n"))
-        if not self._options:
-            lines.append(("class:selector.hint", "(no options)\n"))
-        for i, opt in enumerate(self._options):
-            label = str(opt.get("label") or opt.get("value", ""))
-            model = str(opt.get("model", ""))
-            provider = str(opt.get("provider", ""))
-            context = str(opt.get("context", ""))
-            extras: list[str] = []
-            if model and model != label:
-                extras.append(model)
-            if provider:
-                extras.append(f"({provider})")
-            if context:
-                extras.append(context)
-            extra = "  ".join(extras)
+        lines.append(("class:selector.title", f"  {title}"))
+        total = len(self._options)
+        visible = len(self._filtered)
+        if self._query and visible < total:
+            lines.append(("class:selector.count", f"   {visible}/{total}"))
+        lines.append(("", "\n\n"))
 
-            is_active = i == self._highlight
-            is_current = bool(opt.get("selected"))
-            pointer = "▶ " if is_active else "  "
-            dot = " ●" if is_current else ""
+    def _render_search(self, lines: StyleAndTextTuples) -> None:
+        lines.append(("class:selector.search.label", "  search "))
+        lines.append(("class:selector.search.arrow", "› "))
+        if self._query:
+            lines.append(("class:selector.search.query", self._query))
+            lines.append(("class:selector.search.cursor", "▏"))
+        else:
+            lines.append(("class:selector.search.placeholder", "type to filter…"))
+        lines.append(("", "\n\n"))
 
-            row_style = (
-                "class:selector.row.highlight" if is_active else "class:selector.row"
-            )
-            lines.append((row_style, f"{pointer}{label}{dot}"))
-            if extra:
-                lines.append(
-                    (
-                        (
-                            "class:selector.row.extra.highlight"
-                            if is_active
-                            else "class:selector.row.extra"
-                        ),
-                        f"  {extra}",
-                    )
-                )
-            lines.append(("", "\n"))
+    def _render_options(self, lines: StyleAndTextTuples) -> None:
+        if not self._filtered:
+            lines.append(("class:selector.empty", "  no matches\n"))
+            return
+        for i, opt in enumerate(self._filtered):
+            self._render_row(lines, opt, is_active=(i == self._highlight))
+
+    def _render_row(
+        self,
+        lines: StyleAndTextTuples,
+        opt: dict[str, Any],
+        is_active: bool,
+    ) -> None:
+        is_current = bool(opt.get("selected"))
+        label = str(opt.get("label") or opt.get("value", ""))
+        model = str(opt.get("model", "") or "")
+        provider = str(opt.get("provider", "") or "")
+        context = str(opt.get("context", "") or "")
+
+        pointer_style = (
+            "class:selector.pointer.highlight"
+            if is_active
+            else "class:selector.pointer"
+        )
+        label_style = (
+            "class:selector.row.label.highlight"
+            if is_active
+            else "class:selector.row.label"
+        )
+        extra_style = (
+            "class:selector.row.extra.highlight"
+            if is_active
+            else "class:selector.row.extra"
+        )
+
+        pointer = "▸" if is_active else " "
+        lines.append(("", "  "))
+        lines.append((pointer_style, pointer))
+        lines.append(("", " "))
+        lines.append((label_style, _fit(label, _COL_LABEL)))
+
+        if model and model != label:
+            lines.append((extra_style, "  " + _fit(model, _COL_MODEL)))
+        else:
+            lines.append(("", "  " + " " * _COL_MODEL))
+
+        if provider:
+            lines.append((extra_style, "  " + _fit(f"({provider})", _COL_PROVIDER)))
+        else:
+            lines.append(("", "  " + " " * _COL_PROVIDER))
+
+        if context:
+            lines.append((extra_style, "  " + _fit(context, _COL_CONTEXT, "right")))
+        else:
+            lines.append(("", "  " + " " * _COL_CONTEXT))
+
+        if is_current:
+            lines.append(("class:selector.row.current", " ●"))
+        else:
+            lines.append(("", "  "))
+        lines.append(("", "\n"))
+
+    def _render_hint(self, lines: StyleAndTextTuples) -> None:
+        lines.append(("", "\n"))
         lines.append(
             (
                 "class:selector.hint",
-                "\n↑↓ navigate   enter select   esc cancel",
+                "  ↑↓ navigate   enter select   esc cancel",
             )
         )
-        return lines
+        if self._query:
+            lines.append(("class:selector.hint", "   ^U clear   ⌫ backspace"))
 
     def _render_confirm(self) -> StyleAndTextTuples:
         message = self._message or "Confirm?"
         return [
-            ("class:selector.title", "Confirm\n\n"),
-            ("", f"{message}\n\n"),
-            ("class:selector.hint", "y confirm   n/esc cancel"),
+            ("class:selector.title", "  Confirm\n\n"),
+            ("", f"  {message}\n\n"),
+            ("class:selector.hint", "  y confirm   n/esc cancel"),
         ]
 
     # ── Key bindings ──
 
     def _build_key_bindings(self) -> KeyBindings:
         kb = KeyBindings()
+        in_select = Condition(lambda: self.is_select)
+        in_confirm = Condition(lambda: self.is_confirm)
 
-        @kb.add("up")
+        @kb.add("up", filter=in_select)
+        @kb.add("c-p", filter=in_select)
         def _up(event) -> None:
-            if self.is_select and self._options:
-                self._highlight = (self._highlight - 1) % len(self._options)
+            if self._filtered:
+                self._highlight = (self._highlight - 1) % len(self._filtered)
                 event.app.invalidate()
 
-        @kb.add("down")
+        @kb.add("down", filter=in_select)
+        @kb.add("c-n", filter=in_select)
         def _down(event) -> None:
-            if self.is_select and self._options:
-                self._highlight = (self._highlight + 1) % len(self._options)
+            if self._filtered:
+                self._highlight = (self._highlight + 1) % len(self._filtered)
                 event.app.invalidate()
 
-        @kb.add("c-p")
-        def _ctrl_p(event) -> None:
-            if self.is_select and self._options:
-                self._highlight = (self._highlight - 1) % len(self._options)
-                event.app.invalidate()
-
-        @kb.add("c-n")
-        def _ctrl_n(event) -> None:
-            if self.is_select and self._options:
-                self._highlight = (self._highlight + 1) % len(self._options)
-                event.app.invalidate()
-
-        @kb.add("home")
+        @kb.add("home", filter=in_select)
         def _home(event) -> None:
-            if self.is_select and self._options:
+            if self._filtered:
                 self._highlight = 0
                 event.app.invalidate()
 
-        @kb.add("end")
+        @kb.add("end", filter=in_select)
         def _end(event) -> None:
-            if self.is_select and self._options:
-                self._highlight = len(self._options) - 1
+            if self._filtered:
+                self._highlight = len(self._filtered) - 1
                 event.app.invalidate()
 
-        @kb.add("enter")
+        @kb.add("enter", filter=in_select)
         def _enter(event) -> None:
-            if not self.is_select:
-                return
             if not self._future or self._future.done():
                 return
-            if not self._options:
+            if not self._filtered:
+                # Nothing to pick — treat as cancel to avoid a stuck overlay.
                 self._future.set_result(None)
                 return
-            self._future.set_result(self._options[self._highlight].get("value"))
+            self._future.set_result(self._filtered[self._highlight].get("value"))
+
+        @kb.add("backspace", filter=in_select)
+        def _backspace(event) -> None:
+            if not self._query:
+                return
+            self._query = self._query[:-1]
+            self._apply_filter()
+            event.app.invalidate()
+
+        @kb.add("c-u", filter=in_select)
+        def _clear_query(event) -> None:
+            if not self._query:
+                return
+            self._query = ""
+            self._apply_filter()
+            event.app.invalidate()
 
         @kb.add("escape", eager=True)
         def _esc(event) -> None:
@@ -360,24 +504,33 @@ class SelectorOverlay:
                 return
             self._future.set_result(None if self.is_select else False)
 
-        @kb.add("y")
+        # Confirm-mode y/n. Gated on ``is_confirm`` so typing 'y' / 'n' in
+        # select mode falls through to the Keys.Any handler below and
+        # becomes part of the search query.
+        @kb.add("y", filter=in_confirm)
+        @kb.add("Y", filter=in_confirm)
         def _y(event) -> None:
-            if self.is_confirm and self._future and not self._future.done():
+            if self._future and not self._future.done():
                 self._future.set_result(True)
 
-        @kb.add("Y")
-        def _y_upper(event) -> None:
-            if self.is_confirm and self._future and not self._future.done():
-                self._future.set_result(True)
-
-        @kb.add("n")
+        @kb.add("n", filter=in_confirm)
+        @kb.add("N", filter=in_confirm)
         def _n(event) -> None:
-            if self.is_confirm and self._future and not self._future.done():
+            if self._future and not self._future.done():
                 self._future.set_result(False)
 
-        @kb.add("N")
-        def _n_upper(event) -> None:
-            if self.is_confirm and self._future and not self._future.done():
-                self._future.set_result(False)
+        # Catch-all for typing into the search box. ``event.data`` is the
+        # raw character(s) the terminal emitted; ignore control chars /
+        # escape sequences / empty data.
+        @kb.add(Keys.Any, filter=in_select)
+        def _any(event) -> None:
+            data = event.data or ""
+            if not data or len(data) != 1:
+                return
+            if not data.isprintable() or data in ("\r", "\n", "\t"):
+                return
+            self._query += data
+            self._apply_filter()
+            event.app.invalidate()
 
         return kb

--- a/src/kohakuterrarium/builtins/cli_rich/selector.py
+++ b/src/kohakuterrarium/builtins/cli_rich/selector.py
@@ -1,0 +1,383 @@
+"""SelectorOverlay — modal arrow-key selector/confirm for the rich CLI.
+
+Lives inside the single RichCLIApp Application (one render loop, one tree).
+Exposes two ConditionalContainer Floats that the app embeds in a
+FloatContainer, plus a key-binding set that the app merges at the
+Application level (gated by ``visible`` so composer keys yield while
+the overlay is up).
+
+Async API: ``show_select(title, options, current)`` returns the picked
+value (or ``None`` on cancel); ``show_confirm(message)`` returns bool.
+Both use an ``asyncio.Future`` set from within the key handlers.
+
+Single-instance: the overlay supports one pending interaction at a time.
+Callers serialize through the app's ``_handle_slash`` task.
+"""
+
+import asyncio
+from typing import Any
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.formatted_text import StyleAndTextTuples
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import HSplit, Window
+from prompt_toolkit.layout.containers import ConditionalContainer, Float
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.widgets import Frame
+
+
+class SelectorOverlay:
+    """Shared select/confirm overlay for RichCLIApp.
+
+    Holds its own mode + highlight state and a single pending future.
+    Two ``ConditionalContainer`` floats (select and confirm) are
+    rendered only while the matching mode is active. Key bindings are
+    centrally registered so the app can merge them with a
+    ``selector.visible`` filter.
+    """
+
+    SELECT = "select"
+    CONFIRM = "confirm"
+
+    def __init__(self) -> None:
+        self._mode: str | None = None
+        self._title: str = ""
+        self._message: str = ""
+        self._options: list[dict[str, Any]] = []
+        self._highlight: int = 0
+        self._future: asyncio.Future[Any] | None = None
+        self._saved_focus: Any | None = None
+
+        self._select_control = FormattedTextControl(
+            text=self._render_select,
+            focusable=True,
+            show_cursor=False,
+        )
+        self._select_window = Window(
+            content=self._select_control,
+            width=Dimension(min=40, max=80, preferred=64),
+            height=Dimension(min=3),
+            dont_extend_height=True,
+            wrap_lines=False,
+            always_hide_cursor=True,
+        )
+        self._select_frame = Frame(
+            self._select_window,
+            title="Select",
+            style="class:selector.frame",
+        )
+
+        self._confirm_control = FormattedTextControl(
+            text=self._render_confirm,
+            focusable=True,
+            show_cursor=False,
+        )
+        self._confirm_window = Window(
+            content=self._confirm_control,
+            width=Dimension(min=30, max=70, preferred=50),
+            height=Dimension(min=3),
+            dont_extend_height=True,
+            wrap_lines=True,
+            always_hide_cursor=True,
+        )
+        self._confirm_frame = Frame(
+            self._confirm_window,
+            title="Confirm",
+            style="class:selector.frame.confirm",
+        )
+
+        self._key_bindings = self._build_key_bindings()
+
+    # ── Public state ──
+
+    @property
+    def visible(self) -> bool:
+        """True while an overlay is open and awaiting user input."""
+        return (
+            self._mode is not None
+            and self._future is not None
+            and not self._future.done()
+        )
+
+    @property
+    def is_select(self) -> bool:
+        return self.visible and self._mode == self.SELECT
+
+    @property
+    def is_confirm(self) -> bool:
+        return self.visible and self._mode == self.CONFIRM
+
+    @property
+    def key_bindings(self) -> KeyBindings:
+        """Global key bindings to merge into the Application's kb stack.
+
+        The caller must gate these with a ``visible`` filter so they
+        only fire while an overlay is active.
+        """
+        return self._key_bindings
+
+    # ── Layout integration ──
+
+    def build_floats(self) -> list[Float]:
+        """Return the Floats to attach to the app's FloatContainer."""
+        select_float = Float(
+            content=ConditionalContainer(
+                content=HSplit([self._select_frame]),
+                filter=Condition(lambda: self.is_select),
+            ),
+        )
+        confirm_float = Float(
+            content=ConditionalContainer(
+                content=HSplit([self._confirm_frame]),
+                filter=Condition(lambda: self.is_confirm),
+            ),
+        )
+        return [select_float, confirm_float]
+
+    # ── Async entry points ──
+
+    async def show_select(
+        self,
+        title: str,
+        options: list[dict[str, Any]],
+        current: str,
+        app: Application | None,
+    ) -> str | None:
+        """Open the select overlay; resolves to picked value or None."""
+        if not options:
+            return None
+        if self.visible:
+            # Refuse concurrent overlays; caller serializes.
+            return None
+
+        self._mode = self.SELECT
+        self._title = title or "Select"
+        self._options = list(options)
+        self._highlight = self._initial_highlight(options, current)
+        self._future = asyncio.get_event_loop().create_future()
+
+        self._claim_focus(app)
+        try:
+            return await self._future
+        finally:
+            self._release_focus(app)
+            self._reset()
+
+    async def show_confirm(
+        self,
+        message: str,
+        app: Application | None,
+    ) -> bool:
+        """Open the confirm overlay; resolves to True (y) or False (n/Esc)."""
+        if self.visible:
+            return False
+
+        self._mode = self.CONFIRM
+        self._message = message
+        self._future = asyncio.get_event_loop().create_future()
+
+        self._claim_focus(app)
+        try:
+            result = await self._future
+            return bool(result)
+        finally:
+            self._release_focus(app)
+            self._reset()
+
+    # ── Internal state ──
+
+    @staticmethod
+    def _initial_highlight(options: list[dict[str, Any]], current: str) -> int:
+        """Preselect the option marked ``selected`` or matching ``current``."""
+        for i, opt in enumerate(options):
+            if opt.get("selected"):
+                return i
+        if current:
+            for i, opt in enumerate(options):
+                if opt.get("value") == current or opt.get("model") == current:
+                    return i
+        return 0
+
+    def _reset(self) -> None:
+        self._mode = None
+        self._title = ""
+        self._message = ""
+        self._options = []
+        self._highlight = 0
+        self._future = None
+
+    def _claim_focus(self, app: Application | None) -> None:
+        if app is None:
+            return
+        try:
+            self._saved_focus = app.layout.current_window
+        except Exception:
+            self._saved_focus = None
+        try:
+            target = (
+                self._select_window
+                if self._mode == self.SELECT
+                else self._confirm_window
+            )
+            app.layout.focus(target)
+        except Exception:
+            pass
+        app.invalidate()
+
+    def _release_focus(self, app: Application | None) -> None:
+        if app is None:
+            return
+        try:
+            if self._saved_focus is not None:
+                app.layout.focus(self._saved_focus)
+        except Exception:
+            pass
+        self._saved_focus = None
+        app.invalidate()
+
+    # ── Rendering ──
+
+    def _render_select(self) -> StyleAndTextTuples:
+        lines: StyleAndTextTuples = []
+        title = self._title or "Select"
+        lines.append(("class:selector.title", f"{title}\n\n"))
+        if not self._options:
+            lines.append(("class:selector.hint", "(no options)\n"))
+        for i, opt in enumerate(self._options):
+            label = str(opt.get("label") or opt.get("value", ""))
+            model = str(opt.get("model", ""))
+            provider = str(opt.get("provider", ""))
+            context = str(opt.get("context", ""))
+            extras: list[str] = []
+            if model and model != label:
+                extras.append(model)
+            if provider:
+                extras.append(f"({provider})")
+            if context:
+                extras.append(context)
+            extra = "  ".join(extras)
+
+            is_active = i == self._highlight
+            is_current = bool(opt.get("selected"))
+            pointer = "▶ " if is_active else "  "
+            dot = " ●" if is_current else ""
+
+            row_style = (
+                "class:selector.row.highlight" if is_active else "class:selector.row"
+            )
+            lines.append((row_style, f"{pointer}{label}{dot}"))
+            if extra:
+                lines.append(
+                    (
+                        (
+                            "class:selector.row.extra.highlight"
+                            if is_active
+                            else "class:selector.row.extra"
+                        ),
+                        f"  {extra}",
+                    )
+                )
+            lines.append(("", "\n"))
+        lines.append(
+            (
+                "class:selector.hint",
+                "\n↑↓ navigate   enter select   esc cancel",
+            )
+        )
+        return lines
+
+    def _render_confirm(self) -> StyleAndTextTuples:
+        message = self._message or "Confirm?"
+        return [
+            ("class:selector.title", "Confirm\n\n"),
+            ("", f"{message}\n\n"),
+            ("class:selector.hint", "y confirm   n/esc cancel"),
+        ]
+
+    # ── Key bindings ──
+
+    def _build_key_bindings(self) -> KeyBindings:
+        kb = KeyBindings()
+
+        @kb.add("up")
+        def _up(event) -> None:
+            if self.is_select and self._options:
+                self._highlight = (self._highlight - 1) % len(self._options)
+                event.app.invalidate()
+
+        @kb.add("down")
+        def _down(event) -> None:
+            if self.is_select and self._options:
+                self._highlight = (self._highlight + 1) % len(self._options)
+                event.app.invalidate()
+
+        @kb.add("c-p")
+        def _ctrl_p(event) -> None:
+            if self.is_select and self._options:
+                self._highlight = (self._highlight - 1) % len(self._options)
+                event.app.invalidate()
+
+        @kb.add("c-n")
+        def _ctrl_n(event) -> None:
+            if self.is_select and self._options:
+                self._highlight = (self._highlight + 1) % len(self._options)
+                event.app.invalidate()
+
+        @kb.add("home")
+        def _home(event) -> None:
+            if self.is_select and self._options:
+                self._highlight = 0
+                event.app.invalidate()
+
+        @kb.add("end")
+        def _end(event) -> None:
+            if self.is_select and self._options:
+                self._highlight = len(self._options) - 1
+                event.app.invalidate()
+
+        @kb.add("enter")
+        def _enter(event) -> None:
+            if not self.is_select:
+                return
+            if not self._future or self._future.done():
+                return
+            if not self._options:
+                self._future.set_result(None)
+                return
+            self._future.set_result(self._options[self._highlight].get("value"))
+
+        @kb.add("escape", eager=True)
+        def _esc(event) -> None:
+            if not self.visible or not self._future or self._future.done():
+                return
+            self._future.set_result(None if self.is_select else False)
+
+        @kb.add("c-c")
+        def _ctrl_c(event) -> None:
+            if not self.visible or not self._future or self._future.done():
+                return
+            self._future.set_result(None if self.is_select else False)
+
+        @kb.add("y")
+        def _y(event) -> None:
+            if self.is_confirm and self._future and not self._future.done():
+                self._future.set_result(True)
+
+        @kb.add("Y")
+        def _y_upper(event) -> None:
+            if self.is_confirm and self._future and not self._future.done():
+                self._future.set_result(True)
+
+        @kb.add("n")
+        def _n(event) -> None:
+            if self.is_confirm and self._future and not self._future.done():
+                self._future.set_result(False)
+
+        @kb.add("N")
+        def _n_upper(event) -> None:
+            if self.is_confirm and self._future and not self._future.done():
+                self._future.set_result(False)
+
+        return kb

--- a/src/kohakuterrarium/builtins/cli_rich/selector.py
+++ b/src/kohakuterrarium/builtins/cli_rich/selector.py
@@ -42,6 +42,11 @@ _COL_MODEL = 26
 _COL_PROVIDER = 12
 _COL_CONTEXT = 6
 
+# Cap the option viewport so a long model list doesn't inflate the Float
+# past the terminal height. The overlay scrolls within this window using
+# ``_viewport_start`` + ``▲ / ▼`` scroll indicators.
+_MAX_VISIBLE_OPTIONS = 8
+
 
 # Pointer-led highlight: calm in the terminal, no full-width reverse bar.
 SELECTOR_STYLES: dict[str, str] = {
@@ -102,6 +107,7 @@ class SelectorOverlay:
         self._query: str = ""
         self._filtered: list[dict[str, Any]] = []
         self._highlight: int = 0
+        self._viewport_start: int = 0
         self._future: asyncio.Future[Any] | None = None
         self._saved_focus: Any | None = None
 
@@ -110,10 +116,13 @@ class SelectorOverlay:
             focusable=True,
             show_cursor=False,
         )
+        # ``min=3`` keeps the floor at a header + one option + hint so the
+        # Float still fits when the user runs with a tight terminal; ``max``
+        # caps the overlay at header + 8 options + 2 scroll hints + hint.
         self._select_window = Window(
             content=self._select_control,
             width=Dimension(min=52, max=96, preferred=76),
-            height=Dimension(min=5),
+            height=Dimension(min=3, max=_MAX_VISIBLE_OPTIONS + 4),
             dont_extend_height=True,
             wrap_lines=False,
             always_hide_cursor=True,
@@ -213,6 +222,8 @@ class SelectorOverlay:
         self._query = ""
         self._filtered = list(options)
         self._highlight = self._initial_highlight(options, current)
+        self._viewport_start = 0
+        self._ensure_highlight_visible()
         self._future = asyncio.get_event_loop().create_future()
 
         self._claim_focus(app)
@@ -265,6 +276,7 @@ class SelectorOverlay:
         self._query = ""
         self._filtered = []
         self._highlight = 0
+        self._viewport_start = 0
         self._future = None
 
     def _claim_focus(self, app: Application | None) -> None:
@@ -317,47 +329,77 @@ class SelectorOverlay:
         ]
         if not self._filtered:
             self._highlight = 0
+            self._viewport_start = 0
             return
         if self._highlight >= len(self._filtered):
             self._highlight = len(self._filtered) - 1
         if self._highlight < 0:
             self._highlight = 0
+        self._viewport_start = 0
+        self._ensure_highlight_visible()
+
+    # ── Viewport scrolling ──
+
+    def _viewport_range(self) -> tuple[int, int]:
+        """Return ``(start, end)`` indices to render, honouring the cap."""
+        total = len(self._filtered)
+        if total <= _MAX_VISIBLE_OPTIONS:
+            return 0, total
+        start = max(0, min(self._viewport_start, total - _MAX_VISIBLE_OPTIONS))
+        return start, start + _MAX_VISIBLE_OPTIONS
+
+    def _ensure_highlight_visible(self) -> None:
+        """Scroll the viewport so ``_highlight`` is inside the visible slice."""
+        total = len(self._filtered)
+        if total <= _MAX_VISIBLE_OPTIONS:
+            self._viewport_start = 0
+            return
+        if self._highlight < self._viewport_start:
+            self._viewport_start = self._highlight
+        elif self._highlight >= self._viewport_start + _MAX_VISIBLE_OPTIONS:
+            self._viewport_start = self._highlight - _MAX_VISIBLE_OPTIONS + 1
+        # Clamp to valid range in case ``_filtered`` shrank.
+        self._viewport_start = max(
+            0, min(self._viewport_start, total - _MAX_VISIBLE_OPTIONS)
+        )
 
     # ── Rendering ──
 
     def _render_select(self) -> StyleAndTextTuples:
         lines: StyleAndTextTuples = []
-        self._render_title(lines)
-        self._render_search(lines)
+        self._render_header(lines)
         self._render_options(lines)
         self._render_hint(lines)
         return lines
 
-    def _render_title(self, lines: StyleAndTextTuples) -> None:
+    def _render_header(self, lines: StyleAndTextTuples) -> None:
+        """Compact one-row header: title ›  query   N/M count badge."""
         title = self._title or "Select"
-        lines.append(("class:selector.title", f"  {title}"))
-        total = len(self._options)
-        visible = len(self._filtered)
-        if self._query and visible < total:
-            lines.append(("class:selector.count", f"   {visible}/{total}"))
-        lines.append(("", "\n\n"))
-
-    def _render_search(self, lines: StyleAndTextTuples) -> None:
-        lines.append(("class:selector.search.label", "  search "))
+        lines.append(("class:selector.title", f"  {title}  "))
         lines.append(("class:selector.search.arrow", "› "))
         if self._query:
             lines.append(("class:selector.search.query", self._query))
             lines.append(("class:selector.search.cursor", "▏"))
         else:
             lines.append(("class:selector.search.placeholder", "type to filter…"))
-        lines.append(("", "\n\n"))
+        total = len(self._options)
+        visible = len(self._filtered)
+        if self._query and visible < total:
+            lines.append(("class:selector.count", f"  {visible}/{total}"))
+        lines.append(("", "\n"))
 
     def _render_options(self, lines: StyleAndTextTuples) -> None:
         if not self._filtered:
             lines.append(("class:selector.empty", "  no matches\n"))
             return
-        for i, opt in enumerate(self._filtered):
-            self._render_row(lines, opt, is_active=(i == self._highlight))
+        start, end = self._viewport_range()
+        if start > 0:
+            lines.append(("class:selector.hint", f"  ▲ {start} more above\n"))
+        for i in range(start, end):
+            self._render_row(lines, self._filtered[i], is_active=(i == self._highlight))
+        below = len(self._filtered) - end
+        if below > 0:
+            lines.append(("class:selector.hint", f"  ▼ {below} more below\n"))
 
     def _render_row(
         self,
@@ -415,15 +457,10 @@ class SelectorOverlay:
         lines.append(("", "\n"))
 
     def _render_hint(self, lines: StyleAndTextTuples) -> None:
-        lines.append(("", "\n"))
-        lines.append(
-            (
-                "class:selector.hint",
-                "  ↑↓ navigate   enter select   esc cancel",
-            )
-        )
+        hint = "  ↑↓ navigate   enter select   esc cancel"
         if self._query:
-            lines.append(("class:selector.hint", "   ^U clear   ⌫ backspace"))
+            hint += "   ^U clear"
+        lines.append(("class:selector.hint", hint))
 
     def _render_confirm(self) -> StyleAndTextTuples:
         message = self._message or "Confirm?"
@@ -445,6 +482,7 @@ class SelectorOverlay:
         def _up(event) -> None:
             if self._filtered:
                 self._highlight = (self._highlight - 1) % len(self._filtered)
+                self._ensure_highlight_visible()
                 event.app.invalidate()
 
         @kb.add("down", filter=in_select)
@@ -452,18 +490,21 @@ class SelectorOverlay:
         def _down(event) -> None:
             if self._filtered:
                 self._highlight = (self._highlight + 1) % len(self._filtered)
+                self._ensure_highlight_visible()
                 event.app.invalidate()
 
         @kb.add("home", filter=in_select)
         def _home(event) -> None:
             if self._filtered:
                 self._highlight = 0
+                self._ensure_highlight_visible()
                 event.app.invalidate()
 
         @kb.add("end", filter=in_select)
         def _end(event) -> None:
             if self._filtered:
                 self._highlight = len(self._filtered) - 1
+                self._ensure_highlight_visible()
                 event.app.invalidate()
 
         @kb.add("enter", filter=in_select)

--- a/src/kohakuterrarium/builtins/cli_rich/selector.py
+++ b/src/kohakuterrarium/builtins/cli_rich/selector.py
@@ -185,20 +185,41 @@ class SelectorOverlay:
     # ── Layout integration ──
 
     def build_floats(self) -> list[Float]:
-        """Return the Floats to attach to the app's FloatContainer."""
-        select_float = Float(
-            content=ConditionalContainer(
-                content=HSplit([self._select_frame]),
-                filter=Condition(lambda: self.is_select),
+        """Return Floats anchored at ``top=0`` so they land inside the
+        spacer RichCLIApp reserves above the composer while open."""
+        return [
+            Float(
+                content=ConditionalContainer(
+                    content=HSplit([self._select_frame]),
+                    filter=Condition(lambda: self.is_select),
+                ),
+                top=0,
             ),
-        )
-        confirm_float = Float(
-            content=ConditionalContainer(
-                content=HSplit([self._confirm_frame]),
-                filter=Condition(lambda: self.is_confirm),
+            Float(
+                content=ConditionalContainer(
+                    content=HSplit([self._confirm_frame]),
+                    filter=Condition(lambda: self.is_confirm),
+                ),
+                top=0,
             ),
-        )
-        return [select_float, confirm_float]
+        ]
+
+    def current_height(self) -> int:
+        """Rows the Float needs right now (0 while hidden).
+
+        RichCLIApp uses this to reserve space above the composer so the
+        Float has room to render in non-full-screen mode.
+        """
+        if not self.visible:
+            return 0
+        if self.is_select:
+            start, end = self._viewport_range()
+            options_rows = max(1, end - start)
+            scroll_up = 1 if start > 0 else 0
+            scroll_down = 1 if len(self._filtered) - end > 0 else 0
+            # header + scroll_up + options + scroll_down + hint + 2 border
+            return 1 + scroll_up + options_rows + scroll_down + 1 + 2
+        return 3 + 2  # confirm content + border
 
     # ── Async entry points ──
 

--- a/src/kohakuterrarium/builtins/cli_rich/slash.py
+++ b/src/kohakuterrarium/builtins/cli_rich/slash.py
@@ -1,0 +1,145 @@
+"""Slash command dispatch for RichCLIApp.
+
+Pulls user commands from the global builtin registry, runs them with a
+``UserCommandContext``, and routes structured UI payloads (``select`` /
+``confirm``) through the ``SelectorOverlay``. Lives in its own module
+so the main app file stays under the 600-line cap.
+
+Holds no state beyond the command registry; everything else is read
+off the ``RichCLIApp`` reference at dispatch time.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from kohakuterrarium.builtins.user_commands import (
+    get_builtin_user_command,
+    list_builtin_user_commands,
+)
+from kohakuterrarium.modules.user_command.base import (
+    UserCommandContext,
+    UserCommandResult,
+    parse_slash_command,
+)
+
+if TYPE_CHECKING:
+    from kohakuterrarium.builtins.cli_rich.app import RichCLIApp
+
+
+class SlashHandler:
+    """Dispatcher for ``/command`` input typed in the rich CLI."""
+
+    def __init__(self, app: "RichCLIApp") -> None:
+        self._app = app
+        self._registry: dict[str, Any] = {}
+
+    @property
+    def registry(self) -> dict[str, Any]:
+        """Read-only view of the wired command registry."""
+        return self._registry
+
+    def wire_builtins(self) -> dict[str, Any]:
+        """Populate the registry with every registered builtin command."""
+        registry: dict[str, Any] = {}
+        for name in list_builtin_user_commands():
+            cmd = get_builtin_user_command(name)
+            if cmd:
+                registry[name] = cmd
+        self._registry = registry
+        return registry
+
+    async def handle(self, text: str) -> None:
+        """Parse and execute a slash-command line, rendering any UI payload."""
+        name, args = parse_slash_command(text)
+        cmd = self._registry.get(name) or get_builtin_user_command(name)
+        if cmd is None:
+            self._app._commit_text(f"[red]Unknown command:[/red] /{name}")
+            return
+
+        try:
+            result = await cmd.execute(args, self._build_context())
+        except Exception as e:
+            self._app._commit_text(f"[red]Command error:[/red] {e}")
+            return
+
+        # Interactive rendering: if the command returned a structured
+        # UI payload (select/confirm) and no error, open an overlay.
+        # The follow-up command's result replaces the original.
+        if result.data and not result.error:
+            followup = await self._render_data(result, name)
+            if followup is not None:
+                result = followup
+
+        if result.error:
+            self._app._commit_text(f"[red]{result.error}[/red]")
+        elif result.output:
+            self._app._commit_text(result.output)
+
+        if name in ("exit", "quit"):
+            self._app._exit_requested = True
+            if self._app.app is not None:
+                self._app.app.exit()
+
+    # ── Internals ──
+
+    def _build_context(self) -> UserCommandContext:
+        agent = self._app.agent
+        return UserCommandContext(
+            agent=agent,
+            session=getattr(agent, "session", None),
+            input_module=getattr(agent, "input", None),
+            extra={"command_registry": self._registry},
+        )
+
+    async def _render_data(
+        self, result: UserCommandResult, command_name: str
+    ) -> UserCommandResult | None:
+        """Open an interactive overlay for a command's UI payload.
+
+        Mirrors ``BaseInputModule.render_command_data`` for the rich
+        CLI: ``select`` → arrow-key picker, ``confirm`` → y/n dialog.
+        If the user chooses a value that wires to an ``action``, we
+        execute that command and return its result.
+        """
+        data = result.data or {}
+        data_type = data.get("type", "")
+        selector = self._app.selector
+        pt_app = self._app.app
+
+        if data_type == "select":
+            options = data.get("options", [])
+            if not options:
+                return None
+            selected = await selector.show_select(
+                title=data.get("title", "Select"),
+                options=options,
+                current=data.get("current", ""),
+                app=pt_app,
+            )
+            if selected:
+                action = data.get("action", "")
+                if action:
+                    return await self._execute_followup(action, selected)
+            return UserCommandResult(output="", consumed=True)
+
+        if data_type == "confirm":
+            confirmed = await selector.show_confirm(
+                data.get("message", "Confirm?"),
+                app=pt_app,
+            )
+            if confirmed:
+                action = data.get("action", "")
+                args = data.get("action_args", "")
+                if action:
+                    return await self._execute_followup(action, args)
+            return UserCommandResult(output="Cancelled.", consumed=True)
+
+        return None
+
+    async def _execute_followup(
+        self, action: str, args: str
+    ) -> UserCommandResult | None:
+        """Run a follow-up command resolved from a UI payload action."""
+        cmd = self._registry.get(action) or get_builtin_user_command(action)
+        if cmd is None:
+            return None
+        return await cmd.execute(args, self._build_context())

--- a/tests/unit/test_cli_rich_selector.py
+++ b/tests/unit/test_cli_rich_selector.py
@@ -1,0 +1,429 @@
+"""Tests for the rich CLI SelectorOverlay — the arrow-key picker that
+replaces ``/model``'s numbered-list output (issue #27).
+
+The overlay lives inside the single RichCLIApp Application, so these
+tests drive it via its public async API plus direct key-handler
+invocation. We never spin up a real prompt_toolkit Application —
+``show_select`` / ``show_confirm`` accept ``app=None`` for exactly this
+reason.
+"""
+
+import asyncio
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import KEY_ALIASES, Keys
+
+from kohakuterrarium.builtins.cli_rich.selector import SelectorOverlay
+
+# Prompt_toolkit rewrites ``@kb.add("enter")`` → Keys.ControlM (value "c-m")
+# via KEY_ALIASES and then resolves the string to the Keys enum member.
+# Mirror that resolution so tests can address bindings by friendly name.
+_KEY_VALUES = {k.value: k for k in Keys}
+
+
+def _normalize_key(key: str):
+    resolved = KEY_ALIASES.get(key, key)
+    return _KEY_VALUES.get(resolved, resolved)
+
+
+def _handler_for(kb: KeyBindings, *keys: str) -> Callable:
+    """Find the handler registered for the given key sequence."""
+    target = tuple(_normalize_key(k) for k in keys)
+    for binding in kb.bindings:
+        if binding.keys == target:
+            return binding.handler
+    raise KeyError(f"no binding for {target!r}")
+
+
+def _event() -> MagicMock:
+    """Minimal stand-in for prompt_toolkit's KeyPressEvent."""
+    evt = MagicMock()
+    evt.app = MagicMock()
+    return evt
+
+
+# ── Initial state ──────────────────────────────────────────────────────
+
+
+class TestInitialState:
+    def test_not_visible_at_construction(self):
+        overlay = SelectorOverlay()
+        assert overlay.visible is False
+        assert overlay.is_select is False
+        assert overlay.is_confirm is False
+
+    def test_build_floats_returns_two(self):
+        overlay = SelectorOverlay()
+        floats = overlay.build_floats()
+        assert len(floats) == 2
+
+    def test_key_bindings_exposed(self):
+        overlay = SelectorOverlay()
+        assert isinstance(overlay.key_bindings, KeyBindings)
+
+
+# ── Initial highlight ──────────────────────────────────────────────────
+
+
+class TestInitialHighlight:
+    def test_defaults_to_zero(self):
+        opts = [{"value": "a"}, {"value": "b"}, {"value": "c"}]
+        assert SelectorOverlay._initial_highlight(opts, "") == 0
+
+    def test_prefers_selected_flag(self):
+        opts = [
+            {"value": "a"},
+            {"value": "b", "selected": True},
+            {"value": "c"},
+        ]
+        assert SelectorOverlay._initial_highlight(opts, "") == 1
+
+    def test_falls_back_to_current_value(self):
+        opts = [{"value": "a"}, {"value": "b"}, {"value": "c"}]
+        assert SelectorOverlay._initial_highlight(opts, "c") == 2
+
+    def test_falls_back_to_current_model_field(self):
+        opts = [
+            {"value": "opus-4-7", "model": "claude-opus-4-7"},
+            {"value": "sonnet-4-6", "model": "claude-sonnet-4-6"},
+        ]
+        assert SelectorOverlay._initial_highlight(opts, "claude-sonnet-4-6") == 1
+
+    def test_selected_flag_wins_over_current(self):
+        opts = [
+            {"value": "a"},
+            {"value": "b", "selected": True},
+            {"value": "c"},
+        ]
+        # Even if current matches a different option, selected takes priority.
+        assert SelectorOverlay._initial_highlight(opts, "c") == 1
+
+
+# ── show_select: happy paths ───────────────────────────────────────────
+
+
+class TestShowSelect:
+    async def test_empty_options_returns_none_without_opening(self):
+        overlay = SelectorOverlay()
+        result = await overlay.show_select("Pick", [], "", app=None)
+        assert result is None
+        assert overlay.visible is False
+
+    async def test_enter_resolves_highlighted_value(self):
+        overlay = SelectorOverlay()
+        opts = [
+            {"value": "opus-4-7", "label": "opus-4-7"},
+            {"value": "sonnet-4-6", "label": "sonnet-4-6", "selected": True},
+            {"value": "haiku-4-5", "label": "haiku-4-5"},
+        ]
+        task = asyncio.create_task(
+            overlay.show_select("Switch Model", opts, "", app=None)
+        )
+        # Yield so the coroutine actually starts and sets state.
+        await asyncio.sleep(0)
+        assert overlay.is_select is True
+        assert overlay._highlight == 1  # preselected via "selected"
+
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        result = await task
+        assert result == "sonnet-4-6"
+        assert overlay.visible is False
+        assert overlay.is_select is False
+
+    async def test_down_then_enter_picks_next_option(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}, {"value": "c"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "down")(_event())
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        assert await task == "b"
+
+    async def test_down_wraps_around(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # a → b → a (wrap)
+        _handler_for(overlay.key_bindings, "down")(_event())
+        _handler_for(overlay.key_bindings, "down")(_event())
+        assert overlay._highlight == 0
+
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        assert await task == "a"
+
+    async def test_up_wraps_around(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}, {"value": "c"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "up")(_event())
+        assert overlay._highlight == 2
+
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        assert await task == "c"
+
+    async def test_home_and_end_jump(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}, {"value": "c"}, {"value": "d"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "b", app=None))
+        await asyncio.sleep(0)
+
+        assert overlay._highlight == 1
+        _handler_for(overlay.key_bindings, "end")(_event())
+        assert overlay._highlight == 3
+        _handler_for(overlay.key_bindings, "home")(_event())
+        assert overlay._highlight == 0
+
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        assert await task == "a"
+
+    async def test_ctrl_n_and_ctrl_p_navigate(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}, {"value": "c"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "c-n")(_event())
+        _handler_for(overlay.key_bindings, "c-n")(_event())
+        _handler_for(overlay.key_bindings, "c-p")(_event())
+        assert overlay._highlight == 1
+
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        assert await task == "b"
+
+
+# ── show_select: cancel paths ──────────────────────────────────────────
+
+
+class TestShowSelectCancel:
+    async def test_escape_resolves_none(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "escape")(_event())
+        assert await task is None
+        assert overlay.visible is False
+
+    async def test_ctrl_c_resolves_none(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "c-c")(_event())
+        assert await task is None
+
+
+# ── show_confirm ───────────────────────────────────────────────────────
+
+
+class TestShowConfirm:
+    async def test_y_resolves_true(self):
+        overlay = SelectorOverlay()
+        task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
+        await asyncio.sleep(0)
+        assert overlay.is_confirm is True
+        assert overlay.is_select is False
+
+        _handler_for(overlay.key_bindings, "y")(_event())
+        assert await task is True
+        assert overlay.visible is False
+
+    async def test_capital_y_resolves_true(self):
+        overlay = SelectorOverlay()
+        task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "Y")(_event())
+        assert await task is True
+
+    async def test_n_resolves_false(self):
+        overlay = SelectorOverlay()
+        task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "n")(_event())
+        assert await task is False
+
+    async def test_escape_resolves_false(self):
+        overlay = SelectorOverlay()
+        task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "escape")(_event())
+        assert await task is False
+
+
+# ── Guard: inactive-mode keys are no-ops ───────────────────────────────
+
+
+class TestInactiveModeGuards:
+    async def test_y_does_nothing_in_select_mode(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # Pressing 'y' while in select mode must NOT resolve the future.
+        _handler_for(overlay.key_bindings, "y")(_event())
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        _handler_for(overlay.key_bindings, "escape")(_event())
+        assert await task is None
+
+    async def test_up_does_nothing_in_confirm_mode(self):
+        overlay = SelectorOverlay()
+        task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
+        await asyncio.sleep(0)
+
+        _handler_for(overlay.key_bindings, "up")(_event())
+        # Highlight state is irrelevant to confirm; just ensure no crash
+        # and no resolution.
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        _handler_for(overlay.key_bindings, "n")(_event())
+        assert await task is False
+
+
+# ── Concurrent show refused ────────────────────────────────────────────
+
+
+class TestConcurrentShow:
+    async def test_concurrent_select_returns_none(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}]
+        first = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # Second call while first is in-flight must bail out without
+        # stomping on the active future.
+        second = await overlay.show_select("Pick", opts, "", app=None)
+        assert second is None
+        assert overlay.visible is True  # first is still up
+
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        assert await first == "a"
+
+    async def test_concurrent_confirm_returns_false(self):
+        overlay = SelectorOverlay()
+        first = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
+        await asyncio.sleep(0)
+
+        second = await overlay.show_confirm("Also sure?", app=None)
+        assert second is False  # refused, not an acceptance
+
+        _handler_for(overlay.key_bindings, "y")(_event())
+        assert await first is True
+
+
+# ── Rendering sanity ───────────────────────────────────────────────────
+
+
+class TestRendering:
+    async def test_select_renders_options_and_highlight(self):
+        overlay = SelectorOverlay()
+        opts = [
+            {"value": "a", "label": "opus", "provider": "anthropic"},
+            {"value": "b", "label": "sonnet", "provider": "anthropic"},
+        ]
+        task = asyncio.create_task(
+            overlay.show_select("Switch Model", opts, "", app=None)
+        )
+        await asyncio.sleep(0)
+
+        fragments = overlay._render_select()
+        # Concatenate all text; verify title, labels, and hint are present.
+        joined = "".join(text for _, text in fragments)
+        assert "Switch Model" in joined
+        assert "opus" in joined
+        assert "sonnet" in joined
+        assert "↑↓" in joined  # navigation hint
+
+        # The highlighted (first) row uses the highlight style.
+        highlight_styles = {style for style, text in fragments if "opus" in text}
+        assert any("selector.row.highlight" in s for s in highlight_styles)
+
+        _handler_for(overlay.key_bindings, "escape")(_event())
+        await task
+
+    async def test_confirm_renders_message(self):
+        overlay = SelectorOverlay()
+        task = asyncio.create_task(overlay.show_confirm("Delete everything?", app=None))
+        await asyncio.sleep(0)
+
+        fragments = overlay._render_confirm()
+        joined = "".join(text for _, text in fragments)
+        assert "Confirm" in joined
+        assert "Delete everything?" in joined
+        assert "y confirm" in joined
+
+        _handler_for(overlay.key_bindings, "escape")(_event())
+        await task
+
+
+# ── State cleanup ──────────────────────────────────────────────────────
+
+
+class TestStateReset:
+    async def test_state_cleared_after_select(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        await task
+
+        assert overlay._mode is None
+        assert overlay._options == []
+        assert overlay._highlight == 0
+        assert overlay._future is None
+
+    async def test_state_cleared_after_cancel(self):
+        overlay = SelectorOverlay()
+        task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
+        await asyncio.sleep(0)
+        _handler_for(overlay.key_bindings, "escape")(_event())
+        await task
+
+        assert overlay._mode is None
+        assert overlay._message == ""
+        assert overlay._future is None
+
+    async def test_second_select_after_first_completes(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a"}, {"value": "b"}]
+
+        # First select.
+        first = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        assert await first == "a"
+
+        # Second select works with fresh state.
+        second = asyncio.create_task(
+            overlay.show_select("Pick again", opts, "b", app=None)
+        )
+        await asyncio.sleep(0)
+        assert overlay._highlight == 1  # preselected via current="b"
+        _handler_for(overlay.key_bindings, "enter")(_event())
+        assert await second == "b"
+
+
+# ── Fixture/plumbing ───────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fast_event_loop():
+    """Ensure each test gets a clean loop via pytest-asyncio default."""
+    yield

--- a/tests/unit/test_cli_rich_selector.py
+++ b/tests/unit/test_cli_rich_selector.py
@@ -661,6 +661,69 @@ class TestViewport:
         _press(overlay, "escape")
         await task
 
+    async def test_current_height_is_zero_when_hidden(self):
+        overlay = SelectorOverlay()
+        assert overlay.current_height() == 0
+
+    async def test_current_height_scales_with_option_count(self):
+        overlay = SelectorOverlay()
+        opts = _many_options(3)
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # 3 options: header(1) + 3 options + hint(1) + border(2) = 7 rows.
+        assert overlay.current_height() == 7
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_current_height_adds_scroll_indicator_rows(self):
+        from kohakuterrarium.builtins.cli_rich.selector import _MAX_VISIBLE_OPTIONS
+
+        overlay = SelectorOverlay()
+        opts = _many_options(_MAX_VISIBLE_OPTIONS + 4)
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # At top: header + cap + "▼ N more" + hint + border = 1+8+1+1+2 = 13.
+        assert overlay.current_height() == 13
+
+        # Navigate to middle — both indicators present: +1.
+        for _ in range(_MAX_VISIBLE_OPTIONS):
+            _press(overlay, "down")
+        assert overlay.current_height() == 14
+
+        # Jump to end — only "▲ N more" indicator remains: back to 13.
+        _press(overlay, "end")
+        assert overlay.current_height() == 13
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_current_height_for_confirm_mode(self):
+        overlay = SelectorOverlay()
+        task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
+        await asyncio.sleep(0)
+        assert overlay.current_height() == 5  # 3 content + 2 border
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_current_height_no_matches_keeps_floor(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a", "label": "a"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        for ch in "zzz":
+            _press(overlay, ch)
+        # No matches collapses to options_rows=1, so 5 rows stays the floor
+        # — keeps header + empty message + hint + border visible.
+        assert overlay.current_height() == 5
+
+        _press(overlay, "escape")
+        await task
+
     async def test_filter_resets_viewport(self):
         from kohakuterrarium.builtins.cli_rich.selector import _MAX_VISIBLE_OPTIONS
 

--- a/tests/unit/test_cli_rich_selector.py
+++ b/tests/unit/test_cli_rich_selector.py
@@ -2,21 +2,20 @@
 replaces ``/model``'s numbered-list output (issue #27).
 
 The overlay lives inside the single RichCLIApp Application, so these
-tests drive it via its public async API plus direct key-handler
-invocation. We never spin up a real prompt_toolkit Application —
+tests drive it via its public async API plus a filter-aware key-press
+simulator. We never spin up a real prompt_toolkit Application —
 ``show_select`` / ``show_confirm`` accept ``app=None`` for exactly this
 reason.
 """
 
 import asyncio
-from typing import Callable
 from unittest.mock import MagicMock
 
 import pytest
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import KEY_ALIASES, Keys
 
-from kohakuterrarium.builtins.cli_rich.selector import SelectorOverlay
+from kohakuterrarium.builtins.cli_rich.selector import SelectorOverlay, _fit
 
 # Prompt_toolkit rewrites ``@kb.add("enter")`` → Keys.ControlM (value "c-m")
 # via KEY_ALIASES and then resolves the string to the Keys enum member.
@@ -29,20 +28,42 @@ def _normalize_key(key: str):
     return _KEY_VALUES.get(resolved, resolved)
 
 
-def _handler_for(kb: KeyBindings, *keys: str) -> Callable:
-    """Find the handler registered for the given key sequence."""
-    target = tuple(_normalize_key(k) for k in keys)
-    for binding in kb.bindings:
-        if binding.keys == target:
-            return binding.handler
-    raise KeyError(f"no binding for {target!r}")
-
-
-def _event() -> MagicMock:
+def _event(data: str = "") -> MagicMock:
     """Minimal stand-in for prompt_toolkit's KeyPressEvent."""
     evt = MagicMock()
     evt.app = MagicMock()
+    evt.data = data
     return evt
+
+
+def _press(overlay: SelectorOverlay, *keys: str, data: str = "") -> bool:
+    """Simulate a key press that respects binding filters.
+
+    Prompt_toolkit's real dispatch evaluates filters before invoking
+    handlers and falls back to ``Keys.Any`` when no specific binding
+    fires. This helper mirrors that so tests exercise the same paths
+    the user would hit.
+
+    Returns True if a handler fired.
+    """
+    target = tuple(_normalize_key(k) for k in keys)
+    any_binding = None
+    for b in overlay.key_bindings.bindings:
+        if b.keys == (Keys.Any,):
+            any_binding = b
+            continue
+        if b.keys != target:
+            continue
+        if not b.filter():
+            continue
+        evt_data = data or (keys[0] if len(keys) == 1 and len(keys[0]) == 1 else "")
+        b.handler(_event(evt_data))
+        return True
+    if any_binding is not None and any_binding.filter():
+        evt_data = data or (keys[0] if len(keys) == 1 and len(keys[0]) == 1 else "")
+        any_binding.handler(_event(evt_data))
+        return True
+    return False
 
 
 # ── Initial state ──────────────────────────────────────────────────────
@@ -63,6 +84,23 @@ class TestInitialState:
     def test_key_bindings_exposed(self):
         overlay = SelectorOverlay()
         assert isinstance(overlay.key_bindings, KeyBindings)
+
+
+# ── _fit helper ────────────────────────────────────────────────────────
+
+
+class TestFit:
+    def test_pads_short_text(self):
+        assert _fit("opus", 8) == "opus    "
+
+    def test_truncates_with_ellipsis(self):
+        assert _fit("opus-4-7-mega-long", 10) == "opus-4-7-…"
+
+    def test_exact_width_unchanged(self):
+        assert _fit("abcdef", 6) == "abcdef"
+
+    def test_right_align(self):
+        assert _fit("12", 6, "right") == "    12"
 
 
 # ── Initial highlight ──────────────────────────────────────────────────
@@ -92,15 +130,6 @@ class TestInitialHighlight:
         ]
         assert SelectorOverlay._initial_highlight(opts, "claude-sonnet-4-6") == 1
 
-    def test_selected_flag_wins_over_current(self):
-        opts = [
-            {"value": "a"},
-            {"value": "b", "selected": True},
-            {"value": "c"},
-        ]
-        # Even if current matches a different option, selected takes priority.
-        assert SelectorOverlay._initial_highlight(opts, "c") == 1
-
 
 # ── show_select: happy paths ───────────────────────────────────────────
 
@@ -122,16 +151,12 @@ class TestShowSelect:
         task = asyncio.create_task(
             overlay.show_select("Switch Model", opts, "", app=None)
         )
-        # Yield so the coroutine actually starts and sets state.
         await asyncio.sleep(0)
         assert overlay.is_select is True
         assert overlay._highlight == 1  # preselected via "selected"
 
-        _handler_for(overlay.key_bindings, "enter")(_event())
-        result = await task
-        assert result == "sonnet-4-6"
-        assert overlay.visible is False
-        assert overlay.is_select is False
+        _press(overlay, "enter")
+        assert await task == "sonnet-4-6"
 
     async def test_down_then_enter_picks_next_option(self):
         overlay = SelectorOverlay()
@@ -139,35 +164,21 @@ class TestShowSelect:
         task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
 
-        _handler_for(overlay.key_bindings, "down")(_event())
-        _handler_for(overlay.key_bindings, "enter")(_event())
+        _press(overlay, "down")
+        _press(overlay, "enter")
         assert await task == "b"
 
-    async def test_down_wraps_around(self):
+    async def test_navigation_wraps(self):
         overlay = SelectorOverlay()
         opts = [{"value": "a"}, {"value": "b"}]
         task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
 
-        # a → b → a (wrap)
-        _handler_for(overlay.key_bindings, "down")(_event())
-        _handler_for(overlay.key_bindings, "down")(_event())
-        assert overlay._highlight == 0
+        _press(overlay, "up")
+        assert overlay._highlight == 1  # wrap from 0 to last
 
-        _handler_for(overlay.key_bindings, "enter")(_event())
-        assert await task == "a"
-
-    async def test_up_wraps_around(self):
-        overlay = SelectorOverlay()
-        opts = [{"value": "a"}, {"value": "b"}, {"value": "c"}]
-        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
-        await asyncio.sleep(0)
-
-        _handler_for(overlay.key_bindings, "up")(_event())
-        assert overlay._highlight == 2
-
-        _handler_for(overlay.key_bindings, "enter")(_event())
-        assert await task == "c"
+        _press(overlay, "enter")
+        assert await task == "b"
 
     async def test_home_and_end_jump(self):
         overlay = SelectorOverlay()
@@ -176,26 +187,26 @@ class TestShowSelect:
         await asyncio.sleep(0)
 
         assert overlay._highlight == 1
-        _handler_for(overlay.key_bindings, "end")(_event())
+        _press(overlay, "end")
         assert overlay._highlight == 3
-        _handler_for(overlay.key_bindings, "home")(_event())
+        _press(overlay, "home")
         assert overlay._highlight == 0
 
-        _handler_for(overlay.key_bindings, "enter")(_event())
+        _press(overlay, "enter")
         assert await task == "a"
 
-    async def test_ctrl_n_and_ctrl_p_navigate(self):
+    async def test_ctrl_navigation(self):
         overlay = SelectorOverlay()
         opts = [{"value": "a"}, {"value": "b"}, {"value": "c"}]
         task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
 
-        _handler_for(overlay.key_bindings, "c-n")(_event())
-        _handler_for(overlay.key_bindings, "c-n")(_event())
-        _handler_for(overlay.key_bindings, "c-p")(_event())
+        _press(overlay, "c-n")
+        _press(overlay, "c-n")
+        _press(overlay, "c-p")
         assert overlay._highlight == 1
 
-        _handler_for(overlay.key_bindings, "enter")(_event())
+        _press(overlay, "enter")
         assert await task == "b"
 
 
@@ -209,7 +220,7 @@ class TestShowSelectCancel:
         task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
 
-        _handler_for(overlay.key_bindings, "escape")(_event())
+        _press(overlay, "escape")
         assert await task is None
         assert overlay.visible is False
 
@@ -219,8 +230,206 @@ class TestShowSelectCancel:
         task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
 
-        _handler_for(overlay.key_bindings, "c-c")(_event())
+        _press(overlay, "c-c")
         assert await task is None
+
+
+# ── Type-to-filter search ──────────────────────────────────────────────
+
+
+class TestFilterSearch:
+    @staticmethod
+    def _model_options():
+        return [
+            {
+                "value": "opus-4-7",
+                "label": "opus-4-7",
+                "model": "claude-opus-4-7",
+                "provider": "anthropic",
+            },
+            {
+                "value": "sonnet-4-6",
+                "label": "sonnet-4-6",
+                "model": "claude-sonnet-4-6",
+                "provider": "anthropic",
+            },
+            {
+                "value": "gpt-5",
+                "label": "gpt-5",
+                "model": "gpt-5-turbo",
+                "provider": "openai",
+            },
+        ]
+
+    async def test_typing_filters_by_label_substring(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _press(overlay, "o")
+        _press(overlay, "p")
+        _press(overlay, "u")
+        assert overlay._query == "opu"
+        assert [o["value"] for o in overlay._filtered] == ["opus-4-7"]
+
+        _press(overlay, "enter")
+        assert await task == "opus-4-7"
+
+    async def test_filter_is_case_insensitive(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _press(overlay, "S")
+        _press(overlay, "O")
+        assert [o["value"] for o in overlay._filtered] == ["sonnet-4-6"]
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_filter_matches_model_field(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # "turbo" only appears in the model field of gpt-5.
+        for ch in "turbo":
+            _press(overlay, ch)
+        assert [o["value"] for o in overlay._filtered] == ["gpt-5"]
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_filter_matches_provider_field(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        for ch in "openai":
+            _press(overlay, ch)
+        assert [o["value"] for o in overlay._filtered] == ["gpt-5"]
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_backspace_removes_last_char(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        for ch in "opus":
+            _press(overlay, ch)
+        assert overlay._query == "opus"
+
+        _press(overlay, "backspace")
+        assert overlay._query == "opu"
+        _press(overlay, "backspace")
+        assert overlay._query == "op"
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_backspace_on_empty_query_is_noop(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        assert overlay._query == ""
+        _press(overlay, "backspace")
+        assert overlay._query == ""
+        assert len(overlay._filtered) == 3
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_ctrl_u_clears_query(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        for ch in "opus":
+            _press(overlay, ch)
+        assert overlay._query == "opus"
+
+        _press(overlay, "c-u")
+        assert overlay._query == ""
+        assert len(overlay._filtered) == 3
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_highlight_clamps_when_filter_shrinks_list(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # Move highlight to the last option (index 2).
+        _press(overlay, "end")
+        assert overlay._highlight == 2
+
+        # Type a filter that leaves only opus — highlight must clamp to 0.
+        for ch in "opus":
+            _press(overlay, ch)
+        assert len(overlay._filtered) == 1
+        assert overlay._highlight == 0
+
+        _press(overlay, "enter")
+        assert await task == "opus-4-7"
+
+    async def test_enter_on_no_matches_resolves_none(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        for ch in "zzzzz":
+            _press(overlay, ch)
+        assert overlay._filtered == []
+
+        _press(overlay, "enter")
+        assert await task is None
+
+    async def test_clearing_query_restores_full_list(self):
+        overlay = SelectorOverlay()
+        opts = self._model_options()
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        for ch in "gpt":
+            _press(overlay, ch)
+        assert len(overlay._filtered) == 1
+
+        _press(overlay, "c-u")
+        assert len(overlay._filtered) == 3
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_space_and_punctuation_append_to_query(self):
+        overlay = SelectorOverlay()
+        opts = [
+            {"value": "x", "label": "x 1"},
+            {"value": "y", "label": "y 2"},
+        ]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _press(overlay, "x")
+        _press(overlay, " ", data=" ")
+        _press(overlay, "1")
+        assert overlay._query == "x 1"
+        assert [o["value"] for o in overlay._filtered] == ["x"]
+
+        _press(overlay, "escape")
+        await task
 
 
 # ── show_confirm ───────────────────────────────────────────────────────
@@ -232,18 +441,16 @@ class TestShowConfirm:
         task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
         await asyncio.sleep(0)
         assert overlay.is_confirm is True
-        assert overlay.is_select is False
 
-        _handler_for(overlay.key_bindings, "y")(_event())
+        _press(overlay, "y")
         assert await task is True
-        assert overlay.visible is False
 
     async def test_capital_y_resolves_true(self):
         overlay = SelectorOverlay()
         task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
         await asyncio.sleep(0)
 
-        _handler_for(overlay.key_bindings, "Y")(_event())
+        _press(overlay, "Y", data="Y")
         assert await task is True
 
     async def test_n_resolves_false(self):
@@ -251,7 +458,7 @@ class TestShowConfirm:
         task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
         await asyncio.sleep(0)
 
-        _handler_for(overlay.key_bindings, "n")(_event())
+        _press(overlay, "n")
         assert await task is False
 
     async def test_escape_resolves_false(self):
@@ -259,40 +466,60 @@ class TestShowConfirm:
         task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
         await asyncio.sleep(0)
 
-        _handler_for(overlay.key_bindings, "escape")(_event())
+        _press(overlay, "escape")
         assert await task is False
 
 
-# ── Guard: inactive-mode keys are no-ops ───────────────────────────────
+# ── Mode isolation (y/n as search in select, not trigger) ──────────────
 
 
-class TestInactiveModeGuards:
-    async def test_y_does_nothing_in_select_mode(self):
+class TestModeIsolation:
+    async def test_y_typed_as_search_in_select_mode(self):
         overlay = SelectorOverlay()
-        opts = [{"value": "a"}, {"value": "b"}]
+        opts = [
+            {"value": "yolo", "label": "yolo"},
+            {"value": "other", "label": "other"},
+        ]
         task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
 
-        # Pressing 'y' while in select mode must NOT resolve the future.
-        _handler_for(overlay.key_bindings, "y")(_event())
-        await asyncio.sleep(0)
+        # 'y' must not resolve the future — it filters the list.
+        _press(overlay, "y")
         assert not task.done()
+        assert overlay._query == "y"
+        assert [o["value"] for o in overlay._filtered] == ["yolo"]
 
-        _handler_for(overlay.key_bindings, "escape")(_event())
-        assert await task is None
+        _press(overlay, "enter")
+        assert await task == "yolo"
 
-    async def test_up_does_nothing_in_confirm_mode(self):
+    async def test_n_typed_as_search_in_select_mode(self):
+        overlay = SelectorOverlay()
+        opts = [
+            {"value": "nano", "label": "nano"},
+            {"value": "opus", "label": "opus"},
+        ]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _press(overlay, "n")
+        assert not task.done()
+        assert overlay._query == "n"
+        assert [o["value"] for o in overlay._filtered] == ["nano"]
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_navigation_keys_ignored_in_confirm_mode(self):
         overlay = SelectorOverlay()
         task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
         await asyncio.sleep(0)
 
-        _handler_for(overlay.key_bindings, "up")(_event())
-        # Highlight state is irrelevant to confirm; just ensure no crash
-        # and no resolution.
-        await asyncio.sleep(0)
+        # Up/down must not fire in confirm mode; overlay stays open.
+        _press(overlay, "up")
+        _press(overlay, "down")
         assert not task.done()
 
-        _handler_for(overlay.key_bindings, "n")(_event())
+        _press(overlay, "n")
         assert await task is False
 
 
@@ -306,13 +533,11 @@ class TestConcurrentShow:
         first = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
 
-        # Second call while first is in-flight must bail out without
-        # stomping on the active future.
         second = await overlay.show_select("Pick", opts, "", app=None)
         assert second is None
-        assert overlay.visible is True  # first is still up
+        assert overlay.visible is True
 
-        _handler_for(overlay.key_bindings, "enter")(_event())
+        _press(overlay, "enter")
         assert await first == "a"
 
     async def test_concurrent_confirm_returns_false(self):
@@ -321,9 +546,9 @@ class TestConcurrentShow:
         await asyncio.sleep(0)
 
         second = await overlay.show_confirm("Also sure?", app=None)
-        assert second is False  # refused, not an acceptance
+        assert second is False
 
-        _handler_for(overlay.key_bindings, "y")(_event())
+        _press(overlay, "y")
         assert await first is True
 
 
@@ -331,11 +556,21 @@ class TestConcurrentShow:
 
 
 class TestRendering:
-    async def test_select_renders_options_and_highlight(self):
+    async def test_select_renders_title_search_and_options(self):
         overlay = SelectorOverlay()
         opts = [
-            {"value": "a", "label": "opus", "provider": "anthropic"},
-            {"value": "b", "label": "sonnet", "provider": "anthropic"},
+            {
+                "value": "opus",
+                "label": "opus",
+                "model": "claude-opus-4-7",
+                "provider": "anthropic",
+            },
+            {
+                "value": "sonnet",
+                "label": "sonnet",
+                "model": "claude-sonnet-4-6",
+                "provider": "anthropic",
+            },
         ]
         task = asyncio.create_task(
             overlay.show_select("Switch Model", opts, "", app=None)
@@ -343,18 +578,62 @@ class TestRendering:
         await asyncio.sleep(0)
 
         fragments = overlay._render_select()
-        # Concatenate all text; verify title, labels, and hint are present.
         joined = "".join(text for _, text in fragments)
         assert "Switch Model" in joined
+        assert "search" in joined
+        assert "type to filter" in joined
         assert "opus" in joined
         assert "sonnet" in joined
-        assert "↑↓" in joined  # navigation hint
+        assert "↑↓" in joined
 
-        # The highlighted (first) row uses the highlight style.
-        highlight_styles = {style for style, text in fragments if "opus" in text}
-        assert any("selector.row.highlight" in s for s in highlight_styles)
+        _press(overlay, "escape")
+        await task
 
-        _handler_for(overlay.key_bindings, "escape")(_event())
+    async def test_query_replaces_placeholder(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a", "label": "a"}, {"value": "b", "label": "b"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _press(overlay, "a")
+        joined = "".join(text for _, text in overlay._render_select())
+        assert "type to filter" not in joined
+        assert "  search " in joined
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_no_matches_message(self):
+        overlay = SelectorOverlay()
+        opts = [{"value": "a", "label": "a"}]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        for ch in "zzz":
+            _press(overlay, ch)
+        joined = "".join(text for _, text in overlay._render_select())
+        assert "no matches" in joined
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_count_shown_when_filtered(self):
+        overlay = SelectorOverlay()
+        opts = [
+            {"value": "a", "label": "alpha"},
+            {"value": "b", "label": "bravo"},
+            {"value": "c", "label": "charlie"},
+        ]
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # 'r' appears in bravo + charlie, not alpha.
+        _press(overlay, "r")
+        assert len(overlay._filtered) == 2
+        joined = "".join(text for _, text in overlay._render_select())
+        assert "2/3" in joined
+
+        _press(overlay, "escape")
         await task
 
     async def test_confirm_renders_message(self):
@@ -368,7 +647,7 @@ class TestRendering:
         assert "Delete everything?" in joined
         assert "y confirm" in joined
 
-        _handler_for(overlay.key_bindings, "escape")(_event())
+        _press(overlay, "escape")
         await task
 
 
@@ -381,49 +660,36 @@ class TestStateReset:
         opts = [{"value": "a"}, {"value": "b"}]
         task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
-        _handler_for(overlay.key_bindings, "enter")(_event())
+        _press(overlay, "enter")
         await task
 
         assert overlay._mode is None
         assert overlay._options == []
+        assert overlay._filtered == []
+        assert overlay._query == ""
         assert overlay._highlight == 0
         assert overlay._future is None
 
-    async def test_state_cleared_after_cancel(self):
-        overlay = SelectorOverlay()
-        task = asyncio.create_task(overlay.show_confirm("Sure?", app=None))
-        await asyncio.sleep(0)
-        _handler_for(overlay.key_bindings, "escape")(_event())
-        await task
-
-        assert overlay._mode is None
-        assert overlay._message == ""
-        assert overlay._future is None
-
-    async def test_second_select_after_first_completes(self):
+    async def test_query_cleared_between_sessions(self):
         overlay = SelectorOverlay()
         opts = [{"value": "a"}, {"value": "b"}]
 
-        # First select.
+        # First session: type something, then cancel.
         first = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
-        _handler_for(overlay.key_bindings, "enter")(_event())
-        assert await first == "a"
+        _press(overlay, "a")
+        _press(overlay, "escape")
+        assert await first is None
 
-        # Second select works with fresh state.
-        second = asyncio.create_task(
-            overlay.show_select("Pick again", opts, "b", app=None)
-        )
+        # Second session: query must start empty.
+        second = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
         await asyncio.sleep(0)
-        assert overlay._highlight == 1  # preselected via current="b"
-        _handler_for(overlay.key_bindings, "enter")(_event())
-        assert await second == "b"
-
-
-# ── Fixture/plumbing ───────────────────────────────────────────────────
+        assert overlay._query == ""
+        assert len(overlay._filtered) == 2
+        _press(overlay, "enter")
+        assert await second == "a"
 
 
 @pytest.fixture(autouse=True)
 def _fast_event_loop():
-    """Ensure each test gets a clean loop via pytest-asyncio default."""
     yield

--- a/tests/unit/test_cli_rich_selector.py
+++ b/tests/unit/test_cli_rich_selector.py
@@ -552,6 +552,140 @@ class TestConcurrentShow:
         assert await first is True
 
 
+# ── Viewport scrolling ─────────────────────────────────────────────────
+
+
+def _many_options(n: int) -> list[dict]:
+    """Build ``n`` dummy options: opt00, opt01, …"""
+    return [{"value": f"opt{i:02d}", "label": f"opt{i:02d}"} for i in range(n)]
+
+
+class TestViewport:
+    """Long option lists scroll within the overlay via ``_viewport_start``."""
+
+    async def test_short_list_never_scrolls(self):
+        overlay = SelectorOverlay()
+        opts = _many_options(3)
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        assert overlay._viewport_start == 0
+        start, end = overlay._viewport_range()
+        assert (start, end) == (0, 3)
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_long_list_caps_visible_rows(self):
+        from kohakuterrarium.builtins.cli_rich.selector import _MAX_VISIBLE_OPTIONS
+
+        overlay = SelectorOverlay()
+        opts = _many_options(_MAX_VISIBLE_OPTIONS + 5)
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        start, end = overlay._viewport_range()
+        assert end - start == _MAX_VISIBLE_OPTIONS
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_down_scrolls_viewport_when_past_cap(self):
+        from kohakuterrarium.builtins.cli_rich.selector import _MAX_VISIBLE_OPTIONS
+
+        overlay = SelectorOverlay()
+        opts = _many_options(_MAX_VISIBLE_OPTIONS + 3)
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # Move past the cap; viewport should slide down.
+        for _ in range(_MAX_VISIBLE_OPTIONS + 1):
+            _press(overlay, "down")
+        assert overlay._highlight == _MAX_VISIBLE_OPTIONS + 1
+        start, end = overlay._viewport_range()
+        assert start <= overlay._highlight < end
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_up_scrolls_viewport_backwards(self):
+        from kohakuterrarium.builtins.cli_rich.selector import _MAX_VISIBLE_OPTIONS
+
+        overlay = SelectorOverlay()
+        opts = _many_options(_MAX_VISIBLE_OPTIONS + 5)
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # Jump to the end, then walk back to the top.
+        _press(overlay, "end")
+        assert overlay._highlight == _MAX_VISIBLE_OPTIONS + 4
+        last_start, _ = overlay._viewport_range()
+        assert last_start > 0  # scrolled down
+
+        _press(overlay, "home")
+        assert overlay._highlight == 0
+        start, _ = overlay._viewport_range()
+        assert start == 0  # scrolled back to top
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_scroll_indicator_strings_in_render(self):
+        from kohakuterrarium.builtins.cli_rich.selector import _MAX_VISIBLE_OPTIONS
+
+        overlay = SelectorOverlay()
+        opts = _many_options(_MAX_VISIBLE_OPTIONS + 4)
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        # At the top: only "▼ N more below" should appear.
+        joined = "".join(text for _, text in overlay._render_select())
+        assert "▼" in joined
+        assert "more below" in joined
+        assert "▲" not in joined
+
+        # Scroll past the last visible row: both indicators appear.
+        for _ in range(_MAX_VISIBLE_OPTIONS):
+            _press(overlay, "down")
+        joined = "".join(text for _, text in overlay._render_select())
+        assert "▲" in joined
+        assert "more above" in joined
+        assert "▼" in joined
+
+        # Jump to the end: only "▲ N more above" remains.
+        _press(overlay, "end")
+        joined = "".join(text for _, text in overlay._render_select())
+        assert "▲" in joined
+        assert "▼" not in joined
+
+        _press(overlay, "escape")
+        await task
+
+    async def test_filter_resets_viewport(self):
+        from kohakuterrarium.builtins.cli_rich.selector import _MAX_VISIBLE_OPTIONS
+
+        overlay = SelectorOverlay()
+        opts = _many_options(_MAX_VISIBLE_OPTIONS + 5)
+        task = asyncio.create_task(overlay.show_select("Pick", opts, "", app=None))
+        await asyncio.sleep(0)
+
+        _press(overlay, "end")
+        assert overlay._viewport_start > 0
+
+        # Filter to a short match → viewport resets.
+        _press(overlay, "o")  # every option contains "opt"
+        _press(overlay, "p")
+        _press(overlay, "t")
+        _press(overlay, "0")
+        _press(overlay, "0")
+        assert overlay._filtered[0]["value"] == "opt00"
+        assert len(overlay._filtered) == 1
+        assert overlay._viewport_start == 0
+
+        _press(overlay, "escape")
+        await task
+
+
 # ── Rendering sanity ───────────────────────────────────────────────────
 
 
@@ -580,7 +714,7 @@ class TestRendering:
         fragments = overlay._render_select()
         joined = "".join(text for _, text in fragments)
         assert "Switch Model" in joined
-        assert "search" in joined
+        assert "›" in joined  # search arrow lives in the compact header
         assert "type to filter" in joined
         assert "opus" in joined
         assert "sonnet" in joined
@@ -598,7 +732,9 @@ class TestRendering:
         _press(overlay, "a")
         joined = "".join(text for _, text in overlay._render_select())
         assert "type to filter" not in joined
-        assert "  search " in joined
+        # Header remains: "  Pick  › a▏  1/2"
+        assert "› " in joined
+        assert "a" in joined  # the typed query
 
         _press(overlay, "escape")
         await task


### PR DESCRIPTION
## Summary

Replaces the plain numbered-list output of `/model` in `kt run ... --mode cli` (rich CLI) with an arrow-key modal selector that matches what Claude Code / Cursor / Gemini CLI ship. Closes #27.

- **Arrow-key navigation** — ↑↓ / Ctrl+P / Ctrl+N / Home / End; Enter picks the highlighted model; Esc or Ctrl+C cancels.
- **Type-to-filter search** — any printable key appends to a live query, Backspace deletes, Ctrl+U clears. Case-insensitive substring match across label / value / model / provider so typing `opus` instantly narrows a 20-model list.
- **Pre-highlight** — current model is pre-selected (by `selected` flag, falling back to matching `current` value).
- **Viewport scrolling with ▲ / ▼ indicators** — caps visible options at 8 and scrolls the window around the highlight so long model lists don't blow the height budget.
- **Compact rendering + reserved spacer** — one-row header folds title / search / count; overlay height adapts to content; a conditional spacer above the composer reserves exactly as many rows as the Float needs, so it works even when the terminal is scrolled to the bottom.
- **Works for `confirm` payloads too** — y/n dialog used by commands like `/clear`, `/exit` (via the same overlay, gated so `y` / `n` typed in select mode append to the search query instead of resolving).

## Architecture notes

- Lives inside the single `RichCLIApp` Application (one render loop, one tree — per the file header contract). No second `Application`; the overlay is a `FloatContainer` + two `ConditionalContainer` Floats gated on `is_select` / `is_confirm`.
- Composer key bindings are wrapped in `ConditionalKeyBindings(filter=~selector_visible)` so Enter/Esc yield to the overlay while it's up.
- Slash-command dispatch extracted into `SlashHandler` (new `cli_rich/slash.py`) so `app.py` stays under the 600-line cap.

## Files

| New / modified | Purpose |
|---|---|
| `src/kohakuterrarium/builtins/cli_rich/selector.py` (new) | `SelectorOverlay` — async `show_select` / `show_confirm`, key bindings, rendering, viewport |
| `src/kohakuterrarium/builtins/cli_rich/slash.py` (new) | `SlashHandler` — command dispatch + UI payload rendering |
| `src/kohakuterrarium/builtins/cli_rich/app.py` | Wires overlay into layout, adds reserved spacer, merges key bindings |
| `tests/unit/test_cli_rich_selector.py` (new) | 57 unit tests covering state, key bindings, filter, viewport, height, rendering |

## Test plan

- [x] `pytest tests/unit/` — 1985 passed, 11 skipped
- [x] `ruff check` clean
- [x] `black` formatted
- [x] All files ≤ 600 lines per project convention
- [x] Manual: `kt run kt-biome/creatures/swe --mode cli`, typed `/model`, navigated with arrows, filtered by typing partial names, confirmed switch
- [x] Manual: ran `/model` with the terminal cursor at the very bottom — overlay scrolls terminal content up to make room instead of falling back to "Window too small…"

## Out of scope

- Simple `CLIInput` mode (plain stdin, used in scripts / non-TTY) keeps its text-mode numbered-list rendering.
- TUI mode already had a native arrow-key modal via `builtins/tui/widgets/modals.py`.