### PR TITLE
cli_rich: decode Esc under kitty CSI u so it fires the interrupt hotkey

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/composer.py
+++ b/src/kohakuterrarium/builtins/cli_rich/composer.py
@@ -70,9 +70,10 @@ def _register_enhanced_keyboard_keys() -> None:
 
       where ``<codepoint>`` is the lowercase ASCII value (97..122).
 
-    - **Enter / Tab / Backspace** under Kitty CSI u — some terminals
-      disambiguate these even without modifiers:
+    - **Esc / Enter / Tab / Backspace** under Kitty CSI u — some
+      terminals disambiguate these even without modifiers:
 
+      - Esc       → ``ESC [ 27 u``   → ``Keys.Escape``
       - Enter     → ``ESC [ 13 u``   → ``Keys.ControlM``
       - Tab       → ``ESC [ 9 u``    → ``Keys.ControlI``
       - Backspace → ``ESC [ 127 u``  → ``Keys.ControlH``
@@ -120,10 +121,14 @@ def _register_enhanced_keyboard_keys() -> None:
         ANSI_SEQUENCES[f"\x1b[{codepoint};5u"] = key
         ANSI_SEQUENCES[f"\x1b[27;5;{codepoint}~"] = key
 
-    # Enter / Tab / Backspace — Kitty CSI u disambiguated forms.
+    # Esc / Enter / Tab / Backspace — Kitty CSI u disambiguated forms.
     # Terminals emit these when flag 1 of the protocol is active and
     # they choose to disambiguate all keys (not every terminal does,
     # but it costs us nothing to register defensively).
+    # Without the Esc mapping, pressing Esc on macOS (Ghostty / Kitty /
+    # WezTerm / recent iTerm2) leaks the bytes `[27u` into the composer
+    # instead of firing the interrupt hotkey.
+    ANSI_SEQUENCES["\x1b[27u"] = Keys.Escape  # Esc
     ANSI_SEQUENCES["\x1b[13u"] = Keys.ControlM  # Enter
     ANSI_SEQUENCES["\x1b[9u"] = Keys.ControlI  # Tab
     ANSI_SEQUENCES["\x1b[127u"] = Keys.ControlH  # Backspace

--- a/tests/unit/test_cli_rich_enhanced_keyboard.py
+++ b/tests/unit/test_cli_rich_enhanced_keyboard.py
@@ -1,0 +1,82 @@
+"""Regression tests for the enhanced-keyboard ANSI_SEQUENCES patches.
+
+The rich CLI enables the Kitty keyboard protocol + xterm modifyOtherKeys
+at startup (see ``cli_rich/runtime.py``). Once that's active, terminals
+emit escape sequences that prompt_toolkit's built-in parser does not
+know how to decode, so ``cli_rich/composer.py`` patches the global
+``ANSI_SEQUENCES`` table at import time.
+
+Missing entries here silently break interactive keybindings — the
+affected key gets its raw escape bytes dumped into the composer
+instead of firing the bound action. Pin the full set of mappings so
+any accidental removal is caught immediately.
+"""
+
+import pytest
+
+pytest.importorskip("prompt_toolkit")
+
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.keys import Keys
+
+# Side-effect import: registers the patches. Must come after the
+# importorskip so environments without prompt_toolkit skip cleanly.
+import kohakuterrarium.builtins.cli_rich.composer as composer  # noqa: F401,E402
+
+
+def test_kitty_csi_u_esc_decodes_to_escape():
+    """Regression: Esc under Kitty CSI u must decode to Keys.Escape.
+
+    Before the fix, pressing Esc on macOS terminals that honor the
+    Kitty keyboard protocol (Ghostty / Kitty / WezTerm / recent iTerm2)
+    leaked the bytes ``[27u`` into the composer buffer instead of
+    interrupting the agent.
+    """
+    assert ANSI_SEQUENCES["\x1b[27u"] == Keys.Escape
+
+
+def test_kitty_csi_u_enter_tab_backspace_decoded():
+    """Enter / Tab / Backspace disambiguated forms are covered."""
+    assert ANSI_SEQUENCES["\x1b[13u"] == Keys.ControlM
+    assert ANSI_SEQUENCES["\x1b[9u"] == Keys.ControlI
+    assert ANSI_SEQUENCES["\x1b[127u"] == Keys.ControlH
+
+
+def test_modifier_enter_proxies_registered():
+    """Shift/Ctrl/Ctrl+Shift + Enter hit the F19/F20/F21 proxy slots.
+
+    Both the xterm modifyOtherKeys=2 (`ESC [ 27 ; mod ; 13 ~`) and
+    Kitty CSI u (`ESC [ 13 ; mod u`) forms must land on the same
+    proxy keys or the "insert newline" key bindings stop firing.
+    """
+    assert ANSI_SEQUENCES["\x1b[27;2;13~"] == composer.SHIFT_ENTER_KEY
+    assert ANSI_SEQUENCES["\x1b[27;5;13~"] == composer.CTRL_ENTER_KEY
+    assert ANSI_SEQUENCES["\x1b[27;6;13~"] == composer.CTRL_SHIFT_ENTER_KEY
+    assert ANSI_SEQUENCES["\x1b[13;2u"] == composer.SHIFT_ENTER_KEY
+    assert ANSI_SEQUENCES["\x1b[13;5u"] == composer.CTRL_ENTER_KEY
+    assert ANSI_SEQUENCES["\x1b[13;6u"] == composer.CTRL_SHIFT_ENTER_KEY
+
+
+@pytest.mark.parametrize("letter", list("abcdefghijklmnopqrstuvwxyz"))
+def test_ctrl_letter_decoded_under_both_encodings(letter):
+    """Ctrl+a..z must decode identically under Kitty CSI u and
+    modifyOtherKeys=2 — otherwise Ctrl+C, Ctrl+D, Ctrl+L etc. silently
+    stop firing on terminals that enable the disambiguation flag.
+    """
+    codepoint = ord(letter)
+    expected = getattr(Keys, f"Control{letter.upper()}")
+    assert ANSI_SEQUENCES[f"\x1b[{codepoint};5u"] == expected
+    assert ANSI_SEQUENCES[f"\x1b[27;5;{codepoint}~"] == expected
+
+
+def test_registration_is_idempotent():
+    """Re-running the registration must not raise or mutate entries.
+
+    The module-level guard (`_ENHANCED_KEYS_REGISTERED`) exists so
+    test harnesses that reload the module don't repeatedly rewrite
+    the shared ANSI_SEQUENCES dict.
+    """
+    before = ANSI_SEQUENCES["\x1b[27u"]
+    composer._register_enhanced_keyboard_keys()
+    composer._register_enhanced_keyboard_keys()
+    assert ANSI_SEQUENCES["\x1b[27u"] == before


### PR DESCRIPTION
## Summary

- Fixes #34 — pressing Esc on macOS terminals that honor the Kitty keyboard protocol (Ghostty / Kitty / WezTerm / recent iTerm2) leaked the bytes `[27u` into the composer instead of firing the interrupt hotkey.
- Root cause: `runtime.enable_enhanced_keyboard` enables the Kitty CSI u "Disambiguate escape codes" flag, which makes the terminal emit Esc as `ESC [ 27 u`. `composer._register_enhanced_keyboard_keys` already patched the disambiguated forms of Enter / Tab / Backspace into `prompt_toolkit`'s `ANSI_SEQUENCES`, but the Esc entry was missing — so the bytes fell through as raw text.
- Adds the one-line mapping alongside the sibling entries, plus pinning tests covering the full enhanced-keyboard patch set (Esc, Enter/Tab/Backspace disambiguation, Shift/Ctrl/Ctrl+Shift+Enter proxies, all 26 Ctrl+letter mappings under both encodings, and idempotency).

## Test plan

- [x] `.venv/bin/python -m pytest tests/unit/test_cli_rich_enhanced_keyboard.py` — 30 passed
- [x] `.venv/bin/python -m pytest tests/unit/` — 1973 passed, 11 skipped (no regressions)
- [x] `.venv/bin/python -m black --check src/ tests/` — clean
- [x] `.venv/bin/python -m ruff check src/ tests/` — clean
- [x] Manual verification on macOS: `kt run` in a Kitty-protocol terminal → pressing Esc now interrupts instead of inserting `[27u`.