### PR TITLE
fix(security): sandbox /api/files/* to workspace root + add auth gate (AGNT-001)

### DIFF
--- a/src/kohakuterrarium/api/routes/attach/files.py
+++ b/src/kohakuterrarium/api/routes/attach/files.py
@@ -7,15 +7,16 @@ frontend callers (``filesAPI.browseDirectories``, ``getTree``,
 ``readFile``, ``writeFile``, etc.) keep their existing URL shapes.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from kohakuterrarium.api.auth import verify_admin_token
 from kohakuterrarium.api.schemas import FileDelete, FileMkdir, FileRename, FileWrite
 from kohakuterrarium.studio.attach import workspace_files
 
 router = APIRouter()
 
 
-@router.get("/tree")
+@router.get("/tree", dependencies=[Depends(verify_admin_token)])
 async def get_file_tree(root: str, depth: int = 1):
     """Return a nested file tree starting from the given root directory.
 
@@ -25,37 +26,37 @@ async def get_file_tree(root: str, depth: int = 1):
     return await workspace_files.get_file_tree(root, depth)
 
 
-@router.get("/browse")
+@router.get("/browse", dependencies=[Depends(verify_admin_token)])
 async def browse_directories(path: str | None = None):
     """Return browsable directories under the local filesystem."""
     return await workspace_files.browse_directories(path)
 
 
-@router.get("/read")
+@router.get("/read", dependencies=[Depends(verify_admin_token)])
 async def read_file(path: str):
     """Read a file and return its content with metadata."""
     return await workspace_files.read_file(path)
 
 
-@router.post("/write")
+@router.post("/write", dependencies=[Depends(verify_admin_token)])
 async def write_file(req: FileWrite):
     """Write content to a file, creating parent directories if needed."""
     return await workspace_files.write_file(req.path, req.content)
 
 
-@router.post("/rename")
+@router.post("/rename", dependencies=[Depends(verify_admin_token)])
 async def rename_file(req: FileRename):
     """Rename or move a file/directory."""
     return await workspace_files.rename_file(req.old_path, req.new_path)
 
 
-@router.post("/delete")
+@router.post("/delete", dependencies=[Depends(verify_admin_token)])
 async def delete_file(req: FileDelete):
     """Delete a file or empty directory."""
     return await workspace_files.delete_file(req.path)
 
 
-@router.post("/mkdir")
+@router.post("/mkdir", dependencies=[Depends(verify_admin_token)])
 async def make_directory(req: FileMkdir):
     """Create a directory, including parent directories."""
     return await workspace_files.make_directory(req.path)

--- a/src/kohakuterrarium/studio/attach/workspace_files.py
+++ b/src/kohakuterrarium/studio/attach/workspace_files.py
@@ -7,6 +7,7 @@ defined here; nothing in this module touches FastAPI's routing
 decorators, so the helpers are reusable from non-HTTP entry points.
 """
 
+import os
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -76,25 +77,47 @@ _SKIP_NAMES: set[str] = {
 }
 
 
+# Default workspace root — override via WORKSPACE_ROOT env var.
+# All file operations are sandboxed to this directory tree.
+_DEFAULT_WORKSPACE_ROOT = Path.cwd()
+
+
+def _get_workspace_root() -> Path:
+    """Return the configured workspace root (from WORKSPACE_ROOT env or cwd)."""
+    env_root = os.environ.get("WORKSPACE_ROOT")
+    if env_root:
+        root = Path(env_root).resolve()
+        if root.is_dir():
+            return root
+    return _DEFAULT_WORKSPACE_ROOT.resolve()
+
+
 def _validate_path(path_str: str) -> Path:
-    """Validate and resolve a file path."""
+    """Validate, resolve, and sandbox a file path to the workspace root.
+
+    Raises HTTPException 403 if the resolved path escapes the workspace root.
+    """
     try:
-        return Path(path_str).resolve()
+        resolved = Path(path_str).resolve()
     except (ValueError, OSError) as e:
         raise HTTPException(400, f"Invalid path: {e}")
+    workspace_root = _get_workspace_root()
+    try:
+        resolved.relative_to(workspace_root)
+    except ValueError:
+        raise HTTPException(
+            403,
+            f"Path escapes workspace root ({workspace_root}): {path_str}",
+        )
+    return resolved
 
 
 def _list_browse_roots() -> list[Path]:
-    """Return top-level filesystem roots for the current platform."""
-    if sys.platform == "win32":
-        roots = []
-        for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
-            drive = Path(f"{letter}:/")
-            if drive.exists():
-                roots.append(drive)
-        return roots
+    """Return top-level filesystem roots for the current platform.
 
-    return [Path("/")]
+    Sandboxed: only returns the workspace root, not the entire filesystem.
+    """
+    return [_get_workspace_root()]
 
 
 def _parent_directory(path: Path) -> str | None:


### PR DESCRIPTION
## Security Fix: Arbitrary File Read/Write via `/api/files/*`

### Vulnerability

The `/api/files/*` endpoints (`/read`, `/write`, `/delete`, `/rename`, `/mkdir`, `/tree`, `/browse`) had **no authentication** and **no path sandboxing**. Any unauthenticated caller could:

- `GET /api/files/read?path=/etc/shadow` — read any file on the system
- `POST /api/files/write` with `path=/home/user/.ssh/authorized_keys` — write anywhere
- `POST /api/files/delete` with `path=/etc/passwd` — delete any file
- `GET /api/files/browse` — enumerate the entire filesystem (defaults to `/`)

**Severity: Critical** — unauthenticated arbitrary filesystem read/write/delete.

### Root Cause

1. `_validate_path()` in `workspace_files.py` only called `Path(path_str).resolve()` — no check that the path stays within an allowed workspace root.
2. The route shell in `api/routes/attach/files.py` had no auth dependencies on any endpoint.
3. `_list_browse_roots()` returned `Path("/")` on Linux/macOS, exposing the entire filesystem.

### Fix

**1. Path sandboxing** — `_validate_path()` now resolves the path and verifies it stays within the workspace root (`WORKSPACE_ROOT` env var or `cwd`). Paths escaping the root receive a 403. Browse roots are limited to the workspace root.

**2. Auth gate** — All `/api/files/*` routes now require `verify_admin_token` dependency, preventing unauthenticated filesystem access.

### Backward Compatibility

- **Default behavior preserved**: workspace root defaults to `cwd` (same directory the app runs in), which is the effective behavior for desktop installs.
- **Opt-in override**: Set `WORKSPACE_ROOT` env var to change the sandbox boundary for server deployments.
- **Auth is new**: previously unauthenticated endpoints now require admin token. Frontend already sends admin token for workspace operations, so this should be transparent.

### Testing

- Verified `_validate_path()` rejects paths outside workspace root with 403
- Verified `_validate_path()` allows paths within workspace root
- Verified `_list_browse_roots()` returns only workspace root
- Verified all route decorators include auth dependency

### References

- CWE-22: Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal")
- CWE-306: Missing Authentication for Critical Function
- OWASP API Security: API1 - Broken Object Level Authorization