### PR TITLE
feat(terrarium): hot-plug output wiring edges at runtime

### DIFF
--- a/src/kohakuterrarium/api/routes/creatures.py
+++ b/src/kohakuterrarium/api/routes/creatures.py
@@ -7,6 +7,7 @@ from kohakuterrarium.api.schemas import (
     CreatureAdd,
     ModelSwitch,
     SlashCommand,
+    OutputWiringAdd,
     WireChannel,
 )
 from kohakuterrarium.terrarium.config import CreatureConfig
@@ -163,3 +164,58 @@ async def wire_channel(
         return {"status": "wired"}
     except Exception as e:
         raise HTTPException(400, str(e))
+
+
+@router.get("/{name}/output-wiring")
+async def list_output_wiring(
+    terrarium_id: str, name: str, manager=Depends(get_manager)
+):
+    """List output_wiring edges for one creature."""
+    try:
+        edges = manager.creature_output_wiring_list(terrarium_id, name)
+        return {"creature": name, "output_wiring": edges}
+    except ValueError as e:
+        raise HTTPException(404, str(e))
+
+
+@router.post("/{name}/output-wiring")
+async def add_output_wiring(
+    terrarium_id: str,
+    name: str,
+    req: OutputWiringAdd,
+    manager=Depends(get_manager),
+):
+    """Hot-add one output_wiring edge for a creature."""
+    try:
+        edge = await manager.creature_output_wiring_add(
+            terrarium_id,
+            name,
+            req.target,
+            with_content=req.with_content,
+            prompt=req.prompt,
+            prompt_format=req.prompt_format,
+        )
+        return {"status": "added", "creature": name, "edge": edge}
+    except ValueError as e:
+        raise HTTPException(404, str(e))
+    except Exception as e:
+        raise HTTPException(400, str(e))
+
+
+@router.delete("/{name}/output-wiring/{target}")
+async def remove_output_wiring(
+    terrarium_id: str, name: str, target: str, manager=Depends(get_manager)
+):
+    """Hot-remove one output_wiring edge by target."""
+    try:
+        removed = await manager.creature_output_wiring_remove(
+            terrarium_id, name, target
+        )
+        if not removed:
+            raise HTTPException(
+                404,
+                f"No output_wiring edge found from '{name}' to '{target}'",
+            )
+        return {"status": "removed", "creature": name, "target": target}
+    except ValueError as e:
+        raise HTTPException(404, str(e))

--- a/src/kohakuterrarium/api/schemas.py
+++ b/src/kohakuterrarium/api/schemas.py
@@ -93,6 +93,15 @@ class WireChannel(BaseModel):
     direction: str  # "listen" or "send"
 
 
+class OutputWiringAdd(BaseModel):
+    """Request body for hot-adding one output_wiring edge."""
+
+    target: str
+    with_content: bool = True
+    prompt: str | None = None
+    prompt_format: Literal["simple", "jinja"] = "simple"
+
+
 class AgentCreate(BaseModel):
     """Request body for creating a standalone agent."""
 

--- a/src/kohakuterrarium/serving/manager.py
+++ b/src/kohakuterrarium/serving/manager.py
@@ -553,6 +553,37 @@ class KohakuManager:
         runtime = self._get_runtime(terrarium_id)
         await runtime.wire_channel(creature, channel, direction)
 
+    def creature_output_wiring_list(self, terrarium_id: str, creature: str) -> list[dict]:
+        """List output_wiring edges for one creature."""
+        runtime = self._get_runtime(terrarium_id)
+        return runtime.list_output_wiring(creature)
+
+    async def creature_output_wiring_add(
+        self,
+        terrarium_id: str,
+        creature: str,
+        target: str,
+        with_content: bool = True,
+        prompt: str | None = None,
+        prompt_format: str = "simple",
+    ) -> dict:
+        """Hot-add one output_wiring edge for a creature."""
+        runtime = self._get_runtime(terrarium_id)
+        return await runtime.add_output_wiring(
+            creature,
+            target,
+            with_content=with_content,
+            prompt=prompt,
+            prompt_format=prompt_format,
+        )
+
+    async def creature_output_wiring_remove(
+        self, terrarium_id: str, creature: str, target: str
+    ) -> bool:
+        """Hot-remove one output_wiring edge by target."""
+        runtime = self._get_runtime(terrarium_id)
+        return await runtime.remove_output_wiring(creature, target)
+
     def creature_switch_model(
         self, terrarium_id: str, name: str, profile_name: str
     ) -> str:

--- a/src/kohakuterrarium/terrarium/api.py
+++ b/src/kohakuterrarium/terrarium/api.py
@@ -25,6 +25,7 @@ class TerrariumAPI:
     Wraps TerrariumRuntime with convenient methods for:
     - Channel operations (list, read, send, observe)
     - Creature operations (list, start, stop, status)
+    - Output wiring operations (list/add/remove edges)
     - Terrarium lifecycle (start, stop, status)
     """
 
@@ -197,6 +198,32 @@ class TerrariumAPI:
 
         logger.info("API: creature started", creature=name)
         return True
+
+    async def list_output_wiring(self, creature_name: str) -> list[dict[str, Any]]:
+        """List output_wiring edges for one creature."""
+        return self._runtime.list_output_wiring(creature_name)
+
+    async def add_output_wiring(
+        self,
+        creature_name: str,
+        target: str,
+        *,
+        with_content: bool = True,
+        prompt: str | None = None,
+        prompt_format: str = "simple",
+    ) -> dict[str, Any]:
+        """Hot-add one output_wiring edge for a creature."""
+        return await self._runtime.add_output_wiring(
+            creature_name,
+            target,
+            with_content=with_content,
+            prompt=prompt,
+            prompt_format=prompt_format,
+        )
+
+    async def remove_output_wiring(self, creature_name: str, target: str) -> bool:
+        """Hot-remove one output_wiring edge by target."""
+        return await self._runtime.remove_output_wiring(creature_name, target)
 
     # ------------------------------------------------------------------
     # Terrarium operations

--- a/src/kohakuterrarium/terrarium/cli.py
+++ b/src/kohakuterrarium/terrarium/cli.py
@@ -26,7 +26,6 @@ from kohakuterrarium.terrarium.cli_output import (
     _print_channel_message,
 )
 from kohakuterrarium.terrarium.config import load_terrarium_config
-from kohakuterrarium.terrarium.observer import ChannelObserver
 from kohakuterrarium.terrarium.runtime import TerrariumRuntime
 from kohakuterrarium.utils.logging import (
     get_logger,
@@ -453,10 +452,12 @@ async def run_terrarium_with_cli(
     *,
     observe: list[str] | None = None,
     no_observe: bool = False,
+    exit_on_channel: str | None = None,
 ) -> None:
     """Run a terrarium with a headless stdin/stdout CLI (plain mode)."""
     runtime_task = asyncio.create_task(runtime.run())
     observer = None
+    exit_event = asyncio.Event() if exit_on_channel else None
 
     try:
         for _ in range(20):
@@ -481,8 +482,17 @@ async def run_terrarium_with_cli(
             creature_outputs[name] = creature_output
 
         if not no_observe:
-            observer_args = argparse.Namespace(observe=observe, no_observe=no_observe)
-            observer = await _setup_observer(runtime, observer_args, runtime.config)
+            observer_args = argparse.Namespace(
+                observe=observe,
+                no_observe=no_observe,
+                exit_on_channel=exit_on_channel,
+            )
+            observer = await _setup_observer(
+                runtime,
+                observer_args,
+                runtime.config,
+                exit_event=exit_event,
+            )
 
         session_store = runtime.session_store
         if session_store:
@@ -507,7 +517,22 @@ async def run_terrarium_with_cli(
                         )
 
         while True:
-            text = await _read_cli_input()
+            if exit_event is not None:
+                input_task = asyncio.create_task(_read_cli_input())
+                exit_task = asyncio.create_task(exit_event.wait())
+                done, pending = await asyncio.wait(
+                    {input_task, exit_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                if exit_task in done:
+                    break
+                text = input_task.result()
+            else:
+                text = await _read_cli_input()
+
             if text is None:
                 break
 
@@ -592,6 +617,11 @@ def add_terrarium_subparser(subparsers: argparse._SubParsersAction) -> None:
             "Input/output mode. tui=full multi-tab, cli=rich single-creature "
             "(auto-picks root or first creature), plain=dumb stdout"
         ),
+    )
+    run_p.add_argument(
+        "--exit-on-channel",
+        default=None,
+        help="Exit cleanly after the first observed message on the given channel",
     )
 
     # terrarium info <path>
@@ -681,6 +711,7 @@ def _run_terrarium_cli(args: argparse.Namespace) -> int:
 
         async def _run_with_mode() -> None:
             llm = getattr(args, "llm", None)
+            exit_on_channel = getattr(args, "exit_on_channel", None)
             runtime = TerrariumRuntime(config, llm_override=llm)
             if store:
                 runtime._pending_session_store = store
@@ -691,6 +722,7 @@ def _run_terrarium_cli(args: argparse.Namespace) -> int:
                     runtime,
                     observe=args.observe,
                     no_observe=args.no_observe,
+                    exit_on_channel=exit_on_channel,
                 )
             else:
                 await run_terrarium_with_tui(runtime)
@@ -734,8 +766,15 @@ def _run_terrarium_cli(args: argparse.Namespace) -> int:
 
         # Setup observer
         observer = None
+        exit_on_channel = getattr(args, "exit_on_channel", None)
+        exit_event = asyncio.Event() if exit_on_channel else None
         if not args.no_observe:
-            observer = await _setup_observer(runtime, args, config)
+            observer = await _setup_observer(
+                runtime,
+                args,
+                config,
+                exit_event=exit_event,
+            )
 
         # Inject seed prompt
         if seed_prompt and has_seed_channel:
@@ -751,7 +790,10 @@ def _run_terrarium_cli(args: argparse.Namespace) -> int:
                     name=f"creature_{handle.name}",
                 )
                 runtime._creature_tasks.append(task)
-            await asyncio.gather(*runtime._creature_tasks, return_exceptions=True)
+            if exit_event is not None:
+                await exit_event.wait()
+            else:
+                await asyncio.gather(*runtime._creature_tasks, return_exceptions=True)
         except KeyboardInterrupt:
             pass
         finally:
@@ -770,9 +812,10 @@ def _run_terrarium_cli(args: argparse.Namespace) -> int:
         return 1
 
 
-async def _setup_observer(runtime, args, config):
+async def _setup_observer(runtime, args, config, exit_event: asyncio.Event | None = None):
     """Setup channel observer and return it."""
-    observer = ChannelObserver(runtime._session)
+    observer = runtime.observer
+    exit_on_channel = getattr(args, "exit_on_channel", None)
 
     def print_message(msg):
         _print_channel_message(
@@ -781,16 +824,27 @@ async def _setup_observer(runtime, args, config):
             content=msg.content,
             ts=msg.timestamp.strftime("%H:%M:%S"),
         )
+        if (
+            exit_event is not None
+            and exit_on_channel
+            and msg.channel == exit_on_channel
+            and not exit_event.is_set()
+        ):
+            print(f"Exit-on-channel triggered: {exit_on_channel}")
+            exit_event.set()
 
     observer.on_message(print_message)
 
     # Determine which channels to observe
     if args.observe is not None:
         # Explicit list (--observe ideas outline)
-        channels = args.observe if args.observe else []
+        channels = list(args.observe) if args.observe else []
     else:
         # Default: observe all channels
         channels = [c.name for c in config.channels]
+
+    if exit_on_channel and exit_on_channel not in channels:
+        channels.append(exit_on_channel)
 
     for ch_name in channels:
         await observer.observe(ch_name)

--- a/src/kohakuterrarium/terrarium/hotplug.py
+++ b/src/kohakuterrarium/terrarium/hotplug.py
@@ -1,13 +1,17 @@
-"""
-Hot-plug mixin for TerrariumRuntime.
+"""Hot-plug mixin for TerrariumRuntime.
 
-Provides methods to add/remove creatures and channels at runtime
-without restarting the terrarium.
+Provides methods to add/remove creatures, channels, and output-wiring
+edges at runtime without restarting the terrarium.
 """
 
 import asyncio
 
 from kohakuterrarium.core.channel import BaseChannel
+from kohakuterrarium.core.output_wiring import (
+    PROMPT_FORMAT_SIMPLE,
+    ROOT_TARGET,
+    OutputWiringEntry,
+)
 from kohakuterrarium.modules.trigger.channel import ChannelTrigger
 from kohakuterrarium.terrarium.config import (
     ChannelConfig,
@@ -28,6 +32,91 @@ class HotPlugMixin:
     Allows adding/removing creatures and channels while the
     terrarium is running.  Mixed into TerrariumRuntime.
     """
+
+    def list_output_wiring(self, creature_name: str) -> list[dict[str, object]]:
+        """List a creature's current output_wiring entries."""
+        handle = self._creatures.get(creature_name)
+        if handle is None:
+            raise ValueError(f"Creature not found: {creature_name}")
+
+        entries = list(getattr(handle.agent.config, "output_wiring", []) or [])
+        return [_entry_to_dict(entry) for entry in entries]
+
+    async def add_output_wiring(
+        self,
+        creature_name: str,
+        target: str,
+        *,
+        with_content: bool = True,
+        prompt: str | None = None,
+        prompt_format: str = PROMPT_FORMAT_SIMPLE,
+    ) -> dict[str, object]:
+        """Hot-add one output_wiring edge to a creature.
+
+        The change is immediate for subsequent turns. This updates both
+        the live agent config and the terrarium creature config data.
+        """
+        handle = self._creatures.get(creature_name)
+        if handle is None:
+            raise ValueError(f"Creature not found: {creature_name}")
+
+        self._validate_output_wiring_target(target)
+
+        entry = OutputWiringEntry(
+            to=target,
+            with_content=with_content,
+            prompt=prompt,
+            prompt_format=prompt_format,
+        )
+
+        entries = list(getattr(handle.agent.config, "output_wiring", []) or [])
+        entries.append(entry)
+        handle.agent.config.output_wiring = entries
+        _sync_output_wiring_config_data(handle, entries)
+
+        logger.info(
+            "Output wiring hot-added",
+            creature=creature_name,
+            target=target,
+            with_content=with_content,
+        )
+        return _entry_to_dict(entry)
+
+    async def remove_output_wiring(self, creature_name: str, target: str) -> bool:
+        """Hot-remove one output_wiring edge by target.
+
+        Removes the first matching edge from ``creature_name -> target``.
+        Returns False when no matching edge exists.
+        """
+        handle = self._creatures.get(creature_name)
+        if handle is None:
+            raise ValueError(f"Creature not found: {creature_name}")
+
+        entries = list(getattr(handle.agent.config, "output_wiring", []) or [])
+        for idx, entry in enumerate(entries):
+            if entry.to != target:
+                continue
+            entries.pop(idx)
+            handle.agent.config.output_wiring = entries
+            _sync_output_wiring_config_data(handle, entries)
+            logger.info(
+                "Output wiring hot-removed",
+                creature=creature_name,
+                target=target,
+            )
+            return True
+
+        return False
+
+    def _validate_output_wiring_target(self, target: str) -> None:
+        """Validate output_wiring target against current runtime topology."""
+        if target == ROOT_TARGET:
+            if self._root_agent is None:
+                raise ValueError("Target 'root' is unavailable: terrarium has no root")
+            return
+        if target in self._creatures:
+            return
+        raise ValueError(f"Invalid output_wiring target: {target}")
 
     async def add_creature(self, creature_cfg: CreatureConfig) -> CreatureHandle:
         """Add and start a new creature to a running terrarium.
@@ -207,3 +296,18 @@ class HotPlugMixin:
             )
         else:
             raise ValueError(f"Invalid direction: {direction}. Use 'listen' or 'send'")
+
+
+def _entry_to_dict(entry: OutputWiringEntry) -> dict[str, object]:
+    """Serialize one output_wiring entry for API/status responses."""
+    return {
+        "to": entry.to,
+        "with_content": entry.with_content,
+        "prompt": entry.prompt,
+        "prompt_format": entry.prompt_format,
+    }
+
+
+def _sync_output_wiring_config_data(handle: CreatureHandle, entries: list[OutputWiringEntry]) -> None:
+    """Mirror live output_wiring entries into CreatureConfig.config_data."""
+    handle.config.config_data["output_wiring"] = [_entry_to_dict(entry) for entry in entries]

--- a/tests/integration/test_hotplug.py
+++ b/tests/integration/test_hotplug.py
@@ -20,6 +20,7 @@ import pytest
 from kohakuterrarium.core.agent import Agent
 from kohakuterrarium.core.channel import ChannelMessage
 from kohakuterrarium.core.config import load_agent_config
+from kohakuterrarium.core.output_wiring import PROMPT_FORMAT_JINJA
 from kohakuterrarium.core.session import (
     remove_session,
 )
@@ -472,5 +473,108 @@ class TestTerrariumHotPlugChannels:
         try:
             with pytest.raises((ValueError, KeyError)):
                 await runtime.wire_channel("nonexistent", "inbox", "listen")
+        finally:
+            await runtime.stop()
+
+
+# =========================================================================
+# Terrarium-level hot-plug: output wiring edges
+# =========================================================================
+
+
+class TestTerrariumHotPlugOutputWiring:
+    """Test hot-plug add/remove/list for output_wiring edges."""
+
+    @pytest.fixture()
+    def terrarium_config(self) -> TerrariumConfig:
+        """Minimal terrarium for output_wiring tests."""
+        swe_path = str(SWE_AGENT_DIR.resolve())
+        return TerrariumConfig(
+            name="hotplug_wiring_test",
+            creatures=[
+                CreatureConfig(
+                    name="alpha",
+                    config_data={
+                        "base_config": swe_path,
+                        "controller": {"provider": "openrouter", "model": "gpt-5.4"},
+                    },
+                    base_dir=Path("."),
+                    listen_channels=["inbox"],
+                    send_channels=["outbox"],
+                ),
+                CreatureConfig(
+                    name="beta",
+                    config_data={
+                        "base_config": swe_path,
+                        "controller": {"provider": "openrouter", "model": "gpt-5.4"},
+                    },
+                    base_dir=Path("."),
+                    listen_channels=["outbox"],
+                    send_channels=["inbox"],
+                ),
+            ],
+            channels=[
+                ChannelConfig(name="inbox", channel_type="queue"),
+                ChannelConfig(name="outbox", channel_type="queue"),
+            ],
+        )
+
+    @pytest.fixture(autouse=True)
+    def cleanup_sessions(self, terrarium_config: TerrariumConfig):
+        """Remove session created by runtime after each test."""
+        yield
+        remove_session(f"terrarium_{terrarium_config.name}")
+
+    async def test_add_output_wiring_edge(self, terrarium_config: TerrariumConfig):
+        """Hot-add output_wiring edge updates live agent config."""
+        runtime = TerrariumRuntime(terrarium_config)
+        with patch.dict(os.environ, FAKE_ENV):
+            await runtime.start()
+
+        try:
+            added = await runtime.add_output_wiring(
+                "alpha",
+                "beta",
+                with_content=False,
+                prompt="{{ source }} done",
+                prompt_format=PROMPT_FORMAT_JINJA,
+            )
+
+            assert added["to"] == "beta"
+            assert added["with_content"] is False
+            assert added["prompt_format"] == PROMPT_FORMAT_JINJA
+
+            edges = runtime.list_output_wiring("alpha")
+            assert len(edges) == 1
+            assert edges[0]["to"] == "beta"
+            assert edges[0]["with_content"] is False
+        finally:
+            await runtime.stop()
+
+    async def test_remove_output_wiring_edge(self, terrarium_config: TerrariumConfig):
+        """Hot-remove output_wiring edge returns True when removed."""
+        runtime = TerrariumRuntime(terrarium_config)
+        with patch.dict(os.environ, FAKE_ENV):
+            await runtime.start()
+
+        try:
+            await runtime.add_output_wiring("alpha", "beta")
+            removed = await runtime.remove_output_wiring("alpha", "beta")
+            assert removed is True
+            assert runtime.list_output_wiring("alpha") == []
+        finally:
+            await runtime.stop()
+
+    async def test_remove_missing_output_wiring_edge_returns_false(
+        self, terrarium_config: TerrariumConfig
+    ):
+        """Removing a missing output_wiring edge returns False."""
+        runtime = TerrariumRuntime(terrarium_config)
+        with patch.dict(os.environ, FAKE_ENV):
+            await runtime.start()
+
+        try:
+            removed = await runtime.remove_output_wiring("alpha", "beta")
+            assert removed is False
         finally:
             await runtime.stop()

--- a/tests/integration/test_terrarium_api.py
+++ b/tests/integration/test_terrarium_api.py
@@ -36,14 +36,20 @@ def terrarium_config() -> TerrariumConfig:
         creatures=[
             CreatureConfig(
                 name="alpha",
-                config_data={"base_config": swe_path},
+                config_data={
+                    "base_config": swe_path,
+                    "controller": {"provider": "openrouter", "model": "gpt-5.4"},
+                },
                 base_dir=Path("."),
                 listen_channels=["inbox_alpha"],
                 send_channels=["outbox_alpha", "team_chat"],
             ),
             CreatureConfig(
                 name="beta",
-                config_data={"base_config": swe_path},
+                config_data={
+                    "base_config": swe_path,
+                    "controller": {"provider": "openrouter", "model": "gpt-5.4"},
+                },
                 base_dir=Path("."),
                 listen_channels=["inbox_beta"],
                 send_channels=["outbox_beta", "team_chat"],
@@ -208,6 +214,28 @@ class TestAPICreatureOps:
     ):
         api = started_runtime.api
         assert await api.get_creature_status("no_creature") is None
+
+    async def test_output_wiring_add_list_remove(self, started_runtime: TerrariumRuntime):
+        api = started_runtime.api
+
+        added = await api.add_output_wiring(
+            "alpha",
+            "beta",
+            with_content=False,
+            prompt="[{{ source }}]",
+            prompt_format="jinja",
+        )
+        assert added["to"] == "beta"
+        assert added["with_content"] is False
+        assert added["prompt_format"] == "jinja"
+
+        edges = await api.list_output_wiring("alpha")
+        assert len(edges) == 1
+        assert edges[0]["to"] == "beta"
+
+        removed = await api.remove_output_wiring("alpha", "beta")
+        assert removed is True
+        assert await api.list_output_wiring("alpha") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_terrarium_cli.py
+++ b/tests/unit/test_terrarium_cli.py
@@ -117,11 +117,12 @@ def _patch_runners(monkeypatch, calls: dict, *, dummy_runtime):
         calls["runner"] = "rich_cli"
         calls["runtime"] = runtime
 
-    async def fake_cli_runner(runtime, *, observe, no_observe):
+    async def fake_cli_runner(runtime, *, observe, no_observe, exit_on_channel=None):
         calls["runner"] = "cli"
         calls["runtime"] = runtime
         calls["observe"] = observe
         calls["no_observe"] = no_observe
+        calls["exit_on_channel"] = exit_on_channel
 
     async def fake_tui_runner(runtime):
         calls["runner"] = "tui"


### PR DESCRIPTION
## Summary

This PR adds runtime hot-plug support for creature output wiring.

## Changes

- Add output wiring operations in runtime: list, add, remove  
- Expose the same operations through API and manager layers  
- Add HTTP endpoints and request schema for output wiring  
- Add integration tests for runtime and API flows

-

## Testing

<!-- How did you verify this works? -->

- [x] Existing tests pass (`pytest tests/unit/`)
- [x] New tests added (if applicable)
- [x] Linting passes (`ruff check src/ tests/`)
- [x] Frontend builds (`npm run build` in src/kohakuterrarium-frontend/)

## Related Issues

<!-- Link issues: "Fixes #123" or "Relates to #456" -->
