### PR TITLE
docs: fix GitHub Issues URL organization name in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Open a thread before you write code. The fastest channels:
 
 - **QQ group**: 1097666427
 - **Discord**: https://discord.gg/xWYrkyvJ2s
-- **GitHub Issues**: https://github.com/KohakuBlueleaf/KohakuTerrarium/issues
+- **GitHub Issues**: https://github.com/Kohaku-Lab/KohakuTerrarium/issues
 
 Issue templates live in [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/).
 


### PR DESCRIPTION
## Description
This PR fixes the organization handle in the GitHub Issues link in `CONTRIBUTING.md`.

## Details
Updated `https://github.com/KohakuBlueleaf/KohakuTerrarium/issues` -> `https://github.com/Kohaku-Lab/KohakuTerrarium/issues`.