### PR TITLE
fix(security): restrict workspace file API to workspace root (path traversal)

### DIFF
--- a/src/kohakuterrarium/studio/attach/workspace_files.py
+++ b/src/kohakuterrarium/studio/attach/workspace_files.py
@@ -7,6 +7,7 @@ defined here; nothing in this module touches FastAPI's routing
 decorators, so the helpers are reusable from non-HTTP entry points.
 """
 
+import os
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -76,12 +77,31 @@ _SKIP_NAMES: set[str] = {
 }
 
 
+# Workspace root — all file operations are restricted to this directory.
+# Defaults to the current working directory; override via KT_WORKSPACE_ROOT env var.
+WORKSPACE_ROOT: Path = Path(os.environ.get("KT_WORKSPACE_ROOT", str(Path.cwd()))).resolve()
+
+
 def _validate_path(path_str: str) -> Path:
-    """Validate and resolve a file path."""
+    """Validate and resolve a file path, restricting to the workspace root."""
     try:
-        return Path(path_str).resolve()
+        resolved = Path(path_str).resolve()
     except (ValueError, OSError) as e:
         raise HTTPException(400, f"Invalid path: {e}")
+    if not _is_relative_to(resolved, WORKSPACE_ROOT):
+        raise HTTPException(
+            403, f"Path is outside the workspace root: {path_str}"
+        )
+    return resolved
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    """Check whether *path* is inside *base* (both must be resolved)."""
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
 
 
 def _list_browse_roots() -> list[Path]:


### PR DESCRIPTION
## Security Fix: Path Traversal in Workspace Files API

### Vulnerability
The `_validate_path()` function in `studio/attach/workspace_files.py` only called `Path.resolve()` without restricting the resulting path to any workspace boundary. This allowed any authenticated user to **read, write, rename, or delete arbitrary files** on the host filesystem via the `/api/files/*` endpoints.

**Severity:** Critical — full filesystem read/write/delete

### Attack Scenario
```bash
# Read any file on the system
curl "http://host:8001/api/files/read?path=/etc/shadow" -H "Authorization: Bearer $TOKEN"

# Write arbitrary file (e.g., plant cron backdoor)
curl -X POST http://host:8001/api/files/write \
  -H "Authorization: Bearer $TOKEN" \
  -d "{\"path\": \"/etc/cron.d/backdoor\", \"content\": \"* * * * * root /tmp/pwned\"}"
```

### Fix
- Added `WORKSPACE_ROOT` constant (configurable via `KT_WORKSPACE_ROOT` env var, defaults to `cwd`)
- Added path boundary check in `_validate_path()` that rejects paths resolving outside the workspace root with 403 Forbidden
- All file operations (read, write, rename, delete, tree, browse, mkdir) are now restricted

### Opt-in Default
The `KT_WORKSPACE_ROOT` env var defaults to the current working directory, so existing deployments that already operate from their workspace directory are unaffected. Operators who want a different root set the env var explicitly.

### Testing
- Paths within workspace: ✅ allowed
- Paths with `..` escaping workspace: ✅ rejected (403)
- Absolute paths outside workspace: ✅ rejected (403)
- Symlinks pointing outside workspace: ✅ rejected (resolve() follows symlinks)