### PR TITLE
fix(ci): restore deterministic cross-platform unit tests

### DIFF
--- a/src/kohakuterrarium/builtins/tools/subprocess/shell_utils.py
+++ b/src/kohakuterrarium/builtins/tools/subprocess/shell_utils.py
@@ -1,6 +1,7 @@
 """Shared helpers for shell-like built-in tools."""
 
 import asyncio
+import contextlib
 import os
 import signal
 import subprocess
@@ -50,7 +51,8 @@ async def terminate_process_tree(process: asyncio.subprocess.Process) -> None:
             try:
                 os.killpg(process.pid, signal.SIGTERM)
             except ProcessLookupError:
-                return
+                with contextlib.suppress(ProcessLookupError):
+                    process.terminate()
             except Exception:
                 process.terminate()
             try:
@@ -60,7 +62,8 @@ async def terminate_process_tree(process: asyncio.subprocess.Process) -> None:
                 try:
                     os.killpg(process.pid, signal.SIGKILL)
                 except ProcessLookupError:
-                    return
+                    with contextlib.suppress(ProcessLookupError):
+                        process.kill()
                 except Exception:
                     process.kill()
         await asyncio.wait_for(process.wait(), timeout=5)

--- a/tests/integration/test_studio.py
+++ b/tests/integration/test_studio.py
@@ -20,13 +20,14 @@ Each test method runs ONE complete lifecycle end-to-end:
   LLM profiles + keys + MCP registry + UI prefs CRUD, plus the
   read-only builtin catalog + introspection.
 
-The ONLY seam is the LLM: BOTH ``create_llm_provider`` import sites
-(``bootstrap.llm`` and ``bootstrap.agent_init``) are monkeypatched to a
-:class:`ScriptedLLM`. Every other collaborator is real — a real
-:class:`Studio` over a real :class:`Terrarium` engine wrapped in a real
-:class:`LocalTerrariumService`, real on-disk ``.kohakutr`` session
-files in a ``tmp_path`` dir, real workspace directories, the real
-identity YAML stores (redirected to ``tmp_path``).
+The only seams are genuine external I/O: BOTH ``create_llm_provider``
+import sites (``bootstrap.llm`` and ``bootstrap.agent_init``) use a
+:class:`ScriptedLLM`, and the auto memory-search workflow uses a
+deterministic :class:`BaseEmbedder`. Every other collaborator is real
+— a real :class:`Studio` over a real :class:`Terrarium` engine wrapped
+in a real :class:`LocalTerrariumService`, real on-disk ``.kohakutr``
+session files in a ``tmp_path`` dir, real workspace directories, the
+real identity YAML stores (redirected to ``tmp_path``).
 
 No shape asserts: every assertion pins an exact value or an observable
 side effect.
@@ -34,6 +35,7 @@ side effect.
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from kohakuterrarium.errors import (
@@ -43,8 +45,10 @@ from kohakuterrarium.errors import (
 )
 from kohakuterrarium.bootstrap import agent_init as _agent_init_mod
 from kohakuterrarium.bootstrap import llm as _bootstrap_llm_mod
+from kohakuterrarium.session.embedding import BaseEmbedder
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio.persistence import store as _persistence_store_mod
+from kohakuterrarium.studio.sessions import memory_search as _session_memory_mod
 from kohakuterrarium.studio.studio import Studio
 from kohakuterrarium.testing.llm import ScriptedLLM
 
@@ -52,8 +56,24 @@ pytestmark = pytest.mark.timeout(30)
 
 
 # ---------------------------------------------------------------------------
-# Fixtures — isolate every module-global path + the LLM seam.
+# Fixtures — isolate module-global paths and genuine external I/O.
 # ---------------------------------------------------------------------------
+
+
+class _HashEmbedder(BaseEmbedder):
+    """Deterministic stand-in for the external embedding provider."""
+
+    dimensions = 64
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        vectors = np.zeros((len(texts), self.dimensions), dtype=np.float32)
+        for row, text in enumerate(texts):
+            for token in text.lower().split():
+                vectors[row, sum(token.encode("utf-8")) % self.dimensions] += 1.0
+            norm = float(np.linalg.norm(vectors[row]))
+            if norm > 0:
+                vectors[row] /= norm
+        return vectors
 
 
 @pytest.fixture
@@ -73,6 +93,16 @@ def scripted_llm(monkeypatch):
     monkeypatch.setattr(_bootstrap_llm_mod, "create_llm_provider", _fake_create)
     monkeypatch.setattr(_agent_init_mod, "create_llm_provider", _fake_create)
     return holder
+
+
+@pytest.fixture
+def deterministic_embedder(monkeypatch):
+    """Keep auto memory search on its real path without downloading a model."""
+    monkeypatch.setattr(
+        _session_memory_mod,
+        "create_embedder",
+        lambda _config: _HashEmbedder(),
+    )
 
 
 @pytest.fixture
@@ -163,7 +193,7 @@ class TestStudioIntegration:
     """Each method runs one complete studio-tier lifecycle."""
 
     async def test_workspace_to_session_to_persistence_lifecycle(
-        self, scripted_llm, isolated_paths
+        self, scripted_llm, deterministic_embedder, isolated_paths
     ):
         """The headline flow, end-to-end through the Studio façade:
 
@@ -634,8 +664,8 @@ class TestStudioIntegration:
             assert mem["mode"] == "fts"
             assert mem["session_name"] == saved_stem
             assert mem["count"] >= 1
-            # ``auto`` mode resolves the embedder + falls back to FTS when
-            # no vector index exists — still hits the recorded turn.
+            # ``auto`` resolves the deterministic embedder and exercises
+            # hybrid search; its FTS side still finds the recorded turn.
             mem_auto = await studio.sessions.search_memory(
                 saved_path,  # a direct .kohakutr path works too
                 "ping",

--- a/tests/unit/api/routes/persistence/test_memory_index_routes.py
+++ b/tests/unit/api/routes/persistence/test_memory_index_routes.py
@@ -8,15 +8,45 @@ shape, error paths, and the WS frame contract using a real on-disk
 """
 
 import json
+import threading
 from pathlib import Path
 
+import numpy as np
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from kohakuterrarium.api.routes.persistence import memory_index as memory_index_mod
 from kohakuterrarium.api.ws import memory_build as ws_memory_build
+from kohakuterrarium.session.embedding import BaseEmbedder
 from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.studio.persistence import store as store_mod
+from kohakuterrarium.studio.sessions import memory_build as memory_build_service
+
+
+class _FakeEmbedder(BaseEmbedder):
+    dimensions = 4
+
+    def __init__(
+        self,
+        encode_started: threading.Event,
+        encode_release: threading.Event,
+    ):
+        self._encode_started = encode_started
+        self._encode_release = encode_release
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        self._encode_started.set()
+        if not self._encode_release.wait(timeout=30.0):
+            raise TimeoutError("fake embedder was not released")
+        rows = [
+            [
+                float((sum(text.encode("utf-8")) + dimension) % 31 + 1)
+                for dimension in range(self.dimensions)
+            ]
+            for text in texts
+        ]
+        return np.asarray(rows, dtype=np.float32).reshape(len(texts), self.dimensions)
 
 
 def _real_session(tmp_path: Path, *, with_events: bool = True) -> Path:
@@ -48,14 +78,20 @@ def _real_session(tmp_path: Path, *, with_events: bool = True) -> Path:
 @pytest.fixture
 def app(monkeypatch, tmp_path):
     monkeypatch.setenv("KT_CONFIG_DIR", str(tmp_path))
-    # Resolve session names against ``tmp_path`` so the routes find the
-    # files this test writes.
-    from kohakuterrarium.studio.persistence import store as store_mod
-
+    encode_started = threading.Event()
+    encode_release = threading.Event()
+    encode_release.set()
+    monkeypatch.setattr(
+        memory_build_service,
+        "create_embedder",
+        lambda _config: _FakeEmbedder(encode_started, encode_release),
+    )
     monkeypatch.setattr(store_mod, "_SESSION_DIR", tmp_path, raising=True)
 
     app = FastAPI()
     app.state.lab_mode = "standalone"
+    app.state.embedder_encode_started = encode_started
+    app.state.embedder_encode_release = encode_release
     app.include_router(memory_index_mod.router, prefix="/api/sessions")
     app.include_router(ws_memory_build.router)
     return app
@@ -188,14 +224,14 @@ class TestBuildWebSocket:
 
 
 class TestConcurrentBuildGuard:
-    def test_second_build_for_same_session_rejected(self, client, tmp_path):
+    def test_second_build_for_same_session_rejected(self, app, client, tmp_path):
         """The WS module owns a per-session in-flight set. A second
         build while the first is mid-stream gets a terminal ``failed``
         frame instead of racing through ``SessionMemory`` write paths.
         """
-        import threading
-
         _real_session(tmp_path)
+        app.state.embedder_encode_started.clear()
+        app.state.embedder_encode_release.clear()
         first_connected = threading.Event()
         first_terminal = threading.Event()
         first_frames: list = []
@@ -215,10 +251,8 @@ class TestConcurrentBuildGuard:
         t = threading.Thread(target=run_first)
         t.start()
         try:
-            first_connected.wait(timeout=5.0)
-            # First build is in flight. Open a second WS on the same
-            # session and assert it receives a "failed" terminal frame
-            # without waiting on the first.
+            assert first_connected.wait(timeout=5.0)
+            assert app.state.embedder_encode_started.wait(timeout=5.0)
             second_frames: list = []
             with client.websocket_connect(
                 "/ws/sessions/alice/memory/build?embedder=auto"
@@ -231,5 +265,8 @@ class TestConcurrentBuildGuard:
             assert second_frames[-1]["status"] == "failed"
             assert "already running" in (second_frames[-1]["error"] or "").lower()
         finally:
-            first_terminal.wait(timeout=30.0)
-            t.join(timeout=2.0)
+            app.state.embedder_encode_release.set()
+            assert first_terminal.wait(timeout=5.0)
+            t.join(timeout=5.0)
+        assert not t.is_alive()
+        assert first_frames[-1]["status"] == "ok"

--- a/tests/unit/builtins/tools/subprocess/test_shell_utils.py
+++ b/tests/unit/builtins/tools/subprocess/test_shell_utils.py
@@ -105,3 +105,49 @@ class TestTerminateProcessTree:
             return process.returncode
 
         assert asyncio.run(scenario()) is not None
+
+    def test_non_group_child_escalates_to_direct_kill(self, monkeypatch):
+        class FakeProcess:
+            pid = 1234
+            returncode = None
+            terminated = False
+            killed = False
+
+            async def wait(self):
+                return self.returncode
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                self.killed = True
+                self.returncode = -9
+
+        process = FakeProcess()
+        group_signals = []
+        wait_timeouts = []
+
+        def missing_group(pid, sig):
+            assert pid == process.pid
+            group_signals.append(sig)
+            raise ProcessLookupError
+
+        async def controlled_wait(awaitable, timeout):
+            wait_timeouts.append(timeout)
+            if len(wait_timeouts) == 1:
+                awaitable.close()
+                raise asyncio.TimeoutError
+            return await awaitable
+
+        monkeypatch.setattr(shell_utils.sys, "platform", "linux")
+        monkeypatch.setattr(shell_utils.os, "killpg", missing_group, raising=False)
+        monkeypatch.setattr(shell_utils.signal, "SIGKILL", 9, raising=False)
+        monkeypatch.setattr(shell_utils.asyncio, "wait_for", controlled_wait)
+
+        asyncio.run(shell_utils.terminate_process_tree(process))
+
+        assert group_signals == [shell_utils.signal.SIGTERM, 9]
+        assert wait_timeouts == [3, 5]
+        assert process.terminated is True
+        assert process.killed is True
+        assert process.returncode == -9

--- a/tests/unit/session/test_embedding.py
+++ b/tests/unit/session/test_embedding.py
@@ -2,10 +2,11 @@
 
 Note: The provider-specific classes (Model2Vec / SentenceTransformer / API)
 depend on third-party libraries or the network. Those paths are exercised
-via mock injection; the real model loading is out of scope per the
-``CLAUDE.md`` policy on 3rd-party deterministic-test exceptions.
+through deterministic dependency seams; real model loading is out of scope
+per the ``CLAUDE.md`` policy on 3rd-party deterministic-test exceptions.
 """
 
+import model2vec
 import numpy as np
 import pytest
 
@@ -223,22 +224,53 @@ class TestCreateEmbedder:
         assert isinstance(emb, NullEmbedder)
 
 
-# ── Model2VecEmbedder (real, deterministic — model2vec is a dep) ──
+# ── Model2VecEmbedder ─────────────────────────────────────────────
+
+
+class _DeterministicStaticModel:
+    dim = 4
+
+    def __init__(self):
+        self.batches: list[list[str]] = []
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        batch = list(texts)
+        self.batches.append(batch)
+        rows = [
+            [float(len(text) + dimension) for dimension in range(self.dim)]
+            for text in batch
+        ]
+        return np.asarray(rows, dtype=np.float64).reshape(len(batch), self.dim)
 
 
 class TestModel2VecEmbedder:
-    def test_real_encode_round_trip(self):
-        # model2vec ships as a project dependency and is fully
-        # deterministic — load the small default model and verify the
-        # encode contract: (n, dims) float32, dims matches the property.
-        emb = Model2VecEmbedder()
-        assert emb.dimensions > 0
-        vecs = emb.encode(["hello world", "second text"])
+    def test_encode_round_trip_without_model_download(self, monkeypatch):
+        model_name = "example/deterministic-model"
+        static_model = _DeterministicStaticModel()
+        loaded_models: list[str] = []
+
+        def fake_from_pretrained(_cls, path, **_kwargs):
+            loaded_models.append(str(path))
+            return static_model
+
+        monkeypatch.setattr(
+            model2vec.StaticModel,
+            "from_pretrained",
+            classmethod(fake_from_pretrained),
+        )
+
+        emb = Model2VecEmbedder(model_name=model_name)
+        assert loaded_models == [model_name]
+        assert emb.dimensions == static_model.dim
+        batch = ["hello world", "second text"]
+        vecs = emb.encode(batch)
+        assert static_model.batches == [batch]
         assert vecs.shape == (2, emb.dimensions)
         assert vecs.dtype == np.float32
-        # encode_one unwraps the batch dim.
         one = emb.encode_one("solo")
+        assert static_model.batches == [batch, ["solo"]]
         assert one.shape == (emb.dimensions,)
+        assert one.dtype == np.float32
 
     def test_import_error_when_model2vec_absent(self, monkeypatch):
         # If model2vec can't be imported the constructor raises a clear


### PR DESCRIPTION
## Summary

Fix POSIX process termination when a child does not own a process group, and make the memory-index unit and Studio integration tests deterministic and fully offline. This restores useful cross-platform CI coverage without changing production embedding selection or model behavior.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The current `main` branch deterministically fails all six Linux/macOS unit-test matrix jobs because `terminate_process_tree()` returns when `killpg(process.pid, ...)` cannot find a process group for an ordinary child. The same unit suite also performs real Hugging Face downloads, which makes cold-cache and fork CI depend on network latency and rate limits despite the repository's deterministic-unit-test policy.

## Changes

- Fall back from a missing POSIX process group to direct `process.terminate()` and `process.kill()`, then continue waiting so the child is reaped.
- Add a deterministic regression for the non-group TERM-to-KILL escalation path while preserving the existing real ordinary-child and process-group tests.
- Inject a fixed-dimension float32 embedder at the external model boundary in the memory-index HTTP/WebSocket tests while retaining the real `SessionStore`, `SessionMemory`, HTTP, and WebSocket paths.
- Make the concurrent-build guard wait on explicit start/release events instead of relying on model-download latency to keep the first build in flight.
- Replace the Model2Vec download in the adapter round-trip test with a deterministic `StaticModel.from_pretrained` seam while retaining model-name, dimension, batch, `encode_one`, shape, and dtype assertions.
- Inject a deterministic `BaseEmbedder` only at the Studio memory-search provider boundary, retaining the real Studio, Terrarium, `SessionStore`, on-disk `.kohakutr`, vector vault, and hybrid-search workflow.

## Validation

```bash
pytest tests/unit/builtins/tools/subprocess/test_shell_utils.py -vv --tb=long
pytest tests/unit/api/routes/persistence/test_memory_index_routes.py tests/unit/session/test_embedding.py -q
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
pytest tests/unit/test_file_sizes.py -q
pytest tests/integration/ -q
ruff check src/ tests/
black --check --target-version py313 src/ tests/
```

- Subprocess helper tests: 6 passed, 1 skipped on Windows; the deterministic test exercises the POSIX fallback and escalation branch.
- Memory-index and embedding tests: 33 passed. The concurrent-build regression also passed 10 consecutive isolated runs.
- Empty-cache offline rerun with `HF_HUB_OFFLINE=1`, `TRANSFORMERS_OFFLINE=1`, and `HF_DATASETS_OFFLINE=1`: 33 passed; the temporary `HF_HOME` remained empty.
- Full integration suite under the same empty-cache offline environment: 170 passed, 1 skipped; the temporary `HF_HOME` remained empty.
- Full unit suite excluding file-size guards: 11,536 passed, 9 skipped, 1 failed. The only failure is the clean-base Windows `EDITOR=true` environment issue explained below.
- File-size guard: 1,618 passed.
- Integration suite: 170 passed, 1 skipped.
- Repository-wide Ruff and Black checks passed.
- Fork CI for the current three-commit head: [all 13 jobs passed](https://github.com/VVittgenstein/KohakuTerrarium/actions/runs/30343743298), including both Windows unit and integration jobs.
- `git diff --check` passed, the worktree is clean, and all three commits are SSH-signed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [ ] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

2026-07-28

## Notes for Reviewers

- The three commits deliberately separate the production POSIX fallback, unit-test network determinism, and the Studio integration seam.
- Please focus on the `ProcessLookupError` fallbacks: a child that has already exited is tolerated, while a live child without its own process group is signaled directly and still awaited.
- The embedding changes are confined to tests. Production provider detection, presets, model names, downloads, and vector generation are unchanged.
- Signed candidate head: `7376c5249d360427ef127f5009c16cc7754dc456` (3 commits, 5 files, +185/-37).

## Screenshots / Logs (if applicable)

Not applicable; there are no UI changes.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- No permalink or maintainer handle is recorded for the community discussion, so the discussion-link checkbox remains empty; the available record is the date above.
- The full local unit run has one failure in `TestSettings::test_edit_config_with_editor`: this Windows environment cannot execute the test's Unix `EDITOR=true` command. The same node fails on clean base, while the changed subprocess and embedding test files pass.
- The first upstream run's Windows 3.12 job hit an unchanged session-index debounce timing test. The PR does not touch that test or implementation, the other seven matrix jobs passed it, and it passed 20 consecutive local Windows runs. The separate Windows 3.13 Hugging Face timeout exposed the Studio integration seam fixed by the third commit.
- No frontend files changed, so frontend formatting and build commands are not applicable.
- E2E was not rerun because this change is limited to a subprocess helper and deterministic unit/integration external-I/O seams; the full affected unit and integration tiers were run.
