### PR TITLE
fix(serve): publish actual bound port from daemon to CLI state

### DIFF
--- a/scripts/dep_graph_allowlist.json
+++ b/scripts/dep_graph_allowlist.json
@@ -31,33 +31,33 @@
   },
   {
     "file": "src/kohakuterrarium/serving/web.py",
-    "line": 31,
+    "line": 32,
     "function": "_resolve_config_dirs",
     "reason": "package-discovery cold-path; avoids loading packages module on bare uvicorn boot"
   },
   {
     "file": "src/kohakuterrarium/serving/web.py",
-    "line": 32,
+    "line": 33,
     "function": "_resolve_config_dirs",
-    "reason": "package-discovery cold-path; sibling of line 31 — same justification"
+    "reason": "package-discovery cold-path; sibling of line 32 — same justification"
   },
   {
     "file": "src/kohakuterrarium/serving/web.py",
-    "line": 105,
+    "line": 134,
     "function": "run_web_server",
     "reason": "FastAPI app factory: serving->api lazy boot avoids pulling all routes when only the helper is touched"
   },
   {
     "file": "src/kohakuterrarium/serving/web.py",
-    "line": 157,
+    "line": 188,
     "function": "run_desktop_app",
     "reason": "subprocess used only when relaunching as desktop process"
   },
   {
     "file": "src/kohakuterrarium/serving/web.py",
-    "line": 221,
+    "line": 252,
     "function": "_run_desktop_app_blocking",
-    "reason": "FastAPI app factory: same as line 104, desktop variant"
+    "reason": "FastAPI app factory: same as line 134, desktop variant"
   },
   {
     "file": "src/kohakuterrarium/api/studio/introspect.py",
@@ -187,13 +187,13 @@
   },
   {
     "file": "src/kohakuterrarium/serving/web.py",
-    "line": 103,
+    "line": 132,
     "function": "run_web_server",
     "reason": "uvicorn is heavy; imported only when serving HTTP for real"
   },
   {
     "file": "src/kohakuterrarium/serving/web.py",
-    "line": 219,
+    "line": 250,
     "function": "_run_desktop_app_blocking",
     "reason": "uvicorn import deferred to desktop-app launch path"
   },

--- a/src/kohakuterrarium/cli/__init__.py
+++ b/src/kohakuterrarium/cli/__init__.py
@@ -330,6 +330,7 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",
     )
+    internal_serve_parser.add_argument("--state-path", default=None)
 
     return parser
 
@@ -449,6 +450,7 @@ COMMANDS: dict[str, callable] = {
             port=args.port,
             dev=args.dev,
             log_level=args.log_level,
+            state_path=args.state_path,
         )
     ),
     "extension": _dispatch_extension,

--- a/src/kohakuterrarium/cli/serve.py
+++ b/src/kohakuterrarium/cli/serve.py
@@ -127,6 +127,8 @@ def _spawn_server_process(host: str, port: int, dev: bool, log_level: str) -> in
         host,
         "--port",
         str(port),
+        "--state-path",
+        str(STATE_PATH),
     ]
     if dev:
         cmd.append("--dev")
@@ -155,6 +157,18 @@ def _wait_until_alive(pid: int, timeout: float = 3.0) -> bool:
     return _is_pid_alive(pid)
 
 
+def _wait_until_bound(pid: int, timeout: float = 3.0) -> bool:
+    """Wait for the subprocess to publish its actual bound port to the state file."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _is_pid_alive(pid):
+            return False
+        if _load_state().get("bound"):
+            return True
+        time.sleep(0.1)
+    return _is_pid_alive(pid) and bool(_load_state().get("bound"))
+
+
 def serve_start_cli(args: argparse.Namespace) -> int:
     runtime = _current_runtime()
     if runtime["alive"]:
@@ -169,11 +183,6 @@ def serve_start_cli(args: argparse.Namespace) -> int:
         _remove_runtime_files()
 
     pid = _spawn_server_process(args.host, args.port, args.dev, args.log_level)
-    if not _wait_until_alive(pid):
-        print("Failed to start KohakuTerrarium web daemon.")
-        print(f"Check log: {LOG_PATH}")
-        return 1
-
     _write_started_state(
         pid=pid,
         host=args.host,
@@ -181,6 +190,11 @@ def serve_start_cli(args: argparse.Namespace) -> int:
         dev=args.dev,
         log_level=args.log_level,
     )
+    if not _wait_until_bound(pid):
+        print("Failed to start KohakuTerrarium web daemon.")
+        print(f"Check log: {LOG_PATH}")
+        return 1
+
     state = _load_state()
     print("KohakuTerrarium web daemon started")
     print(f"  pid:  {pid}")
@@ -307,6 +321,7 @@ def run_server_internal(args: argparse.Namespace) -> int:
         port=args.port,
         dev=args.dev,
         log_level=args.log_level,
+        state_path=getattr(args, "state_path", None),
     )
     return 0
 

--- a/src/kohakuterrarium/serving/web.py
+++ b/src/kohakuterrarium/serving/web.py
@@ -6,6 +6,7 @@ Web server and desktop app launcher for KohakuTerrarium.
 """
 
 import ctypes
+import json
 import os
 import socket
 import sys
@@ -85,11 +86,37 @@ def find_free_port(
     raise RuntimeError(f"No free port found in range {start}-{start + max_tries - 1}")
 
 
+def _publish_actual_port(state_path: str | None, host: str, port: int) -> None:
+    """Update daemon state file with the actual bound port.
+
+    No-op if state_path is None (e.g. ``kt web`` direct invocation) or the
+    file does not exist. CLI polls this file's ``bound`` field after spawn.
+    """
+    if not state_path:
+        return
+    path = Path(state_path)
+    if not path.exists():
+        return
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return
+        data["port"] = port
+        data["url"] = f"http://{host}:{port}"
+        data["bound"] = True
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2, sort_keys=True)
+    except Exception:
+        pass
+
+
 def run_web_server(
     host: str = "127.0.0.1",
     port: int = 8001,
     dev: bool = False,
     log_level: str = "INFO",
+    state_path: str | None = None,
 ) -> None:
     """Start the FastAPI server, optionally serving the built frontend.
 
@@ -97,6 +124,8 @@ def run_web_server(
         host: Bind address.
         port: Bind port.
         dev: If True, skip static file serving (user runs vite dev separately).
+        state_path: When set (daemon mode), write the actual bound port back
+            to this JSON file so the launching CLI can show the truth.
     """
     configure_utf8_stdio(log=True)
 
@@ -129,6 +158,8 @@ def run_web_server(
     except RuntimeError as e:
         logger.error("Port allocation failed", error=str(e))
         sys.exit(1)
+
+    _publish_actual_port(state_path, host, port)
 
     if dev:
         print(f"API-only mode on http://{host}:{port}")


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 sentences. -->

`kt serve` (and `kt serve restart`) was printing `http://127.0.0.1:8001` even when the daemon had silently drifted to a different port via `find_free_port`. The subprocess now publishes its actual bound port to `web.json`, and the CLI waits for that flag before reporting success — so the printed URL always matches the listening socket.

## PR Type

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

<!-- Why is this change needed? What problem does it solve? -->

Reproduction:

1. Something is already bound to port 8001 (e.g. an orphaned previous daemon).
2. `kt serve start` (or `restart`) spawns the subprocess; `find_free_port(start=8001)` walks to 8002 and uvicorn binds there.
3. CLI prints `url: http://127.0.0.1:8001` — wrong. `~/.kohakuterrarium/run/web.json` also stores `port: 8001`.

Root cause: `_write_started_state` was called by the CLI with `args.port` and never reconciled against what the subprocess actually bound. `_wait_until_alive` only checked pid liveness, not port readiness.

## Changes

<!-- Bullet points of what changed. -->

- `src/kohakuterrarium/serving/web.py`
  - New `_publish_actual_port(state_path, host, port)` helper — read-modify-writes `web.json` with the real `port` / `url` and a `bound: true` flag. No-op when `state_path` is `None` (e.g. direct `kt web` invocation).
  - `run_web_server` accepts `state_path: str | None = None`; calls `_publish_actual_port` after `find_free_port`.
- `src/kohakuterrarium/cli/__init__.py`
  - Internal `__run-server` parser accepts `--state-path`; dispatch table forwards it.
- `src/kohakuterrarium/cli/serve.py`
  - `_spawn_server_process` passes `--state-path STATE_PATH` to the subprocess.
  - `_write_started_state` now runs *before* the wait so the subprocess has a file to update.
  - New `_wait_until_bound(pid, timeout=3.0)` — checks both pid liveness and the `bound` flag in `web.json`. Replaces the `_wait_until_alive` call in `serve_start_cli`.
  - `run_server_internal` forwards `state_path` to `run_web_server`.
- `scripts/dep_graph_allowlist.json` — refresh `serving/web.py` line numbers shifted by the new `import json` (+1) and `_publish_actual_port` (+~26).

The existing 3 s timeout is reused as-is; uvicorn startup completes well within that window.

## Validation

<!-- How did you verify this works? Include the exact commands you ran. -->

```bash
# Lint
ruff check src/kohakuterrarium/serving/web.py \
           src/kohakuterrarium/cli/serve.py \
           src/kohakuterrarium/cli/__init__.py
black --check src/kohakuterrarium/serving/web.py \
              src/kohakuterrarium/cli/serve.py \
              src/kohakuterrarium/cli/__init__.py

# dep-graph lint (this is the test that initially failed in CI)
python3 scripts/dep_graph.py --lint-imports
# → In-function imports allowed: 40 / violating: 0

# Functional: happy path
kt serve stop
kt serve start
cat ~/.kohakuterrarium/run/web.json | grep -E '"(bound|port|url)"'
ss -ltnp | grep -E ':800[0-9]'

# Functional: port-drift case (the actual bug)
kt serve stop
python3 -c "import socket,time; s=socket.socket(); s.bind(('127.0.0.1',8001)); s.listen(1); time.sleep(60)" &
sleep 0.3
kt serve start
# Expected: CLI prints url: http://127.0.0.1:8002 (not 8001)
# Expected: web.json has port: 8002, bound: true
# Expected: `ss -ltnp` shows the daemon on 8002
```

Verified manually: with 8001 occupied, `kt serve start` correctly prints `http://127.0.0.1:8002`; `web.json` reflects `port: 8002` and `bound: true`; `ss` confirms uvicorn bound 8002.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below — N/A (small bug fix, no prior issue)
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it — N/A (bug fix)
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow — no doc-visible behavior change (CLI just stops lying)
- [ ] I added or updated tests when needed — see *Notes for Reviewers*
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite — see *Exceptions*
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/` — no frontend changes
- [x] CI on my fork is green, or I explained the exception below — initial CI failed `test_dep_graph_lint` due to allowlist line shift; fixed in this PR (allowlist refresh).
## Related Issues / Discussions

<!-- Required for feature PRs. Link issues/discussions explicitly.
Examples:
- Fixes #123
- Relates to #456
- Approved in #789
- Discord / QQ discussion approved by @maintainer on YYYY-MM-DD
-->

## Notes for Reviewers

<!-- Optional: call out risky areas, follow-ups, tradeoffs, or places where you'd like focused review. -->

## Screenshots / Logs (if applicable)

Before:
<img width="1516" height="760" alt="image" src="https://github.com/user-attachments/assets/de486f97-ce12-43a3-8422-5c8a33b6ac09" />
After:
<img width="1106" height="311" alt="image" src="https://github.com/user-attachments/assets/73befef5-84d2-4756-9ca5-cf168c97a239" />

<!-- UI changes, CLI output, benchmark tables, stack traces, etc. -->

## Breaking Changes (if applicable)

<!-- Describe migration steps, compatibility impact, and what downstream users need to do. -->

## Exceptions / Not Run

<!-- If you skipped any checklist item, explain exactly why. -->
