### PR TITLE
fix(session): make attached agents the default in dashboard view

### DIFF
--- a/src/kohakuterrarium/session/attachment_service.py
+++ b/src/kohakuterrarium/session/attachment_service.py
@@ -166,6 +166,22 @@ def attach_agent_to_session(
         session_id=session_id,
     )
 
+    # Tell the session viewer to dispatch under the attach namespace
+    # by default; otherwise the host namespace (which only carries
+    # lineage events) wins and the conversation tab renders empty.
+    # Last-attach wins; earlier attaches stay reachable via explicit
+    # ``?agent=``. Stored in a viewer-only meta field so resume /
+    # hot-plug / token-loop enumeration keep ``meta["agents"]`` clean.
+    try:
+        store.set_viewer_default_agent(prefix)
+    except Exception as e:  # pragma: no cover — observability
+        logger.debug(
+            "set_viewer_default_agent failed",
+            namespace=prefix,
+            error=str(e),
+            exc_info=True,
+        )
+
     logger.info(
         "Agent attached to session",
         agent_name=agent.config.name,

--- a/src/kohakuterrarium/session/store.py
+++ b/src/kohakuterrarium/session/store.py
@@ -632,6 +632,25 @@ class SessionStore:
         self.meta["status"] = status
         self.meta["last_active"] = datetime.now(timezone.utc).isoformat()
 
+    def set_viewer_default_agent(self, namespace: str) -> None:
+        """Record ``namespace`` as the session viewer's default agent.
+
+        Writes ``meta["viewer_default_agent"]``. Used by
+        ``attach_agent_to_session`` so the Wave F attach namespace
+        (``<host>:attached:<role>:<seq>``) becomes the default the viewer
+        dispatches under; without this the host namespace (which only
+        carries lineage events) would win and the conversation tab would
+        render empty. Last-attach wins; earlier attaches stay reachable
+        via ``discover_attached_agents`` and explicit ``?agent=`` query.
+
+        Kept off ``meta["agents"]`` so resume / hot-plug / token-loop
+        enumeration keep treating that list as main creatures only.
+        """
+
+        if not isinstance(namespace, str) or not namespace:
+            return
+        self.meta["viewer_default_agent"] = namespace
+
     def touch(self) -> None:
         """Update last_active timestamp."""
 

--- a/src/kohakuterrarium/studio/persistence/viewer/diff.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/diff.py
@@ -16,14 +16,32 @@ from kohakuterrarium.session.history import replay_conversation
 from kohakuterrarium.session.store import SessionStore
 
 
-def _agents_for(meta: dict[str, Any], requested: str | None) -> str:
-    """Pick a single agent name to diff (one slice at a time)."""
-    all_agents = list(meta.get("agents") or [])
+def _agents_for(
+    meta: dict[str, Any], store: SessionStore, requested: str | None
+) -> str:
+    """Pick a single agent name to diff (one slice at a time).
+
+    Accepts main creatures (``meta["agents"]``) and Wave F attached
+    namespaces (via ``discover_attached_agents``); when ``requested`` is
+    ``None``, prefers ``meta["viewer_default_agent"]`` over the first
+    main creature so attach-driven sessions diff against the namespace
+    that actually carries per-turn activity.
+    """
+    main_agents = list(meta.get("agents") or [])
+    attached_namespaces = [
+        e["namespace"] for e in store.discover_attached_agents() if e.get("namespace")
+    ]
+    known_agents = main_agents + [
+        n for n in attached_namespaces if n not in main_agents
+    ]
     if requested is None:
-        if not all_agents:
+        default = meta.get("viewer_default_agent")
+        if isinstance(default, str) and default in known_agents:
+            return default
+        if not main_agents:
             raise HTTPException(404, "Session has no agents")
-        return all_agents[0]
-    if requested not in all_agents:
+        return main_agents[0]
+    if requested not in known_agents:
         raise HTTPException(404, f"Agent not found in session: {requested}")
     return requested
 
@@ -84,7 +102,7 @@ def _load_messages(path: Path, agent_arg: str | None) -> tuple[list[dict], str, 
     try:
         meta = store.load_meta()
         name = str(meta.get("session_id") or path.stem)
-        agent = _agents_for(meta, agent_arg)
+        agent = _agents_for(meta, store, agent_arg)
         events = store.get_events(agent)
         msgs = replay_conversation(events) if events else []
         return msgs, name, agent

--- a/src/kohakuterrarium/studio/persistence/viewer/events.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/events.py
@@ -39,12 +39,22 @@ def build_events_payload(
     — cross-agent enumeration is a separate concern (see ``/turns``).
     """
     meta = store.load_meta()
+    main_agents = list(meta.get("agents") or [])
+    attached_namespaces = [
+        e["namespace"] for e in store.discover_attached_agents() if e.get("namespace")
+    ]
+    known_agents = main_agents + [
+        n for n in attached_namespaces if n not in main_agents
+    ]
     if agent is None:
-        all_agents = list(meta.get("agents") or [])
-        if not all_agents:
+        default = meta.get("viewer_default_agent")
+        if isinstance(default, str) and default in known_agents:
+            agent = default
+        elif main_agents:
+            agent = main_agents[0]
+        else:
             raise HTTPException(404, f"Session has no agents: {session_name}")
-        agent = all_agents[0]
-    elif agent not in (meta.get("agents") or []):
+    elif agent not in known_agents:
         raise HTTPException(404, f"Agent not found in session: {agent}")
 
     type_set = parse_type_filter(types)

--- a/src/kohakuterrarium/studio/persistence/viewer/summary.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/summary.py
@@ -32,16 +32,31 @@ def _subagent_failed(evt: dict) -> bool:
     )
 
 
-def _agents_for_summary(meta: dict[str, Any], requested: str | None) -> list[str]:
+def _agents_for_summary(
+    meta: dict[str, Any], store: SessionStore, requested: str | None
+) -> list[str]:
     """Return the agent list to summarise.
 
     ``requested`` narrows to one agent (404 if not present); ``None``
-    summarises every agent in ``meta["agents"]``.
+    summarises every main creature in ``meta["agents"]`` plus every
+    Wave F attached namespace, with ``meta["viewer_default_agent"]``
+    moved to the front when set so attach-driven sessions surface the
+    active namespace first in the Overview tab.
     """
-    all_agents = list(meta.get("agents") or [])
+    main_agents = list(meta.get("agents") or [])
+    attached_namespaces = [
+        e["namespace"] for e in store.discover_attached_agents() if e.get("namespace")
+    ]
+    known_agents = main_agents + [
+        n for n in attached_namespaces if n not in main_agents
+    ]
     if requested is None:
-        return all_agents
-    if requested not in all_agents:
+        default = meta.get("viewer_default_agent")
+        if isinstance(default, str) and default in known_agents:
+            ordered = [default] + [a for a in known_agents if a != default]
+            return ordered
+        return known_agents
+    if requested not in known_agents:
         raise HTTPException(404, f"Agent not found in session: {requested}")
     return [requested]
 
@@ -130,7 +145,7 @@ def build_summary_payload(
     top-5 by total tokens when cost is unavailable for the provider.
     """
     meta = store.load_meta()
-    agents = _agents_for_summary(meta, agent)
+    agents = _agents_for_summary(meta, store, agent)
 
     if agent is None:
         flat_rollups = aggregate_turn_rollups(store)

--- a/src/kohakuterrarium/studio/persistence/viewer/turns.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/turns.py
@@ -39,12 +39,24 @@ def build_turns_payload(
         rows = aggregate_turn_rollups(store)
         agent_used = None
     else:
+        main_agents = list(meta.get("agents") or [])
+        attached_namespaces = [
+            e["namespace"]
+            for e in store.discover_attached_agents()
+            if e.get("namespace")
+        ]
+        known_agents = main_agents + [
+            n for n in attached_namespaces if n not in main_agents
+        ]
         if agent is None:
-            all_agents = list(meta.get("agents") or [])
-            if not all_agents:
+            default = meta.get("viewer_default_agent")
+            if isinstance(default, str) and default in known_agents:
+                agent = default
+            elif main_agents:
+                agent = main_agents[0]
+            else:
                 raise HTTPException(404, f"Session has no agents: {session_name}")
-            agent = all_agents[0]
-        elif agent not in (meta.get("agents") or []):
+        elif agent not in known_agents:
             raise HTTPException(404, f"Agent not found in session: {agent}")
         rows = rollups_or_derived(store, agent)
         agent_used = agent

--- a/tests/unit/test_session_viewer_endpoints.py
+++ b/tests/unit/test_session_viewer_endpoints.py
@@ -585,3 +585,130 @@ class TestTurnsAggregate:
         data = client.get("/api/sessions/alice/turns?aggregate=true&agent=ghost").json()
         assert data["aggregate"] is True
         assert data["turns"][0]["tokens_in"] == 300
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Wave F attached-agent viewer default (issue #53):
+# attach_agent_to_session emits events under
+# ``<host>:attached:<role>:<seq>:e*``. Before this fix the host
+# namespace (which only carries lineage events) won the default-agent
+# slot and the viewer's conversation tab rendered empty. The fix is
+# ``SessionStore.set_viewer_default_agent``: ``attach_agent_to_session``
+# records the attach namespace in ``meta["viewer_default_agent"]`` and
+# the viewer entry points (events / turns / summary / diff) honour it
+# while still treating the namespace as a valid agent for explicit
+# ``?agent=`` lookups. ``meta["agents"]`` stays untouched so resume,
+# hot-plug, and token-loop enumeration keep main-creature semantics.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestAttachedAgentViewerDefault:
+    @staticmethod
+    def _seed_attached_events(
+        session_dir: Path, name: str = "host"
+    ) -> tuple[Path, str]:
+        """Create a session containing the kind of events
+        ``attach_agent_to_session`` produces. Does NOT set
+        ``viewer_default_agent`` — the per-test setup decides whether
+        to invoke it."""
+        path = session_dir / f"{name}.kohakutr"
+        store = SessionStore(path)
+        store.init_meta(
+            session_id=name,
+            config_type="agent",
+            config_path="",
+            pwd=str(session_dir),
+            agents=[],
+        )
+        ns = "host:attached:root:0"
+        store.append_event(
+            "host",
+            "agent_attached",
+            {"role": "root", "attach_seq": 0},
+            turn_index=1,
+        )
+        store.append_event(ns, "user_input", {"content": "go"}, turn_index=1)
+        store.append_event(ns, "tool_call", {"tool": "search"}, turn_index=1)
+        store.append_event(ns, "tool_result", {"ok": True}, turn_index=1)
+        store.save_turn_rollup(
+            ns,
+            1,
+            {"tokens_in": 42, "tokens_out": 7, "tokens_cached": 0, "cost_usd": 0.001},
+        )
+        store.close(update_status=False)
+        return path, ns
+
+    def test_default_dispatches_to_attach_namespace(self, app_with_sessions):
+        app, tmp = app_with_sessions
+        path, ns = self._seed_attached_events(tmp)
+        store = SessionStore(path)
+        store.set_viewer_default_agent(ns)
+        store.close(update_status=False)
+        client = TestClient(app)
+
+        events = client.get("/api/sessions/host/events").json()
+        assert events["agent"] == ns
+        types = sorted({e.get("type") for e in events["events"]})
+        assert "tool_call" in types and "tool_result" in types
+
+        summary = client.get("/api/sessions/host/summary").json()
+        assert summary["agents"][0] == ns
+        # The attach-namespace tool_call is visible in totals.
+        assert summary["totals"]["tool_calls"] == 1
+        assert summary["totals"]["tokens"]["prompt"] == 42
+
+        turns = client.get("/api/sessions/host/turns").json()
+        assert turns["agent"] == ns
+        assert turns["total"] == 1
+
+    def test_set_viewer_default_does_not_pollute_meta_agents(self, app_with_sessions):
+        app, tmp = app_with_sessions
+        path = _make_session(tmp, "alice", agents=["root"])
+        store = SessionStore(path)
+        store.set_viewer_default_agent("alice:attached:helper:0")
+        store.set_viewer_default_agent("alice:attached:helper:0")
+        agents = list(store.meta["agents"])
+        default = store.meta.get("viewer_default_agent")
+        store.close(update_status=False)
+
+        # meta["agents"] stays clean — last-attach wins, no list mutation.
+        assert agents == ["root"]
+        assert default == "alice:attached:helper:0"
+
+    def test_set_viewer_default_ignores_blank_input(self, app_with_sessions):
+        app, tmp = app_with_sessions
+        path = _make_session(tmp, "alice", agents=["root"])
+        store = SessionStore(path)
+        store.set_viewer_default_agent("")
+        store.set_viewer_default_agent(None)  # type: ignore[arg-type]
+        agents = list(store.meta["agents"])
+        default = store.meta.get("viewer_default_agent")
+        store.close(update_status=False)
+        assert agents == ["root"]
+        assert default is None
+
+    def test_attach_namespace_addressable_without_default(self, app_with_sessions):
+        """Even without ``viewer_default_agent`` set, the attach
+        namespace must be reachable via explicit ``?agent=`` so older
+        sessions and earlier-attached agents stay queryable."""
+        app, tmp = app_with_sessions
+        _, ns = self._seed_attached_events(tmp)
+        client = TestClient(app)
+        resp = client.get(f"/api/sessions/host/events?agent={ns}")
+        assert resp.status_code == 200
+        assert resp.json()["agent"] == ns
+
+    def test_unset_default_falls_through_to_host(self, app_with_sessions):
+        """Backwards-compat: a pre-fix session whose viewer default was
+        never set still resolves *something* — the viewer dispatches
+        under the host namespace (which carries the lineage event). The
+        conversation tab will look thin until the operator runs a
+        one-off backfill (``store.set_viewer_default_agent(ns)``) — issue
+        #53 has the recipe — but the endpoint must not 500."""
+        app, tmp = app_with_sessions
+        self._seed_attached_events(tmp)
+        client = TestClient(app)
+        resp = client.get("/api/sessions/host/events")
+        assert resp.status_code == 200
+        # Default agent is the host namespace (load_meta auto-discovered it).
+        assert resp.json()["agent"] == "host"


### PR DESCRIPTION
Closes #53.

## Problem

`attach_agent_to_session` writes events under `<host>:attached:<role>:<seq>:e*`,
but the dashboard view (`build_summary_payload` / `build_events_payload` /
`build_turns_payload` / `build_diff_payload`) dispatches under
`meta["agents"][0]`. After `load_meta`'s auto-discovery, that ends up being
the host namespace — which only carries `agent_attached` / `agent_detached`
lineage events. The Conversation tab therefore renders empty for any session
built via the Wave F attach path.

The list endpoint (`/api/sessions`) shows the session, but every per-session
call (`/summary`, `/events`, `/turns`) reports `turns=0`, `tool_calls=0`,
no events. Reproduction script + API symptoms are in #53.

## Fix

Add `SessionStore.set_viewer_default_agent(name)` — a small helper that
records the attach namespace in a dedicated `meta["viewer_default_agent"]`
field (idempotent, blank-input-safe). Call it from `attach_agent_to_session`
for the freshly-built attach namespace.

The four viewer entry points (`events` / `turns` / `summary` / `diff`) honour
`meta["viewer_default_agent"]` when no explicit `?agent=` is passed, and
accept Wave F attached namespaces as valid explicit targets via
`discover_attached_agents`.

`meta["agents"]` is **left untouched** — it stays the main-creature list,
so resume, hot-plug, and `token_usage_all_loops` keep their existing
semantics. Routing the viewer default through a dedicated meta field
avoids mixing main-loop semantics with viewer dispatch.

After the fix:
- `meta["agents"]` for an attach session stays `["<host>"]` (load_meta
  auto-discovery unchanged).
- `meta["viewer_default_agent"]` becomes `"<host>:attached:<role>:<seq>"`.
- The viewer's default agent is the attach namespace — the one that
  actually carries per-turn activity.
- Conversation, Cost tab, and event timeline render correctly for attach
  sessions.

## What is preserved

- **Standalone-agent sessions**: untouched. No attach call → no
  `viewer_default_agent` mutation, no behavior change.
- **Multi-attach**: each attach overwrites the viewer default
  (last-attach wins). Earlier attaches stay addressable via
  `discover_attached_agents` and explicit `?agent=<ns>`. Attach-seq
  bumping and the host-vs-attached event-namespace separation (the
  Wave F design intent) are unchanged.
- **Fork / lineage / token_views / rollups / tree**: read paths over
  `discover_attached_agents()` are unaffected. `meta["agents"]`
  consumers (resume, hot-plug, `token_usage_all_loops`,
  `_first_agent_name`, viewer rollups, summary, diff) all see the
  same main-creature list as before.

## Tests

`tests/unit/test_session_viewer_endpoints.py::TestAttachedAgentViewerDefault`
adds:

| Case | Asserts |
| --- | --- |
| `test_default_dispatches_to_attach_namespace` | After `set_viewer_default_agent(ns)`: `/events`, `/summary`, `/turns` all default to the attach namespace and surface the per-turn tool_call + tokens |
| `test_set_viewer_default_does_not_pollute_meta_agents` | `meta["agents"]` stays clean; last call wins for `viewer_default_agent` |
| `test_set_viewer_default_ignores_blank_input` | Empty string and `None` are no-ops |
| `test_attach_namespace_addressable_without_default` | Explicit `?agent=<ns>` works even when no default was set |
| `test_unset_default_falls_through_to_host` | Backwards compat: pre-fix sessions still resolve to the host namespace (one-off operator backfill recipe below) |

All existing attach tests (`test_attach_session.py`, `test_hot_plug_attach.py`,
`test_session_store.py`, prior `test_session_viewer_endpoints.py` cases,
`test_session_token_views.py`) continue to pass — verified locally on
Python 3.13 (4371 passed, 10 skipped).

## Diff size

```
src/kohakuterrarium/session/attachment_service.py          |  16 +++
src/kohakuterrarium/session/store.py                       |  19 +++
src/kohakuterrarium/studio/persistence/viewer/diff.py      |  32 +++--
src/kohakuterrarium/studio/persistence/viewer/events.py    |  18 ++-
src/kohakuterrarium/studio/persistence/viewer/summary.py   |  27 +++-
src/kohakuterrarium/studio/persistence/viewer/turns.py     |  20 +++-
tests/unit/test_session_viewer_endpoints.py                | 127 ++++++++++++++++
7 files changed, 238 insertions(+), 21 deletions(-)
```

## Operator backfill for pre-fix sessions

For any `.kohakutr` file written by an older version, run once:

```python
from kohakuterrarium.session.store import SessionStore
store = SessionStore("path/to/session.kohakutr")
store.set_viewer_default_agent("host:attached:root:0")  # use your actual ns
store.close()
```

Or fold it into a sweep over `discover_attached_agents()`:

```python
for entry in store.discover_attached_agents():
    store.set_viewer_default_agent(entry["namespace"])
# Note: last call wins. If you need to control which namespace becomes the
# default, sort entries first or call set_viewer_default_agent() last on
# the one you want.
```