### PR TITLE
fix: sanitize surrogate characters in streaming output

### DIFF
--- a/src/kohakuterrarium/llm/openai.py
+++ b/src/kohakuterrarium/llm/openai.py
@@ -403,9 +403,12 @@ class OpenAIProvider(BaseLLMProvider):
                         reasoning_extra.get("reasoning", "") + r_piece
                     )
 
-            # Yield text content
+            # Yield text content (sanitize surrogates from LLM output)
             if delta.content:
-                yield delta.content
+                # Remove surrogate characters that some APIs emit
+                # which cause UnicodeEncodeError when encoded to UTF-8
+                clean = delta.content.encode('utf-8', errors='ignore').decode('utf-8')
+                yield clean
 
         # Finalize tool calls
         if pending_calls:


### PR DESCRIPTION
## Summary

Sanitize surrogate characters from LLM streaming output to prevent `UnicodeEncodeError`.

## Problem

Some OpenAI-compatible APIs (e.g. OpenRouter, certain model backends) emit surrogate characters (e.g. `\udcaf`) in streamed `delta.content`. Python's `utf-8` codec rejects surrogates, causing:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udcaf' in position 11617: surrogates not allowed
```

This crashes the agent's processing loop and terminates the session.

## Fix

In `OpenAIProvider._stream_chat()`, sanitize each streamed content chunk before yielding:

```python
if delta.content:
    clean = delta.content.encode("utf-8", errors="ignore").decode("utf-8")
    yield clean
```

This strips any surrogate characters that cannot be represented in UTF-8, which is the correct behavior since they are invalid Unicode artifacts.

## Testing

Verified by running `kt run @kt-biome/creatures/general` against an API that previously triggered the error. Agent now completes responses successfully.