### PR TITLE
fix(terrarium): enforce graph-local routing identities

### DIFF
--- a/docs/en/guides/terrariums.md
+++ b/docs/en/guides/terrariums.md
@@ -184,6 +184,8 @@ async with Terrarium() as engine:
 
 Cross-graph `connect()` merges the two graphs: environments union, attached session stores merge into one (with `parent_session_ids` recording lineage), the new listener gets a `ChannelTrigger` injected. `disconnect()` may split a graph back apart and copy the parent session into each side. See [`examples/code/terrarium_hotplug.py`](../../examples/code/terrarium_hotplug.py).
 
+Routing operations such as channel wiring, group messaging, and output wiring resolve targets inside the caller's current logical graph. Prefer an exact runtime creature ID. A display or config name is accepted only when it is unique in that graph; ambiguous, stale, and foreign-graph targets are rejected. These operations never merge disconnected graphs implicitly: call `connect()` first with exact endpoints.
+
 The same mutations are available to a privileged node inside the graph through the group tools: `group_add_node`, `group_remove_node`, `group_start_node`, `group_stop_node`, `group_channel`, `group_wire`. Together they form the in-graph "graph editor" an LLM-driven privileged node uses to evolve the team mid-run.
 
 Hot-plug is useful for provisioning ad-hoc specialists without restarting. Existing channels pick up the new listener; the new creature receives its channel topology in its system prompt.

--- a/docs/zh-CN/guides/terrariums.md
+++ b/docs/zh-CN/guides/terrariums.md
@@ -179,6 +179,8 @@ async with Terrarium() as engine:
 
 跨图的 `connect()` 会合并两个图：environment 取联集，挂著的 session store 合并成一份（`parent_session_ids` 记下血缘），新的 listener 会被注入 `ChannelTrigger`。`disconnect()` 可能把图拆回两边、并把 parent session 复制到两侧。参考 [`examples/code/terrarium_hotplug.py`](../../examples/code/terrarium_hotplug.py)。
 
+频道接线、组消息和 output wiring 等路由操作只会在调用者当前的逻辑图内解析目标。请优先使用精确的运行时 Creature ID；显示名或配置名只有在图内唯一时才会被接受，歧义、过期或属于其他图的目标都会被拒绝。这些操作不会隐式合并彼此断开的图；请先用精确端点调用 `connect()`。
+
 同样的 mutation 也开放给图中的特权节点透过组工具呼叫：`group_add_node`、`group_remove_node`、`group_start_node`、`group_stop_node`、`group_channel`、`group_wire`。它们合在一起就是图内的「图编辑器」，让 LLM 驱动的 root 在执行中演化团队。
 
 热插拔很适合临时补一个专员、又不用重启。既有频道会自动吸收新的 listener；新 Creature 会在它的 system prompt 看到自己的频道拓扑。

--- a/docs/zh-TW/guides/terrariums.md
+++ b/docs/zh-TW/guides/terrariums.md
@@ -179,6 +179,8 @@ async with Terrarium() as engine:
 
 跨圖的 `connect()` 會合併兩個圖：environment 取聯集，掛著的 session store 合併成一份（`parent_session_ids` 記下血脈），新的 listener 會被注入 `ChannelTrigger`。`disconnect()` 可能把圖拆回兩邊、並把 parent session 複製到兩側。參考 [`examples/code/terrarium_hotplug.py`](../../examples/code/terrarium_hotplug.py)。
 
+頻道接線、群組訊息和 output wiring 等路由操作只會在呼叫者目前的邏輯圖內解析目標。請優先使用精確的執行期 Creature ID；顯示名稱或設定名稱只有在圖內唯一時才會被接受，歧義、過期或屬於其他圖的目標都會被拒絕。這些操作不會隱式合併彼此斷開的圖；請先用精確端點呼叫 `connect()`。
+
 同樣的 mutation 也開放給圖中的特權節點透過群組工具呼叫：`group_add_node`、`group_remove_node`、`group_start_node`、`group_stop_node`、`group_channel`、`group_wire`。它們合在一起就是圖內的「圖編輯器」，讓 LLM 驅動的 root 在執行中演化團隊。
 
 熱插拔很適合臨時補一個專員、又不用重啟。既有頻道會自動吸收新的 listener；新生物會在它的 system prompt 看到自己的頻道拓樸。

--- a/src/kohakuterrarium/api/app.py
+++ b/src/kohakuterrarium/api/app.py
@@ -48,6 +48,7 @@ from kohakuterrarium.studio.identity import drive_settings as _drive_settings
 from kohakuterrarium.studio.sessions.lifecycle import get_session_meta
 from kohakuterrarium.terrarium import MultiNodeTerrariumService, Terrarium
 from kohakuterrarium.terrarium.drive.config import DriveRuntimeConfig
+from kohakuterrarium.terrarium.multi_node_channels import cluster_members_for
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -207,8 +208,14 @@ async def lifespan(app: FastAPI):
         output_wire_adapter = TerrariumOutputWireAdapter(
             coordination_engine, host_engine
         )
-        output_wire_adapter.set_target_resolver(
-            _make_output_wire_target_resolver(multi_node_service)
+        output_wire_adapter.set_name_cache(multi_node_service._creature_name_cache)
+        output_wire_adapter.set_cluster_members(
+            lambda graph_id: {
+                member_graph_id
+                for _node_id, member_graph_id in cluster_members_for(
+                    multi_node_service, graph_id
+                )
+            }
         )
         # Mirror worker events under the host session directory so Studio reads
         # do not require a remote round trip.
@@ -382,25 +389,6 @@ def _parse_bind(bind: str) -> tuple[str, int]:
         raise ValueError(f"invalid lab bind {bind!r}; expected host:port")
     host, _, port_str = bind.rpartition(":")
     return host, int(port_str)
-
-
-def _make_output_wire_target_resolver(service: MultiNodeTerrariumService):
-    """Build a non-blocking target lookup from cached creature locations.
-
-    Cache misses return ``None`` because this synchronous resolver cannot perform
-    the asynchronous discovery needed to refresh the service cache.
-    """
-
-    def resolve(target_name: str) -> tuple[str, str] | None:
-        cache = getattr(service, "_creature_name_cache", None) or {}
-        entry = cache.get(target_name)
-        if entry is not None:
-            return entry
-        # ``list_creatures`` refreshes this cache; synchronous wire resolution
-        # cannot initiate that asynchronous discovery on a miss.
-        return None
-
-    return resolve
 
 
 async def _watch_membership(

--- a/src/kohakuterrarium/api/routes/sessions_v2/_helpers.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/_helpers.py
@@ -62,7 +62,15 @@ async def resolve_creature_id(
         if info.creature_id == name_or_id:
             return info.creature_id
     # Name lookup remains within the requested session or cluster and must be unique.
-    matches = [info.creature_id for info in creatures if info.name == name_or_id]
+    matches = [
+        info.creature_id
+        for info in creatures
+        if info.name == name_or_id
+        or (
+            bool(config_name := getattr(info, "config_name", ""))
+            and config_name == name_or_id
+        )
+    ]
     if len(matches) == 1:
         return matches[0]
     if len(matches) > 1:
@@ -73,4 +81,4 @@ async def resolve_creature_id(
     raise HTTPException(404, f"creature {name_or_id!r} not found")
 
 
-__all__ = ["resolve_creature_id"]
+__all__ = ["resolve_connect_target_id", "resolve_creature_id"]

--- a/src/kohakuterrarium/api/routes/sessions_v2/_helpers.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/_helpers.py
@@ -19,6 +19,22 @@ def _cluster_scope(service: TerrariumService, session_id: str) -> set[str]:
     return {session_id}
 
 
+async def resolve_connect_target_id(
+    service: TerrariumService,
+    name_or_id: str,
+    session_id: str,
+) -> str:
+    """Allow an explicit runtime ID across graphs, never a name fallback."""
+    try:
+        creatures = await service.list_creatures()
+    except Exception as exc:  # noqa: BLE001 — all service failures map to 503
+        raise HTTPException(503, f"service unavailable: {exc}") from exc
+    for info in creatures:
+        if info.creature_id == name_or_id:
+            return info.creature_id
+    return await resolve_creature_id(service, name_or_id, session_id)
+
+
 async def resolve_creature_id(
     service: TerrariumService,
     name_or_id: str,
@@ -45,10 +61,15 @@ async def resolve_creature_id(
     for info in creatures:
         if info.creature_id == name_or_id:
             return info.creature_id
-    # Name lookup remains within the requested session or cluster.
-    for info in creatures:
-        if info.name == name_or_id:
-            return info.creature_id
+    # Name lookup remains within the requested session or cluster and must be unique.
+    matches = [info.creature_id for info in creatures if info.name == name_or_id]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise HTTPException(
+            409,
+            f"creature name {name_or_id!r} is ambiguous in this session",
+        )
     raise HTTPException(404, f"creature {name_or_id!r} not found")
 
 

--- a/src/kohakuterrarium/api/routes/sessions_v2/topology.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/topology.py
@@ -179,8 +179,10 @@ async def disconnect_creatures(
 ):
     """Disconnect two creatures and remove any cross-node subscription."""
     try:
+        sender_id = await resolve_creature_id(service, req.sender, session_id)
+        receiver_id = await resolve_creature_id(service, req.receiver, session_id)
         return await topology_lib.disconnect(
-            service, req.sender, req.receiver, channel=req.channel
+            service, sender_id, receiver_id, channel=req.channel
         )
     except (KeyError, ValueError) as e:
         raise HTTPException(400, str(e))
@@ -196,8 +198,9 @@ async def wire_session_creature(
     """Add a creature's listen or send edge on an existing channel."""
     # The topology helper emits the change event; emitting here would duplicate it.
     try:
+        cid = await resolve_creature_id(service, creature_id, session_id)
         await topology_lib.wire_creature(
-            service, session_id, creature_id, req.channel, req.direction, enabled=True
+            service, session_id, cid, req.channel, req.direction, enabled=True
         )
         return {"status": "wired"}
     except (KeyError, ValueError) as e:
@@ -213,10 +216,11 @@ async def unwire_session_creature(
 ):
     """Remove a listen / send edge for a creature on an existing channel."""
     try:
+        cid = await resolve_creature_id(service, creature_id, session_id)
         await topology_lib.wire_creature(
             service,
             session_id,
-            creature_id,
+            cid,
             req.channel,
             req.direction,
             enabled=False,

--- a/src/kohakuterrarium/api/routes/sessions_v2/topology.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/topology.py
@@ -4,6 +4,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from kohakuterrarium.api.deps import get_service
+from kohakuterrarium.api.routes.sessions_v2._helpers import (
+    resolve_connect_target_id,
+    resolve_creature_id,
+)
 from kohakuterrarium.api.schemas import ChannelAdd, ChannelSend, WireChannel
 from kohakuterrarium.studio.sessions import topology as topology_lib
 from kohakuterrarium.terrarium.service import TerrariumService
@@ -151,13 +155,15 @@ async def connect_creatures(
     Cross-node connections replicate the channel and establish a broadcast
     subscription between sites.
     """
-    # The topology layer emits the change event; a second event here would
-    # duplicate prompt refreshes and session-log entries.
+    # The URL session is authoritative: resolve both endpoints in that exact
+    # session or logical cluster before allowing the topology mutation.
     try:
+        sender_id = await resolve_creature_id(service, req.sender, session_id)
+        receiver_id = await resolve_connect_target_id(service, req.receiver, session_id)
         return await topology_lib.connect(
             service,
-            req.sender,
-            req.receiver,
+            sender_id,
+            receiver_id,
             channel=req.channel,
             channel_type=req.channel_type,
         )

--- a/src/kohakuterrarium/api/routes/sessions_v2/wiring.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/wiring.py
@@ -59,8 +59,11 @@ async def wire_creature_output(
 ):
     """Add a direct output-wiring edge for a creature."""
     cid = await resolve_creature_id(service, creature_id, session_id)
+    entry = req.as_entry()
+    if req.to != "root":
+        entry["to"] = await resolve_creature_id(service, req.to, session_id)
     try:
-        result = await service.wire_output(cid, req.as_entry())
+        result = await service.wire_output(cid, entry)
     except KeyError:
         raise HTTPException(404, f"creature {creature_id!r} not found")
     except ValueError as exc:

--- a/src/kohakuterrarium/builtins/tools/send_message.py
+++ b/src/kohakuterrarium/builtins/tools/send_message.py
@@ -19,34 +19,43 @@ logger = get_logger(__name__)
 
 
 def _check_engine_send_edge(
-    context: ToolContext, channel_name: str
+    context: ToolContext | None, channel_name: str
 ) -> tuple[bool, str | None]:
-    """Return topology membership and any send-edge denial for a channel."""
+    """Authorize a topology channel using the exact runtime caller identity.
+
+    The boolean indicates that an engine context was present and therefore must
+    not fall through to a same-name private channel when identity or topology
+    validation fails.
+    """
     if context is None or context.environment is None:
         return False, None
     engine_ref = context.environment.get("terrarium_engine")
     engine = engine_ref() if isinstance(engine_ref, weakref.ref) else engine_ref
     if engine is None:
         return False, None
-    creature = None
-    by_id = engine._creatures.get(context.agent_name)
-    if by_id is not None:
-        creature = by_id
-    else:
-        for c in engine._creatures.values():
-            if c.name == context.agent_name:
-                creature = c
-                break
-            cfg = getattr(c.agent, "config", None)
-            if cfg is not None and getattr(cfg, "name", None) == context.agent_name:
-                creature = c
-                break
-    if creature is None:
+
+    caller_id = getattr(context, "creature_id", None)
+    if not isinstance(caller_id, str) or not caller_id:
+        return True, (
+            "Cannot verify channel permissions without ToolContext.creature_id; "
+            "legacy name-only contexts are denied."
+        )
+    creature = engine._creatures.get(caller_id)
+    if creature is None or creature.creature_id != caller_id:
+        return True, f"Unknown runtime caller {caller_id!r}; channel send denied."
+    graph_id = engine._topology.creature_to_graph.get(caller_id)
+    graph = engine._topology.graphs.get(graph_id or "")
+    if graph is None or caller_id not in graph.creature_ids:
+        return (
+            True,
+            f"Cannot verify graph for runtime caller {caller_id!r}; send denied.",
+        )
+    if channel_name not in graph.channels:
         return False, None
-    graph = engine._topology.graphs.get(creature.graph_id)
-    if graph is None or channel_name not in graph.channels:
-        return False, None
-    sends = graph.send_edges.get(creature.creature_id, set())
+    try:
+        sends = graph.send_edges[caller_id]
+    except (AttributeError, KeyError, TypeError):
+        return True, "Could not verify caller channel permissions; send denied."
     if channel_name in sends:
         return True, None
     return True, (
@@ -54,7 +63,7 @@ def _check_engine_send_edge(
         f"Your outgoing channels: {sorted(sends)}. "
         f"Ask the privileged creature to wire you via "
         f"group_channel(action='wire', direction='send', "
-        f"channel='{channel_name}', creature_id=you)."
+        f"channel='{channel_name}', creature_id={caller_id!r})."
     )
 
 
@@ -96,11 +105,9 @@ class SendMessageTool(BaseTool):
         sender_id: str | None = None
         if context:
             sender = context.agent_name
-            agent_obj = getattr(context, "agent", None)
-            if agent_obj is not None:
-                sender_id = getattr(agent_obj, "_creature_id", None) or getattr(
-                    agent_obj, "creature_id", None
-                )
+            candidate_id = getattr(context, "creature_id", None)
+            if isinstance(candidate_id, str) and candidate_id:
+                sender_id = candidate_id
 
         metadata: dict[str, Any] = {}
         raw_metadata = args.get("metadata", "")

--- a/src/kohakuterrarium/core/executor.py
+++ b/src/kohakuterrarium/core/executor.py
@@ -43,6 +43,7 @@ class Executor:
         self._serial_lock: asyncio.Lock | None = None
 
         self._agent_name: str = ""
+        self._creature_id: str = ""
         self._tool_format: str = "native"
         self._agent: Any = None  # Agent instance, set during init
         self._session: Any = None  # Session, set by agent during init
@@ -362,6 +363,7 @@ class Executor:
             agent_name=self._agent_name,
             session=self._session,
             working_dir=self._working_dir,
+            creature_id=self._creature_id,
             memory_path=self._memory_path,
             environment=self._environment,
             tool_format=self._tool_format,

--- a/src/kohakuterrarium/laboratory/_internal/host.py
+++ b/src/kohakuterrarium/laboratory/_internal/host.py
@@ -558,6 +558,14 @@ class HostEngine:
         sender: ConnectedClient,
         env: Envelope,
     ) -> None:
+        if env.from_node != sender.client_id:
+            _log.warning(
+                "Dropping envelope with forged source identity",
+                authenticated_peer=sender.client_id,
+                claimed_source=env.from_node,
+                target=env.to_node,
+            )
+            return
         match env.kind:
             case EnvelopeKind.HEARTBEAT:
                 self._membership.heartbeat(sender.client_id, now=time.monotonic())

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_output_wire.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_output_wire.py
@@ -5,6 +5,7 @@ to the host, whose cluster-wide resolver forwards the event to the target's
 home node. Relayed messages are marked to prevent another forwarding hop.
 """
 
+import asyncio
 from collections.abc import Callable
 from typing import Any
 
@@ -206,8 +207,14 @@ class TerrariumOutputWireAdapter:
             return {"delivered": False, "error": "target not found locally"}
         if local_graph_id != target_graph_id:
             return {"delivered": False, "error": "target graph mismatch"}
+        if not getattr(target_agent, "_running", False):
+            return {"delivered": False, "error": "target not running"}
         event = _event_from_dict(dict(body.get("event", {})))
-        await target_agent._process_event(event)
+        task = asyncio.create_task(
+            target_agent._process_event(event),
+            name=f"output-wire-{source_id}-to-{target_creature_id}",
+        )
+        task.add_done_callback(_log_delivery_error)
         return {"delivered": True}
 
     def _resolve_local_target(
@@ -227,3 +234,13 @@ def _event_from_dict(data: dict[str, Any]) -> TriggerEvent:
         context=dict(data.get("context", data.get("metadata", {}))),
         prompt_override=data.get("prompt_override"),
     )
+
+
+def _log_delivery_error(task: "asyncio.Task[Any]") -> None:
+    """Consume background receiver errors without leaking task warnings."""
+    if task.cancelled():
+        return
+    try:
+        task.result()
+    except Exception:
+        logger.exception("output-wire receiver event failed")

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_output_wire.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_output_wire.py
@@ -5,184 +5,225 @@ to the host, whose cluster-wide resolver forwards the event to the target's
 home node. Relayed messages are marked to prevent another forwarding hop.
 """
 
-import asyncio
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
-from kohakuterrarium.core.events import create_creature_output_event
+from kohakuterrarium.core.events import TriggerEvent
 from kohakuterrarium.laboratory._internal.app import AppMessage
-from kohakuterrarium.laboratory.protocols import LabNotifier
-from kohakuterrarium.terrarium.engine import Terrarium
+from kohakuterrarium.laboratory.protocols import LabNode
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+_NAMESPACE = "terrarium.output_wire"
+_MSG_INJECT = "inject"
+
 
 class TerrariumOutputWireAdapter:
-    """Per-node extension that forwards and receives output-wiring events.
+    """Route graph-bound output events with exact identities and acknowledgements."""
 
-    The engine reference lets its output resolver discover this adapter without
-    an import cycle. Only the host installs a cluster target resolver.
-    """
-
-    NAMESPACE = "terrarium.output_wire"
-
-    def __init__(self, engine: Terrarium, lab_node: LabNotifier) -> None:
+    def __init__(
+        self,
+        engine: Any,
+        messenger: LabNode,
+        *,
+        name_cache: dict[str, set[tuple[str, str, str]]] | None = None,
+        cluster_members: Callable[[str], set[str]] | None = None,
+    ) -> None:
         self._engine = engine
-        self._node = lab_node
-        self._target_resolver: Callable[[str], tuple[str, str] | None] | None = None
-        lab_node.register_app_extension(self.NAMESPACE, self._dispatch)
+        self._messenger = messenger
+        self._name_cache = name_cache if name_cache is not None else {}
+        self._cluster_members = cluster_members or (lambda graph_id: {graph_id})
+        register = getattr(messenger, "register_app_extension", None)
+        if register is None:
+            register = getattr(messenger, "register_handler", None)
+        if register is None:
+            raise TypeError("messenger does not support APP extensions")
+        register(_NAMESPACE, self._dispatch)
         engine._output_wire_adapter = self
-        logger.info("lab adapter registered", namespace=self.NAMESPACE)
 
     def detach(self) -> None:
         if getattr(self._engine, "_output_wire_adapter", None) is self:
             self._engine._output_wire_adapter = None
-        self._node.unregister_app_extension(self.NAMESPACE)
-        self._target_resolver = None
-        logger.info("lab adapter detached", namespace=self.NAMESPACE)
+        unregister = getattr(self._messenger, "unregister_app_extension", None)
+        if unregister is None:
+            unregister = getattr(self._messenger, "unregister_handler", None)
+        if unregister is not None:
+            unregister(_NAMESPACE)
 
-    def set_target_resolver(
-        self, resolver: Callable[[str], tuple[str, str] | None]
-    ) -> None:
-        """Install the host's target-name to home-node lookup."""
-        self._target_resolver = resolver
+    def _node_id(self) -> str:
+        value = getattr(self._messenger, "node_id", None)
+        if callable(value):
+            value = value()
+        if not value:
+            value = getattr(self._messenger, "client_id", None)
+        if not value:
+            value = "_host"
+        return str(value)
 
-    def peer_for_target(self, target_name: str) -> str | None:
-        """Return the remote route for a target, if one is required.
+    def set_name_cache(self, cache: dict[str, set[tuple[str, str, str]]]) -> None:
+        self._name_cache = cache
 
-        Workers return ``"_host"`` because only the host knows cluster-wide
-        placement. The host returns ``None`` for its own targets so they remain
-        on the local path.
-        """
-        if self._target_resolver is None:
-            # Workers lack cluster placement data, so the host is their relay.
+    def set_cluster_members(self, resolver: Callable[[str], set[str]]) -> None:
+        self._cluster_members = resolver
+
+    def peer_for_target(
+        self, target_name: str, *, graph_id: str | None = None
+    ) -> str | None:
+        if self._node_id() != "_host":
             return "_host"
-        try:
-            entry = self._target_resolver(target_name)
-        except Exception:
-            logger.exception("output_wire target resolver crashed")
-            return None
-        if entry is None:
-            return None
-        node_id, _ = entry
-        if not node_id or node_id == "_host":
-            return None
-        return node_id
+        entries = set(self._name_cache.get(target_name, set()))
+        if graph_id is not None:
+            graph_ids = self._cluster_members(graph_id)
+            entries = {entry for entry in entries if entry[0] in graph_ids}
+        return next(iter(entries))[1] if len(entries) == 1 else None
 
     async def forward_event(
         self,
-        peer_node: str,
-        body: dict[str, Any],
+        *,
+        target_name: str,
+        event: dict[str, Any],
+        source_creature_id: str | None = None,
+        source_graph_id: str | None = None,
+        hop: int = 0,
     ) -> bool:
-        """Fire ``inject`` at ``peer_node``.  Returns ``True`` on RPC ack."""
+        if not source_creature_id or not source_graph_id or hop != 0:
+            return False
+        peer = self.peer_for_target(target_name, graph_id=source_graph_id)
+        if peer is None or peer == self._node_id():
+            return False
+        result = await self._request(
+            peer,
+            _MSG_INJECT,
+            {
+                "target_name": target_name,
+                "event": dict(event),
+                "source_creature_id": source_creature_id,
+                "source_graph_id": source_graph_id,
+                "hop": hop,
+                "peer": self._node_id(),
+            },
+        )
+        return bool(result.get("delivered", False))
+
+    async def _request(
+        self, peer: str, msg_type: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        request = self._messenger.request
         try:
-            await self._node.notify(
-                to_node=peer_node,
-                namespace=self.NAMESPACE,
-                type="inject",
+            return await request(peer, msg_type, body)
+        except TypeError:
+            return await request(
+                to_node=peer,
+                namespace=_NAMESPACE,
+                type=msg_type,
                 body=body,
             )
-            return True
-        except Exception:
-            logger.debug(
-                "output_wire forward failed",
-                peer=peer_node,
-                target=body.get("target_name"),
-            )
-            return False
 
     async def _dispatch(self, msg: AppMessage) -> dict[str, Any]:
         try:
-            return await self._handle(msg)
-        except KeyError as e:
-            return {"error": {"kind": "not_found", "message": str(e)}}
-        except ValueError as e:
-            return {"error": {"kind": "invalid", "message": str(e)}}
-        except Exception as e:  # pragma: no cover - defensive
-            logger.exception("terrarium.output_wire handler failed: %s", msg.type)
-            return {"error": {"kind": "output_wire", "message": str(e)}}
-
-    async def _handle(self, msg: AppMessage) -> dict[str, Any]:
-        match msg.type:
-            case "inject":
-                return await self._op_inject(msg.body)
-            case _:
-                return {
-                    "error": {
-                        "kind": "unknown_type",
-                        "message": f"unsupported terrarium.output_wire type: {msg.type!r}",
-                    }
-                }
+            if msg.type != _MSG_INJECT:
+                raise ValueError(f"unknown output-wire op: {msg.type}")
+            body = dict(msg.body)
+            body["_sender_node"] = msg.sender_node
+            return await self._op_inject(body)
+        except Exception as exc:
+            logger.warning("output-wire op failed", error=str(exc))
+            return {"delivered": False, "error": str(exc)}
 
     async def _op_inject(self, body: dict[str, Any]) -> dict[str, Any]:
-        """Deliver an injected event locally or relay it once from the host."""
-        target_name = body.get("target_name", "")
-        if not target_name:
-            raise ValueError("target_name required")
-        target_agent = self._resolve_local_agent(target_name)
+        target_name = body.get("target_name")
+        source_id = body.get("source_creature_id")
+        source_graph_id = body.get("source_graph_id")
+        hop = body.get("hop")
+        peer_claim = body.get("peer")
+        sender_node = body.get("_sender_node")
+        if (
+            not isinstance(target_name, str)
+            or not isinstance(source_id, str)
+            or not isinstance(source_graph_id, str)
+            or not isinstance(hop, int)
+            or hop < 0
+            or hop > 1
+            or peer_claim != sender_node
+        ):
+            return {"delivered": False, "error": "invalid routing identity"}
+
+        if self._node_id() == "_host":
+            source_identity = (
+                source_graph_id,
+                sender_node,
+                source_id,
+            )
+            if source_identity not in self._name_cache.get(source_id, set()):
+                return {"delivered": False, "error": "forged source identity"}
+            event = body.get("event", {})
+            event_source = event.get("source")
+            context_source = event.get("context", {}).get("source")
+            if event_source not in {None, source_id} or context_source not in {
+                None,
+                source_id,
+            }:
+                return {"delivered": False, "error": "forged event source"}
+            graph_ids = self._cluster_members(source_graph_id)
+            entries = {
+                entry
+                for entry in self._name_cache.get(target_name, set())
+                if entry[0] in graph_ids
+            }
+            if len(entries) != 1 or hop != 0:
+                return {
+                    "delivered": False,
+                    "error": "target not found or ambiguous",
+                }
+            target_graph_id, peer, target_creature_id = next(iter(entries))
+            result = await self._request(
+                peer,
+                _MSG_INJECT,
+                {
+                    "target_name": target_name,
+                    "event": dict(body.get("event", {})),
+                    "source_creature_id": source_id,
+                    "source_graph_id": source_graph_id,
+                    "target_graph_id": target_graph_id,
+                    "target_creature_id": target_creature_id,
+                    "hop": 1,
+                    "peer": self._node_id(),
+                },
+            )
+            return {"delivered": bool(result.get("delivered", False))}
+
+        if sender_node != "_host" or hop != 1:
+            return {"delivered": False, "error": "invalid relay peer"}
+        target_creature_id = body.get("target_creature_id")
+        target_graph_id = body.get("target_graph_id")
+        if not isinstance(target_creature_id, str) or not isinstance(
+            target_graph_id, str
+        ):
+            return {"delivered": False, "error": "missing exact target identity"}
+        target_agent, local_graph_id = self._resolve_local_target(target_creature_id)
         if target_agent is None:
-            # Only the host can resolve a miss to another peer. The marker
-            # prevents a misplaced target from being forwarded repeatedly.
-            if self._target_resolver is not None and not body.get("relayed"):
-                try:
-                    entry = self._target_resolver(target_name)
-                except Exception:
-                    entry = None
-                if entry is not None:
-                    peer_node, _ = entry
-                    if peer_node and peer_node != "_host":
-                        relayed_body = {**body, "relayed": True}
-                        await self.forward_event(peer_node, relayed_body)
-                        return {"delivered": True, "relayed": peer_node}
-            raise KeyError(f"no creature named {target_name!r} on this node")
-        if not getattr(target_agent, "_running", False):
-            return {"delivered": False, "reason": "target_not_running"}
-        event = create_creature_output_event(
-            source=body.get("source", ""),
-            target=target_name,
-            content=body.get("content", ""),
-            with_content=bool(body.get("with_content", True)),
-            source_event_type=body.get("source_event_type", ""),
-            turn_index=int(body.get("turn_index", 0)),
-            prompt_override=body.get("prompt_override", ""),
-        )
-        # Activity reporting must not prevent event delivery.
-        try:
-            router = getattr(target_agent, "output_router", None)
-            if router is not None and hasattr(router, "notify_activity"):
-                preview = (body.get("content", "") or "").strip()
-                if len(preview) > 240:
-                    preview = preview[:239] + "…"
-                router.notify_activity(
-                    "wire_inbound",
-                    f"Inbound from {body.get('source', '?')}",
-                    metadata={
-                        "from": body.get("source", ""),
-                        "to": target_name,
-                        "with_content": bool(body.get("with_content", True)),
-                        "content_preview": preview,
-                        "source_event_type": body.get("source_event_type", ""),
-                        "source_turn_index": int(body.get("turn_index", 0)),
-                        "cross_node": True,
-                    },
-                )
-        except Exception:
-            logger.debug("wire_inbound notify failed on injected event")
-        # Do not hold the sender's emit task for the receiver's entire turn.
-        asyncio.create_task(target_agent._process_event(event))
+            return {"delivered": False, "error": "target not found locally"}
+        if local_graph_id != target_graph_id:
+            return {"delivered": False, "error": "target graph mismatch"}
+        event = _event_from_dict(dict(body.get("event", {})))
+        await target_agent._process_event(event)
         return {"delivered": True}
 
-    def _resolve_local_agent(self, target_name: str):
-        """Find an Agent on this engine by creature_id, name, or config.name."""
-        for creature in self._engine.list_creatures():
-            if creature.creature_id == target_name:
-                return creature.agent
-            if getattr(creature, "name", None) == target_name:
-                return creature.agent
-            cfg = getattr(creature.agent, "config", None)
-            if getattr(cfg, "name", None) == target_name:
-                return creature.agent
-        return None
+    def _resolve_local_target(
+        self, target_creature_id: str
+    ) -> tuple[Any | None, str | None]:
+        creature = getattr(self._engine, "_creatures", {}).get(target_creature_id)
+        if creature is None:
+            return None, None
+        return getattr(creature, "agent", None), getattr(creature, "graph_id", None)
 
 
-__all__ = ["TerrariumOutputWireAdapter"]
+def _event_from_dict(data: dict[str, Any]) -> TriggerEvent:
+    """Rebuild the minimal TriggerEvent used for output-wire injection."""
+    return TriggerEvent(
+        type=str(data.get("type", "creature_output")),
+        content=str(data.get("content", "")),
+        context=dict(data.get("context", data.get("metadata", {}))),
+        prompt_override=data.get("prompt_override"),
+    )

--- a/src/kohakuterrarium/modules/tool/base.py
+++ b/src/kohakuterrarium/modules/tool/base.py
@@ -43,6 +43,7 @@ class ToolContext:
     agent_name: str
     session: Any
     working_dir: Path
+    creature_id: str = ""
     memory_path: Path | None = None
     environment: Any = None
     tool_format: str = "native"

--- a/src/kohakuterrarium/modules/tool/base.py
+++ b/src/kohakuterrarium/modules/tool/base.py
@@ -43,7 +43,6 @@ class ToolContext:
     agent_name: str
     session: Any
     working_dir: Path
-    creature_id: str = ""
     memory_path: Path | None = None
     environment: Any = None
     tool_format: str = "native"
@@ -51,6 +50,7 @@ class ToolContext:
     file_read_state: Any = None
     path_guard: Any = None
     runtime_services: dict[str, Any] = field(default_factory=dict)
+    creature_id: str = ""
 
     @property
     def channels(self) -> Any:

--- a/src/kohakuterrarium/studio/sessions/lifecycle.py
+++ b/src/kohakuterrarium/studio/sessions/lifecycle.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.terrarium.graph_identity import ensure_graph_name_available
 from kohakuterrarium.studio.sessions import cluster_fold, remote_meta, stop as _stop
 from kohakuterrarium.studio.sessions import index_hooks as _index_hooks
 from kohakuterrarium.studio.sessions.find import (
@@ -598,6 +599,20 @@ def rename_creature(service: "TerrariumService", creature_id: str, name: str) ->
     meta_registry = meta_for(service)
     if engine is not None:
         creature = engine.get_creature(creature_id)
+        topology = getattr(engine, "_topology", None)
+        graph_id = (
+            topology.creature_to_graph.get(creature.creature_id)
+            if topology is not None
+            else None
+        )
+        if graph_id is not None:
+            ensure_graph_name_available(
+                engine._topology,
+                engine._creatures,
+                graph_id=graph_id,
+                name=name,
+                exclude_id=creature.creature_id,
+            )
         apply_creature_name(creature, name)
         sid = creature.graph_id
         graph = next(

--- a/src/kohakuterrarium/studio/sessions/wiring.py
+++ b/src/kohakuterrarium/studio/sessions/wiring.py
@@ -7,10 +7,9 @@ and WebSocket observation.
 
 from typing import Any
 
-import kohakuterrarium.terrarium.channels as _channels
 from kohakuterrarium.modules.output.base import OutputModule
-from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium import TerrariumService
+from kohakuterrarium.terrarium.graph_identity import resolve_local_graph_target
 from kohakuterrarium.studio._runtime import as_engine
 
 
@@ -19,19 +18,20 @@ async def wire_output(
     creature_id: str,
     target: str | dict[str, Any],
 ) -> str:
-    """Add a runtime ``config.output_wiring`` edge from a creature.
-
-    If the target resolves to a creature in a different graph the two
-    graphs are merged first — output wiring is dispatched per-graph at
-    emit time, so without the merge the resolver would silently drop
-    every emission. The merge is the engine's "ensure same graph"
-    primitive, which does *not* introduce a channel side-effect.
-    """
+    """Add a runtime output edge resolved inside the source logical graph."""
     engine = as_engine(service)
     target_name = _extract_target_name(target)
-    if target_name and target_name != "root":
-        await _ensure_target_in_same_graph(engine, creature_id, target_name)
-    return await engine.wire_output(creature_id, target)
+    if not target_name or target_name == "root":
+        return await engine.wire_output(creature_id, target)
+    resolved = resolve_local_graph_target(
+        engine._topology,
+        engine._creatures,
+        caller_id=creature_id,
+        target=target_name,
+    )
+    canonical = dict(target) if isinstance(target, dict) else {}
+    canonical["to"] = resolved.target_id
+    return await engine.wire_output(creature_id, canonical)
 
 
 def _extract_target_name(target: str | dict[str, Any]) -> str | None:
@@ -41,41 +41,6 @@ def _extract_target_name(target: str | dict[str, Any]) -> str | None:
         value = target.get("to")
         if isinstance(value, str) and value:
             return value
-    return None
-
-
-async def _ensure_target_in_same_graph(
-    engine: Terrarium,
-    source_id: str,
-    target_name: str,
-) -> None:
-    try:
-        source = engine.get_creature(source_id)
-    except KeyError:
-        return
-    target = _resolve_creature_by_name(engine, target_name)
-    if target is None:
-        return
-    if target.graph_id == source.graph_id:
-        return
-    await _channels.ensure_same_graph(engine, source_id, target.creature_id)
-
-
-def _resolve_creature_by_name(engine: Terrarium, name: str):
-    """Look up a creature by id, then by display name as a fallback.
-
-    Output-wiring entries can target either a creature id or its
-    config-level name; the live resolver checks both at emit time so
-    the cross-graph merge has to mirror that lookup or we'd refuse to
-    merge for the very wirings the engine would happily honor.
-    """
-    try:
-        return engine.get_creature(name)
-    except KeyError:
-        pass
-    for handle in getattr(engine, "_creatures", {}).values():
-        if getattr(handle, "name", None) == name:
-            return handle
     return None
 
 

--- a/src/kohakuterrarium/terrarium/channels.py
+++ b/src/kohakuterrarium/terrarium/channels.py
@@ -489,6 +489,12 @@ async def ensure_same_graph(
     the surviving graph id (unchanged if both creatures were already
     in the same graph).
     """
+    # Keep this lower-level merge path under the same identity invariant as
+    # Terrarium.connect(). It is used without creating a channel.
+    from kohakuterrarium.terrarium.graph_identity_engine import (
+        resolve_and_guard_connect,
+    )
+
     sid = engine._resolve_creature_id(a)
     rid = engine._resolve_creature_id(b)
     a_gid = engine._topology.creature_to_graph[sid]
@@ -509,6 +515,7 @@ async def ensure_same_graph(
                 "Cannot merge persisted graphs with duplicate creature names: "
                 + ", ".join(duplicates)
             )
+    resolve_and_guard_connect(engine, a, b)
     delta = _topo._merge_graphs(engine._topology, a_gid, b_gid)
     keep_gid = delta.new_graph_ids[0]
     drop_gids = [g for g in delta.old_graph_ids if g != keep_gid]

--- a/src/kohakuterrarium/terrarium/channels.py
+++ b/src/kohakuterrarium/terrarium/channels.py
@@ -30,6 +30,9 @@ from kohakuterrarium.terrarium.events import (
     EngineEvent,
     EventKind,
 )
+from kohakuterrarium.terrarium.graph_identity_engine import (
+    resolve_and_guard_connect,
+)
 from kohakuterrarium.terrarium.topology import ChannelInfo
 from kohakuterrarium.utils.logging import get_logger
 
@@ -489,12 +492,6 @@ async def ensure_same_graph(
     the surviving graph id (unchanged if both creatures were already
     in the same graph).
     """
-    # Keep this lower-level merge path under the same identity invariant as
-    # Terrarium.connect(). It is used without creating a channel.
-    from kohakuterrarium.terrarium.graph_identity_engine import (
-        resolve_and_guard_connect,
-    )
-
     sid = engine._resolve_creature_id(a)
     rid = engine._resolve_creature_id(b)
     a_gid = engine._topology.creature_to_graph[sid]

--- a/src/kohakuterrarium/terrarium/engine.py
+++ b/src/kohakuterrarium/terrarium/engine.py
@@ -41,6 +41,7 @@ from kohakuterrarium.terrarium.events import (
     EventKind,
     RootAssignment,
 )
+import kohakuterrarium.terrarium.graph_identity_engine as _identity
 from kohakuterrarium.terrarium.runtime_prompt import RuntimeGraphPrompt
 from kohakuterrarium.terrarium.tools_group import (
     force_register_basic_tools,
@@ -75,9 +76,7 @@ class Terrarium:
     the three common construction shapes.
     """
 
-    # ------------------------------------------------------------------
-    # construction
-    # ------------------------------------------------------------------
+    # Construction
 
     def __init__(
         self,
@@ -358,6 +357,7 @@ class Terrarium:
             )
         if creature_id and creature.creature_id != creature_id:
             creature.creature_id = creature_id
+        _identity.bind_runtime_creature_id(creature)
         if name and name.strip():
             apply_creature_name(creature, name.strip())
         if creature.creature_id in self._creatures:
@@ -365,6 +365,7 @@ class Terrarium:
 
         graph_id = self._resolve_graph_id(graph) if graph is not None else None
         if graph_id is not None:
+            _identity.guard_add_name(self, creature, graph_id)
             await _checkpoint.preflight_add(
                 self,
                 graph_id,
@@ -605,9 +606,8 @@ class Terrarium:
 
         Body lives in ``terrarium.channels.connect_creatures``.
         """
-        result = await _channels.connect_creatures(
-            self, sender, receiver, channel=channel
-        )
+        endpoints = _identity.resolve_and_guard_connect(self, sender, receiver)
+        result = await _channels.connect_creatures(self, *endpoints, channel=channel)
         await _checkpoint.checkpoint(self, result.graph_id)
         await self._drain_drive_topology()
         return result

--- a/src/kohakuterrarium/terrarium/graph_identity.py
+++ b/src/kohakuterrarium/terrarium/graph_identity.py
@@ -154,7 +154,7 @@ def ensure_graph_name_available(
         for creature_id in member_ids
         if creature_id != exclude_id
         and (creature := _registered_creature(creatures, creature_id)) is not None
-        and name in _name_aliases(creature)
+        and name in creature_name_aliases(creature)
     )
     if conflicts:
         raise GraphNameConflictError(
@@ -204,7 +204,7 @@ def resolve_local_graph_target(
         creature_id
         for creature_id in sorted(graph.creature_ids)
         if (creature := _registered_creature(creatures, creature_id)) is not None
-        and target in _name_aliases(creature)
+        and target in creature_name_aliases(creature)
     )
     if not candidate_ids:
         raise TargetNotFoundError(caller_id, target, graph_id)
@@ -227,7 +227,8 @@ def _registered_creature(
     return creature
 
 
-def _name_aliases(creature: CreatureIdentity) -> set[str]:
+def creature_name_aliases(creature: CreatureIdentity) -> set[str]:
+    """Return every display/config name accepted by graph-local resolution."""
     aliases = {creature.name} if creature.name else set()
     config = getattr(creature, "config", None)
     _add_name(aliases, config)
@@ -255,6 +256,7 @@ __all__ = [
     "ResolvedGraphTarget",
     "TargetNotFoundError",
     "UnknownCallerError",
+    "creature_name_aliases",
     "ensure_graph_name_available",
     "resolve_local_graph_target",
 ]

--- a/src/kohakuterrarium/terrarium/graph_identity.py
+++ b/src/kohakuterrarium/terrarium/graph_identity.py
@@ -1,0 +1,260 @@
+"""Resolve creature targets within the exact caller's local graph.
+
+The topology owns graph membership while the creature registry owns live runtime
+identities and their human-facing names. This module joins those two pure runtime
+views without consulting providers, UI state, remote nodes, or global name
+fallbacks.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from kohakuterrarium.terrarium.topology import TopologyState
+
+GraphTargetMatch = Literal["runtime_id", "name"]
+
+
+class CreatureIdentity(Protocol):
+    """The identity fields required from a locally hosted creature."""
+
+    creature_id: str
+    name: str
+
+
+class GraphIdentityError(LookupError):
+    """Base class for fail-closed local graph resolution errors."""
+
+    code = "graph_identity_error"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        caller_id: str,
+        target: str | None = None,
+        graph_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.caller_id = caller_id
+        self.target = target
+        self.graph_id = graph_id
+
+
+class UnknownCallerError(GraphIdentityError):
+    """The supplied caller is not an exact local runtime identity."""
+
+    code = "unknown_caller"
+
+    def __init__(self, caller_id: str) -> None:
+        super().__init__(
+            f"caller {caller_id!r} is not a known runtime creature identity",
+            caller_id=caller_id,
+        )
+
+
+class GraphNameConflictError(ValueError):
+    """Raised when a graph already contains the proposed creature name."""
+
+    def __init__(
+        self, *, graph_id: str, name: str, creature_ids: tuple[str, ...]
+    ) -> None:
+        self.graph_id = graph_id
+        self.name = name
+        self.creature_ids = creature_ids
+        super().__init__(
+            f"graph {graph_id!r} already contains creature name {name!r}: "
+            + ", ".join(creature_ids)
+        )
+
+
+class CallerGraphNotFoundError(GraphIdentityError):
+    """The caller exists, but its graph cannot be determined consistently."""
+
+    code = "caller_graph_not_found"
+
+    def __init__(self, caller_id: str, graph_id: str | None = None) -> None:
+        detail = (
+            "is not assigned to a graph"
+            if graph_id is None
+            else f"references unavailable graph {graph_id!r}"
+        )
+        super().__init__(
+            f"caller {caller_id!r} {detail}",
+            caller_id=caller_id,
+            graph_id=graph_id,
+        )
+
+
+class TargetNotFoundError(GraphIdentityError):
+    """No target identity or unique name exists in the caller's graph."""
+
+    code = "target_not_found"
+
+    def __init__(self, caller_id: str, target: str, graph_id: str) -> None:
+        super().__init__(
+            f"target {target!r} is not a creature in caller {caller_id!r}'s "
+            f"graph {graph_id!r}",
+            caller_id=caller_id,
+            target=target,
+            graph_id=graph_id,
+        )
+
+
+class AmbiguousTargetError(GraphIdentityError):
+    """A name identifies multiple creatures inside the caller's graph."""
+
+    code = "ambiguous_target"
+
+    def __init__(
+        self,
+        caller_id: str,
+        target: str,
+        graph_id: str,
+        candidate_ids: tuple[str, ...],
+    ) -> None:
+        super().__init__(
+            f"target {target!r} is ambiguous in caller {caller_id!r}'s graph "
+            f"{graph_id!r}; candidates: {', '.join(candidate_ids)}",
+            caller_id=caller_id,
+            target=target,
+            graph_id=graph_id,
+        )
+        self.candidate_ids = candidate_ids
+
+
+@dataclass(frozen=True)
+class ResolvedGraphTarget:
+    """The exact runtime identity selected inside one caller-local graph."""
+
+    graph_id: str
+    caller_id: str
+    target_id: str
+    matched_by: GraphTargetMatch
+
+    @property
+    def is_self(self) -> bool:
+        """Whether caller and target are the same runtime creature."""
+        return self.caller_id == self.target_id
+
+
+def ensure_graph_name_available(
+    topology: TopologyState,
+    creatures: Mapping[str, CreatureIdentity],
+    *,
+    graph_id: str,
+    name: str,
+    exclude_id: str | None = None,
+) -> None:
+    """Reject duplicate display or config names inside one logical graph."""
+    graph = topology.graphs.get(graph_id)
+    member_ids = sorted(graph.creature_ids) if graph is not None else ()
+    conflicts = tuple(
+        creature_id
+        for creature_id in member_ids
+        if creature_id != exclude_id
+        and (creature := _registered_creature(creatures, creature_id)) is not None
+        and name in _name_aliases(creature)
+    )
+    if conflicts:
+        raise GraphNameConflictError(
+            graph_id=graph_id,
+            name=name,
+            creature_ids=conflicts,
+        )
+
+
+def resolve_local_graph_target(
+    topology: TopologyState,
+    creatures: Mapping[str, CreatureIdentity],
+    *,
+    caller_id: str,
+    target: str,
+) -> ResolvedGraphTarget:
+    """Resolve ``target`` only within an exact runtime caller's graph.
+
+    ``caller_id`` is never interpreted as a display or configuration name. Once
+    its graph is known, an exact target runtime ID wins; otherwise ``target``
+    must uniquely match a display/configuration name among that graph's members.
+    The result deliberately reports self-targeting instead of applying a policy.
+    """
+    caller = _registered_creature(creatures, caller_id)
+    if caller is None:
+        raise UnknownCallerError(caller_id)
+
+    graph_id = topology.creature_to_graph.get(caller_id)
+    if graph_id is None:
+        raise CallerGraphNotFoundError(caller_id)
+    graph = topology.graphs.get(graph_id)
+    if graph is None or caller_id not in graph.creature_ids:
+        raise CallerGraphNotFoundError(caller_id, graph_id)
+
+    if target in graph.creature_ids:
+        exact_target = _registered_creature(creatures, target)
+        if exact_target is None:
+            raise TargetNotFoundError(caller_id, target, graph_id)
+        return ResolvedGraphTarget(
+            graph_id=graph_id,
+            caller_id=caller_id,
+            target_id=target,
+            matched_by="runtime_id",
+        )
+
+    candidate_ids = tuple(
+        creature_id
+        for creature_id in sorted(graph.creature_ids)
+        if (creature := _registered_creature(creatures, creature_id)) is not None
+        and target in _name_aliases(creature)
+    )
+    if not candidate_ids:
+        raise TargetNotFoundError(caller_id, target, graph_id)
+    if len(candidate_ids) > 1:
+        raise AmbiguousTargetError(caller_id, target, graph_id, candidate_ids)
+    return ResolvedGraphTarget(
+        graph_id=graph_id,
+        caller_id=caller_id,
+        target_id=candidate_ids[0],
+        matched_by="name",
+    )
+
+
+def _registered_creature(
+    creatures: Mapping[str, CreatureIdentity], creature_id: str
+) -> CreatureIdentity | None:
+    creature = creatures.get(creature_id)
+    if creature is None or creature.creature_id != creature_id:
+        return None
+    return creature
+
+
+def _name_aliases(creature: CreatureIdentity) -> set[str]:
+    aliases = {creature.name} if creature.name else set()
+    config = getattr(creature, "config", None)
+    _add_name(aliases, config)
+    agent = getattr(creature, "agent", None)
+    _add_name(aliases, getattr(agent, "config", None))
+    return aliases
+
+
+def _add_name(aliases: set[str], value: object) -> None:
+    if isinstance(value, Mapping):
+        name = value.get("name")
+    else:
+        name = getattr(value, "name", None)
+    if isinstance(name, str) and name:
+        aliases.add(name)
+
+
+__all__ = [
+    "AmbiguousTargetError",
+    "CallerGraphNotFoundError",
+    "CreatureIdentity",
+    "GraphIdentityError",
+    "GraphNameConflictError",
+    "GraphTargetMatch",
+    "ResolvedGraphTarget",
+    "TargetNotFoundError",
+    "UnknownCallerError",
+    "ensure_graph_name_available",
+    "resolve_local_graph_target",
+]

--- a/src/kohakuterrarium/terrarium/graph_identity_engine.py
+++ b/src/kohakuterrarium/terrarium/graph_identity_engine.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from kohakuterrarium.terrarium.graph_identity import (
     GraphNameConflictError,
+    creature_name_aliases,
     ensure_graph_name_available,
 )
 
@@ -25,12 +26,13 @@ def guard_add_name(
     """Reject a duplicate role name when adding into an existing graph."""
     if graph_id is None:
         return
-    ensure_graph_name_available(
-        engine._topology,
-        engine._creatures,
-        graph_id=graph_id,
-        name=creature.name,
-    )
+    for name in sorted(creature_name_aliases(creature)):
+        ensure_graph_name_available(
+            engine._topology,
+            engine._creatures,
+            graph_id=graph_id,
+            name=name,
+        )
 
 
 def _graph_aliases(engine: "Terrarium", graph_id: str) -> dict[str, set[str]]:
@@ -42,10 +44,8 @@ def _graph_aliases(engine: "Terrarium", graph_id: str) -> dict[str, set[str]]:
         creature = engine._creatures.get(creature_id)
         if creature is None:
             continue
-        config = getattr(getattr(creature, "agent", None), "config", None)
-        for alias in {creature.name, getattr(config, "name", None)}:
-            if alias:
-                aliases.setdefault(alias, set()).add(creature_id)
+        for alias in creature_name_aliases(creature):
+            aliases.setdefault(alias, set()).add(creature_id)
     return aliases
 
 

--- a/src/kohakuterrarium/terrarium/graph_identity_engine.py
+++ b/src/kohakuterrarium/terrarium/graph_identity_engine.py
@@ -1,0 +1,84 @@
+"""Engine mutation guards for graph-local creature identities."""
+
+from typing import TYPE_CHECKING, Any
+
+from kohakuterrarium.terrarium.graph_identity import (
+    GraphNameConflictError,
+    ensure_graph_name_available,
+)
+
+if TYPE_CHECKING:
+    from kohakuterrarium.terrarium.creature_host import Creature, CreatureRef
+    from kohakuterrarium.terrarium.engine import Terrarium
+
+
+def bind_runtime_creature_id(creature: "Creature") -> None:
+    """Expose the final engine runtime ID to tool execution contexts."""
+    executor = getattr(creature.agent, "executor", None)
+    if executor is not None:
+        executor._creature_id = creature.creature_id
+
+
+def guard_add_name(
+    engine: "Terrarium", creature: "Creature", graph_id: str | None
+) -> None:
+    """Reject a duplicate role name when adding into an existing graph."""
+    if graph_id is None:
+        return
+    ensure_graph_name_available(
+        engine._topology,
+        engine._creatures,
+        graph_id=graph_id,
+        name=creature.name,
+    )
+
+
+def _graph_aliases(engine: "Terrarium", graph_id: str) -> dict[str, set[str]]:
+    graph = engine._topology.graphs.get(graph_id)
+    aliases: dict[str, set[str]] = {}
+    if graph is None:
+        return aliases
+    for creature_id in graph.creature_ids:
+        creature = engine._creatures.get(creature_id)
+        if creature is None:
+            continue
+        config = getattr(getattr(creature, "agent", None), "config", None)
+        for alias in {creature.name, getattr(config, "name", None)}:
+            if alias:
+                aliases.setdefault(alias, set()).add(creature_id)
+    return aliases
+
+
+def resolve_and_guard_connect(
+    engine: "Terrarium",
+    sender: "CreatureRef",
+    receiver: "CreatureRef",
+) -> tuple[Any, Any]:
+    """Resolve endpoints and reject merges that create duplicate names."""
+    sender_creature = engine.get_creature(engine._resolve_creature_id(sender))
+    receiver_creature = engine.get_creature(engine._resolve_creature_id(receiver))
+    sender_graph_id = engine._topology.creature_to_graph.get(
+        sender_creature.creature_id
+    )
+    receiver_graph_id = engine._topology.creature_to_graph.get(
+        receiver_creature.creature_id
+    )
+    if (
+        sender_graph_id != receiver_graph_id
+        and sender_graph_id is not None
+        and receiver_graph_id is not None
+    ):
+        sender_aliases = _graph_aliases(engine, sender_graph_id)
+        receiver_aliases = _graph_aliases(engine, receiver_graph_id)
+        conflicts = sorted(set(sender_aliases) & set(receiver_aliases))
+        if conflicts:
+            alias = conflicts[0]
+            creature_ids = tuple(
+                sorted(sender_aliases[alias] | receiver_aliases[alias])
+            )
+            raise GraphNameConflictError(
+                graph_id=f"{sender_graph_id}+{receiver_graph_id}",
+                name=alias,
+                creature_ids=creature_ids,
+            )
+    return sender_creature, receiver_creature

--- a/src/kohakuterrarium/terrarium/group_tool_context.py
+++ b/src/kohakuterrarium/terrarium/group_tool_context.py
@@ -8,8 +8,7 @@ generic :class:`ToolContext` into a :class:`GroupContext` carrying:
 - the calling :class:`Creature`,
 - its current graph topology,
 
-and computes the caller's *group* (caller's graph members ∪ caller's
-spawned children regardless of which graph they are currently in).
+and computes the caller's local group (the live members of its graph).
 """
 
 import weakref
@@ -18,6 +17,12 @@ from typing import TYPE_CHECKING
 
 from kohakuterrarium.modules.tool.base import ToolContext
 from kohakuterrarium.terrarium.channels import TERRARIUM_ENGINE_KEY
+from kohakuterrarium.terrarium.graph_identity import (
+    CallerGraphNotFoundError,
+    GraphIdentityError,
+    UnknownCallerError,
+    resolve_local_graph_target,
+)
 
 if TYPE_CHECKING:
     from kohakuterrarium.terrarium.creature_host import Creature
@@ -63,69 +68,53 @@ def resolve_group_context(
         engine = engine_ref
     if engine is None:
         raise GroupToolError("group tools require a live terrarium engine")
-    caller = find_creature(engine, ctx.agent_name)
-    if caller is None:
+    caller_id = getattr(ctx, "creature_id", None)
+    if not isinstance(caller_id, str) or not caller_id:
         raise GroupToolError(
-            f"caller {ctx.agent_name!r} is not a creature in the engine"
+            "group tools require ToolContext.creature_id; legacy name-only "
+            "contexts are not safe to route"
         )
+    caller = engine._creatures.get(caller_id)
+    if caller is None or caller.creature_id != caller_id:
+        error = UnknownCallerError(caller_id)
+        raise GroupToolError(str(error)) from error
     if require_privileged and not getattr(caller, "is_privileged", False):
         raise GroupToolError("this tool is only callable by privileged creatures")
-    graph = engine._topology.graphs.get(caller.graph_id)
-    if graph is None:
-        raise GroupToolError(
-            f"caller's graph {caller.graph_id!r} is not present in topology"
-        )
+    graph_id = engine._topology.creature_to_graph.get(caller_id)
+    graph = engine._topology.graphs.get(graph_id or "")
+    if graph is None or caller_id not in graph.creature_ids:
+        error = CallerGraphNotFoundError(caller_id, graph_id)
+        raise GroupToolError(str(error)) from error
     return GroupContext(engine=engine, caller=caller, graph=graph)
 
 
-def find_creature(engine: "Terrarium", identifier: str) -> "Creature | None":
-    """Look up a creature by ``creature_id``, ``name``, or
-    ``agent.config.name``. Returns ``None`` if not found."""
-    by_id = engine._creatures.get(identifier)
-    if by_id is not None:
-        return by_id
-    for c in engine._creatures.values():
-        if c.name == identifier:
-            return c
-        cfg = getattr(c.agent, "config", None)
-        if cfg is not None and getattr(cfg, "name", None) == identifier:
-            return c
-    return None
-
-
 def compute_group(ctx: GroupContext) -> dict[str, "Creature"]:
-    """Return all creatures in the caller's group keyed by creature_id.
-
-    Group = (caller's graph members) ∪ (caller's spawned children,
-    regardless of which graph they currently live in).
-    """
+    """Return live creatures in the caller's graph, keyed by runtime ID."""
     out: dict[str, "Creature"] = {}
-    for cid in ctx.graph.creature_ids:
-        c = ctx.engine._creatures.get(cid)
-        if c is not None:
-            out[cid] = c
-    for c in ctx.engine._creatures.values():
-        if getattr(c, "parent_creature_id", None) == ctx.caller.creature_id:
-            out[c.creature_id] = c
+    for creature_id in ctx.graph.creature_ids:
+        creature = ctx.engine._creatures.get(creature_id)
+        if creature is not None and creature.creature_id == creature_id:
+            out[creature_id] = creature
     return out
 
 
-def resolve_group_target(gctx: GroupContext, identifier: str) -> "Creature | None":
-    """Resolve a target identifier (id or name) to a creature in the
-    caller's group. Returns ``None`` when the target is not in-group or
-    does not exist.
+def resolve_group_target(gctx: GroupContext, identifier: str) -> "Creature":
+    """Resolve a unique target inside the exact runtime caller's graph.
+
+    Resolution errors are preserved as :class:`GroupToolError` so ambiguous,
+    cross-graph, and unknown targets all fail closed rather than silently
+    selecting a similarly named creature.
     """
-    group = compute_group(gctx)
-    target = group.get(identifier)
-    if target is not None:
-        return target
-    for c in group.values():
-        if c.name == identifier:
-            return c
-        cfg = getattr(c.agent, "config", None)
-        if cfg is not None and getattr(cfg, "name", None) == identifier:
-            return c
-    return None
+    try:
+        resolved = resolve_local_graph_target(
+            gctx.engine._topology,
+            gctx.engine._creatures,
+            caller_id=gctx.caller.creature_id,
+            target=identifier,
+        )
+    except GraphIdentityError as exc:
+        raise GroupToolError(str(exc)) from exc
+    return gctx.engine._creatures[resolved.target_id]
 
 
 def engine_is_in_cluster(engine: "Terrarium") -> bool:

--- a/src/kohakuterrarium/terrarium/multi_node_replication.py
+++ b/src/kohakuterrarium/terrarium/multi_node_replication.py
@@ -71,6 +71,41 @@ def drop_cross_sub(
         service._cross_subs[key] -= 1
 
 
+def record_cluster_link(
+    service: "MultiNodeTerrariumService",
+    link: frozenset[tuple[str, str]],
+) -> None:
+    """Record one independently removable bridge between two engine graphs."""
+    refs = getattr(service, "_cluster_link_refs", None)
+    if refs is None:
+        refs = {}
+        service._cluster_link_refs = refs
+    current = refs.get(link)
+    if current is None:
+        current = 1 if link in service._cluster_links else 0
+    refs[link] = current + 1
+    service._cluster_links.add(link)
+
+
+def drop_cluster_link(
+    service: "MultiNodeTerrariumService",
+    link: frozenset[tuple[str, str]],
+) -> None:
+    """Remove one bridge while retaining the logical link for remaining channels."""
+    refs = getattr(service, "_cluster_link_refs", None)
+    if refs is None:
+        refs = {}
+        service._cluster_link_refs = refs
+    current = refs.get(link)
+    if current is None:
+        current = 1 if link in service._cluster_links else 0
+    if current <= 1:
+        refs.pop(link, None)
+        service._cluster_links.discard(link)
+        return
+    refs[link] = current - 1
+
+
 async def _graph_aliases(remote: Any, graph_id: str) -> dict[str, set[str]]:
     aliases: dict[str, set[str]] = {}
     for info in await remote.list_creatures():
@@ -214,13 +249,14 @@ async def cross_node_connect(
     # Cluster-graph linkage: connect() over a cross-site bridge also
     # makes sender's graph and receiver's graph one logical cluster.
     # Record it for ``runtime_graph_snapshot``.
-    service._cluster_links.add(
+    record_cluster_link(
+        service,
         frozenset(
             {
                 (sender_home, info_send.graph_id),
                 (receiver_home, info_recv.graph_id),
             }
-        )
+        ),
     )
     return ConnectionResult(
         channel=chan_name,
@@ -282,7 +318,7 @@ async def cross_node_disconnect(
             (receiver_home, info_recv.graph_id),
         }
     )
-    service._cluster_links.discard(link_key)
+    drop_cluster_link(service, link_key)
     return DisconnectionResult(
         channels=[chan_name],
         delta_kind="cross_node",
@@ -353,8 +389,9 @@ async def ensure_channel_replicated(
     # for cross-node connection" UX invariant.  Stored as a frozenset
     # so direction doesn't matter and the same pair doesn't appear
     # twice.
-    service._cluster_links.add(
-        frozenset({(target_node, target_graph), (source_node, source_graph)})
+    record_cluster_link(
+        service,
+        frozenset({(target_node, target_graph), (source_node, source_graph)}),
     )
     bcast = await local_broadcast_adapter(service)
     if bcast is None:
@@ -424,9 +461,11 @@ async def find_channel_elsewhere(
 __all__ = [
     "cross_node_connect",
     "cross_node_disconnect",
+    "drop_cluster_link",
     "drop_cross_sub",
     "ensure_channel_replicated",
     "find_channel_elsewhere",
     "local_broadcast_adapter",
+    "record_cluster_link",
     "record_cross_sub",
 ]

--- a/src/kohakuterrarium/terrarium/multi_node_replication.py
+++ b/src/kohakuterrarium/terrarium/multi_node_replication.py
@@ -82,6 +82,34 @@ async def _graph_aliases(remote: Any, graph_id: str) -> dict[str, set[str]]:
     return aliases
 
 
+def _logical_graph_members(
+    service: "MultiNodeTerrariumService",
+    node_id: str,
+    graph_id: str,
+) -> set[tuple[str, str]]:
+    """Return the complete logical component containing one worker graph."""
+    members = set(cluster_members_for(service, graph_id))
+    return members or {(node_id, graph_id)}
+
+
+async def _logical_graph_aliases(
+    service: "MultiNodeTerrariumService",
+    members: set[tuple[str, str]],
+) -> dict[str, set[str]]:
+    """Collect aliases across every worker-local graph in one component."""
+    alias_sets = await asyncio.gather(
+        *(
+            _graph_aliases(service.service_for(node_id), graph_id)
+            for node_id, graph_id in sorted(members)
+        )
+    )
+    aliases: dict[str, set[str]] = {}
+    for member_aliases in alias_sets:
+        for alias, creature_ids in member_aliases.items():
+            aliases.setdefault(alias, set()).update(creature_ids)
+    return aliases
+
+
 async def _guard_cross_node_name_conflicts(
     service: "MultiNodeTerrariumService",
     sender_home: str,
@@ -89,9 +117,13 @@ async def _guard_cross_node_name_conflicts(
     receiver_home: str,
     receiver_graph: str,
 ) -> None:
+    sender_members = _logical_graph_members(service, sender_home, sender_graph)
+    receiver_members = _logical_graph_members(service, receiver_home, receiver_graph)
+    if sender_members & receiver_members:
+        return
     sender_aliases, receiver_aliases = await asyncio.gather(
-        _graph_aliases(service._remotes[sender_home], sender_graph),
-        _graph_aliases(service._remotes[receiver_home], receiver_graph),
+        _logical_graph_aliases(service, sender_members),
+        _logical_graph_aliases(service, receiver_members),
     )
     conflicts = sorted(set(sender_aliases) & set(receiver_aliases))
     if not conflicts:

--- a/src/kohakuterrarium/terrarium/multi_node_replication.py
+++ b/src/kohakuterrarium/terrarium/multi_node_replication.py
@@ -5,7 +5,7 @@ graph isolated; cross-node ``connect`` / ``disconnect`` and lazy
 ``wire_creature`` replication need a small body of shared logic to:
 
 - Replicate a named channel onto a peer node's graph (idempotently).
-- Find a channel by name across all connected workers.
+- Find a channel only inside the same logical cluster component.
 - Cross-subscribe the broadcast adapter so messages flow.
 - Track cluster-link bookkeeping for the runtime-graph fold.
 - Track per-subscription refcounts for clean teardown.
@@ -14,12 +14,15 @@ Each helper receives the service explicitly because replication mutates its
 cluster-link and cross-subscription caches and uses its coordination adapter.
 """
 
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Any
 
 from kohakuterrarium.terrarium.events import (
     ConnectionResult,
     DisconnectionResult,
 )
+from kohakuterrarium.terrarium.graph_identity import GraphNameConflictError
+from kohakuterrarium.terrarium.multi_node_channels import cluster_members_for
 from kohakuterrarium.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -68,6 +71,39 @@ def drop_cross_sub(
         service._cross_subs[key] -= 1
 
 
+async def _graph_aliases(remote: Any, graph_id: str) -> dict[str, set[str]]:
+    aliases: dict[str, set[str]] = {}
+    for info in await remote.list_creatures():
+        if info.graph_id != graph_id:
+            continue
+        for alias in {info.name, getattr(info, "config_name", None)}:
+            if alias:
+                aliases.setdefault(alias, set()).add(info.creature_id)
+    return aliases
+
+
+async def _guard_cross_node_name_conflicts(
+    service: "MultiNodeTerrariumService",
+    sender_home: str,
+    sender_graph: str,
+    receiver_home: str,
+    receiver_graph: str,
+) -> None:
+    sender_aliases, receiver_aliases = await asyncio.gather(
+        _graph_aliases(service._remotes[sender_home], sender_graph),
+        _graph_aliases(service._remotes[receiver_home], receiver_graph),
+    )
+    conflicts = sorted(set(sender_aliases) & set(receiver_aliases))
+    if not conflicts:
+        return
+    alias = conflicts[0]
+    raise GraphNameConflictError(
+        graph_id=f"{sender_graph}+{receiver_graph}",
+        name=alias,
+        creature_ids=tuple(sorted(sender_aliases[alias] | receiver_aliases[alias])),
+    )
+
+
 async def cross_node_connect(
     service: "MultiNodeTerrariumService",
     sender_id: str,
@@ -95,6 +131,13 @@ async def cross_node_connect(
         raise KeyError(sender_id)
     if info_recv is None:
         raise KeyError(receiver_id)
+    await _guard_cross_node_name_conflicts(
+        service,
+        sender_home,
+        info_send.graph_id,
+        receiver_home,
+        info_recv.graph_id,
+    )
     chan_name = channel or f"{info_send.name}_to_{info_recv.name}"
     # Both nodes need the channel object — add_channel is idempotent
     # at the engine layer when the channel already exists, but we
@@ -252,7 +295,12 @@ async def ensure_channel_replicated(
         return
     if any(getattr(c, "name", None) == channel for c in existing):
         return
-    source = await find_channel_elsewhere(service, channel, exclude=target_node)
+    source = await find_channel_elsewhere(
+        service,
+        channel,
+        exclude=target_node,
+        graph_id=target_graph,
+    )
     if source is None:
         # Channel doesn't exist anywhere — let the wire call below
         # raise the canonical "channel not found" error so the user
@@ -312,18 +360,14 @@ async def find_channel_elsewhere(
     channel: str,
     *,
     exclude: str,
+    graph_id: str,
 ) -> tuple[str, str] | None:
-    """Fan out across worker nodes to locate a graph hosting ``channel``.
-
-    Returns ``(node_id, graph_id)`` of the first match (or ``None`` if
-    no node hosts it).  ``exclude`` skips the target node — the caller
-    has already verified the channel is absent there.
-
-    Errors from individual nodes are swallowed so a single misbehaving
-    worker can't make the search fail; the worst case is "we didn't
-    find a peer that had it" and the wire call downstream raises the
-    canonical not-found error.
-    """
+    """Locate one same-component graph hosting ``channel``."""
+    members = {
+        member_graph_id
+        for _node_id, member_graph_id in cluster_members_for(service, graph_id)
+    }
+    candidates: list[tuple[str, str]] = []
     for node_id, svc in list(service._remotes.items()):
         if node_id == exclude:
             continue
@@ -332,17 +376,17 @@ async def find_channel_elsewhere(
         except Exception:
             logger.debug("list_graphs failed on %s during channel lookup", node_id)
             continue
-        for g in graphs:
-            gid = getattr(g, "graph_id", None) or ""
-            if not gid:
+        for graph in graphs:
+            candidate_graph_id = getattr(graph, "graph_id", None) or ""
+            if candidate_graph_id not in members:
                 continue
             try:
-                chans = await svc.list_channels(gid)
+                channels = await svc.list_channels(candidate_graph_id)
             except Exception:
                 continue
-            if any(getattr(c, "name", None) == channel for c in chans):
-                return node_id, gid
-    return None
+            if any(getattr(item, "name", None) == channel for item in channels):
+                candidates.append((node_id, candidate_graph_id))
+    return candidates[0] if len(candidates) == 1 else None
 
 
 __all__ = [

--- a/src/kohakuterrarium/terrarium/multi_node_routing.py
+++ b/src/kohakuterrarium/terrarium/multi_node_routing.py
@@ -4,7 +4,7 @@
 lock-step with worker membership:
 
 - ``_home``: ``creature_id → node_id``.
-- ``_creature_name_cache``: ``name → (node_id, creature_id)``.
+- ``_creature_name_cache``: ``name → {(graph_id, node_id, creature_id)}``.
 - ``_cluster_links``: ``frozenset[(node_id, graph_id)]`` pairs.
 - ``_cross_subs``: per-subscription refcount keyed by ``(my_node,
   peer_node, graph_id, channel)``.
@@ -57,9 +57,13 @@ def purge_node_caches(service: "MultiNodeTerrariumService", node_id: str) -> Non
     # Drop home_node entries pointing at this client.
     for cid in [c for c, n in service._home.items() if n == node_id]:
         service._home.pop(cid, None)
-    # Drop name-cache entries whose value targets the dead node.
-    for key in [k for k, v in service._creature_name_cache.items() if v[0] == node_id]:
-        service._creature_name_cache.pop(key, None)
+    # Drop only identities hosted by the dead node; preserve same-name peers.
+    for key, entries in list(service._creature_name_cache.items()):
+        retained = {entry for entry in entries if entry[1] != node_id}
+        if retained:
+            service._creature_name_cache[key] = retained
+        else:
+            service._creature_name_cache.pop(key, None)
     # Drop cluster links touching the dead node on either endpoint.
     for link in [
         link
@@ -104,7 +108,9 @@ async def list_creatures_fanout(
     )
 
     # Start from the prior cache so failing workers' entries survive.
-    merged_cache: dict[str, tuple[str, str]] = dict(service._creature_name_cache)
+    merged_cache: dict[str, set[tuple[str, str, str]]] = {
+        key: set(value) for key, value in service._creature_name_cache.items()
+    }
     # For workers that successfully reported, their list IS
     # authoritative — drop any stale entries we may have for them
     # before re-adding what they reported now.
@@ -115,18 +121,24 @@ async def list_creatures_fanout(
             continue
         # Authoritative refresh for this node: drop any cache rows that
         # point at this node so creature removals propagate.
-        for key, val in list(merged_cache.items()):
-            if val[0] == node_id:
+        for key, entries in list(merged_cache.items()):
+            retained = {entry for entry in entries if entry[1] != node_id}
+            if retained:
+                merged_cache[key] = retained
+            else:
                 merged_cache.pop(key, None)
         for c in resp:
             results.append(c)
             service._home[c.creature_id] = node_id
-            merged_cache[c.name] = (node_id, c.creature_id)
-            merged_cache[c.creature_id] = (node_id, c.creature_id)
-    # Atomic swap so concurrent reads of the cache never see a
-    # half-built dict.  The resolver is sync and reads this attribute
-    # without a lock.
-    service._creature_name_cache = merged_cache
+            identity = (c.graph_id, node_id, c.creature_id)
+            merged_cache.setdefault(c.name, set()).add(identity)
+            config_name = getattr(c, "config_name", None)
+            if config_name:
+                merged_cache.setdefault(config_name, set()).add(identity)
+            merged_cache.setdefault(c.creature_id, set()).add(identity)
+    # Preserve the live cache object held by adapters while replacing contents.
+    service._creature_name_cache.clear()
+    service._creature_name_cache.update(merged_cache)
     return tuple(results)
 
 

--- a/src/kohakuterrarium/terrarium/multi_node_routing.py
+++ b/src/kohakuterrarium/terrarium/multi_node_routing.py
@@ -71,6 +71,7 @@ def purge_node_caches(service: "MultiNodeTerrariumService", node_id: str) -> Non
         if any(endpoint[0] == node_id for endpoint in link)
     ]:
         service._cluster_links.discard(link)
+        getattr(service, "_cluster_link_refs", {}).pop(link, None)
     # Drop cross-sub bookkeeping referencing the dead node as either
     # ``my_node`` or ``peer_node``.
     for key in [k for k in service._cross_subs if k[0] == node_id or k[1] == node_id]:

--- a/src/kohakuterrarium/terrarium/multi_node_service.py
+++ b/src/kohakuterrarium/terrarium/multi_node_service.py
@@ -124,7 +124,7 @@ class MultiNodeTerrariumService(
         # ``list_creatures``.  Read by the controller's
         # :class:`TerrariumOutputWireAdapter` target resolver to route
         # cross-node output-wiring emits without an async hop.
-        self._creature_name_cache: dict[str, tuple[str, str]] = {}
+        self._creature_name_cache: dict[str, set[tuple[str, str, str]]] = {}
         # Cross-node subscription bookkeeping — keyed by
         # ``(my_node, peer_node, graph_id, channel)`` to a refcount.
         self._cross_subs: dict[tuple[str, str, str, str], int] = {}
@@ -359,6 +359,12 @@ class MultiNodeTerrariumService(
             name=name,
         )
         self._home[info.creature_id] = on_node
+        identity = (info.graph_id, on_node, info.creature_id)
+        self._creature_name_cache.setdefault(info.creature_id, set()).add(identity)
+        self._creature_name_cache.setdefault(info.name, set()).add(identity)
+        config_name = getattr(info, "config_name", None)
+        if config_name:
+            self._creature_name_cache.setdefault(config_name, set()).add(identity)
         return info
 
     async def remove_creature(self, creature_id: str) -> None:
@@ -371,10 +377,12 @@ class MultiNodeTerrariumService(
         # reads this cache without an async hop, so a stale entry would
         # keep routing emits to the dead address until the next
         # ``list_creatures`` fan-out.
-        for key in [
-            k for k, v in self._creature_name_cache.items() if v[1] == creature_id
-        ]:
-            self._creature_name_cache.pop(key, None)
+        for key, entries in list(self._creature_name_cache.items()):
+            retained = {entry for entry in entries if entry[2] != creature_id}
+            if retained:
+                self._creature_name_cache[key] = retained
+            else:
+                self._creature_name_cache.pop(key, None)
 
     async def start_creature(self, creature_id: str) -> None:
         await self._route_per_creature(
@@ -714,10 +722,15 @@ class MultiNodeTerrariumService(
         )
 
     async def _find_channel_elsewhere(
-        self, channel: str, *, exclude: str
+        self, channel: str, *, exclude: str, graph_id: str
     ) -> tuple[str, str] | None:
-        """Thin delegator to :func:`multi_node_replication.find_channel_elsewhere`."""
-        return await find_channel_elsewhere(self, channel, exclude=exclude)
+        """Thin delegator to graph-scoped channel lookup."""
+        return await find_channel_elsewhere(
+            self,
+            channel,
+            exclude=exclude,
+            graph_id=graph_id,
+        )
 
     async def attach_policies(self, creature_id: str) -> list[str]:
         return await self._route_per_creature(

--- a/src/kohakuterrarium/terrarium/multi_node_service.py
+++ b/src/kohakuterrarium/terrarium/multi_node_service.py
@@ -137,6 +137,10 @@ class MultiNodeTerrariumService(
         # ordinary single-host graph has no entries here and renders
         # as itself.
         self._cluster_links: set[frozenset[tuple[str, str]]] = set()
+        # Multiple channels can bridge the same pair of worker graphs. Keep the
+        # cluster folded until the final bridge is removed.
+        self._cluster_link_refs: dict[frozenset[tuple[str, str]], int] = {}
+        self._cluster_mutation_lock = asyncio.Lock()
         # Studio-tier session metadata lookup, injected at boot — used
         # to enrich ``runtime_graph_snapshot`` graphs with name / kind.
         self._runtime_graph_meta_lookup = None
@@ -452,24 +456,25 @@ class MultiNodeTerrariumService(
         *,
         channel: str | None = None,
     ) -> ConnectionResult:
-        sender_home = await self._resolve_home(sender_id)
-        receiver_home = await self._resolve_home(receiver_id)
-        if sender_home is None:
-            raise KeyError(sender_id)
-        if receiver_home is None:
-            raise KeyError(receiver_id)
-        if sender_home == receiver_home:
-            return await self.service_for(sender_home).connect(
-                sender_id, receiver_id, channel=channel
+        async with self._cluster_lock():
+            sender_home = await self._resolve_home(sender_id)
+            receiver_home = await self._resolve_home(receiver_id)
+            if sender_home is None:
+                raise KeyError(sender_id)
+            if receiver_home is None:
+                raise KeyError(receiver_id)
+            if sender_home == receiver_home:
+                return await self.service_for(sender_home).connect(
+                    sender_id, receiver_id, channel=channel
+                )
+            return await cross_node_connect(
+                self,
+                sender_id,
+                receiver_id,
+                sender_home,
+                receiver_home,
+                channel,
             )
-        return await cross_node_connect(
-            self,
-            sender_id,
-            receiver_id,
-            sender_home,
-            receiver_home,
-            channel,
-        )
 
     async def disconnect(
         self,
@@ -478,24 +483,33 @@ class MultiNodeTerrariumService(
         *,
         channel: str | None = None,
     ) -> DisconnectionResult:
-        sender_home = await self._resolve_home(sender_id)
-        receiver_home = await self._resolve_home(receiver_id)
-        if sender_home is None:
-            raise KeyError(sender_id)
-        if receiver_home is None:
-            raise KeyError(receiver_id)
-        if sender_home == receiver_home:
-            return await self.service_for(sender_home).disconnect(
-                sender_id, receiver_id, channel=channel
+        async with self._cluster_lock():
+            sender_home = await self._resolve_home(sender_id)
+            receiver_home = await self._resolve_home(receiver_id)
+            if sender_home is None:
+                raise KeyError(sender_id)
+            if receiver_home is None:
+                raise KeyError(receiver_id)
+            if sender_home == receiver_home:
+                return await self.service_for(sender_home).disconnect(
+                    sender_id, receiver_id, channel=channel
+                )
+            return await cross_node_disconnect(
+                self,
+                sender_id,
+                receiver_id,
+                sender_home,
+                receiver_home,
+                channel,
             )
-        return await cross_node_disconnect(
-            self,
-            sender_id,
-            receiver_id,
-            sender_home,
-            receiver_home,
-            channel,
-        )
+
+    def _cluster_lock(self) -> asyncio.Lock:
+        """Return the lock, including for lightweight test/service doubles."""
+        lock = getattr(self, "_cluster_mutation_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._cluster_mutation_lock = lock
+        return lock
 
     async def _local_broadcast_adapter(self):
         """Thin delegator to :func:`multi_node_replication.local_broadcast_adapter`."""

--- a/src/kohakuterrarium/terrarium/output_wiring.py
+++ b/src/kohakuterrarium/terrarium/output_wiring.py
@@ -29,6 +29,10 @@ from kohakuterrarium.core.output_wiring import (
     OutputWiringEntry,
     render_prompt,
 )
+from kohakuterrarium.terrarium.graph_identity import (
+    GraphIdentityError,
+    resolve_local_graph_target,
+)
 from kohakuterrarium.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -79,10 +83,10 @@ class TerrariumOutputWiringResolver:
                 self._warn_once(target, "terrarium has no root agent configured")
             return root_agent
 
-        handle = self._resolve_handle(target)
+        handle = self._resolve_handle(target, source=source)
         if handle is None:
             if not self._has_cross_node_peer(target):
-                self._warn_once(target, "no such creature in this terrarium")
+                self._warn_once(target, "no such creature in the source graph")
             return None
         return handle.agent
 
@@ -110,21 +114,41 @@ class TerrariumOutputWiringResolver:
         )
         return True
 
-    def _resolve_handle(self, target: str):
-        handle = self._creatures.get(target)
-        if handle is not None:
-            return handle
-        for creature in self._creatures.values():
-            if getattr(creature, "name", None) == target:
-                return creature
-            agent = getattr(creature, "agent", None)
-            config = getattr(agent, "config", None)
-            if getattr(config, "name", None) == target:
-                return creature
-        return None
+    def _resolve_handle(self, target: str, *, source: str = ""):
+        if self._engine is None:
+            handle = self._creatures.get(target)
+            if handle is not None:
+                return handle
+            matches = [
+                creature
+                for creature in self._creatures.values()
+                if target
+                in {
+                    getattr(creature, "name", None),
+                    getattr(getattr(creature, "config", None), "name", None),
+                    getattr(
+                        getattr(getattr(creature, "agent", None), "config", None),
+                        "name",
+                        None,
+                    ),
+                }
+            ]
+            return matches[0] if len(matches) == 1 else None
+        try:
+            resolved = resolve_local_graph_target(
+                self._engine._topology,
+                self._creatures,
+                caller_id=source,
+                target=target,
+            )
+        except GraphIdentityError:
+            return None
+        return self._creatures.get(resolved.target_id)
 
     def _resolve_graph_root_agent(self, source: str | None) -> "Agent | None":
-        source_handle = self._resolve_handle(source or "")
+        source_handle = self._creatures.get(source or "")
+        if source_handle is None and self._engine is None:
+            source_handle = self._resolve_handle(source or "", source=source or "")
         source_graph = getattr(source_handle, "graph_id", None)
         candidates = [
             c
@@ -188,8 +212,11 @@ class TerrariumOutputWiringResolver:
                 # client mode); standalone runs miss and skip as before.
                 forwarder = getattr(self._engine, "_output_wire_adapter", None)
                 if forwarder is not None:
-                    peer = forwarder.peer_for_target(entry.to)
-                    if peer is not None:
+                    source_graph_id = self._engine._topology.creature_to_graph.get(
+                        source
+                    )
+                    peer = forwarder.peer_for_target(entry.to, graph_id=source_graph_id)
+                    if peer is not None and source_graph_id is not None:
                         delivered_content = content if entry.with_content else ""
                         prompt_text = render_prompt(
                             entry,
@@ -201,16 +228,20 @@ class TerrariumOutputWiringResolver:
                         )
                         asyncio.create_task(
                             forwarder.forward_event(
-                                peer,
-                                {
-                                    "target_name": entry.to,
-                                    "source": source,
+                                target_name=entry.to,
+                                event={
+                                    "type": "creature_output",
                                     "content": delivered_content,
-                                    "with_content": bool(entry.with_content),
-                                    "source_event_type": source_event_type,
-                                    "turn_index": turn_index,
+                                    "context": {
+                                        "source": source,
+                                        "with_content": bool(entry.with_content),
+                                        "source_event_type": source_event_type,
+                                        "turn_index": turn_index,
+                                    },
                                     "prompt_override": prompt_text,
                                 },
+                                source_creature_id=source,
+                                source_graph_id=source_graph_id,
                             ),
                             name=f"wiring_remote_{source}_to_{entry.to}_{turn_index}",
                         )

--- a/src/kohakuterrarium/terrarium/output_wiring.py
+++ b/src/kohakuterrarium/terrarium/output_wiring.py
@@ -147,14 +147,36 @@ class TerrariumOutputWiringResolver:
 
     def _resolve_graph_root_agent(self, source: str | None) -> "Agent | None":
         source_handle = self._creatures.get(source or "")
-        if source_handle is None and self._engine is None:
-            source_handle = self._resolve_handle(source or "", source=source or "")
-        source_graph = getattr(source_handle, "graph_id", None)
+        if self._engine is not None:
+            if (
+                source_handle is None
+                or source_handle.creature_id != source
+                or (
+                    source_graph := self._engine._topology.creature_to_graph.get(source)
+                )
+                is None
+            ):
+                return None
+            graph = self._engine._topology.graphs.get(source_graph)
+            if graph is None or source not in graph.creature_ids:
+                return None
+            candidate_ids = graph.creature_ids
+        else:
+            if source_handle is None:
+                source_handle = self._resolve_handle(source or "", source=source or "")
+            source_graph = getattr(source_handle, "graph_id", None)
+            candidate_ids = self._creatures
         candidates = [
             c
-            for c in self._creatures.values()
+            for creature_id in candidate_ids
+            if (c := self._creatures.get(creature_id)) is not None
+            if c.creature_id == creature_id
             if getattr(c, "is_privileged", False)
-            and (source_graph is None or getattr(c, "graph_id", None) == source_graph)
+            and (
+                self._engine is not None
+                or source_graph is None
+                or getattr(c, "graph_id", None) == source_graph
+            )
         ]
         if not candidates and self._root_agent is not None:
             return self._root_agent
@@ -226,7 +248,7 @@ class TerrariumOutputWiringResolver:
                             turn_index=turn_index,
                             source_event_type=source_event_type,
                         )
-                        asyncio.create_task(
+                        task = asyncio.create_task(
                             forwarder.forward_event(
                                 target_name=entry.to,
                                 event={
@@ -234,6 +256,7 @@ class TerrariumOutputWiringResolver:
                                     "content": delivered_content,
                                     "context": {
                                         "source": source,
+                                        "target": entry.to,
                                         "with_content": bool(entry.with_content),
                                         "source_event_type": source_event_type,
                                         "turn_index": turn_index,
@@ -244,6 +267,9 @@ class TerrariumOutputWiringResolver:
                                 source_graph_id=source_graph_id,
                             ),
                             name=f"wiring_remote_{source}_to_{entry.to}_{turn_index}",
+                        )
+                        task.add_done_callback(
+                            lambda t, tgt=entry.to: _log_task_error(t, source, tgt)
                         )
                         continue
                 continue

--- a/src/kohakuterrarium/terrarium/recipe.py
+++ b/src/kohakuterrarium/terrarium/recipe.py
@@ -22,6 +22,7 @@ and gives every other creature a send edge on ``report_to_root``.
 agent, so no recipe-side tool injection is needed.
 """
 
+from collections import Counter
 from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
@@ -35,6 +36,7 @@ from kohakuterrarium.terrarium.config import (
     load_terrarium_config,
 )
 from kohakuterrarium.terrarium.creature_host import Creature, build_creature
+from kohakuterrarium.terrarium.graph_identity import ensure_graph_name_available
 from kohakuterrarium.terrarium.topology import GraphTopology
 from kohakuterrarium.utils.logging import get_logger
 
@@ -81,6 +83,7 @@ async def apply_recipe(
     task added meanwhile.
     """
     config = _resolve_recipe(recipe)
+    _preflight_recipe_names(engine, config, graph)
     builder = creature_builder or build_creature
     use_default_builder = creature_builder is None
 
@@ -254,6 +257,33 @@ async def apply_recipe(
         root=has_root,
     )
     return engine.get_graph(graph_id)
+
+
+def _preflight_recipe_names(
+    engine: "Terrarium",
+    config: TerrariumConfig,
+    graph: GraphTopology | str | None,
+) -> None:
+    """Reject ambiguous names before recipe application mutates the engine."""
+    names = [creature.name for creature in config.creatures]
+    if config.root is not None:
+        names.append("root")
+    duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+    if duplicates:
+        raise ValueError(
+            "Terrarium recipe contains duplicate logical creature name(s): "
+            + ", ".join(repr(name) for name in duplicates)
+        )
+    if graph is None:
+        return
+    graph_id = engine._resolve_graph_id(graph)
+    for name in names:
+        ensure_graph_name_available(
+            engine._topology,
+            engine._creatures,
+            graph_id=graph_id,
+            name=name,
+        )
 
 
 def _allocate_unique_creature_id(engine: "Terrarium", name: str) -> str:

--- a/src/kohakuterrarium/terrarium/runtime_prompt.py
+++ b/src/kohakuterrarium/terrarium/runtime_prompt.py
@@ -179,7 +179,10 @@ def build_runtime_graph_section(engine: "Terrarium", creature: "Creature") -> st
     output_in: list[str] = []
     output_out: list[str] = []
     self_id = getattr(creature.agent, "_creature_id", creature.creature_id)
-    for other_cid, other_creature in engine._creatures.items():
+    for other_cid in sorted(graph.creature_ids):
+        other_creature = engine._creatures.get(other_cid)
+        if other_creature is None:
+            continue
         agent_cfg = getattr(other_creature.agent, "config", None)
         wiring_entries = (
             getattr(agent_cfg, "output_wiring", None) if agent_cfg else None
@@ -193,7 +196,7 @@ def build_runtime_graph_section(engine: "Terrarium", creature: "Creature") -> st
     own_entries = (getattr(own_cfg, "output_wiring", None) if own_cfg else None) or []
     for entry in own_entries:
         target = getattr(entry, "to", "")
-        if target:
+        if target == "root" or target in graph.creature_ids:
             output_out.append(target)
 
     spawned: list[tuple[str, str]] = []

--- a/src/kohakuterrarium/terrarium/service.py
+++ b/src/kohakuterrarium/terrarium/service.py
@@ -75,6 +75,7 @@ from kohakuterrarium.terrarium.events import (
     EngineEvent,
     EventFilter,
 )
+from kohakuterrarium.terrarium.graph_identity import resolve_local_graph_target
 from kohakuterrarium.terrarium.topology import (
     ChannelInfo,
     GraphTopology,
@@ -908,7 +909,21 @@ class LocalTerrariumService(DriveServiceMixin):
         creature_id: str,
         target: str | dict[str, Any],
     ) -> dict[str, Any]:
-        edge_id = await self._engine.wire_output(creature_id, target)
+        if isinstance(target, dict):
+            target_name = str(target.get("to", ""))
+            canonical = dict(target)
+        else:
+            target_name = str(target)
+            canonical = {"to": target_name}
+        if target_name != "root":
+            resolved = resolve_local_graph_target(
+                self._engine._topology,
+                self._engine._creatures,
+                caller_id=creature_id,
+                target=target_name,
+            )
+            canonical["to"] = resolved.target_id
+        edge_id = await self._engine.wire_output(creature_id, canonical)
         return {"edge_id": str(edge_id)}
 
     async def unwire_output(self, creature_id: str, edge_id: str) -> bool:

--- a/src/kohakuterrarium/terrarium/service_dto.py
+++ b/src/kohakuterrarium/terrarium/service_dto.py
@@ -64,6 +64,7 @@ class CreatureInfo:
     # Empty values preserve deferred model resolution.
     model: str = ""
     llm_name: str = ""
+    config_name: str = ""
 
 
 def _channel_message_to_dict(m: Any) -> dict[str, Any]:
@@ -105,6 +106,8 @@ def creature_to_info(creature: CreatureLike) -> CreatureInfo:
         except Exception:
             pass
     llm_name = llm_name or str(model or "")
+    config = getattr(creature, "config", None) or getattr(agent, "config", None)
+    config_name = getattr(config, "name", "") if config is not None else ""
     return CreatureInfo(
         creature_id=creature.creature_id,
         name=creature.name,
@@ -116,6 +119,7 @@ def creature_to_info(creature: CreatureLike) -> CreatureInfo:
         send_channels=tuple(creature.send_channels),
         model=str(model or ""),
         llm_name=str(llm_name or ""),
+        config_name=str(config_name or ""),
     )
 
 

--- a/src/kohakuterrarium/terrarium/tools_group_channel.py
+++ b/src/kohakuterrarium/terrarium/tools_group_channel.py
@@ -131,7 +131,10 @@ class GroupChannelTool(BaseTool):
             )
 
         ident = (args.get("creature_id") or "").strip()
-        target = resolve_group_target(gctx, ident)
+        try:
+            target = resolve_group_target(gctx, ident)
+        except Exception as exc:
+            return err(str(exc))
         if target is None:
             return err(cross_cluster_target_error(gctx.engine, ident))
         direction = (args.get("direction") or "").strip()

--- a/src/kohakuterrarium/terrarium/tools_group_common.py
+++ b/src/kohakuterrarium/terrarium/tools_group_common.py
@@ -12,6 +12,7 @@ from kohakuterrarium.terrarium.group_tool_context import (
     GroupContext,
     GroupToolError,
     resolve_group_context,
+    resolve_group_target,
 )
 
 
@@ -36,6 +37,16 @@ def resolve_or_error(
             resolve_group_context(ctx, require_privileged=require_privileged),
             None,
         )
+    except GroupToolError as exc:
+        return None, err(str(exc))
+
+
+def resolve_target_or_error(
+    gctx: GroupContext, identifier: str
+) -> tuple[Any | None, ToolResult | None]:
+    """Resolve one caller-graph target while preserving safe resolver errors."""
+    try:
+        return resolve_group_target(gctx, identifier), None
     except GroupToolError as exc:
         return None, err(str(exc))
 

--- a/src/kohakuterrarium/terrarium/tools_group_lifecycle.py
+++ b/src/kohakuterrarium/terrarium/tools_group_lifecycle.py
@@ -37,7 +37,10 @@ def _resolve_worker_target(
     gctx: GroupContext, ident: str, verb: str
 ) -> tuple[Any, ToolResult | None]:
     """Resolve a worker while reserving privileged lifecycle control for Studio."""
-    target = resolve_group_target(gctx, ident)
+    try:
+        target = resolve_group_target(gctx, ident)
+    except Exception as exc:
+        return None, err(str(exc))
     if target is None:
         return None, err(cross_cluster_target_error(gctx.engine, ident))
     if target.is_privileged:
@@ -164,7 +167,10 @@ class GroupRemoveNodeTool(BaseTool):
         if err_result is not None:
             return err_result
         ident = (args.get("creature_id") or "").strip()
-        target = resolve_group_target(gctx, ident)
+        try:
+            target = resolve_group_target(gctx, ident)
+        except Exception as exc:
+            return err(str(exc))
         if target is None:
             return err(cross_cluster_target_error(gctx.engine, ident))
         if target.is_privileged:
@@ -224,7 +230,10 @@ class GroupStartNodeTool(BaseTool):
         if err_result is not None:
             return err_result
         ident = (args.get("creature_id") or "").strip()
-        target = resolve_group_target(gctx, ident)
+        try:
+            target = resolve_group_target(gctx, ident)
+        except Exception as exc:
+            return err(str(exc))
         if target is None:
             return err(cross_cluster_target_error(gctx.engine, ident))
         if target.is_privileged:
@@ -275,7 +284,10 @@ class GroupStopNodeTool(BaseTool):
         if err_result is not None:
             return err_result
         ident = (args.get("creature_id") or "").strip()
-        target = resolve_group_target(gctx, ident)
+        try:
+            target = resolve_group_target(gctx, ident)
+        except Exception as exc:
+            return err(str(exc))
         if target is None:
             return err(cross_cluster_target_error(gctx.engine, ident))
         if target.is_privileged:

--- a/src/kohakuterrarium/terrarium/tools_group_send.py
+++ b/src/kohakuterrarium/terrarium/tools_group_send.py
@@ -26,12 +26,13 @@ from kohakuterrarium.modules.tool.base import (
     ToolContext,
     ToolResult,
 )
-from kohakuterrarium.terrarium.group_tool_context import (
-    cross_cluster_target_error,
-    resolve_group_target,
-)
 from kohakuterrarium.terrarium.output_wiring import notify_inbound_delivery
-from kohakuterrarium.terrarium.tools_group_common import err, ok, resolve_or_error
+from kohakuterrarium.terrarium.tools_group_common import (
+    err,
+    ok,
+    resolve_or_error,
+    resolve_target_or_error,
+)
 from kohakuterrarium.utils.logging import get_logger
 
 _logger = get_logger(__name__)
@@ -98,9 +99,11 @@ class GroupSendTool(BaseTool):
         message = args.get("message")
         if not to_id or message is None:
             return err("'to' and 'message' are required")
-        target = resolve_group_target(gctx, to_id)
-        if target is None:
-            return err(cross_cluster_target_error(gctx.engine, to_id))
+        target, target_error = resolve_target_or_error(gctx, to_id)
+        if target_error is not None:
+            return target_error
+        if target.creature_id == gctx.caller.creature_id:
+            return err("group_send cannot target the caller itself")
         if not target.is_running:
             return err(f"target {target.name!r} is not running")
         if not gctx.caller.is_privileged and not target.is_privileged:
@@ -197,7 +200,10 @@ class SendChannelTool(BaseTool):
                 f"channel {channel_name!r} does not exist in your graph; "
                 f"available: {sorted(graph.channels)}"
             )
-        sends = graph.send_edges.get(gctx.caller.creature_id, set())
+        try:
+            sends = graph.send_edges[gctx.caller.creature_id]
+        except (AttributeError, KeyError, TypeError):
+            return err("could not verify caller channel permissions; send denied")
         if channel_name not in sends:
             # Privileged callers can self-wire; non-privileged need a
             # privileged creature to wire them.
@@ -237,6 +243,6 @@ class SendChannelTool(BaseTool):
             {
                 "channel": channel_name,
                 "message_id": msg.message_id,
-                "caller_graph_id": gctx.caller.graph_id,
+                "caller_graph_id": gctx.graph.graph_id,
             }
         )

--- a/src/kohakuterrarium/terrarium/tools_group_wire.py
+++ b/src/kohakuterrarium/terrarium/tools_group_wire.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-import kohakuterrarium.terrarium.channels as _channels
 from kohakuterrarium.builtins.tool_catalog import register_builtin
 from kohakuterrarium.modules.tool.base import (
     BaseTool,
@@ -10,11 +9,12 @@ from kohakuterrarium.modules.tool.base import (
     ToolContext,
     ToolResult,
 )
-from kohakuterrarium.terrarium.group_tool_context import (
-    cross_cluster_target_error,
-    resolve_group_target,
+from kohakuterrarium.terrarium.tools_group_common import (
+    err,
+    ok,
+    resolve_or_error,
+    resolve_target_or_error,
 )
-from kohakuterrarium.terrarium.tools_group_common import err, ok, resolve_or_error
 
 
 @register_builtin("group_wire")
@@ -60,26 +60,19 @@ class GroupWireTool(BaseTool):
             return err_result
         action = (args.get("action") or "").strip()
         from_id = (args.get("from") or "").strip() or gctx.caller.creature_id
-        from_creature = resolve_group_target(gctx, from_id)
-        if from_creature is None:
-            return err(cross_cluster_target_error(gctx.engine, from_id))
+        from_creature, target_error = resolve_target_or_error(gctx, from_id)
+        if target_error is not None:
+            return target_error
 
         if action == "add":
             to_id = (args.get("to") or "").strip()
             if not to_id:
                 return err("'to' is required for action='add'")
-            to_creature = resolve_group_target(gctx, to_id)
-            if to_creature is None:
-                return err(cross_cluster_target_error(gctx.engine, to_id))
-            if from_creature.graph_id != to_creature.graph_id:
-                try:
-                    await _channels.ensure_same_graph(
-                        gctx.engine, from_creature, to_creature
-                    )
-                except Exception as exc:
-                    return err(f"cross-graph merge failed: {exc}")
+            to_creature, target_error = resolve_target_or_error(gctx, to_id)
+            if target_error is not None:
+                return target_error
             target: dict[str, Any] = {
-                "to": to_creature.name,
+                "to": to_creature.creature_id,
                 "with_content": bool(args.get("with_content", True)),
             }
             if args.get("prompt"):
@@ -99,7 +92,7 @@ class GroupWireTool(BaseTool):
                     "edge_id": edge_id,
                     "from": from_creature.creature_id,
                     "to": to_creature.creature_id,
-                    "caller_graph_id": gctx.caller.graph_id,
+                    "caller_graph_id": gctx.graph.graph_id,
                 }
             )
 
@@ -118,7 +111,7 @@ class GroupWireTool(BaseTool):
                     "removed": removed,
                     "edge_id": edge_id,
                     "from": from_creature.creature_id,
-                    "caller_graph_id": gctx.caller.graph_id,
+                    "caller_graph_id": gctx.graph.graph_id,
                 }
             )
 

--- a/src/kohakuterrarium/terrarium/wire.py
+++ b/src/kohakuterrarium/terrarium/wire.py
@@ -99,6 +99,7 @@ def pack_creature_info(c: CreatureInfo) -> dict[str, Any]:
         "send_channels": list(c.send_channels),
         "model": c.model,
         "llm_name": c.llm_name,
+        "config_name": c.config_name,
     }
 
 
@@ -118,6 +119,8 @@ def unpack_creature_info(d: dict[str, Any]) -> CreatureInfo:
         # Older workers may also omit ``llm_name``; use the same
         # forward-compatibility treatment as ``model``.
         llm_name=str(d.get("llm_name", "") or ""),
+        # Graph-local name resolution accepts the original config alias too.
+        config_name=str(d.get("config_name", "") or ""),
     )
 
 

--- a/tests/e2e/test_api_terrarium.py
+++ b/tests/e2e/test_api_terrarium.py
@@ -585,14 +585,14 @@ class TestApiTerrariumJourney:
         assert "ops" not in creatures["bob"]["send_channels"]
 
         # 7e. Topology error branches — every route's reject path.
-        #     connect with a missing creature is a 400 (engine raises
-        #     KeyError, route maps it); channel send on a missing channel
+        #     connect with a missing creature is rejected as 404 during
+        #     session-scoped identity resolution; channel send on a missing channel
         #     is a 404; a missing session's channel list is a 404.
         resp = client.post(
             f"/api/sessions/topology/{session_id}/connect",
             json={"sender": "alice", "receiver": "ghost", "channel": "ops"},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 404
         resp = client.get(
             f"/api/sessions/topology/{session_id}/channels/no_such_channel"
         )

--- a/tests/e2e/test_cross_node_forwarding_audit.py
+++ b/tests/e2e/test_cross_node_forwarding_audit.py
@@ -125,14 +125,14 @@ async def _setup_cross_node_a_to_b(host, w1_name, w2_name, cfg_a, cfg_b, channel
         sb["creatures"][0].get("name"),
     )
     assert graph_a != graph_b
-    r_ch = await asyncio.wait_for(
+    r_connect = await asyncio.wait_for(
         host.http.post(
-            f"/api/sessions/topology/{graph_a}/channels",
-            json={"name": channel},
+            f"/api/sessions/topology/{graph_a}/connect",
+            json={"sender": a_id, "receiver": b_id, "channel": channel},
         ),
         timeout=OP_TIMEOUT,
     )
-    assert r_ch.status_code == 200, r_ch.text
+    assert r_connect.status_code == 200, r_connect.text
     r_send = await asyncio.wait_for(
         host.http.post(
             f"/api/sessions/topology/{graph_a}/creatures/{a_id}/wire",
@@ -413,6 +413,18 @@ async def test_cross_node_output_wire_fires_on_target_worker(tmp_path, monkeypat
             ).json()
             graph_a, a_id = sa["session_id"], sa["creatures"][0]["creature_id"]
             _graph_b, b_id = sb["session_id"], sb["creatures"][0]["creature_id"]
+            r_connect = await asyncio.wait_for(
+                host.http.post(
+                    f"/api/sessions/topology/{graph_a}/connect",
+                    json={
+                        "sender": a_id,
+                        "receiver": b_id,
+                        "channel": "output-bridge",
+                    },
+                ),
+                timeout=OP_TIMEOUT * 2,
+            )
+            assert r_connect.status_code == 200, r_connect.text
 
             # Cross-worker direct output wire alpha → bravo.
             r_wire = await asyncio.wait_for(

--- a/tests/e2e/test_multinode_audit_findings.py
+++ b/tests/e2e/test_multinode_audit_findings.py
@@ -124,23 +124,10 @@ def _get_service(host):
 class TestMultiNodeAuditFindings:
     """One method per suspected bug — each fails on current impl."""
 
-    async def test_cross_node_disconnect_must_clear_cluster_link(
+    async def test_cross_graph_wire_does_not_create_cluster_link(
         self, tmp_path, monkeypatch
     ):
-        """``_cluster_links`` is added on ``connect`` (line 504) and on
-        ``_ensure_channel_replicated`` (line 990) but is NEVER cleaned —
-        not on ``disconnect``, not on ``remove_channel``, not on
-        ``remove_creature``, not on ``drop_remote``.
-
-        User-facing symptom: after a user wires a cross-node bridge and
-        then disconnects it, ``runtime_graph_snapshot`` STILL folds the
-        two engine graphs into a single cluster (``is_cluster=True``,
-        ``members`` carries both sides) — the UI continues to render
-        ONE merged graph forever.  The cluster is also "sticky": after
-        disconnect, both graphs are still ad-hoc joined, so even a
-        single-node user op against either graph_id may surface
-        creatures from the other side.
-        """
+        """Separate logical graphs remain separate after same-channel wiring."""
         monkeypatch.setenv("KT_SESSION_DIR", str(tmp_path / "host-sessions"))
         install_scripted_llm(
             monkeypatch,
@@ -148,56 +135,21 @@ class TestMultiNodeAuditFindings:
         )
         cfg_a = _write_cfg(tmp_path, "alpha")
         cfg_b = _write_cfg(tmp_path, "bravo")
-
         async with RealLabHost(tmp_path) as host:
             async with (
-                RealLabWorker("w1", host.lab_ws_url, tmp_path / "w1") as _w1,
-                RealLabWorker("w2", host.lab_ws_url, tmp_path / "w2") as _w2,
+                RealLabWorker("w1", host.lab_ws_url, tmp_path / "w1"),
+                RealLabWorker("w2", host.lab_ws_url, tmp_path / "w2"),
             ):
                 await asyncio.sleep(0.3)
-                ga, gb, a_id, _a_name, b_id, _b_name = await _spawn_cross_cluster(
-                    host, cfg_a, cfg_b
-                )
-
-                # Sanity: after cross-wire, snapshot folds into a cluster.
-                snap_before = (await host.http.get("/api/runtime/graph")).json()
-                fused_before = [
-                    g for g in snap_before.get("graphs", []) if g.get("is_cluster")
-                ]
-                assert fused_before, (
-                    "precondition: cross-wire should produce a cluster fold; "
-                    f"got graphs={[g.get('graph_id') for g in snap_before.get('graphs', [])]}"
-                )
-
-                # Disconnect the cross-node bridge.
-                disc = await host.http.post(
-                    f"/api/sessions/topology/{ga}/disconnect",
-                    json={"sender": a_id, "receiver": b_id, "channel": "ch1"},
-                )
-                assert (
-                    disc.status_code == 200
-                ), f"disconnect call must succeed: {disc.status_code} {disc.text}"
-
-                # BEHAVIOR ASSERTION: after disconnect, the two engine
-                # graphs MUST surface as separate graphs again — no
-                # cluster fold, ``is_cluster`` absent or False on both.
-                snap_after = (await host.http.get("/api/runtime/graph")).json()
-                still_fused = [
-                    g for g in snap_after.get("graphs", []) if g.get("is_cluster")
-                ]
-                # Also assert the cross-node bookkeeping was cleaned.
+                ga, gb, *_ = await _spawn_cross_cluster(host, cfg_a, cfg_b)
+                snapshot = (await host.http.get("/api/runtime/graph")).json()
+                graph_ids = {graph.get("graph_id") for graph in snapshot["graphs"]}
                 service = _get_service(host)
-                cluster_links_after = set(service._cluster_links)
-
-                assert not still_fused and not cluster_links_after, (
-                    "BUG: cross-node disconnect leaves _cluster_links and "
-                    "the cluster fold intact.  After disconnect, the two "
-                    "engine graphs should render as separate graphs.\n"
-                    f"still_fused graphs: {[g.get('graph_id') for g in still_fused]}\n"
-                    f"cluster_links: {cluster_links_after}\n"
-                    f"file:line — multi_node_service.py:518-573 (disconnect) "
-                    f"never removes from self._cluster_links."
-                )
+                assert ga in graph_ids and gb in graph_ids
+                assert not [
+                    graph for graph in snapshot["graphs"] if graph.get("is_cluster")
+                ]
+                assert not service._cluster_links
 
     async def test_remove_creature_must_purge_name_cache(self, tmp_path, monkeypatch):
         """``remove_creature`` (line 380) clears ``_home`` but NOT
@@ -258,19 +210,8 @@ class TestMultiNodeAuditFindings:
                     f"name cache used by _make_output_wire_target_resolver."
                 )
 
-                # And the public resolver entry — built from the same
-                # cache — must miss for the dead name.
-                from kohakuterrarium.api.app import (
-                    _make_output_wire_target_resolver,
-                )
-
-                resolve = _make_output_wire_target_resolver(service)
-                assert resolve(a_name) is None and resolve(a_id) is None, (
-                    "BUG: output-wire resolver returns a hit for a "
-                    f"removed creature; resolve({a_name!r})="
-                    f"{resolve(a_name)!r} resolve({a_id!r})="
-                    f"{resolve(a_id)!r}"
-                )
+                # Exact graph-scoped routing cannot retain either alias.
+                assert a_name not in cache_after and a_id not in cache_after
 
     async def test_drop_remote_must_purge_name_cache_and_cluster_links(
         self, tmp_path, monkeypatch
@@ -312,8 +253,7 @@ class TestMultiNodeAuditFindings:
                 assert (
                     b_name in service._creature_name_cache
                 ), "precondition: bravo name cached"
-                links_before = set(service._cluster_links)
-                assert links_before, "precondition: cluster link recorded"
+                assert not service._cluster_links
 
                 # w2 disconnects (clean shutdown — host gets LEFT).
                 await w2.__aexit__(None, None, None)
@@ -338,7 +278,11 @@ class TestMultiNodeAuditFindings:
                 bravo_in_cache = (
                     b_name in cache_after
                     or b_id in cache_after
-                    or any(v[0] == "w2" for v in cache_after.values())
+                    or any(
+                        entry[1] == "w2"
+                        for entries in cache_after.values()
+                        for entry in entries
+                    )
                 )
                 links_pointing_at_w2 = {
                     link
@@ -356,16 +300,12 @@ class TestMultiNodeAuditFindings:
                 )
 
                 # And the resolver returns a dead address — the most
-                # user-visible consequence:
-                from kohakuterrarium.api.app import (
-                    _make_output_wire_target_resolver,
-                )
-
-                resolve = _make_output_wire_target_resolver(service)
-                entry = resolve(b_name)
-                assert entry is None or entry[0] != "w2", (
-                    "BUG: output-wire resolver still routes to the dead "
-                    f"node; resolve({b_name!r})={entry!r}"
+                # User-visible consequence: no graph-scoped identity can
+                # retain the disconnected peer.
+                entries = service._creature_name_cache.get(b_name, set())
+                assert all(entry[1] != "w2" for entry in entries), (
+                    "BUG: output-wire cache still routes to the dead "
+                    f"node; entries={entries!r}"
                 )
             finally:
                 if w2 is not None:

--- a/tests/e2e/test_multinode_deep_probes.py
+++ b/tests/e2e/test_multinode_deep_probes.py
@@ -98,17 +98,11 @@ async def _spawn_alpha_bravo_cluster(host, w1, w2, cfg_alpha, cfg_bravo):
     b_id = sb["creatures"][0]["creature_id"]
     b_name = sb["creatures"][0]["name"]
 
-    await host.http.post(
-        f"/api/sessions/topology/{graph_a}/channels", json={"name": "ch1"}
+    connected = await host.http.post(
+        f"/api/sessions/topology/{graph_a}/connect",
+        json={"sender": a_id, "receiver": b_id, "channel": "ch1"},
     )
-    await host.http.post(
-        f"/api/sessions/topology/{graph_a}/creatures/{a_id}/wire",
-        json={"channel": "ch1", "direction": "send"},
-    )
-    await host.http.post(
-        f"/api/sessions/topology/{graph_b}/creatures/{b_id}/wire",
-        json={"channel": "ch1", "direction": "listen"},
-    )
+    assert connected.status_code == 200, connected.text
     return graph_a, graph_b, a_id, a_name, b_id, b_name
 
 
@@ -735,9 +729,17 @@ class TestMultinodeDeepProbes:
                         r.status_code == 200
                     ), f"create chan{i}: {r.status_code} {r.text}"
 
-                # Wire alpha as sender on odd, listener on even;
-                # bravo opposite. Forces cross-node replication for all 10.
-                for i in range(1, 11):
+                # Establish the logical cluster with exact endpoint identities.
+                linked = await host.http.post(
+                    f"/api/sessions/topology/{ga}/connect",
+                    json={"sender": a_id, "receiver": b_id, "channel": "chan1"},
+                )
+                assert linked.status_code == 200, linked.text
+
+                # Wire alpha as sender on later odd channels and listener on
+                # even channels; bravo is the opposite. Once the explicit
+                # link exists, same-component replication handles chan2..10.
+                for i in range(2, 11):
                     a_dir = "send" if i % 2 else "listen"
                     b_dir = "listen" if i % 2 else "send"
                     ra = await host.http.post(

--- a/tests/e2e/test_multinode_real.py
+++ b/tests/e2e/test_multinode_real.py
@@ -349,42 +349,20 @@ async def test_cross_node_user_named_channel_wires_both_sides(tmp_path, monkeypa
                 graph_a != graph_b
             ), "creatures on different workers must start in different graphs"
 
-            # --- declare 'my_channel' in A's graph ---------------------
-            ch_resp = await asyncio.wait_for(
+            # Explicit endpoint identities establish the cross-node link and
+            # declare the user-named channel on both worker-local graphs.
+            connected = await asyncio.wait_for(
                 host.http.post(
-                    f"/api/sessions/topology/{graph_a}/channels",
-                    json={"name": "my_channel", "description": "user-named"},
+                    f"/api/sessions/topology/{graph_a}/connect",
+                    json={
+                        "sender": a_id,
+                        "receiver": b_id,
+                        "channel": "my_channel",
+                    },
                 ),
                 timeout=OP_TIMEOUT,
             )
-            assert (
-                ch_resp.status_code == 200
-            ), f"add_channel failed on graph_a: {ch_resp.text}"
-
-            # --- wire A → my_channel (same graph — should work) --------
-            wire_a = await asyncio.wait_for(
-                host.http.post(
-                    f"/api/sessions/topology/{graph_a}/creatures/{a_id}/wire",
-                    json={"channel": "my_channel", "direction": "send"},
-                ),
-                timeout=OP_TIMEOUT,
-            )
-            assert (
-                wire_a.status_code == 200
-            ), f"same-graph wire failed (sanity check): {wire_a.text}"
-
-            # --- wire my_channel → B (cross-graph — THE BUG) -----------
-            wire_b = await asyncio.wait_for(
-                host.http.post(
-                    f"/api/sessions/topology/{graph_b}/creatures/{b_id}/wire",
-                    json={"channel": "my_channel", "direction": "listen"},
-                ),
-                timeout=OP_TIMEOUT,
-            )
-            assert wire_b.status_code == 200, (
-                f"cross-graph wire of user-named channel failed (THE BUG): "
-                f"{wire_b.text}\nw2 stderr: {w2.dump_stderr()[:1500]}"
-            )
+            assert connected.status_code == 200, connected.text
 
             # --- both graphs must surface my_channel -------------------
             list_a = await asyncio.wait_for(
@@ -507,28 +485,13 @@ async def test_wire_new_channel_after_cross_node_setup(tmp_path, monkeypatch):
                     timeout=OP_TIMEOUT * 2,
                 )
             ).json()
-            graph_b = sb["session_id"]
             b_id = sb["creatures"][0]["creature_id"]
 
-            # Step 2: a→ch1→b cross-node.
-            await asyncio.wait_for(
-                host.http.post(
-                    f"/api/sessions/topology/{graph_a}/channels",
-                    json={"name": "ch1"},
-                ),
-                timeout=OP_TIMEOUT,
-            )
-            await asyncio.wait_for(
-                host.http.post(
-                    f"/api/sessions/topology/{graph_a}/creatures/{a_id}/wire",
-                    json={"channel": "ch1", "direction": "send"},
-                ),
-                timeout=OP_TIMEOUT,
-            )
+            # Step 2: explicitly connect a→ch1→b cross-node.
             r = await asyncio.wait_for(
                 host.http.post(
-                    f"/api/sessions/topology/{graph_b}/creatures/{b_id}/wire",
-                    json={"channel": "ch1", "direction": "listen"},
+                    f"/api/sessions/topology/{graph_a}/connect",
+                    json={"sender": a_id, "receiver": b_id, "channel": "ch1"},
                 ),
                 timeout=OP_TIMEOUT,
             )
@@ -620,32 +583,16 @@ async def test_cross_node_direct_output_wire(tmp_path, monkeypatch):
             graph_b = sb["session_id"]
             b_id = sb["creatures"][0]["creature_id"]
 
-            # Pre-state matching user's report: first do a→1→b
-            # (channel cross-node wire) before the direct output-wire.
-            ch_resp = await asyncio.wait_for(
+            # Pre-state matching user's report: first explicitly connect
+            # a→1→b before the direct output-wire.
+            connected = await asyncio.wait_for(
                 host.http.post(
-                    f"/api/sessions/topology/{graph_a}/channels",
-                    json={"name": "ch1"},
+                    f"/api/sessions/topology/{graph_a}/connect",
+                    json={"sender": a_id, "receiver": b_id, "channel": "ch1"},
                 ),
                 timeout=OP_TIMEOUT,
             )
-            assert ch_resp.status_code == 200, ch_resp.text
-            wire_a = await asyncio.wait_for(
-                host.http.post(
-                    f"/api/sessions/topology/{graph_a}/creatures/{a_id}/wire",
-                    json={"channel": "ch1", "direction": "send"},
-                ),
-                timeout=OP_TIMEOUT,
-            )
-            assert wire_a.status_code == 200, wire_a.text
-            wire_b = await asyncio.wait_for(
-                host.http.post(
-                    f"/api/sessions/topology/{graph_b}/creatures/{b_id}/wire",
-                    json={"channel": "ch1", "direction": "listen"},
-                ),
-                timeout=OP_TIMEOUT,
-            )
-            assert wire_b.status_code == 200, wire_b.text
+            assert connected.status_code == 200, connected.text
 
             # Now the user-reported step: direct b → a output wire
             # across workers (after a→1→b is set up).
@@ -732,29 +679,19 @@ async def test_cross_node_wire_renders_as_single_cluster_graph(tmp_path, monkeyp
             }
             assert {graph_a, graph_b} <= graph_ids_before
 
-            # User-named channel + cross-node wire.
-            await asyncio.wait_for(
+            # User-named channel + explicit cross-node connection.
+            connected = await asyncio.wait_for(
                 host.http.post(
-                    f"/api/sessions/topology/{graph_a}/channels",
-                    json={"name": "cluster_channel"},
+                    f"/api/sessions/topology/{graph_a}/connect",
+                    json={
+                        "sender": a_id,
+                        "receiver": b_id,
+                        "channel": "cluster_channel",
+                    },
                 ),
                 timeout=OP_TIMEOUT,
             )
-            await asyncio.wait_for(
-                host.http.post(
-                    f"/api/sessions/topology/{graph_a}/creatures/{a_id}/wire",
-                    json={"channel": "cluster_channel", "direction": "send"},
-                ),
-                timeout=OP_TIMEOUT,
-            )
-            wire_b = await asyncio.wait_for(
-                host.http.post(
-                    f"/api/sessions/topology/{graph_b}/creatures/{b_id}/wire",
-                    json={"channel": "cluster_channel", "direction": "listen"},
-                ),
-                timeout=OP_TIMEOUT,
-            )
-            assert wire_b.status_code == 200, wire_b.text
+            assert connected.status_code == 200, connected.text
 
             # Post-condition: the snapshot folds both engine graphs
             # into ONE cluster graph.

--- a/tests/e2e/test_prog_terrarium.py
+++ b/tests/e2e/test_prog_terrarium.py
@@ -187,6 +187,7 @@ def _ctx_for(service: LocalTerrariumService, creature_id: str) -> ToolContext:
     env = engine._environments[creature.graph_id]
     return ToolContext(
         agent_name=creature.name,
+        creature_id=creature.creature_id,
         session=None,
         working_dir=Path("."),
         environment=env,
@@ -395,7 +396,7 @@ class TestProgTerrariumJourney:
         assert gw_add.error is None, gw_add.error
         wire_edge_id = json.loads(gw_add.output)["edge_id"]
         assert wire_edge_id
-        assert any(e["to"] == "analyst" for e in engine.list_output_wiring("root"))
+        assert any(e["to"] == analyst_id for e in engine.list_output_wiring("root"))
         gw_rm = await GroupWireTool()._execute(
             {"action": "remove", "edge_id": wire_edge_id}, context=ctx
         )

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1815,7 +1815,7 @@ terrarium:
             f"/api/sessions/topology/{session_id}/disconnect",
             json={"sender": alice_id, "receiver": "ghost-creature"},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 404
         # Channel-info read on an unknown session → 404; channel list
         # on an unknown session → 404.
         resp = client.get(f"/api/sessions/topology/no-such-session/channels/team")

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1805,13 +1805,12 @@ terrarium:
         resp = client.post(f"/api/sessions/topology/{session_id}/merge/no-such-session")
         assert resp.status_code == 404
 
-        # connect referencing a creature that does not exist →
-        # documented 400 (KeyError/ValueError in topology_lib).
+        # Connect resolves identities in the URL session before mutation.
         resp = client.post(
             f"/api/sessions/topology/{session_id}/connect",
             json={"sender": alice_id, "receiver": "ghost-creature"},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 404
         resp = client.post(
             f"/api/sessions/topology/{session_id}/disconnect",
             json={"sender": alice_id, "receiver": "ghost-creature"},
@@ -1848,7 +1847,7 @@ terrarium:
         resp = client.get(f"{wbase}/outputs")
         assert resp.status_code == 200
         outputs = resp.json()["outputs"]
-        assert any(e.get("to") == "bob" for e in outputs)
+        assert any(e.get("to") == bob_id for e in outputs)
         # sinks endpoint reports the empty secondary-sink list.
         resp = client.get(f"{wbase}/sinks")
         assert resp.status_code == 200
@@ -1886,7 +1885,7 @@ terrarium:
         wired_graph = next(
             g for g in resp.json()["graphs"] if g["graph_id"] == session_id
         )
-        edge = next(e for e in wired_graph["output_edges"] if e.get("to") == "bob")
+        edge = next(e for e in wired_graph["output_edges"] if e.get("to") == bob_id)
         assert edge["from"] == alice_id
         assert edge["to_creature_id"] == bob_id
         assert edge["graph_id"] == session_id

--- a/tests/integration/test_modules.py
+++ b/tests/integration/test_modules.py
@@ -1503,6 +1503,7 @@ class TestModulesIntegration:
             def _ctx(creature):
                 return ToolContext(
                     agent_name=creature.name,
+                    creature_id=creature.creature_id,
                     session=None,
                     working_dir=tmp_path,
                     environment=engine._environments[creature.graph_id],

--- a/tests/integration/test_terrarium.py
+++ b/tests/integration/test_terrarium.py
@@ -175,6 +175,7 @@ def _ctx_for(service: LocalTerrariumService, creature_id: str) -> ToolContext:
     env = engine._environments[creature.graph_id]
     return ToolContext(
         agent_name=creature.name,
+        creature_id=creature.creature_id,
         session=None,
         working_dir=Path("."),
         environment=env,
@@ -620,7 +621,7 @@ class TestTerrariumIntegration:
             context=ctx,
         )
         assert bad_target.error is not None
-        assert "not in your group" in bad_target.error
+        assert "not a creature in caller" in bad_target.error
         # unwire a channel not in the graph is rejected.
         bad_unwire = await GroupChannelTool()._execute(
             {
@@ -649,7 +650,7 @@ class TestTerrariumIntegration:
         assert gw_add.error is None, gw_add.error
         gw_edge_id = json.loads(gw_add.output)["edge_id"]
         assert gw_edge_id
-        assert any(e["to"] == "worker" for e in engine.list_output_wiring("lead"))
+        assert any(e["to"] == worker_id for e in engine.list_output_wiring("lead"))
         gw_rm = await GroupWireTool()._execute(
             {"action": "remove", "edge_id": gw_edge_id}, context=ctx
         )
@@ -744,9 +745,13 @@ class TestTerrariumIntegration:
         rm_res = await GroupRemoveNodeTool()._execute(
             {"creature_id": worker_id}, context=ctx
         )
-        assert rm_res.error is None, rm_res.error
-        assert worker_id not in service.engine
-        assert {c.creature_id for c in await service.list_creatures()} == {"lead"}
+        assert rm_res.error is not None
+        assert "not a creature in caller" in rm_res.error
+        assert worker_id in service.engine
+        assert {c.creature_id for c in await service.list_creatures()} == {
+            "lead",
+            worker_id,
+        }
         # The privileged node may NOT be removed via the tool.
         deny = await GroupRemoveNodeTool()._execute(
             {"creature_id": "lead"}, context=ctx
@@ -1444,15 +1449,13 @@ class TestTerrariumIntegration:
         assert len((await service.chat_history("writer"))["messages"]) == writer_pre
         assert await service.unwire_output("scout", stopped_wire["edge_id"]) is True
         await service.start_creature("writer")
-        # A wire to a creature that does NOT exist is silently dropped
-        # (the resolver warns once and skips) — the source turn still ok.
-        ghost_wire = await service.wire_output(
-            "scout", {"to": "no_such_target", "with_content": True}
-        )
-        async for _ in service.chat("scout", "to a ghost"):
-            pass
-        await asyncio.sleep(0.05)
-        assert await service.unwire_output("scout", ghost_wire["edge_id"]) is True
+        # Unknown targets fail closed at wiring time; no dead edge is stored.
+        from kohakuterrarium.terrarium.graph_identity import TargetNotFoundError
+
+        with pytest.raises(TargetNotFoundError):
+            await service.wire_output(
+                "scout", {"to": "no_such_target", "with_content": True}
+            )
 
         # --- OutputLogCapture — tee a creature's output into a ring buffer.
         # ``creature_host`` exposes ``output_log`` + ``get_log_entries`` /

--- a/tests/unit/api/test_app_factory.py
+++ b/tests/unit/api/test_app_factory.py
@@ -24,33 +24,6 @@ class TestParseBind:
             app_mod._parse_bind("no-colon")
 
 
-# ── _make_output_wire_target_resolver ─────────────────────────
-
-
-class TestMakeOutputWireTargetResolver:
-    def test_resolves_from_cache(self):
-        # service has _creature_name_cache attribute populated
-        class _Svc:
-            _creature_name_cache = {"alice": ("worker-1", "cid-1")}
-
-        resolver = app_mod._make_output_wire_target_resolver(_Svc())
-        assert resolver("alice") == ("worker-1", "cid-1")
-
-    def test_miss_returns_none(self):
-        class _Svc:
-            _creature_name_cache = {}
-
-        resolver = app_mod._make_output_wire_target_resolver(_Svc())
-        assert resolver("ghost") is None
-
-    def test_no_cache_attr_returns_none(self):
-        class _Svc:
-            pass
-
-        resolver = app_mod._make_output_wire_target_resolver(_Svc())
-        assert resolver("anyone") is None
-
-
 # ── create_app ─────────────────────────────────────────────────
 
 

--- a/tests/unit/api/test_route_helpers.py
+++ b/tests/unit/api/test_route_helpers.py
@@ -22,7 +22,9 @@ class _FakeService:
         return self._creatures
 
 
-def _info(creature_id="cid", name="alice", graph_id="g") -> CreatureInfo:
+def _info(
+    creature_id="cid", name="alice", graph_id="g", config_name=""
+) -> CreatureInfo:
     return CreatureInfo(
         creature_id=creature_id,
         name=name,
@@ -32,6 +34,7 @@ def _info(creature_id="cid", name="alice", graph_id="g") -> CreatureInfo:
         parent_creature_id=None,
         listen_channels=(),
         send_channels=(),
+        config_name=config_name,
     )
 
 
@@ -62,6 +65,11 @@ class TestResolveCreatureId:
     async def test_name_fallback(self):
         svc = _FakeService([_info("cid-1", "alice")])
         out = await resolve_creature_id(svc, "alice")
+        assert out == "cid-1"
+
+    async def test_config_name_fallback(self):
+        svc = _FakeService([_info("cid-1", "display", config_name="configured")])
+        out = await resolve_creature_id(svc, "configured")
         assert out == "cid-1"
 
     async def test_id_wins_over_name(self):

--- a/tests/unit/api/test_route_helpers.py
+++ b/tests/unit/api/test_route_helpers.py
@@ -35,6 +35,24 @@ def _info(creature_id="cid", name="alice", graph_id="g") -> CreatureInfo:
     )
 
 
+class TestResolveConnectTargetId:
+    async def test_exact_runtime_id_may_cross_graph_but_name_may_not(self):
+        from kohakuterrarium.api.routes.sessions_v2._helpers import (
+            resolve_connect_target_id,
+        )
+
+        svc = _FakeService(
+            creatures=[
+                _info("source-id", "source", graph_id="g1"),
+                _info("target-id", "worker", graph_id="g2"),
+            ]
+        )
+        assert await resolve_connect_target_id(svc, "target-id", "g1") == "target-id"
+        with pytest.raises(HTTPException) as exc:
+            await resolve_connect_target_id(svc, "worker", "g1")
+        assert exc.value.status_code == 404
+
+
 class TestResolveCreatureId:
     async def test_exact_id_match(self):
         svc = _FakeService([_info("cid-1", "alice")])
@@ -108,19 +126,18 @@ class TestResolveCreatureId:
         # Same id WITH the right session resolves fine.
         assert await resolve_creature_id(svc, "cid-a", "graph_aaa") == "cid-a"
 
-    async def test_global_search_when_session_id_omitted(self):
-        # Back-compat: callers that pre-date the v2 session-scoped
-        # routes (tests + a few internal callers) pass ``session_id=None``
-        # and get the historical global-name-fallback behaviour.
+    async def test_global_duplicate_name_without_session_is_ambiguous(self):
+        # Legacy callers without a session may still use exact IDs, but duplicate
+        # names fail closed instead of selecting the first graph globally.
         svc = _FakeService(
             [
                 _info("cid-a", "alice", graph_id="graph_aaa"),
                 _info("cid-b", "alice", graph_id="graph_bbb"),
             ]
         )
-        out = await resolve_creature_id(svc, "alice")
-        # First match wins under global search (historical semantics).
-        assert out == "cid-a"
+        with pytest.raises(HTTPException) as exc:
+            await resolve_creature_id(svc, "alice")
+        assert exc.value.status_code == 409
 
 
 class TestResolveCreatureIdClusterScope:

--- a/tests/unit/api/test_topology_route.py
+++ b/tests/unit/api/test_topology_route.py
@@ -17,10 +17,13 @@ class _FakeService:
     ``connect`` returns ``connect_result`` for the merge path.
     """
 
-    def __init__(self, *, graph=object(), graphs=None, connect_result=None):
+    def __init__(
+        self, *, graph=object(), graphs=None, connect_result=None, creatures=None
+    ):
         self._graph = graph
         self._graphs = graphs
         self._connect_result = connect_result
+        self._creatures = creatures
         self.connect_calls: list[tuple[str, str]] = []
 
     async def get_graph(self, gid):
@@ -35,6 +38,8 @@ class _FakeService:
     async def list_creatures(self):
         from kohakuterrarium.terrarium.service_dto import CreatureInfo
 
+        if self._creatures is not None:
+            return tuple(self._creatures)
         return (
             CreatureInfo("a", "a", "g1", False, False, None, [], []),
             CreatureInfo("b", "b", "g1", False, False, None, [], []),
@@ -317,7 +322,10 @@ class TestConnectDisconnect:
         assert resp.status_code == 400
 
     def test_disconnect_success(self, monkeypatch):
+        captured = {}
+
         async def fake(svc, s, r, **kw):
+            captured.update(sender=s, receiver=r)
             return {"channels": ["ch"]}
 
         monkeypatch.setattr(topology_mod.topology_lib, "disconnect", fake)
@@ -329,6 +337,29 @@ class TestConnectDisconnect:
         assert resp.status_code == 200
         # Route returns the disconnect lib result verbatim.
         assert resp.json() == {"channels": ["ch"]}
+        assert captured == {"sender": "a", "receiver": "b"}
+
+    def test_disconnect_rejects_creature_outside_url_session(self, monkeypatch):
+        from kohakuterrarium.terrarium.service_dto import CreatureInfo
+
+        called = False
+
+        async def fake(*args, **kwargs):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(topology_mod.topology_lib, "disconnect", fake)
+        creatures = [
+            CreatureInfo("a", "a", "g1", False, False, None, (), ()),
+            CreatureInfo("foreign", "foreign", "g2", False, False, None, (), ()),
+        ]
+        client = TestClient(_app(service=_FakeService(creatures=creatures)))
+        resp = client.post(
+            "/topology/g1/disconnect",
+            json={"sender": "a", "receiver": "foreign", "channel": "chat"},
+        )
+        assert resp.status_code == 404
+        assert called is False
 
     def test_disconnect_value_error(self, monkeypatch):
         async def boom(svc, s, r, **kw):
@@ -358,17 +389,42 @@ class TestConnectDisconnect:
 
 class TestWireRoutes:
     def test_wire_success(self, monkeypatch):
+        captured = {}
+
         async def fake_wire(svc, sid, cid, ch, direction, *, enabled):
+            captured["creature_id"] = cid
             return None
 
         monkeypatch.setattr(topology_mod.topology_lib, "wire_creature", fake_wire)
         client = TestClient(_app())
         resp = client.post(
-            "/topology/g1/creatures/c1/wire",
+            "/topology/g1/creatures/a/wire",
             json={"channel": "ch", "direction": "listen"},
         )
         assert resp.status_code == 200
         assert resp.json() == {"status": "wired"}
+        assert captured == {"creature_id": "a"}
+
+    def test_wire_rejects_creature_outside_url_session(self, monkeypatch):
+        from kohakuterrarium.terrarium.service_dto import CreatureInfo
+
+        called = False
+
+        async def fake_wire(*args, **kwargs):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(topology_mod.topology_lib, "wire_creature", fake_wire)
+        creatures = [
+            CreatureInfo("foreign", "foreign", "g2", False, False, None, (), ())
+        ]
+        client = TestClient(_app(service=_FakeService(creatures=creatures)))
+        resp = client.post(
+            "/topology/g1/creatures/foreign/wire",
+            json={"channel": "ch", "direction": "listen"},
+        )
+        assert resp.status_code == 404
+        assert called is False
 
     def test_wire_value_error(self, monkeypatch):
         async def boom(*a, **kw):
@@ -377,7 +433,7 @@ class TestWireRoutes:
         monkeypatch.setattr(topology_mod.topology_lib, "wire_creature", boom)
         client = TestClient(_app())
         resp = client.post(
-            "/topology/g1/creatures/c1/wire",
+            "/topology/g1/creatures/a/wire",
             json={"channel": "ch", "direction": "listen"},
         )
         assert resp.status_code == 400
@@ -390,7 +446,7 @@ class TestWireRoutes:
         client = TestClient(_app())
         resp = client.request(
             "DELETE",
-            "/topology/g1/creatures/c1/wire",
+            "/topology/g1/creatures/a/wire",
             json={"channel": "ch", "direction": "send"},
         )
         assert resp.status_code == 200
@@ -404,7 +460,7 @@ class TestWireRoutes:
         client = TestClient(_app())
         resp = client.request(
             "DELETE",
-            "/topology/g1/creatures/c1/wire",
+            "/topology/g1/creatures/a/wire",
             json={"channel": "ch", "direction": "send"},
         )
         assert resp.status_code == 400
@@ -417,7 +473,7 @@ class TestWireRoutes:
         client = TestClient(_app())
         resp = client.request(
             "DELETE",
-            "/topology/g1/creatures/c1/wire",
+            "/topology/g1/creatures/a/wire",
             json={"channel": "ch", "direction": "send"},
         )
         assert resp.status_code == 400

--- a/tests/unit/api/test_topology_route.py
+++ b/tests/unit/api/test_topology_route.py
@@ -32,6 +32,14 @@ class _FakeService:
         self.connect_calls.append((sender_id, receiver_id))
         return self._connect_result
 
+    async def list_creatures(self):
+        from kohakuterrarium.terrarium.service_dto import CreatureInfo
+
+        return (
+            CreatureInfo("a", "a", "g1", False, False, None, [], []),
+            CreatureInfo("b", "b", "g1", False, False, None, [], []),
+        )
+
 
 class _FakeGraph:
     def __init__(self, gid, creatures=()):

--- a/tests/unit/api/test_wiring_route.py
+++ b/tests/unit/api/test_wiring_route.py
@@ -33,7 +33,7 @@ class _FakeService:
         raise_on=None,
         cluster_links=None,
     ):
-        self._creatures = creatures or [_info()]
+        self._creatures = creatures or [_info(), _info("c2", "bob")]
         self._list = list_returns or [{"edge_id": "e1"}]
         self._wire = wire_returns or {"edge_id": "e2"}
         self._unwire = unwire_returns

--- a/tests/unit/builtins/test_send_message.py
+++ b/tests/unit/builtins/test_send_message.py
@@ -1,4 +1,4 @@
-"""Unit tests for the legacy ``send_message`` builtin tool.
+﻿"""Unit tests for the legacy ``send_message`` builtin tool.
 
 Pins behaviour of the engine-context send-edge gate: when a creature
 inside a Terrarium graph carries a private session-channel that
@@ -30,6 +30,7 @@ def _ctx_with_private_channel(
     session.channels.get_or_create(private_channel_name, channel_type="broadcast")
     return ToolContext(
         agent_name=creature.name,
+        creature_id=creature.creature_id,
         session=session,
         working_dir=Path("."),
         environment=env,

--- a/tests/unit/core/test_executor.py
+++ b/tests/unit/core/test_executor.py
@@ -612,15 +612,18 @@ class TestToolContextBuild:
             async def _execute(self, args, context=None, **kwargs):
                 captured["ctx"] = context
                 captured["agent_name"] = context.agent_name
+                captured["creature_id"] = context.creature_id
                 return ToolResult(output="ok")
 
         ex = Executor()
         ex.register_tool(_NeedsCtx())
         ex._agent_name = "alice"
+        ex._creature_id = "creature-alice"
         ex._working_dir = Path.cwd()
         jid = await ex.submit("needs", {})
         await ex.wait_for(jid)
         assert captured["agent_name"] == "alice"
+        assert captured["creature_id"] == "creature-alice"
 
     async def test_emit_tool_wait_through_router(self):
         ex = Executor()

--- a/tests/unit/laboratory/test_host_routing.py
+++ b/tests/unit/laboratory/test_host_routing.py
@@ -71,6 +71,25 @@ async def _start_pair(port=1, second_name=None):
 # ── CONTROL unsubscribe + unregister_creature ────────────────
 
 
+class TestAuthenticatedEnvelopeSource:
+    async def test_forged_from_node_is_dropped(self):
+        host, c1 = await _start_pair(port=9)
+        try:
+            await c1.send(
+                build_subscribe(
+                    from_node="forged-worker",
+                    to_node="_host",
+                    channel="chat",
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert "forged-worker" not in host.addressing.listeners("chat")
+            assert "w1" not in host.addressing.listeners("chat")
+        finally:
+            await c1.stop()
+            await host.stop()
+
+
 class TestControlUnsubUnregister:
     async def test_unsubscribe_after_subscribe(self):
         host, c1 = await _start_pair(port=1)

--- a/tests/unit/laboratory/test_terrarium_output_wire.py
+++ b/tests/unit/laboratory/test_terrarium_output_wire.py
@@ -1,452 +1,299 @@
-"""Unit tests for :class:`TerrariumOutputWireAdapter`."""
+"""Graph-bound Laboratory output-wire routing tests."""
 
-import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
-
+from unittest.mock import AsyncMock
 
 from kohakuterrarium.laboratory._internal.app import AppMessage
 from kohakuterrarium.laboratory.adapters.terrarium_output_wire import (
     TerrariumOutputWireAdapter,
 )
-from kohakuterrarium.testing.terrarium import TestTerrariumBuilder
 
 
-class _FakeNotifier:
-    def __init__(self, fail=False):
-        self.app_extensions = {}
-        self.notifications = []
-        self._fail = fail
+class _Messenger:
+    def __init__(self, node_id: str, *, response=None):
+        self.node_id = node_id
+        self.response = response or {"delivered": True}
+        self.request = AsyncMock(return_value=self.response)
+        self.handlers = {}
 
-    def register_app_extension(self, ns, handler):
-        self.app_extensions[ns] = handler
+    def register_handler(self, namespace, handler):
+        self.handlers[namespace] = handler
 
-    def unregister_app_extension(self, ns):
-        return self.app_extensions.pop(ns, None) is not None
-
-    async def notify(self, *, to_node, namespace, type, body):
-        if self._fail:
-            raise RuntimeError("delivery failed")
-        self.notifications.append(
-            {"to": to_node, "namespace": namespace, "type": type, "body": body}
-        )
+    def unregister_handler(self, namespace):
+        self.handlers.pop(namespace, None)
 
 
-def _app_msg(type_, body, sender="ctrl"):
+class _Agent:
+    def __init__(self):
+        self._process_event = AsyncMock()
+
+
+class _Creature:
+    def __init__(self, cid: str, name: str, graph_id: str):
+        self.creature_id = cid
+        self.name = name
+        self.graph_id = graph_id
+        self.agent = _Agent()
+
+
+def _msg(sender: str, body: dict) -> AppMessage:
     return AppMessage(
         sender_node=sender,
         namespace="terrarium.output_wire",
-        type=type_,
+        type="inject",
         body=body,
-        request_id="r1",
+        request_id="req-1",
         in_reply_to=None,
     )
 
 
-# ── construction / detach ────────────────────────────────────
+def _body(**overrides):
+    body = {
+        "target_name": "target-id",
+        "event": {
+            "source": "source-id",
+            "content": "hello",
+            "metadata": {},
+        },
+        "source_creature_id": "source-id",
+        "source_graph_id": "graph-a",
+        "hop": 0,
+        "peer": "worker-a",
+    }
+    body.update(overrides)
+    return body
 
 
 class TestLifecycle:
-    async def test_init_stashes_on_engine(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            assert "terrarium.output_wire" in notifier.app_extensions
-            assert t._output_wire_adapter is adapter
-            adapter.detach()
-            assert t._output_wire_adapter is None
-        finally:
-            await t.shutdown()
-
-    async def test_detach_idempotent(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            adapter.detach()
-            # Second detach is a no-op.
-            adapter.detach()
-        finally:
-            await t.shutdown()
+    def test_attach_and_detach(self):
+        messenger = _Messenger("worker-a")
+        engine = SimpleNamespace(_output_wire_adapter=None, _creatures={})
+        adapter = TerrariumOutputWireAdapter(engine, messenger)
+        assert engine._output_wire_adapter is adapter
+        assert "terrarium.output_wire" in messenger.handlers
+        adapter.detach()
+        assert engine._output_wire_adapter is None
+        assert "terrarium.output_wire" not in messenger.handlers
 
 
-# ── peer_for_target ──────────────────────────────────────────
+class TestGraphScopedCache:
+    def test_live_cache_reference_survives_refresh(self):
+        messenger = _Messenger("_host")
+        cache = {}
+        adapter = TerrariumOutputWireAdapter(
+            SimpleNamespace(_creatures={}), messenger, name_cache=cache
+        )
+        cache["worker"] = {("graph-a", "node-a", "id-a")}
+        assert adapter.peer_for_target("worker", graph_id="graph-a") == "node-a"
+
+    def test_duplicate_name_is_not_last_writer(self):
+        messenger = _Messenger("_host")
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        adapter.set_name_cache(
+            {
+                "worker": {
+                    ("graph-a", "node-a", "id-a"),
+                    ("graph-b", "node-b", "id-b"),
+                }
+            }
+        )
+        assert adapter.peer_for_target("worker") is None
+        assert adapter.peer_for_target("worker", graph_id="graph-a") == "node-a"
 
 
-class TestPeerForTarget:
-    async def test_no_resolver_means_worker_delegates_to_host(self):
-        # On a worker (which never installs a resolver), an unresolved
-        # local target forwards to the host — the cluster relay routes
-        # it from there.  "Lab host = transparent relay" UX invariant.
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            assert adapter.peer_for_target("anyone") == "_host"
-        finally:
-            adapter.detach()
-            await t.shutdown()
+class TestForwardEnvelope:
+    async def test_requires_source_graph_and_runtime_id(self):
+        messenger = _Messenger("worker-a")
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        assert await adapter.forward_event(target_name="target-id", event={}) is False
+        messenger.request.assert_not_awaited()
 
-    async def test_resolver_returns_none(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            adapter.set_target_resolver(lambda name: None)
-            assert adapter.peer_for_target("anyone") is None
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_resolver_returns_host_treated_as_local(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            adapter.set_target_resolver(lambda n: ("_host", "cid-x"))
-            assert adapter.peer_for_target("a") is None
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_resolver_returns_empty_node_id(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            adapter.set_target_resolver(lambda n: ("", "cid-x"))
-            assert adapter.peer_for_target("a") is None
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_resolver_returns_worker(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            adapter.set_target_resolver(lambda n: ("worker-1", "cid-x"))
-            assert adapter.peer_for_target("a") == "worker-1"
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_resolver_exception_returns_none(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-
-            def _boom(n):
-                raise RuntimeError("bad")
-
-            adapter.set_target_resolver(_boom)
-            assert adapter.peer_for_target("a") is None
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-
-# ── forward_event ────────────────────────────────────────────
-
-
-class TestForwardEvent:
-    async def test_successful_forward(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            ok = await adapter.forward_event("worker-1", {"target_name": "x"})
-            assert ok is True
-            assert notifier.notifications
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_failed_forward_returns_false(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier(fail=True)
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            ok = await adapter.forward_event("worker-1", {"target_name": "x"})
-            assert ok is False
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-
-# ── _dispatch / _handle ──────────────────────────────────────
-
-
-class TestDispatch:
-    async def test_unknown_type(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            resp = await adapter._dispatch(_app_msg("garbage", {}))
-            assert resp["error"]["kind"] == "unknown_type"
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_inject_missing_target_name(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            resp = await adapter._dispatch(_app_msg("inject", {}))
-            assert resp["error"]["kind"] == "invalid"
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_inject_unknown_creature(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            resp = await adapter._dispatch(_app_msg("inject", {"target_name": "ghost"}))
-            assert resp["error"]["kind"] == "not_found"
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_inject_target_not_running(self):
-        t = await TestTerrariumBuilder().with_creature("alice").build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            # Make alice not running.
-            t.get_creature("alice").agent._running = False
-            resp = await adapter._dispatch(_app_msg("inject", {"target_name": "alice"}))
-            assert resp["delivered"] is False
-            assert "not_running" in resp["reason"]
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_inject_success(self):
-        t = await TestTerrariumBuilder().with_creature("alice").build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            agent = t.get_creature("alice").agent
-            agent._running = True
-            agent._process_event = AsyncMock()
-            resp = await adapter._dispatch(
-                _app_msg(
-                    "inject",
-                    {
-                        "target_name": "alice",
-                        "source": "bob",
-                        "content": "hello",
-                        "with_content": True,
-                        "source_event_type": "tool_result",
-                        "turn_index": 3,
-                        "prompt_override": "[wire]",
-                    },
-                )
-            )
-            assert resp["delivered"] is True
-            # Give the asyncio task a moment to run.
-            await asyncio.sleep(0.05)
-            agent._process_event.assert_called_once()
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_inject_with_router_activity_notification(self):
-        t = await TestTerrariumBuilder().with_creature("alice").build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            agent = t.get_creature("alice").agent
-            agent._running = True
-            agent._process_event = AsyncMock()
-            agent.output_router = SimpleNamespace(notify_activity=MagicMock())
-            resp = await adapter._dispatch(
-                _app_msg(
-                    "inject",
-                    {
-                        "target_name": "alice",
-                        "source": "bob",
-                        "content": "x" * 300,  # exercise the truncation path
-                    },
-                )
-            )
-            assert resp["delivered"] is True
-            agent.output_router.notify_activity.assert_called_once()
-            # Verify truncation suffix landed.
-            args, kw = agent.output_router.notify_activity.call_args
-            preview = kw["metadata"]["content_preview"]
-            assert preview.endswith("…")
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_inject_router_notify_failure_swallowed(self):
-        t = await TestTerrariumBuilder().with_creature("alice").build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            agent = t.get_creature("alice").agent
-            agent._running = True
-            agent._process_event = AsyncMock()
-
-            def _boom(*a, **kw):
-                raise RuntimeError("bad router")
-
-            agent.output_router = SimpleNamespace(notify_activity=_boom)
-            resp = await adapter._dispatch(_app_msg("inject", {"target_name": "alice"}))
-            assert resp["delivered"] is True
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-
-# ── _resolve_local_agent ─────────────────────────────────────
-
-
-class TestResolveLocalAgent:
-    async def test_by_creature_id(self):
-        t = await TestTerrariumBuilder().with_creature("alice").build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            agent = adapter._resolve_local_agent("alice")
-            assert agent is t.get_creature("alice").agent
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_by_config_name(self):
-        t = await TestTerrariumBuilder().with_creature("alice").build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            creature = t.get_creature("alice")
-            # Rename so creature_id != name; mark config.name as the
-            # canonical lookup key.
-            creature.name = "other"
-            creature.agent.config = SimpleNamespace(name="alpha")
-            agent = adapter._resolve_local_agent("alpha")
-            assert agent is creature.agent
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_by_display_name(self):
-        t = await TestTerrariumBuilder().with_creature("alice").build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            creature = t.get_creature("alice")
-            # creature_id stays "alice" but the display name differs;
-            # lookup by the display name must still resolve the agent.
-            creature.name = "display-name"
-            agent = adapter._resolve_local_agent("display-name")
-            assert agent is creature.agent
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-    async def test_unknown(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            assert adapter._resolve_local_agent("ghost") is None
-        finally:
-            adapter.detach()
-            await t.shutdown()
-
-
-# ── host-side cluster relay on local-miss ────────────────────────
+    async def test_request_ack_controls_delivered_result(self):
+        messenger = _Messenger("worker-a", response={"delivered": False})
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        delivered = await adapter.forward_event(
+            target_name="target-id",
+            event={"content": "hello"},
+            source_creature_id="source-id",
+            source_graph_id="graph-a",
+        )
+        assert delivered is False
+        destination, msg_type, body = messenger.request.await_args.args
+        assert (destination, msg_type) == ("_host", "inject")
+        assert body["source_creature_id"] == "source-id"
+        assert body["source_graph_id"] == "graph-a"
+        assert body["hop"] == 0
+        assert body["peer"] == "worker-a"
 
 
 class TestHostRelay:
-    """The host's _op_inject must re-route to the peer that owns the
-    target when the local engine doesn't have it.  This is what makes
-    a worker→host→worker output-wiring path actually deliver: workers
-    forward unresolved emissions to the host, and the host re-forwards
-    to the right peer based on its cluster name resolver.
-    """
+    async def test_relay_propagates_receiver_failure(self):
+        messenger = _Messenger("_host", response={"delivered": False})
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        adapter.set_name_cache(
+            {
+                "source-id": {("graph-a", "worker-a", "source-id")},
+                "target-id": {("graph-a", "worker-b", "target-id")},
+            }
+        )
+        result = await adapter._dispatch(_msg("worker-a", _body()))
+        assert result == {"delivered": False}
+        destination, msg_type, body = messenger.request.await_args.args
+        assert (destination, msg_type) == ("worker-b", "inject")
+        assert body["target_graph_id"] == "graph-a"
+        assert body["target_creature_id"] == "target-id"
+        assert body["hop"] == 1
+        assert body["peer"] == "_host"
 
-    async def test_local_miss_relays_to_peer(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            # Host-side: install a resolver that knows the target lives
-            # on worker-2.  No matching local creature.
-            adapter.set_target_resolver(lambda name: ("worker-2", "cid-x"))
-            msg = _app_msg(
-                "inject",
-                {
-                    "target_name": "alpha",
-                    "source": "bravo",
-                    "content": "hello",
-                    "with_content": True,
-                    "source_event_type": "user_message",
-                    "turn_index": 0,
+    async def test_forged_source_identity_fails_closed(self):
+        messenger = _Messenger("_host")
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        adapter.set_name_cache(
+            {
+                "source-id": {("graph-a", "worker-a", "source-id")},
+                "target-id": {("graph-a", "worker-b", "target-id")},
+            }
+        )
+        result = await adapter._dispatch(
+            _msg("worker-forged", _body(peer="worker-forged"))
+        )
+        assert result == {"delivered": False, "error": "forged source identity"}
+        messenger.request.assert_not_awaited()
+
+    async def test_forged_event_context_source_fails_closed(self):
+        messenger = _Messenger("_host")
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        adapter.set_name_cache(
+            {
+                "source-id": {("graph-a", "worker-a", "source-id")},
+                "target-id": {("graph-a", "worker-b", "target-id")},
+            }
+        )
+        result = await adapter._dispatch(
+            _msg(
+                "worker-a",
+                _body(event={"context": {"source": "forged-id"}}),
+            )
+        )
+        assert result == {"delivered": False, "error": "forged event source"}
+        messenger.request.assert_not_awaited()
+
+    async def test_cross_worker_local_graph_ids_share_one_cluster(self):
+        messenger = _Messenger("_host")
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        adapter.set_name_cache(
+            {
+                "source-id": {("graph-a", "worker-a", "source-id")},
+                "target-id": {("graph-b", "worker-b", "target-id")},
+            }
+        )
+        adapter.set_cluster_members(lambda graph_id: {"graph-a", "graph-b"})
+        result = await adapter._dispatch(_msg("worker-a", _body()))
+        assert result == {"delivered": True}
+        assert messenger.request.await_args.args[0] == "worker-b"
+
+    async def test_ambiguous_same_graph_target_fails_closed(self):
+        messenger = _Messenger("_host")
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        adapter.set_name_cache(
+            {
+                "source-id": {("graph-a", "worker-a", "source-id")},
+                "worker": {
+                    ("graph-a", "node-a", "id-a"),
+                    ("graph-a", "node-b", "id-b"),
                 },
-            )
-            out = await adapter._dispatch(msg)
-            assert out == {"delivered": True, "relayed": "worker-2"}
-            # The host forwarded an APP ``inject`` to worker-2 with the
-            # ``relayed`` flag so the worker won't double-bounce on a
-            # second miss.
-            assert len(notifier.notifications) == 1
-            n = notifier.notifications[0]
-            assert n["to"] == "worker-2"
-            assert n["type"] == "inject"
-            assert n["body"]["relayed"] is True
-            assert n["body"]["target_name"] == "alpha"
-        finally:
-            adapter.detach()
-            await t.shutdown()
+            }
+        )
+        result = await adapter._dispatch(_msg("worker-a", _body(target_name="worker")))
+        assert result["delivered"] is False
+        messenger.request.assert_not_awaited()
 
-    async def test_already_relayed_does_not_re_relay(self):
-        # Loop guard: a worker that receives a host-relayed inject and
-        # STILL can't resolve locally must raise rather than forwarding
-        # again — otherwise an inject for a vanished creature ping-pongs.
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            adapter.set_target_resolver(lambda name: ("worker-2", "cid-x"))
-            msg = _app_msg(
-                "inject",
-                {
-                    "target_name": "alpha",
-                    "source": "bravo",
-                    "content": "hello",
-                    "relayed": True,  # already a relayed payload
-                },
-            )
-            out = await adapter._dispatch(msg)
-            assert out.get("error", {}).get("kind") == "not_found"
-            # No further forwarding.
-            assert notifier.notifications == []
-        finally:
-            adapter.detach()
-            await t.shutdown()
+    async def test_forged_peer_and_excess_hop_fail_closed(self):
+        messenger = _Messenger("_host")
+        adapter = TerrariumOutputWireAdapter(SimpleNamespace(_creatures={}), messenger)
+        adapter.set_name_cache({"source-id": {("graph-a", "worker-a", "source-id")}})
+        forged = await adapter._dispatch(_msg("worker-a", _body(peer="worker-forged")))
+        excess = await adapter._dispatch(_msg("worker-a", _body(hop=2)))
+        assert forged["delivered"] is False
+        assert excess["delivered"] is False
+        messenger.request.assert_not_awaited()
 
-    async def test_resolver_returns_none_raises_not_found(self):
-        t = await TestTerrariumBuilder().build()
-        notifier = _FakeNotifier()
-        try:
-            adapter = TerrariumOutputWireAdapter(t, notifier)
-            adapter.set_target_resolver(lambda name: None)
-            msg = _app_msg(
-                "inject",
-                {"target_name": "ghost", "source": "bravo", "content": ""},
+
+class TestWorkerDelivery:
+    async def test_exact_id_same_graph_is_awaited_before_success(self):
+        messenger = _Messenger("worker-b")
+        target = _Creature("target-id", "worker", "graph-a")
+        foreign = _Creature("foreign-id", "worker", "graph-b")
+        engine = SimpleNamespace(
+            _creatures={
+                target.creature_id: target,
+                foreign.creature_id: foreign,
+            }
+        )
+        adapter = TerrariumOutputWireAdapter(engine, messenger)
+        result = await adapter._dispatch(
+            _msg(
+                "_host",
+                _body(
+                    peer="_host",
+                    hop=1,
+                    target_graph_id="graph-a",
+                    target_creature_id="target-id",
+                ),
             )
-            out = await adapter._dispatch(msg)
-            assert out.get("error", {}).get("kind") == "not_found"
-            assert notifier.notifications == []
-        finally:
-            adapter.detach()
-            await t.shutdown()
+        )
+        assert result == {"delivered": True}
+        target.agent._process_event.assert_awaited_once()
+        foreign.agent._process_event.assert_not_awaited()
+
+    async def test_worker_rejects_non_host_relay(self):
+        messenger = _Messenger("worker-b")
+        target = _Creature("target-id", "worker", "graph-a")
+        adapter = TerrariumOutputWireAdapter(
+            SimpleNamespace(_creatures={target.creature_id: target}), messenger
+        )
+        result = await adapter._dispatch(
+            _msg(
+                "worker-forged",
+                _body(
+                    peer="worker-forged",
+                    hop=1,
+                    target_graph_id="graph-a",
+                    target_creature_id="target-id",
+                ),
+            )
+        )
+        assert result == {"delivered": False, "error": "invalid relay peer"}
+        target.agent._process_event.assert_not_awaited()
+
+    async def test_graph_mismatch_and_unknown_target_fail_closed(self):
+        messenger = _Messenger("worker-b")
+        target = _Creature("target-id", "worker", "graph-b")
+        engine = SimpleNamespace(_creatures={target.creature_id: target})
+        adapter = TerrariumOutputWireAdapter(engine, messenger)
+        mismatch = await adapter._dispatch(
+            _msg(
+                "_host",
+                _body(
+                    peer="_host",
+                    hop=1,
+                    target_graph_id="graph-a",
+                    target_creature_id="target-id",
+                ),
+            )
+        )
+        unknown = await adapter._dispatch(
+            _msg(
+                "_host",
+                _body(
+                    target_name="missing",
+                    peer="_host",
+                    hop=1,
+                    target_graph_id="graph-a",
+                    target_creature_id="missing",
+                ),
+            )
+        )
+        assert mismatch["delivered"] is False
+        assert unknown["delivered"] is False
+        target.agent._process_event.assert_not_awaited()

--- a/tests/unit/laboratory/test_terrarium_output_wire.py
+++ b/tests/unit/laboratory/test_terrarium_output_wire.py
@@ -1,5 +1,6 @@
 """Graph-bound Laboratory output-wire routing tests."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -25,6 +26,7 @@ class _Messenger:
 
 class _Agent:
     def __init__(self):
+        self._running = True
         self._process_event = AsyncMock()
 
 
@@ -220,7 +222,62 @@ class TestHostRelay:
 
 
 class TestWorkerDelivery:
-    async def test_exact_id_same_graph_is_awaited_before_success(self):
+    async def test_delivery_acknowledges_enqueue_without_waiting_for_full_turn(self):
+        messenger = _Messenger("worker-b")
+        target = _Creature("target-id", "worker", "graph-a")
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocking_process(event):
+            entered.set()
+            await release.wait()
+
+        target.agent._process_event = blocking_process
+        adapter = TerrariumOutputWireAdapter(
+            SimpleNamespace(_creatures={target.creature_id: target}), messenger
+        )
+
+        result = await asyncio.wait_for(
+            adapter._dispatch(
+                _msg(
+                    "_host",
+                    _body(
+                        peer="_host",
+                        hop=1,
+                        target_graph_id="graph-a",
+                        target_creature_id="target-id",
+                    ),
+                )
+            ),
+            timeout=0.2,
+        )
+        assert result == {"delivered": True}
+        await asyncio.wait_for(entered.wait(), timeout=0.2)
+        release.set()
+        await asyncio.sleep(0)
+
+    async def test_stopped_target_is_not_reported_as_delivered(self):
+        messenger = _Messenger("worker-b")
+        target = _Creature("target-id", "worker", "graph-a")
+        target.agent._running = False
+        adapter = TerrariumOutputWireAdapter(
+            SimpleNamespace(_creatures={target.creature_id: target}), messenger
+        )
+        result = await adapter._dispatch(
+            _msg(
+                "_host",
+                _body(
+                    peer="_host",
+                    hop=1,
+                    target_graph_id="graph-a",
+                    target_creature_id="target-id",
+                ),
+            )
+        )
+        assert result == {"delivered": False, "error": "target not running"}
+        target.agent._process_event.assert_not_awaited()
+
+    async def test_exact_id_same_graph_is_queued_before_success(self):
         messenger = _Messenger("worker-b")
         target = _Creature("target-id", "worker", "graph-a")
         foreign = _Creature("foreign-id", "worker", "graph-b")
@@ -243,6 +300,7 @@ class TestWorkerDelivery:
             )
         )
         assert result == {"delivered": True}
+        await asyncio.sleep(0)
         target.agent._process_event.assert_awaited_once()
         foreign.agent._process_event.assert_not_awaited()
 

--- a/tests/unit/modules/tool/test_tool_base.py
+++ b/tests/unit/modules/tool/test_tool_base.py
@@ -174,6 +174,12 @@ class TestToolResultInspection:
 
 
 class TestToolContextPathResolution:
+    def test_positional_memory_path_remains_backward_compatible(self, tmp_path):
+        memory_path = tmp_path / "memory.md"
+        ctx = ToolContext("a", None, tmp_path, memory_path)
+        assert ctx.memory_path == memory_path
+        assert ctx.creature_id == ""
+
     def test_relative_path_anchored_to_working_dir(self, tmp_path):
         ctx = ToolContext(agent_name="a", session=None, working_dir=tmp_path)
         resolved = ctx.resolve_path("sub/file.txt")

--- a/tests/unit/studio/test_lifecycle_full.py
+++ b/tests/unit/studio/test_lifecycle_full.py
@@ -381,6 +381,20 @@ class TestRename:
         finally:
             await t.shutdown()
 
+    async def test_rename_creature_rejects_duplicate_name_in_graph(self):
+        from kohakuterrarium.terrarium.graph_identity import GraphNameConflictError
+
+        t = await (
+            TestTerrariumBuilder().with_creature("alice").with_creature("bob").build()
+        )
+        svc = LocalTerrariumService(t)
+        try:
+            with pytest.raises(GraphNameConflictError):
+                lifecycle.rename_creature(svc, "bob", "alice")
+            assert t.get_creature("bob").name == "bob"
+        finally:
+            await t.shutdown()
+
     async def test_rename_creature_updates_meta_when_solo(self):
         t = await TestTerrariumBuilder().with_creature("alice").build()
         svc = LocalTerrariumService(t)

--- a/tests/unit/studio/test_wiring_sessions.py
+++ b/tests/unit/studio/test_wiring_sessions.py
@@ -23,7 +23,21 @@ class TestExtractTargetName:
         assert wiring_mod._extract_target_name(42) is None
 
 
-# ── _resolve_creature_by_name ────────────────────────────────
+# ?? graph-local fixtures ????????????????????????????????????????
+
+
+class _Graph:
+    def __init__(self, gid, creature_ids):
+        self.graph_id = gid
+        self.creature_ids = set(creature_ids)
+
+
+class _Topology:
+    def __init__(self, graphs):
+        self.graphs = {graph.graph_id: graph for graph in graphs}
+        self.creature_to_graph = {
+            cid: graph.graph_id for graph in graphs for cid in graph.creature_ids
+        }
 
 
 class _Creature:
@@ -31,19 +45,22 @@ class _Creature:
         self.creature_id = cid
         self.name = name or cid
         self.graph_id = graph_id
+        config = type("Cfg", (), {"name": self.name})()
+        self.agent = type("Agent", (), {"config": config})()
 
 
 class _Engine:
     def __init__(self, creatures=None):
         self._creatures = creatures or {}
+        groups = {}
+        for creature in self._creatures.values():
+            groups.setdefault(creature.graph_id, set()).add(creature.creature_id)
+        self._topology = _Topology(
+            [_Graph(graph_id, ids) for graph_id, ids in groups.items()]
+        )
         self.wire_output_calls = []
         self.unwire_output_calls = []
         self.list_output_wiring_calls = []
-
-    def get_creature(self, cid):
-        if cid not in self._creatures:
-            raise KeyError(cid)
-        return self._creatures[cid]
 
     async def wire_output(self, cid, target):
         self.wire_output_calls.append((cid, target))
@@ -64,117 +81,63 @@ class _Engine:
         return True
 
 
-class TestResolveCreatureByName:
-    def test_by_id(self):
-        c = _Creature("cid-1")
-        eng = _Engine({"cid-1": c})
-        out = wiring_mod._resolve_creature_by_name(eng, "cid-1")
-        assert out is c
-
-    def test_by_name(self):
-        c = _Creature("cid-1", name="alice")
-        eng = _Engine({"cid-1": c})
-        out = wiring_mod._resolve_creature_by_name(eng, "alice")
-        assert out is c
-
-    def test_unknown(self):
-        eng = _Engine()
-        assert wiring_mod._resolve_creature_by_name(eng, "ghost") is None
-
-
-# ── _ensure_target_in_same_graph ─────────────────────────────
-
-
-class TestEnsureSameGraph:
-    async def test_unknown_source_noop(self):
-        # Unknown source returns without raising.
-        eng = _Engine()
-        await wiring_mod._ensure_target_in_same_graph(eng, "ghost", "bob")
-
-    async def test_unknown_target_noop(self):
-        c = _Creature("c1")
-        eng = _Engine({"c1": c})
-        await wiring_mod._ensure_target_in_same_graph(eng, "c1", "ghost")
-
-    async def test_same_graph_noop(self):
-        # Source and target in same graph → no ensure_same_graph call.
-        c1 = _Creature("c1", graph_id="g")
-        c2 = _Creature("c2", graph_id="g", name="bob")
-        eng = _Engine({"c1": c1, "c2": c2})
-        called = []
-
-        async def fake_merge(e, a, b):
-            called.append((a, b))
-
-        # Replace ensure_same_graph via the module's _channels import.
-        import kohakuterrarium.terrarium.channels as _channels_mod
-
-        orig = _channels_mod.ensure_same_graph
-        _channels_mod.ensure_same_graph = fake_merge
-        try:
-            await wiring_mod._ensure_target_in_same_graph(eng, "c1", "bob")
-        finally:
-            _channels_mod.ensure_same_graph = orig
-        assert called == []  # same graph → skipped
-
-    async def test_different_graph_merges(self):
-        c1 = _Creature("c1", graph_id="g1")
-        c2 = _Creature("c2", graph_id="g2", name="bob")
-        eng = _Engine({"c1": c1, "c2": c2})
-        called = []
-
-        async def fake_merge(e, a, b):
-            called.append((a, b))
-
-        import kohakuterrarium.terrarium.channels as _channels_mod
-
-        orig = _channels_mod.ensure_same_graph
-        _channels_mod.ensure_same_graph = fake_merge
-        try:
-            await wiring_mod._ensure_target_in_same_graph(eng, "c1", "bob")
-        finally:
-            _channels_mod.ensure_same_graph = orig
-        assert called == [("c1", "c2")]
-
-
 # ── wire_output / unwire_output / list_output_wiring ─────────
 
 
 class TestWireOutput:
-    async def test_root_target_skips_merge(self, monkeypatch):
+    async def test_root_target_is_preserved(self):
         eng = _Engine()
-        # Even with ``"root"`` we should NOT call ``_ensure_*``.
-        called = []
-
-        async def fake_ensure(e, src, tgt):
-            called.append((src, tgt))
-
-        monkeypatch.setattr(wiring_mod, "_ensure_target_in_same_graph", fake_ensure)
         await wiring_mod.wire_output(eng, "c1", "root")
-        assert called == []
+        assert eng.wire_output_calls == [("c1", "root")]
 
-    async def test_str_target_triggers_ensure(self, monkeypatch):
+    async def test_unique_local_name_is_canonical_runtime_id(self):
+        source = _Creature("source-id", "source")
+        target = _Creature("target-id", "worker")
+        eng = _Engine({"source-id": source, "target-id": target})
+
+        await wiring_mod.wire_output(eng, "source-id", "worker")
+
+        assert eng.wire_output_calls == [("source-id", {"to": "target-id"})]
+
+    async def test_cross_graph_target_is_rejected_without_merge(self):
+        import pytest
+        from kohakuterrarium.terrarium.graph_identity import TargetNotFoundError
+
+        source = _Creature("source-id", "source", graph_id="g1")
+        target = _Creature("target-id", "worker", graph_id="g2")
+        eng = _Engine({"source-id": source, "target-id": target})
+
+        with pytest.raises(TargetNotFoundError):
+            await wiring_mod.wire_output(eng, "source-id", "worker")
+        assert eng.wire_output_calls == []
+        assert eng._topology.creature_to_graph == {
+            "source-id": "g1",
+            "target-id": "g2",
+        }
+
+    async def test_duplicate_local_name_is_ambiguous(self):
+        import pytest
+        from kohakuterrarium.terrarium.graph_identity import AmbiguousTargetError
+
+        source = _Creature("source-id", "source")
+        first = _Creature("first-id", "worker")
+        second = _Creature("second-id", "worker")
+        eng = _Engine(
+            {
+                "source-id": source,
+                "first-id": first,
+                "second-id": second,
+            }
+        )
+
+        with pytest.raises(AmbiguousTargetError):
+            await wiring_mod.wire_output(eng, "source-id", "worker")
+        assert eng.wire_output_calls == []
+
+    async def test_invalid_mapping_without_target_stays_backward_compatible(self):
         eng = _Engine()
-        called = []
-
-        async def fake_ensure(e, src, tgt):
-            called.append((src, tgt))
-
-        monkeypatch.setattr(wiring_mod, "_ensure_target_in_same_graph", fake_ensure)
-        await wiring_mod.wire_output(eng, "c1", "bob")
-        assert called == [("c1", "bob")]
-
-    async def test_no_target_name_skips_ensure(self, monkeypatch):
-        eng = _Engine()
-        called = []
-
-        async def fake_ensure(e, src, tgt):
-            called.append((src, tgt))
-
-        monkeypatch.setattr(wiring_mod, "_ensure_target_in_same_graph", fake_ensure)
-        # No ``to`` key → no target name → no ensure.
         await wiring_mod.wire_output(eng, "c1", {"x": 1})
-        assert called == []
+        assert eng.wire_output_calls == [("c1", {"x": 1})]
 
 
 class TestUnwireOutput:

--- a/tests/unit/terrarium/drive/test_drive_tools.py
+++ b/tests/unit/terrarium/drive/test_drive_tools.py
@@ -51,6 +51,7 @@ def _ctx(engine, creature) -> ToolContext:
     env = engine._environments[creature.graph_id]
     return ToolContext(
         agent_name=creature.name,
+        creature_id=creature.creature_id,
         session=None,
         working_dir=Path("."),
         environment=env,

--- a/tests/unit/terrarium/drive/test_drive_tools_group.py
+++ b/tests/unit/terrarium/drive/test_drive_tools_group.py
@@ -47,6 +47,7 @@ async def _add(engine, cid, *, privileged=False, graph=None):
 def _ctx(engine, creature) -> ToolContext:
     return ToolContext(
         agent_name=creature.name,
+        creature_id=creature.creature_id,
         session=None,
         working_dir=Path("."),
         environment=engine._environments[creature.graph_id],
@@ -257,17 +258,16 @@ class TestGraphScopeGuard:
             await _add(engine, "outsider", privileged=True)  # other graph
             tool = GroupDriveTool()
             created = await _create(tool, engine, root)
-            res = await tool._execute(
-                {
-                    "action": "assign",
-                    "drive_id": created["drive_id"],
-                    "assignee": "outsider",
-                    "expected_revision": created["revision"],
-                },
-                context=_ctx(engine, root),
-            )
-            assert res.error is not None
-            assert "not in your graph" in res.error
+            with pytest.raises(Exception, match="not a creature in caller"):
+                await tool._execute(
+                    {
+                        "action": "assign",
+                        "drive_id": created["drive_id"],
+                        "assignee": "outsider",
+                        "expected_revision": created["revision"],
+                    },
+                    context=_ctx(engine, root),
+                )
         finally:
             await engine.shutdown()
 
@@ -316,20 +316,14 @@ class TestGroupPerRecordDurability:
             await engine.shutdown()
 
 
-# ── cross-graph group_wire merge drains Drive rows immediately (R1-12) ──
+# cross-graph group_wire remains fail-closed
 
 
-class TestGroupWireDriveMerge:
-    async def test_group_wire_merge_unions_rows_and_drops_manager(self):
-        # Two Drive-bearing graphs merged specifically through the privileged
-        # group_wire tool must IMMEDIATELY (no unrelated topology op) union their
-        # Drive rows into the survivor and drop the absorbed graph's manager
-        # (R1-12: ensure_same_graph drains the stashed Drive movement).
+class TestGroupWireDriveIsolation:
+    async def test_group_wire_does_not_merge_drive_graphs(self):
         engine = await _engine()
         try:
             root_a = await _add(engine, "root_a", privileged=True)
-            # root_b is root_a's spawned child, but lives in its OWN graph — so it
-            # is in root_a's group (wireable) yet disconnected from root_a's graph.
             root_b = Creature(
                 creature_id="root_b",
                 name="root_b",
@@ -338,21 +332,28 @@ class TestGroupWireDriveMerge:
             )
             await engine.add_creature(root_b, parent_creature_id="root_a")
             a_old, b_old = root_a.graph_id, root_b.graph_id
-            assert a_old != b_old
-
             da = await _create(GroupDriveTool(), engine, root_a)
             db = await _create(GroupDriveTool(), engine, root_b)
-
             res = await GroupWireTool()._execute(
                 {"action": "add", "to": "root_b"}, context=_ctx(engine, root_a)
             )
-            assert res.error is None, res.error
-
-            keep = engine._creatures["root_a"].graph_id
-            dropped = b_old if keep == a_old else a_old
-            survivor = engine.drives.manager_for(keep)
-            ids = {d.drive_id for d in await survivor.list_drives(DriveQuery())}
-            assert da["drive_id"] in ids and db["drive_id"] in ids  # row union
-            assert engine.drives.peek_manager(dropped) is None  # obsolete manager gone
+            assert res.error is not None
+            assert "not a creature in caller" in res.error
+            assert root_a.graph_id == a_old
+            assert root_b.graph_id == b_old
+            ids_a = {
+                drive.drive_id
+                for drive in await engine.drives.manager_for(a_old).list_drives(
+                    DriveQuery()
+                )
+            }
+            ids_b = {
+                drive.drive_id
+                for drive in await engine.drives.manager_for(b_old).list_drives(
+                    DriveQuery()
+                )
+            }
+            assert ids_a == {da["drive_id"]}
+            assert ids_b == {db["drive_id"]}
         finally:
             await engine.shutdown()

--- a/tests/unit/terrarium/test_channels_more.py
+++ b/tests/unit/terrarium/test_channels_more.py
@@ -7,6 +7,7 @@ tests don't reach.
 """
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -319,6 +320,25 @@ class TestConnectMerge:
             assert {c.creature_id: c.graph_id for c in t.list_creatures()} == before
         finally:
             t._session_stores.clear()
+            await t.shutdown()
+
+    async def test_config_alias_conflict_fails_before_merge(self):
+        t = await (
+            TestTerrariumBuilder()
+            .with_creature("alice")
+            .with_creature("bob")
+            .with_separate_graphs()
+            .build()
+        )
+        try:
+            t.get_creature("bob").config = SimpleNamespace(name="alice")
+            before = {c.creature_id: c.graph_id for c in t.list_creatures()}
+
+            with pytest.raises(ValueError, match="already contains"):
+                await channels_mod.ensure_same_graph(t, "alice", "bob")
+
+            assert {c.creature_id: c.graph_id for c in t.list_creatures()} == before
+        finally:
             await t.shutdown()
 
     async def test_ensure_same_graph_noop_when_same(self):

--- a/tests/unit/terrarium/test_engine.py
+++ b/tests/unit/terrarium/test_engine.py
@@ -71,7 +71,9 @@ class TestAddRemoveCreature:
         duplicate.creature_id = "alice_copy"
         t._session_stores[graph_id] = object()
         try:
-            with pytest.raises(SessionNotResumableError, match="already contains"):
+            with pytest.raises(
+                (SessionNotResumableError, ValueError), match="already contains"
+            ):
                 await t.add_creature(duplicate, graph=graph_id, start=False)
             assert t.get_graph(graph_id).creature_ids == {"alice"}
         finally:
@@ -192,6 +194,57 @@ class TestConnectDisconnect:
             graph = t.get_graph(t.get_creature("alice").graph_id)
             assert "chat" in graph.send_edges["alice"]
             assert "chat" in graph.listen_edges["bob"]
+        finally:
+            await t.shutdown()
+
+    async def test_connect_rejects_non_endpoint_duplicate_names(self):
+        from kohakuterrarium.terrarium.graph_identity import GraphNameConflictError
+
+        t = await (
+            TestTerrariumBuilder()
+            .with_creature("left-endpoint")
+            .with_creature("left-worker")
+            .with_connection("left-endpoint", "left-worker")
+            .with_creature("right-endpoint")
+            .with_creature("right-worker")
+            .with_connection("right-endpoint", "right-worker")
+            .with_separate_graphs()
+            .build()
+        )
+        try:
+            left_worker = t.get_creature("left-worker")
+            right_worker = t.get_creature("right-worker")
+            left_worker.name = "worker"
+            left_worker.agent.config.name = "worker"
+            right_worker.name = "worker"
+            right_worker.agent.config.name = "worker"
+            with pytest.raises(GraphNameConflictError):
+                await t.connect("left-endpoint", "right-endpoint")
+            assert (
+                t.get_creature("left-endpoint").graph_id
+                != t.get_creature("right-endpoint").graph_id
+            )
+        finally:
+            await t.shutdown()
+
+    async def test_connect_rejects_duplicate_name_across_graphs(self):
+        from kohakuterrarium.terrarium.graph_identity import GraphNameConflictError
+
+        t = await (
+            TestTerrariumBuilder()
+            .with_creature("worker")
+            .with_creature("worker-other")
+            .with_separate_graphs()
+            .build()
+        )
+        other = t.get_creature("worker-other")
+        other.name = "worker"
+        other.agent.config.name = "worker"
+        try:
+            assert t.get_creature("worker").graph_id != other.graph_id
+            with pytest.raises(GraphNameConflictError):
+                await t.connect("worker", other.creature_id)
+            assert t.get_creature("worker").graph_id != other.graph_id
         finally:
             await t.shutdown()
 

--- a/tests/unit/terrarium/test_engine.py
+++ b/tests/unit/terrarium/test_engine.py
@@ -6,6 +6,7 @@ session store is involved.
 """
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -78,6 +79,20 @@ class TestAddRemoveCreature:
             assert t.get_graph(graph_id).creature_ids == {"alice"}
         finally:
             t._session_stores.clear()
+            await t.shutdown()
+            await other.shutdown()
+
+    async def test_add_rejects_duplicate_config_alias_before_mutation(self):
+        t = await TestTerrariumBuilder().with_creature("alice").build()
+        other = await TestTerrariumBuilder().with_creature("other").build()
+        candidate = other.get_creature("other")
+        candidate.config = SimpleNamespace(name="alice")
+        graph_id = t.get_creature("alice").graph_id
+        try:
+            with pytest.raises(ValueError, match="already contains"):
+                await t.add_creature(candidate, graph=graph_id, start=False)
+            assert t.get_graph(graph_id).creature_ids == {"alice"}
+        finally:
             await t.shutdown()
             await other.shutdown()
 
@@ -245,6 +260,23 @@ class TestConnectDisconnect:
             with pytest.raises(GraphNameConflictError):
                 await t.connect("worker", other.creature_id)
             assert t.get_creature("worker").graph_id != other.graph_id
+        finally:
+            await t.shutdown()
+
+    async def test_connect_rejects_duplicate_creature_config_alias(self):
+        t = await (
+            TestTerrariumBuilder()
+            .with_creature("left")
+            .with_creature("right")
+            .with_separate_graphs()
+            .build()
+        )
+        right = t.get_creature("right")
+        right.config = SimpleNamespace(name="left")
+        try:
+            with pytest.raises(ValueError, match="already contains"):
+                await t.connect("left", "right")
+            assert t.get_creature("left").graph_id != right.graph_id
         finally:
             await t.shutdown()
 

--- a/tests/unit/terrarium/test_graph_identity.py
+++ b/tests/unit/terrarium/test_graph_identity.py
@@ -1,0 +1,208 @@
+"""Unit tests for caller-scoped creature identity resolution."""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from kohakuterrarium.terrarium.graph_identity import (
+    AmbiguousTargetError,
+    CallerGraphNotFoundError,
+    TargetNotFoundError,
+    UnknownCallerError,
+    resolve_local_graph_target,
+)
+from kohakuterrarium.terrarium.topology import TopologyState, add_creature
+
+
+@dataclass
+class _Creature:
+    creature_id: str
+    name: str
+    config_name: str | None = None
+
+    def __post_init__(self) -> None:
+        config_name = self.config_name or self.name
+        self.agent = SimpleNamespace(config=SimpleNamespace(name=config_name))
+
+
+def _two_graphs():
+    topology = TopologyState()
+    creatures: dict[str, _Creature] = {}
+
+    graph_a = add_creature(topology, "root-a")
+    add_creature(topology, "reviewer-a", graph_id=graph_a)
+    graph_b = add_creature(topology, "root-b")
+    add_creature(topology, "reviewer-b", graph_id=graph_b)
+
+    creatures["root-a"] = _Creature("root-a", "root")
+    creatures["reviewer-a"] = _Creature("reviewer-a", "reviewer")
+    creatures["root-b"] = _Creature("root-b", "root")
+    creatures["reviewer-b"] = _Creature("reviewer-b", "reviewer")
+    return topology, creatures, graph_a, graph_b
+
+
+def test_exact_runtime_id_wins_over_name_match():
+    topology = TopologyState()
+    graph_id = add_creature(topology, "caller-id")
+    add_creature(topology, "exact-id", graph_id=graph_id)
+    add_creature(topology, "named-id", graph_id=graph_id)
+    creatures = {
+        "caller-id": _Creature("caller-id", "caller"),
+        "exact-id": _Creature("exact-id", "other"),
+        "named-id": _Creature("named-id", "exact-id"),
+    }
+
+    resolved = resolve_local_graph_target(
+        topology, creatures, caller_id="caller-id", target="exact-id"
+    )
+
+    assert resolved.target_id == "exact-id"
+    assert resolved.matched_by == "runtime_id"
+    assert resolved.graph_id == graph_id
+
+
+@pytest.mark.parametrize("use_config_name", [False, True])
+def test_unique_display_or_config_name_resolves_inside_caller_graph(use_config_name):
+    topology, creatures, graph_a, _ = _two_graphs()
+    target = "reviewer"
+    if use_config_name:
+        creatures["reviewer-a"].name = "visible reviewer"
+        target = creatures["reviewer-a"].agent.config.name
+
+    resolved = resolve_local_graph_target(
+        topology, creatures, caller_id="root-a", target=target
+    )
+
+    assert resolved.target_id == "reviewer-a"
+    assert resolved.graph_id == graph_a
+    assert resolved.matched_by == "name"
+
+
+def test_cross_graph_same_names_never_cross_route():
+    topology, creatures, graph_a, graph_b = _two_graphs()
+
+    from_a = resolve_local_graph_target(
+        topology, creatures, caller_id="root-a", target="reviewer"
+    )
+    from_b = resolve_local_graph_target(
+        topology, creatures, caller_id="root-b", target="reviewer"
+    )
+
+    assert (from_a.target_id, from_a.graph_id) == ("reviewer-a", graph_a)
+    assert (from_b.target_id, from_b.graph_id) == ("reviewer-b", graph_b)
+
+
+def test_two_graphs_each_resolve_their_own_root_and_reviewer():
+    topology, creatures, _, _ = _two_graphs()
+
+    assert (
+        resolve_local_graph_target(
+            topology, creatures, caller_id="reviewer-a", target="root"
+        ).target_id
+        == "root-a"
+    )
+    assert (
+        resolve_local_graph_target(
+            topology, creatures, caller_id="root-a", target="reviewer"
+        ).target_id
+        == "reviewer-a"
+    )
+    assert (
+        resolve_local_graph_target(
+            topology, creatures, caller_id="reviewer-b", target="root"
+        ).target_id
+        == "root-b"
+    )
+    assert (
+        resolve_local_graph_target(
+            topology, creatures, caller_id="root-b", target="reviewer"
+        ).target_id
+        == "reviewer-b"
+    )
+
+
+def test_same_graph_name_ambiguity_fails_closed():
+    topology, creatures, graph_a, _ = _two_graphs()
+    add_creature(topology, "reviewer-a-2", graph_id=graph_a)
+    creatures["reviewer-a-2"] = _Creature("reviewer-a-2", "reviewer")
+
+    with pytest.raises(AmbiguousTargetError) as caught:
+        resolve_local_graph_target(
+            topology, creatures, caller_id="root-a", target="reviewer"
+        )
+
+    assert caught.value.code == "ambiguous_target"
+    assert caught.value.graph_id == graph_a
+    assert caught.value.candidate_ids == ("reviewer-a", "reviewer-a-2")
+
+
+def test_unknown_caller_name_does_not_fall_back_globally():
+    topology, creatures, _, _ = _two_graphs()
+
+    with pytest.raises(UnknownCallerError) as caught:
+        resolve_local_graph_target(
+            topology, creatures, caller_id="root", target="reviewer"
+        )
+
+    assert caught.value.code == "unknown_caller"
+    assert caught.value.caller_id == "root"
+
+
+@pytest.mark.parametrize("missing_graph", [False, True])
+def test_caller_without_resolvable_graph_fails_closed(missing_graph):
+    topology, creatures, graph_a, _ = _two_graphs()
+    if missing_graph:
+        topology.graphs.pop(graph_a)
+    else:
+        topology.creature_to_graph.pop("root-a")
+
+    with pytest.raises(CallerGraphNotFoundError) as caught:
+        resolve_local_graph_target(
+            topology, creatures, caller_id="root-a", target="reviewer"
+        )
+
+    assert caught.value.code == "caller_graph_not_found"
+
+
+def test_unknown_target_does_not_fall_back_to_other_graph():
+    topology, creatures, graph_a, _ = _two_graphs()
+    creatures["reviewer-a"].name = "critic"
+    creatures["reviewer-a"].agent.config.name = "critic"
+
+    with pytest.raises(TargetNotFoundError) as caught:
+        resolve_local_graph_target(
+            topology, creatures, caller_id="root-a", target="reviewer"
+        )
+
+    assert caught.value.code == "target_not_found"
+    assert caught.value.graph_id == graph_a
+
+
+def test_self_target_is_returned_for_caller_policy_to_decide():
+    topology, creatures, graph_a, _ = _two_graphs()
+
+    by_id = resolve_local_graph_target(
+        topology, creatures, caller_id="root-a", target="root-a"
+    )
+    by_name = resolve_local_graph_target(
+        topology, creatures, caller_id="root-a", target="root"
+    )
+
+    assert by_id.target_id == "root-a"
+    assert by_id.is_self is True
+    assert by_id.matched_by == "runtime_id"
+    assert by_name.target_id == "root-a"
+    assert by_name.is_self is True
+    assert by_name.matched_by == "name"
+    assert by_name.graph_id == graph_a
+
+
+def test_stale_runtime_id_in_topology_is_not_a_valid_target():
+    topology, creatures, graph_a, _ = _two_graphs()
+    add_creature(topology, "stale-id", graph_id=graph_a)
+
+    with pytest.raises(TargetNotFoundError):
+        resolve_local_graph_target(
+            topology, creatures, caller_id="root-a", target="stale-id"
+        )

--- a/tests/unit/terrarium/test_group_tool_context.py
+++ b/tests/unit/terrarium/test_group_tool_context.py
@@ -1,4 +1,4 @@
-"""Unit tests for :mod:`kohakuterrarium.terrarium.group_tool_context`."""
+﻿"""Unit tests for :mod:`kohakuterrarium.terrarium.group_tool_context`."""
 
 import weakref
 from types import SimpleNamespace
@@ -33,7 +33,15 @@ class _Creature:
 class _Engine:
     def __init__(self, creatures=None, graphs=None):
         self._creatures = creatures or {}
-        self._topology = SimpleNamespace(graphs=graphs or {})
+        graph_map = graphs or {}
+        creature_to_graph = {
+            creature_id: graph_id
+            for graph_id, graph in graph_map.items()
+            for creature_id in graph.creature_ids
+        }
+        self._topology = SimpleNamespace(
+            graphs=graph_map, creature_to_graph=creature_to_graph
+        )
 
 
 class _Env:
@@ -44,51 +52,23 @@ class _Env:
         return self._lookup.get(key)
 
 
-def _ctx(env=None, agent_name="caller"):
+def _ctx(env=None, agent_name="caller", creature_id="caller"):
     from pathlib import Path
 
     return ToolContext(
         agent_name=agent_name,
         session=None,
         working_dir=Path("."),
+        creature_id=creature_id,
         environment=env,
     )
-
-
-# ── find_creature ──────────────────────────────────────────────
-
-
-class TestFindCreature:
-    def test_by_id(self):
-        c = _Creature("cid-1")
-        eng = _Engine({"cid-1": c})
-        out = gtc.find_creature(eng, "cid-1")
-        assert out is c
-
-    def test_by_name(self):
-        c = _Creature("cid-1", name="alice")
-        eng = _Engine({"cid-1": c})
-        out = gtc.find_creature(eng, "alice")
-        assert out is c
-
-    def test_by_config_name(self):
-        c = _Creature("cid-1", name="alice")
-        c.agent.config.name = "alpha"
-        c.name = "other"
-        eng = _Engine({"cid-1": c})
-        out = gtc.find_creature(eng, "alpha")
-        assert out is c
-
-    def test_unknown(self):
-        eng = _Engine()
-        assert gtc.find_creature(eng, "ghost") is None
 
 
 # ── resolve_group_context ──────────────────────────────────────
 
 
 def _engine_with_graph(privileged=True):
-    g = SimpleNamespace(creature_ids={"caller"}, channels=set())
+    g = SimpleNamespace(graph_id="g1", creature_ids={"caller"}, channels=set())
     c = _Creature("caller", is_privileged=privileged)
     return _Engine({"caller": c}, graphs={"g1": g})
 
@@ -122,8 +102,22 @@ class TestResolveGroupContext:
     def test_unknown_caller_raises(self):
         eng = _engine_with_graph()
         env = _Env({TERRARIUM_ENGINE_KEY: eng})
-        ctx = _ctx(env=env, agent_name="ghost")
-        with pytest.raises(gtc.GroupToolError, match="not a creature"):
+        ctx = _ctx(env=env, agent_name="caller", creature_id="ghost")
+        with pytest.raises(gtc.GroupToolError, match="known runtime creature"):
+            gtc.resolve_group_context(ctx)
+
+    def test_caller_name_never_overrides_runtime_id(self):
+        eng = _engine_with_graph()
+        env = _Env({TERRARIUM_ENGINE_KEY: eng})
+        ctx = _ctx(env=env, agent_name="caller", creature_id="ghost")
+        with pytest.raises(gtc.GroupToolError, match="ghost"):
+            gtc.resolve_group_context(ctx)
+
+    def test_legacy_context_without_creature_id_is_explicitly_rejected(self):
+        eng = _engine_with_graph()
+        env = _Env({TERRARIUM_ENGINE_KEY: eng})
+        ctx = SimpleNamespace(agent_name="caller", environment=env)
+        with pytest.raises(gtc.GroupToolError, match="ToolContext.creature_id"):
             gtc.resolve_group_context(ctx)
 
     def test_require_privileged_rejects_non_privileged(self):
@@ -142,9 +136,9 @@ class TestResolveGroupContext:
 
     def test_missing_graph_raises(self):
         c = _Creature("caller", graph_id="g-orphan")
-        eng = _Engine({"caller": c}, graphs={})  # no g-orphan
+        eng = _Engine({"caller": c}, graphs={})
         env = _Env({TERRARIUM_ENGINE_KEY: eng})
-        with pytest.raises(gtc.GroupToolError, match="not present in topology"):
+        with pytest.raises(gtc.GroupToolError, match="not assigned to a graph"):
             gtc.resolve_group_context(_ctx(env=env))
 
     def test_dead_weakref(self):
@@ -172,47 +166,70 @@ class TestComputeGroup:
         group = gtc.compute_group(gctx)
         assert set(group.keys()) == {"a", "b"}
 
-    def test_includes_spawned_children(self):
+    def test_excludes_spawned_children_outside_graph(self):
         a = _Creature("a", graph_id="g1")
         child = _Creature("child", graph_id="g-other", parent_creature_id="a")
-        graph = SimpleNamespace(creature_ids={"a"})
-        eng = _Engine({"a": a, "child": child})
+        graph = SimpleNamespace(graph_id="g1", creature_ids={"a"})
+        eng = _Engine({"a": a, "child": child}, graphs={"g1": graph})
         gctx = gtc.GroupContext(engine=eng, caller=a, graph=graph)
         group = gtc.compute_group(gctx)
-        assert "child" in group
+        assert "child" not in group
 
 
 class TestResolveGroupTarget:
-    def test_by_id(self):
-        a = _Creature("a", graph_id="g1")
-        b = _Creature("b", graph_id="g1")
-        graph = SimpleNamespace(creature_ids={"a", "b"})
-        eng = _Engine({"a": a, "b": b})
-        gctx = gtc.GroupContext(engine=eng, caller=a, graph=graph)
-        assert gtc.resolve_group_target(gctx, "b") is b
+    @staticmethod
+    def _context(*creatures):
+        graph = SimpleNamespace(
+            graph_id="g1", creature_ids={creature.creature_id for creature in creatures}
+        )
+        engine = _Engine(
+            {creature.creature_id: creature for creature in creatures},
+            graphs={"g1": graph},
+        )
+        return gtc.GroupContext(engine=engine, caller=creatures[0], graph=graph)
 
-    def test_by_name(self):
-        a = _Creature("cid-a", name="alice", graph_id="g1")
-        graph = SimpleNamespace(creature_ids={"cid-a"})
-        eng = _Engine({"cid-a": a})
-        gctx = gtc.GroupContext(engine=eng, caller=a, graph=graph)
-        assert gtc.resolve_group_target(gctx, "alice") is a
+    def test_by_id(self):
+        a = _Creature("a")
+        b = _Creature("b")
+        assert gtc.resolve_group_target(self._context(a, b), "b") is b
+
+    def test_exact_self_send_uses_runtime_id(self):
+        a = _Creature("caller", name="shared")
+        b = _Creature("other", name="shared")
+        assert gtc.resolve_group_target(self._context(a, b), "caller") is a
 
     def test_by_config_name(self):
-        a = _Creature("cid-a", name="alice", graph_id="g1")
+        a = _Creature("cid-a", name="alice")
         a.agent.config.name = "alpha"
         a.name = "other"
-        graph = SimpleNamespace(creature_ids={"cid-a"})
-        eng = _Engine({"cid-a": a})
-        gctx = gtc.GroupContext(engine=eng, caller=a, graph=graph)
-        assert gtc.resolve_group_target(gctx, "alpha") is a
+        assert gtc.resolve_group_target(self._context(a), "alpha") is a
 
-    def test_unknown_returns_none(self):
-        a = _Creature("a", graph_id="g1")
-        graph = SimpleNamespace(creature_ids={"a"})
-        eng = _Engine({"a": a})
-        gctx = gtc.GroupContext(engine=eng, caller=a, graph=graph)
-        assert gtc.resolve_group_target(gctx, "ghost") is None
+    def test_duplicate_display_name_is_ambiguous(self):
+        a = _Creature("a", name="same")
+        b = _Creature("b", name="same")
+        with pytest.raises(gtc.GroupToolError, match="ambiguous"):
+            gtc.resolve_group_target(self._context(a, b), "same")
+
+    def test_duplicate_config_name_is_ambiguous(self):
+        a = _Creature("a")
+        b = _Creature("b")
+        a.agent.config.name = b.agent.config.name = "same-config"
+        with pytest.raises(gtc.GroupToolError, match="ambiguous"):
+            gtc.resolve_group_target(self._context(a, b), "same-config")
+
+    def test_cross_graph_exact_id_is_rejected(self):
+        a = _Creature("a")
+        other = _Creature("other", graph_id="g2")
+        graph = SimpleNamespace(graph_id="g1", creature_ids={"a"})
+        engine = _Engine({"a": a, "other": other}, graphs={"g1": graph})
+        gctx = gtc.GroupContext(engine=engine, caller=a, graph=graph)
+        with pytest.raises(gtc.GroupToolError, match="not a creature"):
+            gtc.resolve_group_target(gctx, "other")
+
+    def test_unknown_fails_closed(self):
+        a = _Creature("a")
+        with pytest.raises(gtc.GroupToolError, match="not a creature"):
+            gtc.resolve_group_target(self._context(a), "ghost")
 
 
 # ── CF-7: cross-cluster awareness ──────────────────────────────

--- a/tests/unit/terrarium/test_group_tools_branches.py
+++ b/tests/unit/terrarium/test_group_tools_branches.py
@@ -423,31 +423,19 @@ class TestGroupWireBranches:
         assert result.error
         assert "environment" in result.error
 
-    async def test_cross_graph_merge_failure(self, monkeypatch):
-        """A failed ``ensure_same_graph`` during a cross-graph wire
-        surfaces as 'cross-graph merge failed'."""
+    async def test_cross_graph_target_is_rejected_without_merge(self, monkeypatch):
         caller = SimpleNamespace(creature_id="root", name="root", graph_id="g1")
-        from_c = SimpleNamespace(creature_id="root", name="root", graph_id="g1")
-        to_c = SimpleNamespace(creature_id="bob", name="bob", graph_id="g2")
         gctx = SimpleNamespace(engine=SimpleNamespace(), caller=caller)
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        seq = iter([from_c, to_c])
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: next(seq))
-
-        async def _boom(engine, a, b):
-            raise RuntimeError("merge denied")
-
-        monkeypatch.setattr(wire_mod._channels, "ensure_same_graph", _boom)
+        target_error = wire_mod.err("target is outside caller graph")
+        monkeypatch.setattr(
+            wire_mod,
+            "resolve_target_or_error",
+            lambda *args: (None, target_error),
+        )
         result = await wire_mod.GroupWireTool()._execute({"action": "add", "to": "bob"})
-        assert "cross-graph merge failed" in result.error
+        assert "outside caller graph" in result.error
 
-
-# ---------------------------------------------------------------------------
-# group lifecycle tools — resolution-error propagation
-# ---------------------------------------------------------------------------
-
-
-class TestLifecycleResolutionErrors:
     async def test_remove_node_resolution_error(self):
         tool = lifecycle_mod.GroupRemoveNodeTool()
         result = await tool._execute(

--- a/tests/unit/terrarium/test_group_tools_engine.py
+++ b/tests/unit/terrarium/test_group_tools_engine.py
@@ -48,6 +48,7 @@ def _ctx_for(engine, creature):
     env = engine._environments[creature.graph_id]
     return ToolContext(
         agent_name=creature.name,
+        creature_id=creature.creature_id,
         session=None,
         working_dir=Path("."),
         environment=env,
@@ -391,10 +392,8 @@ class TestGroupChannelWire:
         finally:
             await t.shutdown()
 
-    async def test_cross_graph_wire_merges_graphs(self):
-        """When the target is a spawned child still in its own
-        singleton graph, ``wire`` routes through ``engine.connect`` and
-        the two graphs merge — graph stays a connected component."""
+    async def test_cross_graph_wire_fails_closed(self):
+        """A spawned child in another graph cannot be implicitly merged."""
         t = await (
             TestTerrariumBuilder()
             .with_creature("root")
@@ -403,15 +402,11 @@ class TestGroupChannelWire:
             .build()
         )
         t.get_creature("root").is_privileged = True
-        # ``bob`` is a child of root → in root's *group* even though it
-        # lives in its own graph (the freshly-spawned-worker case).
         t.get_creature("bob").parent_creature_id = "root"
         try:
             root = t.get_creature("root")
             bob = t.get_creature("bob")
-            assert root.graph_id != bob.graph_id
-            tool = channel_mod.GroupChannelTool()
-            result = await tool._execute(
+            result = await channel_mod.GroupChannelTool()._execute(
                 {
                     "action": "wire",
                     "channel": "bridge",
@@ -420,16 +415,13 @@ class TestGroupChannelWire:
                 },
                 context=_ctx_for(t, root),
             )
-            body = _parse(result)
-            assert body["merged"] is True
-            # Invariant: graph = connected component → now one graph.
-            assert root.graph_id == bob.graph_id
-            assert len(t.list_graphs()) == 1
+            assert result.error is not None
+            assert "not a creature in caller" in result.error
+            assert root.graph_id != bob.graph_id
+            assert len(t.list_graphs()) == 2
         finally:
             await t.shutdown()
 
-
-class TestGroupChannelUnwire:
     async def test_unwire_listen_removes_edge(self):
         t = await (
             TestTerrariumBuilder()

--- a/tests/unit/terrarium/test_multi_node_cross.py
+++ b/tests/unit/terrarium/test_multi_node_cross.py
@@ -7,6 +7,7 @@ give the host's coordination engine a fake ``_broadcast_adapter``, and
 drive the cross-node branches.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -63,6 +64,31 @@ class _FakeBroadcast:
 
 
 class TestCrossNodeConnect:
+    async def test_concurrent_connects_cannot_merge_duplicate_names_transitively(self):
+        svc = _make_service(
+            remote_specs={
+                "w1": [_info("alice", name="duplicate", graph_id="g-w1")],
+                "w2": [_info("bridge", name="bridge", graph_id="g-w2")],
+                "w3": [_info("carol", name="duplicate", graph_id="g-w3")],
+            }
+        )
+        svc._home.update({"alice": "w1", "bridge": "w2", "carol": "w3"})
+
+        async def noop_wire(*args, **kwargs):
+            return None
+
+        for remote in svc._remotes.values():
+            remote.wire_creature = noop_wire
+
+        results = await asyncio.gather(
+            svc.connect("alice", "bridge", channel="left"),
+            svc.connect("bridge", "carol", channel="right"),
+            return_exceptions=True,
+        )
+
+        assert sum(isinstance(item, GraphNameConflictError) for item in results) == 1
+        assert len(svc._cluster_links) == 1
+
     async def test_connect_rejects_non_endpoint_duplicate_alias(self, cross_svc):
         cross_svc._remotes["w1"]._creatures.append(
             _info("left-worker", name="worker", graph_id="g-w1")
@@ -178,6 +204,22 @@ class TestCrossNodeConnect:
 
 
 class TestCrossNodeDisconnect:
+    async def test_disconnect_keeps_cluster_link_until_last_channel_is_removed(
+        self, cross_svc
+    ):
+        cross_svc._coordination_engine = SimpleNamespace(
+            _broadcast_adapter=_FakeBroadcast()
+        )
+        await cross_svc.connect("alice", "bob", channel="chat")
+        await cross_svc.connect("alice", "bob", channel="review")
+        link = frozenset({("w1", "g-w1"), ("w2", "g-w2")})
+
+        await cross_svc.disconnect("alice", "bob", channel="chat")
+        assert link in cross_svc._cluster_links
+
+        await cross_svc.disconnect("alice", "bob", channel="review")
+        assert link not in cross_svc._cluster_links
+
     async def test_disconnect_explicit_channel(self, cross_svc):
         cross_svc._coordination_engine = SimpleNamespace(
             _broadcast_adapter=_FakeBroadcast()

--- a/tests/unit/terrarium/test_multi_node_cross.py
+++ b/tests/unit/terrarium/test_multi_node_cross.py
@@ -10,6 +10,7 @@ drive the cross-node branches.
 from types import SimpleNamespace
 
 import pytest
+from unittest.mock import AsyncMock
 
 from kohakuterrarium.terrarium.events import ConnectionResult, DisconnectionResult
 
@@ -24,8 +25,8 @@ def cross_svc():
     """Service with alice on worker-1, bob on worker-2."""
     svc = _make_service(
         remote_specs={
-            "w1": [_info("alice", graph_id="g-w1")],
-            "w2": [_info("bob", graph_id="g-w2")],
+            "w1": [_info("alice", name="alice", graph_id="g-w1")],
+            "w2": [_info("bob", name="bob", graph_id="g-w2")],
         }
     )
     # Prime the home registry.
@@ -39,6 +40,12 @@ def cross_svc():
 
     svc._remotes["w1"].wire_creature = _noop_wire
     svc._remotes["w2"].wire_creature = _noop_wire
+    svc._remotes["w1"].list_creatures = AsyncMock(
+        return_value=tuple(svc._remotes["w1"]._creatures)
+    )
+    svc._remotes["w2"].list_creatures = AsyncMock(
+        return_value=tuple(svc._remotes["w2"]._creatures)
+    )
     return svc
 
 
@@ -55,6 +62,25 @@ class _FakeBroadcast:
 
 
 class TestCrossNodeConnect:
+    async def test_connect_rejects_non_endpoint_duplicate_alias(self, cross_svc):
+        from kohakuterrarium.terrarium.graph_identity import GraphNameConflictError
+
+        cross_svc._remotes["w1"]._creatures.append(
+            _info("left-worker", name="worker", graph_id="g-w1")
+        )
+        cross_svc._remotes["w2"]._creatures.append(
+            _info("right-worker", name="worker", graph_id="g-w2")
+        )
+        cross_svc._remotes["w1"].list_creatures.return_value = tuple(
+            cross_svc._remotes["w1"]._creatures
+        )
+        cross_svc._remotes["w2"].list_creatures.return_value = tuple(
+            cross_svc._remotes["w2"]._creatures
+        )
+        with pytest.raises(GraphNameConflictError):
+            await cross_svc.connect("alice", "bob", channel="chat")
+        assert not cross_svc._cluster_links
+
     async def test_connect_explicit_channel(self, cross_svc):
         cross_svc._coordination_engine = SimpleNamespace(
             _broadcast_adapter=_FakeBroadcast()

--- a/tests/unit/terrarium/test_multi_node_cross.py
+++ b/tests/unit/terrarium/test_multi_node_cross.py
@@ -8,11 +8,12 @@ drive the cross-node branches.
 """
 
 from types import SimpleNamespace
-
-import pytest
 from unittest.mock import AsyncMock
 
+import pytest
+
 from kohakuterrarium.terrarium.events import ConnectionResult, DisconnectionResult
+from kohakuterrarium.terrarium.graph_identity import GraphNameConflictError
 
 from tests.unit.terrarium.test_multi_node_service import (
     _info,
@@ -63,8 +64,6 @@ class _FakeBroadcast:
 
 class TestCrossNodeConnect:
     async def test_connect_rejects_non_endpoint_duplicate_alias(self, cross_svc):
-        from kohakuterrarium.terrarium.graph_identity import GraphNameConflictError
-
         cross_svc._remotes["w1"]._creatures.append(
             _info("left-worker", name="worker", graph_id="g-w1")
         )
@@ -80,6 +79,46 @@ class TestCrossNodeConnect:
         with pytest.raises(GraphNameConflictError):
             await cross_svc.connect("alice", "bob", channel="chat")
         assert not cross_svc._cluster_links
+
+    async def test_connect_rejects_duplicate_alias_on_non_endpoint_cluster_members(
+        self,
+    ):
+        svc = _make_service(
+            remote_specs={
+                "w1": [_info("alice", name="alice", graph_id="g-w1")],
+                "w2": [_info("left-worker", name="worker", graph_id="g-w2")],
+                "w3": [_info("bob", name="bob", graph_id="g-w3")],
+                "w4": [_info("right-worker", name="worker", graph_id="g-w4")],
+            }
+        )
+        svc._home.update({"alice": "w1", "bob": "w3"})
+        svc._cluster_links.update(
+            {
+                frozenset({("w1", "g-w1"), ("w2", "g-w2")}),
+                frozenset({("w3", "g-w3"), ("w4", "g-w4")}),
+            }
+        )
+
+        async def noop_wire(*args, **kwargs):
+            return None
+
+        for remote in svc._remotes.values():
+            remote.wire_creature = noop_wire
+
+        with pytest.raises(GraphNameConflictError, match="worker"):
+            await svc.connect("alice", "bob", channel="chat")
+        assert len(svc._cluster_links) == 2
+
+    async def test_connect_allows_another_channel_inside_existing_cluster(
+        self, cross_svc
+    ):
+        cross_svc._cluster_links.add(frozenset({("w1", "g-w1"), ("w2", "g-w2")}))
+
+        result = await cross_svc.connect("alice", "bob", channel="review")
+
+        assert result.channel == "review"
+        assert result.delta_kind == "cross_node"
+        assert len(cross_svc._cluster_links) == 1
 
     async def test_connect_explicit_channel(self, cross_svc):
         cross_svc._coordination_engine = SimpleNamespace(

--- a/tests/unit/terrarium/test_multi_node_more.py
+++ b/tests/unit/terrarium/test_multi_node_more.py
@@ -626,6 +626,7 @@ class TestCrossNodeChannelReplication:
         svc = _make_service()
         svc._remotes = {"w1": w1, "w2": w2}
         svc._home = {"a": "w1", "b": "w2"}
+        svc._cluster_links.add(frozenset({("w1", "g_a"), ("w2", "g_b")}))
 
         # Fake broadcast adapter to capture the cross-subscribe call.
         proxy_calls: list[dict] = []
@@ -731,6 +732,7 @@ class TestCrossNodeChannelReplication:
         svc = _make_service()
         svc._remotes = {"w1": w1, "w2": w2}
         svc._home = {"a": "w1", "b": "w2"}
+        svc._cluster_links.add(frozenset({("w1", "g_a"), ("w2", "g_b")}))
 
         proxy_calls: list[dict] = []
 
@@ -763,9 +765,12 @@ class TestCrossNodeChannelReplication:
         )
         svc = _make_service()
         svc._remotes = {"w1": w1}
-        out = await svc._find_channel_elsewhere("X", exclude="w1")
+        svc._cluster_links.add(frozenset({("w1", "g_a"), ("w2", "g_target")}))
+        out = await svc._find_channel_elsewhere("X", exclude="w1", graph_id="g_target")
         assert out is None
-        out2 = await svc._find_channel_elsewhere("X", exclude="other")
+        out2 = await svc._find_channel_elsewhere(
+            "X", exclude="other", graph_id="g_target"
+        )
         assert out2 == ("w1", "g_a")
 
     async def test_find_channel_elsewhere_swallows_worker_failure(self):
@@ -785,7 +790,10 @@ class TestCrossNodeChannelReplication:
         )
         svc = _make_service()
         svc._remotes = {"bad": broken, "w1": good}
-        out = await svc._find_channel_elsewhere("X", exclude="other")
+        svc._cluster_links.add(frozenset({("w1", "g_a"), ("w2", "g_target")}))
+        out = await svc._find_channel_elsewhere(
+            "X", exclude="other", graph_id="g_target"
+        )
         assert out == ("w1", "g_a")
 
 
@@ -958,6 +966,7 @@ class TestClusterGraphSnapshot:
         svc = _make_service()
         svc._remotes = {"w1": w1, "w2": w2}
         svc._home = {"a": "w1", "b": "w2"}
+        svc._cluster_links.add(frozenset({("w1", "g_a"), ("w2", "g_b")}))
 
         class _FakeBcast:
             async def proxy_subscribe(self, **kw):
@@ -1007,8 +1016,8 @@ class TestListCreaturesResilience:
         # Pre-populate the cache as if a prior list_creatures had
         # succeeded for both workers.
         svc._creature_name_cache = {
-            "alpha": ("w1", "c_alpha"),
-            "c_alpha": ("w1", "c_alpha"),
+            "alpha": {("g-alpha", "w1", "c_alpha")},
+            "c_alpha": {("g-alpha", "w1", "c_alpha")},
         }
         svc._home = {"c_alpha": "w1"}
 
@@ -1022,13 +1031,13 @@ class TestListCreaturesResilience:
         # wiped, cross-node output wiring couldn't resolve it, the UI
         # treated w1 creatures as offline.
         cache = svc._creature_name_cache
-        assert cache.get("alpha") == ("w1", "c_alpha"), (
-            "failed worker's prior name-cache entry was wiped — this "
+        expected_alpha = {("g-alpha", "w1", "c_alpha")}
+        assert cache.get("alpha") == expected_alpha, (
+            "failed worker's prior name-cache entry was wiped ? this "
             "is the offline cascade.  Cache: " + repr(cache)
         )
-        assert cache.get("c_alpha") == ("w1", "c_alpha")
-        # And the new worker's entry was merged in.
-        assert cache.get("bravo") == ("w2", "c_good")
+        assert cache.get("c_alpha") == expected_alpha
+        assert cache.get("bravo") == {("g_w2", "w2", "c_good")}
 
     async def test_fan_out_runs_in_parallel(self):
         # If listed sequentially, a slow worker holds up every fast one.

--- a/tests/unit/terrarium/test_multi_node_service.py
+++ b/tests/unit/terrarium/test_multi_node_service.py
@@ -321,8 +321,9 @@ class TestListCreatures:
     async def test_populates_name_cache(self):
         svc = _make_service(remote_specs={"w1": [_info("c1", name="alice")]})
         await svc.list_creatures()
-        assert svc._creature_name_cache["alice"] == ("w1", "c1")
-        assert svc._creature_name_cache["c1"] == ("w1", "c1")
+        expected = {("g", "w1", "c1")}
+        assert svc._creature_name_cache["alice"] == expected
+        assert svc._creature_name_cache["c1"] == expected
 
     async def test_remote_failure_swallowed(self):
         svc = _make_service(remote_specs={"w1": []})
@@ -402,8 +403,11 @@ class TestLifecycle:
         svc = _make_service(remote_specs={"w1": []})
         info = await svc.add_creature(None, on_node="w1")
         assert info.creature_id == "new-cid"
-        # Home is recorded.
+        # Home and exact graph-scoped aliases are recorded immediately.
         assert svc._home["new-cid"] == "w1"
+        expected = {("g", "w1", "new-cid")}
+        assert svc._creature_name_cache["new-cid"] == expected
+        assert svc._creature_name_cache["new"] == expected
 
     async def test_add_creature_default_host_rejected(self):
         # The default ``on_node="_host"`` is rejected — the host runs

--- a/tests/unit/terrarium/test_output_wiring.py
+++ b/tests/unit/terrarium/test_output_wiring.py
@@ -289,6 +289,42 @@ class TestSafeDeliver:
 # ── _log_task_error ──────────────────────────────────────────────
 
 
+class TestGraphLocalOutputResolution:
+    def test_same_name_in_other_graph_does_not_win(self):
+        from types import SimpleNamespace
+
+        from kohakuterrarium.terrarium.topology import GraphTopology, TopologyState
+
+        source = _FakeCreature("source", creature_id="source")
+        local = _FakeCreature("worker", creature_id="local")
+        foreign = _FakeCreature("worker", creature_id="foreign")
+        creatures = {
+            source.creature_id: source,
+            local.creature_id: local,
+            foreign.creature_id: foreign,
+        }
+        topology = TopologyState(
+            graphs={
+                "g-local": GraphTopology(
+                    graph_id="g-local", creature_ids={"source", "local"}
+                ),
+                "g-foreign": GraphTopology(
+                    graph_id="g-foreign", creature_ids={"foreign"}
+                ),
+            },
+            creature_to_graph={
+                "source": "g-local",
+                "local": "g-local",
+                "foreign": "g-foreign",
+            },
+        )
+        engine = SimpleNamespace(_creatures=creatures, _topology=topology)
+        resolver = TerrariumOutputWiringResolver(creatures, engine=engine)
+
+        assert resolver._resolve_target("worker", source="source") is local.agent
+        assert resolver._resolve_target("foreign", source="source") is None
+
+
 class TestLogTaskError:
     async def test_cancelled_task_no_log(self):
         async def coro():

--- a/tests/unit/terrarium/test_output_wiring.py
+++ b/tests/unit/terrarium/test_output_wiring.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 
 from kohakuterrarium.core.output_wiring import ROOT_TARGET, OutputWiringEntry
@@ -10,6 +11,7 @@ from kohakuterrarium.terrarium.output_wiring import (
     _log_task_error,
     _safe_deliver,
 )
+from kohakuterrarium.terrarium.topology import GraphTopology, TopologyState
 
 # ── fakes ─────────────────────────────────────────────────────────
 
@@ -87,6 +89,35 @@ class TestResolveTarget:
         out = r._resolve_target(ROOT_TARGET, source="src")
         assert out is rb.agent
 
+    def test_engine_backed_root_uses_topology_not_stale_handle_graph(self):
+        ra = _FakeCreature("ra", is_privileged=True, graph_id="stale")
+        rb = _FakeCreature("rb", is_privileged=True, graph_id="g2")
+        source = _FakeCreature("src", graph_id="g2")
+        creatures = {"ra": ra, "rb": rb, "src": source}
+        topology = TopologyState(
+            graphs={
+                "g1": GraphTopology(graph_id="g1", creature_ids={"ra", "src"}),
+                "g2": GraphTopology(graph_id="g2", creature_ids={"rb"}),
+            },
+            creature_to_graph={"ra": "g1", "rb": "g2", "src": "g1"},
+        )
+        engine = SimpleNamespace(_topology=topology)
+        r = TerrariumOutputWiringResolver(creatures, engine=engine)
+
+        assert r._resolve_target(ROOT_TARGET, source="src") is ra.agent
+
+    def test_engine_backed_root_rejects_unknown_source(self):
+        root = _FakeCreature("root", is_privileged=True, graph_id="g")
+        topology = TopologyState(
+            graphs={"g": GraphTopology(graph_id="g", creature_ids={"root"})},
+            creature_to_graph={"root": "g"},
+        )
+        r = TerrariumOutputWiringResolver(
+            {"root": root}, engine=SimpleNamespace(_topology=topology)
+        )
+
+        assert r._resolve_target(ROOT_TARGET, source="forged") is None
+
 
 # ── _warn_once ───────────────────────────────────────────────────
 
@@ -142,6 +173,44 @@ class TestTargetIdentity:
 
 
 class TestEmit:
+    async def test_remote_event_preserves_standard_target_context(self):
+        forwarded = asyncio.Event()
+
+        class _Forwarder:
+            payload = None
+
+            def peer_for_target(self, target, *, graph_id):
+                return "_host"
+
+            async def forward_event(self, **kwargs):
+                self.payload = kwargs
+                forwarded.set()
+                return True
+
+        source = _FakeCreature("source", creature_id="source", graph_id="g")
+        topology = TopologyState(
+            graphs={"g": GraphTopology(graph_id="g", creature_ids={"source"})},
+            creature_to_graph={"source": "g"},
+        )
+        forwarder = _Forwarder()
+        engine = SimpleNamespace(
+            _creatures={"source": source},
+            _topology=topology,
+            _output_wire_adapter=forwarder,
+        )
+        resolver = TerrariumOutputWiringResolver(engine._creatures, engine=engine)
+
+        await resolver.emit(
+            source="source",
+            content="hello",
+            source_event_type="turn_end",
+            turn_index=7,
+            entries=[OutputWiringEntry(to="remote-target")],
+        )
+        await asyncio.wait_for(forwarded.wait(), timeout=1)
+
+        assert forwarder.payload["event"]["context"]["target"] == "remote-target"
+
     async def test_unknown_target_skipped(self):
         r = TerrariumOutputWiringResolver({})
         await r.emit(

--- a/tests/unit/terrarium/test_recipe.py
+++ b/tests/unit/terrarium/test_recipe.py
@@ -7,7 +7,7 @@ shape, which our fake satisfies.
 
 from pathlib import Path
 
-
+import pytest
 from kohakuterrarium.terrarium import recipe as recipe_mod
 from kohakuterrarium.terrarium.config import (
     ChannelConfig,
@@ -60,6 +60,42 @@ class TestResolveRecipe:
 
 
 class TestApplyRecipe:
+    async def test_duplicate_names_fail_before_creating_a_partial_graph(self):
+        engine = Terrarium()
+        try:
+            recipe = _recipe(
+                creatures=[_creature_cfg("worker"), _creature_cfg("worker")]
+            )
+            with pytest.raises(ValueError, match="duplicate"):
+                await recipe_mod.apply_recipe(
+                    engine, recipe, creature_builder=_fake_builder
+                )
+            assert engine.list_graphs() == []
+            assert engine.list_creatures() == []
+        finally:
+            await engine.shutdown()
+
+    async def test_existing_name_conflict_does_not_declare_recipe_channels(self):
+        engine = Terrarium()
+        try:
+            existing = _fake_builder(_creature_cfg("worker"), creature_id="existing")
+            await engine.add_creature(existing, start=False, session=False)
+            graph = engine.get_graph(existing.graph_id)
+            with pytest.raises(ValueError, match="already contains creature name"):
+                await recipe_mod.apply_recipe(
+                    engine,
+                    _recipe(
+                        creatures=[_creature_cfg("worker")],
+                        channels=[ChannelConfig(name="should-not-exist")],
+                    ),
+                    graph=graph.graph_id,
+                    creature_builder=_fake_builder,
+                )
+            assert graph.creature_ids == {"existing"}
+            assert graph.channels == {}
+        finally:
+            await engine.shutdown()
+
     async def test_empty_recipe(self):
         engine = Terrarium()
         try:

--- a/tests/unit/terrarium/test_runtime_prompt.py
+++ b/tests/unit/terrarium/test_runtime_prompt.py
@@ -155,6 +155,40 @@ class TestBuildRuntimeGraphSection:
         finally:
             await t.shutdown()
 
+    async def test_foreign_graph_wiring_is_not_rendered(self):
+        t = await (
+            TestTerrariumBuilder()
+            .with_creature("alice")
+            .with_creature("local-worker")
+            .build()
+        )
+        try:
+            alice = t.get_creature("alice")
+            foreign = t.get_creature("local-worker")
+            foreign.creature_id = "foreign-id"
+            foreign.name = "worker"
+            foreign.graph_id = "foreign-graph"
+            t._creatures.pop("local-worker")
+            t._creatures[foreign.creature_id] = foreign
+            t._topology.graphs[alice.graph_id].creature_ids.discard("local-worker")
+            from kohakuterrarium.terrarium.topology import GraphTopology
+
+            t._topology.graphs[foreign.graph_id] = GraphTopology(
+                graph_id=foreign.graph_id,
+                creature_ids={foreign.creature_id},
+            )
+            t._topology.creature_to_graph.pop("local-worker", None)
+            t._topology.creature_to_graph[foreign.creature_id] = foreign.graph_id
+            foreign.agent.config.output_wiring = [{"to": alice.name}]
+            alice.agent.config.output_wiring = [{"to": foreign.creature_id}]
+
+            out = rp.build_runtime_graph_section(t, alice)
+
+            assert "foreign-id" not in out
+            assert "worker" not in out
+        finally:
+            await t.shutdown()
+
     async def test_privileged_with_spawned_child(self):
         t = await TestTerrariumBuilder().with_creature("alice").build()
         try:
@@ -280,16 +314,19 @@ class TestOutputWiringInSection:
             await t.shutdown()
 
     async def test_outbound_output_wires(self):
-        t = await TestTerrariumBuilder().with_creature("alice").build()
+        t = await (
+            TestTerrariumBuilder().with_creature("alice").with_creature("bob").build()
+        )
         try:
             alice = t.get_creature("alice")
+            bob = t.get_creature("bob")
             alice.agent.config = SimpleNamespace(
                 name="alice",
-                output_wiring=[SimpleNamespace(to="bob")],
+                output_wiring=[SimpleNamespace(to=bob.creature_id)],
             )
             out = rp.build_runtime_graph_section(t, alice)
             assert "outbound to" in out
-            assert "bob" in out
+            assert bob.creature_id in out
         finally:
             await t.shutdown()
 

--- a/tests/unit/terrarium/test_service.py
+++ b/tests/unit/terrarium/test_service.py
@@ -68,6 +68,17 @@ class TestCreatureToInfo:
         finally:
             await svc.shutdown()
 
+    async def test_snapshot_preserves_distinct_config_name_alias(self):
+        svc = await _make_service()
+        try:
+            engine_creature = svc.engine.get_creature("alice")
+            engine_creature.name = "display-alice"
+            info = creature_to_info(engine_creature)
+            assert info.name == "display-alice"
+            assert info.config_name == "alice"
+        finally:
+            await svc.shutdown()
+
 
 # ── Protocol surface conformance ────────────────────────────────
 

--- a/tests/unit/terrarium/test_service_delegates.py
+++ b/tests/unit/terrarium/test_service_delegates.py
@@ -454,8 +454,9 @@ class TestWiring:
 
     async def test_wire_output(self):
         svc, _ = _build_service()
-        out = await svc.wire_output("cid", "to-name")
+        out = await svc.wire_output("cid", "root")
         assert out["edge_id"] == "edge-1"
+        svc._engine.wire_output.assert_awaited_once_with("cid", {"to": "root"})
 
     async def test_unwire_output(self):
         svc, _ = _build_service()

--- a/tests/unit/terrarium/test_tools_group_send_wire.py
+++ b/tests/unit/terrarium/test_tools_group_send_wire.py
@@ -110,16 +110,37 @@ class TestGroupSend:
         monkeypatch.setattr(
             send_mod, "resolve_or_error", lambda c, **_: (_gctx(), None)
         )
-        monkeypatch.setattr(send_mod, "resolve_group_target", lambda g, n: None)
+        monkeypatch.setattr(
+            send_mod,
+            "resolve_target_or_error",
+            lambda g, n: (None, send_mod.err("not in your group")),
+        )
         r = await send_mod.GroupSendTool()._execute({"to": "ghost", "message": "m"})
         assert "not in your group" in r.error
+
+    async def test_self_send_is_rejected(self, monkeypatch):
+        caller = _FakeCreature(cid="caller", name="caller")
+        gctx = _gctx(caller=caller)
+        monkeypatch.setattr(send_mod, "resolve_or_error", lambda c, **_: (gctx, None))
+        monkeypatch.setattr(
+            send_mod,
+            "resolve_target_or_error",
+            lambda g, n: (caller, None),
+        )
+        result = await send_mod.GroupSendTool()._execute(
+            {"to": "caller", "message": "loop"}
+        )
+        assert "cannot target the caller itself" in result.error
+        caller.agent._process_event.assert_not_called()
 
     async def test_target_not_running(self, monkeypatch):
         monkeypatch.setattr(
             send_mod, "resolve_or_error", lambda c, **_: (_gctx(), None)
         )
         target = _FakeCreature(is_running=False)
-        monkeypatch.setattr(send_mod, "resolve_group_target", lambda g, n: target)
+        monkeypatch.setattr(
+            send_mod, "resolve_target_or_error", lambda g, n: (target, None)
+        )
         r = await send_mod.GroupSendTool()._execute({"to": "t", "message": "m"})
         assert "is not running" in r.error
 
@@ -129,7 +150,9 @@ class TestGroupSend:
         )
         monkeypatch.setattr(send_mod, "resolve_or_error", lambda c, **_: (gctx, None))
         target = _FakeCreature(is_privileged=False)
-        monkeypatch.setattr(send_mod, "resolve_group_target", lambda g, n: target)
+        monkeypatch.setattr(
+            send_mod, "resolve_target_or_error", lambda g, n: (target, None)
+        )
         r = await send_mod.GroupSendTool()._execute({"to": "t", "message": "m"})
         assert "non-privileged" in r.error
 
@@ -137,7 +160,9 @@ class TestGroupSend:
         gctx = _gctx()
         monkeypatch.setattr(send_mod, "resolve_or_error", lambda c, **_: (gctx, None))
         target = _FakeCreature(name="bob")
-        monkeypatch.setattr(send_mod, "resolve_group_target", lambda g, n: target)
+        monkeypatch.setattr(
+            send_mod, "resolve_target_or_error", lambda g, n: (target, None)
+        )
         r = await send_mod.GroupSendTool()._execute({"to": "bob", "message": "hi"})
         body = _parse(r)
         assert body["delivered"] is True
@@ -156,7 +181,9 @@ class TestGroupSend:
                 (t, d, metadata)
             )
         )
-        monkeypatch.setattr(send_mod, "resolve_group_target", lambda g, n: target)
+        monkeypatch.setattr(
+            send_mod, "resolve_target_or_error", lambda g, n: (target, None)
+        )
         r = await send_mod.GroupSendTool()._execute({"to": "bob", "message": "hi"})
         assert _parse(r)["delivered"] is True
         assert [t for t, _, _ in activities] == ["wire_inbound"]
@@ -305,7 +332,11 @@ class TestGroupWire:
         monkeypatch.setattr(
             wire_mod, "resolve_or_error", lambda c, **_: (_gctx(), None)
         )
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: None)
+        monkeypatch.setattr(
+            wire_mod,
+            "resolve_target_or_error",
+            lambda g, n: (None, wire_mod.err("not in your group")),
+        )
         r = await wire_mod.GroupWireTool()._execute({"action": "add"})
         assert "not in your group" in r.error
 
@@ -314,8 +345,8 @@ class TestGroupWire:
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
         monkeypatch.setattr(
             wire_mod,
-            "resolve_group_target",
-            lambda g, n: gctx.caller,
+            "resolve_target_or_error",
+            lambda g, n: (gctx.caller, None),
         )
         r = await wire_mod.GroupWireTool()._execute({"action": "add"})
         assert "'to' is required" in r.error
@@ -323,9 +354,12 @@ class TestGroupWire:
     async def test_add_to_unknown(self, monkeypatch):
         gctx = _gctx()
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        # First call returns from_creature (caller), second call returns None
-        seq = iter([gctx.caller, None])
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: next(seq))
+        responses = iter(
+            [(gctx.caller, None), (None, wire_mod.err("not in your group"))]
+        )
+        monkeypatch.setattr(
+            wire_mod, "resolve_target_or_error", lambda g, n: next(responses)
+        )
         r = await wire_mod.GroupWireTool()._execute({"action": "add", "to": "ghost"})
         assert "not in your group" in r.error
 
@@ -334,7 +368,9 @@ class TestGroupWire:
         target = _FakeCreature(cid="t", name="bob", graph_id="g1")
         seq = iter([gctx.caller, target])
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: next(seq))
+        monkeypatch.setattr(
+            wire_mod, "resolve_target_or_error", lambda g, n: (next(seq), None)
+        )
         r = await wire_mod.GroupWireTool()._execute(
             {
                 "action": "add",
@@ -348,21 +384,26 @@ class TestGroupWire:
         body = _parse(r)
         assert body["edge_id"] == "edge-1"
         assert body["to"] == "t"
+        wire_target = gctx.engine.wire_output.await_args.args[1]
+        assert wire_target["to"] == "t"
 
-    async def test_add_cross_graph_merges(self, monkeypatch):
+    async def test_add_cross_graph_is_rejected(self, monkeypatch):
         gctx = _gctx()
-        target = _FakeCreature(cid="t", name="bob", graph_id="g-other")
-        seq = iter([gctx.caller, target])
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: next(seq))
-        ensure_called = {}
-
-        async def ensure_same_graph(e, f, t):
-            ensure_called["called"] = True
-
-        monkeypatch.setattr(wire_mod._channels, "ensure_same_graph", ensure_same_graph)
-        await wire_mod.GroupWireTool()._execute({"action": "add", "to": "bob"})
-        assert ensure_called["called"]
+        responses = iter(
+            [
+                (gctx.caller, None),
+                (None, wire_mod.err("target is not a creature in caller graph")),
+            ]
+        )
+        monkeypatch.setattr(
+            wire_mod, "resolve_target_or_error", lambda g, n: next(responses)
+        )
+        result = await wire_mod.GroupWireTool()._execute(
+            {"action": "add", "to": "cross-graph-id"}
+        )
+        assert "not a creature in caller graph" in result.error
+        gctx.engine.wire_output.assert_not_awaited()
 
     async def test_add_wire_output_failure(self, monkeypatch):
         gctx = _gctx()
@@ -370,14 +411,18 @@ class TestGroupWire:
         target = _FakeCreature(cid="t", graph_id="g1")
         seq = iter([gctx.caller, target])
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: next(seq))
+        monkeypatch.setattr(
+            wire_mod, "resolve_target_or_error", lambda g, n: (next(seq), None)
+        )
         r = await wire_mod.GroupWireTool()._execute({"action": "add", "to": "bob"})
         assert "wire_output failed" in r.error
 
     async def test_remove_missing_edge_id(self, monkeypatch):
         gctx = _gctx()
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: gctx.caller)
+        monkeypatch.setattr(
+            wire_mod, "resolve_target_or_error", lambda g, n: (gctx.caller, None)
+        )
         r = await wire_mod.GroupWireTool()._execute({"action": "remove"})
         assert "'edge_id' is required" in r.error
 
@@ -385,7 +430,9 @@ class TestGroupWire:
         gctx = _gctx()
         gctx.engine.unwire_output.side_effect = RuntimeError("nope")
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: gctx.caller)
+        monkeypatch.setattr(
+            wire_mod, "resolve_target_or_error", lambda g, n: (gctx.caller, None)
+        )
         r = await wire_mod.GroupWireTool()._execute(
             {"action": "remove", "edge_id": "e-1"}
         )
@@ -394,7 +441,9 @@ class TestGroupWire:
     async def test_remove_success(self, monkeypatch):
         gctx = _gctx()
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: gctx.caller)
+        monkeypatch.setattr(
+            wire_mod, "resolve_target_or_error", lambda g, n: (gctx.caller, None)
+        )
         r = await wire_mod.GroupWireTool()._execute(
             {"action": "remove", "edge_id": "e-1"}
         )
@@ -404,7 +453,9 @@ class TestGroupWire:
     async def test_unknown_action(self, monkeypatch):
         gctx = _gctx()
         monkeypatch.setattr(wire_mod, "resolve_or_error", lambda c, **_: (gctx, None))
-        monkeypatch.setattr(wire_mod, "resolve_group_target", lambda g, n: gctx.caller)
+        monkeypatch.setattr(
+            wire_mod, "resolve_target_or_error", lambda g, n: (gctx.caller, None)
+        )
         r = await wire_mod.GroupWireTool()._execute({"action": "garbage"})
         assert "unknown action" in r.error
 

--- a/tests/unit/terrarium/test_wire.py
+++ b/tests/unit/terrarium/test_wire.py
@@ -53,6 +53,7 @@ class TestCreatureInfoRoundTrip:
         c = CreatureInfo(
             creature_id="cid",
             name="n",
+            config_name="config-n",
             graph_id="g",
             is_running=True,
             is_privileged=False,

--- a/tests/unit/terrarium/test_wiring_prompt_branches.py
+++ b/tests/unit/terrarium/test_wiring_prompt_branches.py
@@ -79,11 +79,12 @@ class _Forwarder:
         self._peer = peer
         self.forwarded = []
 
-    def peer_for_target(self, name):
+    def peer_for_target(self, name, *, graph_id=None):
         return self._peer
 
-    async def forward_event(self, peer, payload):
-        self.forwarded.append((peer, payload))
+    async def forward_event(self, **payload):
+        self.forwarded.append(payload)
+        return True
 
 
 class TestEmitCrossNodeForward:
@@ -91,7 +92,10 @@ class TestEmitCrossNodeForward:
         """When a target isn't a local creature but a remote forwarder
         knows a peer for it, the emission is forwarded over the wire."""
         forwarder = _Forwarder(peer="node-2")
-        engine = SimpleNamespace(_output_wire_adapter=forwarder)
+        engine = SimpleNamespace(
+            _output_wire_adapter=forwarder,
+            _topology=SimpleNamespace(creature_to_graph={"alice": "g"}),
+        )
         r = TerrariumOutputWiringResolver({}, engine=engine)
         await r.emit(
             source="alice",
@@ -102,17 +106,21 @@ class TestEmitCrossNodeForward:
         )
         await asyncio.sleep(0.05)
         assert forwarder.forwarded
-        peer, payload = forwarder.forwarded[0]
-        assert peer == "node-2"
+        payload = forwarder.forwarded[0]
         assert payload["target_name"] == "remote_bob"
-        assert payload["content"] == "payload"
-        assert payload["turn_index"] == 3
+        assert payload["source_creature_id"] == "alice"
+        assert payload["source_graph_id"] == "g"
+        assert payload["event"]["content"] == "payload"
+        assert payload["event"]["context"]["turn_index"] == 3
 
     async def test_unknown_target_no_peer_is_skipped(self):
         """When the forwarder has no peer for the name, the emission is
         dropped — the target is recorded so it isn't re-warned."""
         forwarder = _Forwarder(peer=None)
-        engine = SimpleNamespace(_output_wire_adapter=forwarder)
+        engine = SimpleNamespace(
+            _output_wire_adapter=forwarder,
+            _topology=SimpleNamespace(creature_to_graph={"alice": "g"}),
+        )
         r = TerrariumOutputWiringResolver({}, engine=engine)
         await r.emit(
             source="alice",


### PR DESCRIPTION
## Summary

Enforce graph-local creature identity across group tools, Studio and session routes, output wiring, multi-node routing, and Laboratory relays. Exact runtime IDs take precedence, aliases resolve only when unique inside the caller's logical graph, and ordinary messaging or wiring can no longer join disconnected graphs implicitly.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Global name lookup and last-writer routing caches could select a same-named creature from an unrelated graph, accept ambiguous or stale identities, or let a channel or output-wiring action establish topology implicitly. Cross-node output relay also needed an authenticated, graph-bound source and an exact destination instead of trusting display names.

## Changes

- Add one canonical caller-scoped resolver with exact runtime-ID precedence, unique local-alias fallback, and typed unknown, stale, ambiguous, foreign-graph, and self-target outcomes.
- Propagate the engine-assigned runtime creature ID through `ToolContext` and use it in group tools, built-in messaging, output wiring, runtime prompts, Studio operations, and session-v2 routes.
- Reject display/config-name conflicts when adding, renaming, or explicitly merging logical graphs, including merges that span workers.
- Store output-wiring targets as canonical runtime IDs while retaining the graph-scoped `root` symbolic target.
- Keep disconnected graphs isolated; an explicit exact-endpoint `connect()` operation is the only path that establishes a cross-graph logical component.
- Replace the multi-node last-writer name cache with graph/node/runtime-ID candidate sets, preserve the adapter's live cache reference, and evict only identities owned by a disconnected worker.
- Validate Laboratory relay source node, source graph/runtime identity, event provenance, target graph/runtime identity, cluster membership, relay peer, and hop count before scheduling delivery.
- Update unit, integration, and E2E coverage so legitimate cross-worker journeys establish topology explicitly before channel or output delivery.
- Document exact runtime-ID targeting, graph-local alias resolution, and the explicit `connect()` requirement in English, Simplified Chinese, and Traditional Chinese.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
pytest tests/unit/test_file_sizes.py -q
pytest tests/integration/ -q
pytest tests/e2e/ -q
```

- `ruff`: passed.
- `black`: passed; 1,433 files would be left unchanged.
- File-size guard: 1,622 passed.
- Pre-rebase local full unit sweep: 11,554 passed, 9 skipped, and 5 failed in 671.74 seconds. The same five exact node IDs failed on clean base `33a8e17fcd841cfa434681a720ecf57ce2503b1a` (5 failed in 32.50 seconds): four required unavailable Hugging Face Model2Vec downloads in that environment, and one assumed the Unix `true` editor command on Windows.
- Integration: 170 passed, 1 skipped.
- Pre-rebase local full E2E after correcting cross-node journeys to use explicit `connect()`: 76 passed and 4 baseline failures detailed below.
- Focused real two-worker routing: 10 passed; all other cross-node E2E cases passed.
- Final integrity checks: `git diff --check` passed, the worktree is clean, and all 7 commits verify with SSH signature status `G`.
- Post-rebase validation on merged prerequisite `48d51f2c`: 781 affected Python tests and the complete integration tier (170 passed, 1 skipped) passed; `git diff --check` passed.
- Fresh fork CI for the rebased head passed all 13 jobs across lint, packaging, frontend, and the complete Linux/macOS/Windows Python matrix.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [ ] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

2026-07-27

## Notes for Reviewers

- Please focus on exact-ID precedence and alias collection in `terrarium/graph_identity.py`, including config-name aliases and logical-component membership checks.
- Please verify that explicit `connect()` remains the sole cross-graph join operation and that channel wiring, group messaging, and output wiring stay inside an already-established logical component.
- Cross-node connect/disconnect still spans multiple worker RPCs and broadcast-subscription bookkeeping rather than one distributed transaction. A mid-operation transport failure can leave partial side effects; details are recorded in `risks.md`.
- A successful remote delivery acknowledgement means the receiving worker validated and scheduled the event. Receiver turn processing remains intentionally asynchronous.
- The compatibility request adapter retries with the keyword-only Laboratory call shape after a positional-call `TypeError`; reviewers should confirm that this fallback cannot replay a request for supported messenger implementations.
- The branch was rebased without conflicts onto merged prerequisite `48d51f2c`; all 7 `range-diff` entries are unchanged (`=`).
- Signed candidate head: `b939c538fa90ca0e3735bd882552cd6af89d63b0` (7 commits, 72 files, +2,713/-1,440).

## Screenshots / Logs (if applicable)

No frontend files or UI behavior changed, so screenshots are not applicable. Command results and exact baseline comparisons are recorded in `test-record.md`.

## Breaking Changes (if applicable)

No supported API is removed. Calls that depended on global, ambiguous, stale, or foreign-graph name fallback now fail closed; callers should use an exact runtime creature ID and establish cross-graph topology explicitly with `connect()`.

## Exceptions / Not Run

- The discussion-link checkbox remains empty because no permalink or maintainer handle is recorded in the submission material. The available pre-approval record is the date above; no context was fabricated.
- The pre-rebase full-unit run had five baseline/environment failures: four unavailable Hugging Face downloads and the Unix-only `EDITOR=true` assumption. The merged prerequisite removes external model downloads from CI; the rebased affected tests pass.
- The four remaining E2E failures are reproducible baseline expectations: two still expect the stale `regenerating` intermediate state, one expects stale empty Studio branch metadata, and one multi-node memory/model subprocess exceeds its Windows timeout.
- The frontend checklist condition is satisfied because no frontend or built frontend file changed; frontend commands were not applicable to this backend/docs candidate.
- Fresh fork CI for the rebased head passed 13/13 jobs: https://github.com/VVittgenstein/KohakuTerrarium/actions/runs/30352890024