### PR TITLE
fix(terrarium): make recipe application atomic

### DIFF
--- a/docs/en/guides/laboratory.md
+++ b/docs/en/guides/laboratory.md
@@ -313,7 +313,10 @@ info = await service.add_creature(cfg, on_node="worker-gpu-1")
 
 A *terrarium* (multi-creature graph) can span workers via cross-node
 channels. Recipe files don't (yet) include per-creature node
-targeting, so build the topology imperatively:
+targeting. Studio's **Run on** selector (or `apply_recipe(...,
+on_node="worker-1")`) deploys the complete recipe to one connected
+worker, which also owns its session persistence. To split one
+terrarium across multiple workers, build the topology imperatively:
 
 ```python
 # Spawn alpha on worker-1, bravo on worker-2
@@ -444,7 +447,7 @@ won't appear in the host's logs.
 
 | Symptom | Likely cause |
 |---------|--------------|
-| `"on_node" is required` on spawn | You're in lab-host mode and tried to spawn on the host. Pick a worker, or use a recipe (recipes still run on the coordination engine). |
+| `"on_node" is required` on spawn | You're in lab-host mode and tried to spawn on the host. Pick a connected worker. A selected recipe runs wholly on that worker; it is not split across workers automatically. |
 | Worker connects then immediately disconnects | Token mismatch. Hello/Welcome handshake logs the rejection at INFO. |
 | `worker 'X' resume failed: Session has no config_path or config_snapshot in metadata` | The mirror file pre-dates 1.5.x meta-sync ordering. Spawn the creature fresh and resume from the new file. |
 | Codex `re-login due to process mismatch` errors | You're using the host's Codex token from a worker process. Log Codex in **on the worker** via Settings → Providers (with Manage on: set to that worker). |

--- a/docs/zh-CN/guides/laboratory.md
+++ b/docs/zh-CN/guides/laboratory.md
@@ -303,8 +303,11 @@ info = await service.add_creature(cfg, on_node="worker-gpu-1")
 ## 多节点 terrarium
 
 一个 *terrarium*（多生物图）可以通过跨节点通道横跨多个工作节
-点。Recipe 文件目前还不支持每生物的节点指定，所以请用命令式
-的方式搭建拓扑：
+点。Recipe 文件目前还不支持每生物的节点指定。Studio 的
+**Run on** 选择器（或 `apply_recipe(..., on_node="worker-1")`）
+会把整份 recipe 部署到一个已连接的工作节点，并由该节点持有
+session 持久化。若要让一个 terrarium 横跨多个工作节点，请用
+命令式的方式搭建拓扑：
 
 ```python
 # 在 worker-1 上生成 alpha、在 worker-2 上生成 bravo
@@ -430,7 +433,7 @@ WARNING 级别记录在工作节点侧，不会出现在主机的 log 里。
 
 | 现象 | 可能原因 |
 |------|----------|
-| 生成时 `"on_node" is required` | 你处于 lab-host 模式但尝试在主机上生成。选一个工作节点，或者用 recipe（recipe 仍然在 coordination engine 上运行）。 |
+| 生成时 `"on_node" is required` | 你处于 lab-host 模式但尝试在主机上生成。请选择已连接的工作节点；所选 recipe 会完整运行在该节点上，不会自动拆分到多个节点。 |
 | 工作节点连上后立刻断开 | Token 不匹配。Hello/Welcome 握手会在 INFO 级别记录拒绝。 |
 | `worker 'X' resume failed: Session has no config_path or config_snapshot in metadata` | 镜像文件早于 1.5.x 的 meta-sync 顺序。请重新生成该生物，并从新文件 resume。 |
 | Codex `re-login due to process mismatch` 错误 | 你在工作节点进程里使用主机的 Codex token。请通过 Settings → Providers（把 Manage on: 设为该工作节点）**在工作节点上** 登录 Codex。 |

--- a/docs/zh-TW/guides/laboratory.md
+++ b/docs/zh-TW/guides/laboratory.md
@@ -303,8 +303,11 @@ info = await service.add_creature(cfg, on_node="worker-gpu-1")
 ## 多節點生態瓶
 
 一個*生態瓶*（多生物圖）可以透過跨節點頻道橫跨多個 worker。
-Recipe 檔案（目前）不包含每隻生物的節點指定，所以用命令式
-方式建構拓樸：
+Recipe 檔案（目前）不包含每隻生物的節點指定。Studio 的
+**Run on** 選擇器（或 `apply_recipe(..., on_node="worker-1")`）
+會把整份 recipe 部署到一個已連線的 worker，並由該 worker 持有
+session 持久化。若要讓一個 terrarium 橫跨多個 worker，請用
+命令式方式建構拓樸：
 
 ```python
 # 在 worker-1 生 alpha、worker-2 生 bravo
@@ -427,7 +430,7 @@ worker 側以 WARNING 等級記錄，不會出現在主機的 log 裡。
 
 | 症狀 | 可能原因 |
 |---------|--------------|
-| spawn 時 `"on_node" is required` | 你在 lab-host 模式下試圖在主機上 spawn。挑一個 worker，或用 recipe（recipe 仍在協調引擎上執行）。 |
+| spawn 時 `"on_node" is required` | 你在 lab-host 模式下試圖在主機上 spawn。請選擇已連線的 worker；所選 recipe 會完整執行在該 worker 上，不會自動拆分到多個 worker。 |
 | Worker 連上後立刻斷線 | Token 不符。Hello/Welcome handshake 會以 INFO 等級記錄拒絕。 |
 | `worker 'X' resume failed: Session has no config_path or config_snapshot in metadata` | 鏡像檔案比 1.5.x 的 meta-sync 順序還舊。重新 spawn 生物並從新檔案 resume。 |
 | Codex `re-login due to process mismatch` 錯誤 | 你在 worker 行程裡用主機的 Codex token。在 **worker 上**透過 Settings → Providers（Manage on: 設為該 worker）登入 Codex。 |

--- a/src/kohakuterrarium-frontend/src/components/shell/modals/NewTerrariumModal.vue
+++ b/src/kohakuterrarium-frontend/src/components/shell/modals/NewTerrariumModal.vue
@@ -59,6 +59,7 @@ import { computed, onMounted, ref, watch } from "vue"
 
 import ModalShell from "@/components/common/ModalShell.vue"
 import SitePicker from "@/components/cluster/SitePicker.vue"
+import { useClusterStore } from "@/stores/cluster"
 import { useConfigsStore } from "@/stores/configs"
 import { useTabsStore } from "@/stores/tabs"
 import { configAPI } from "@/utils/api"
@@ -72,6 +73,7 @@ const emit = defineEmits(["close"])
 
 const tabs = useTabsStore()
 const configs = useConfigsStore()
+const cluster = useClusterStore()
 const { t } = useI18n()
 
 const pwd = ref("")
@@ -81,7 +83,7 @@ const starting = ref(false)
 const errorMsg = ref("")
 const name = ref("")
 const namePlaceholder = ref(randomNameFor("terrarium"))
-const onNode = ref("_host")
+const onNode = ref(cluster.isCluster ? "" : "_host")
 
 // See NewCreatureModal.vue for the rationale: track whether the user has
 // manually edited the working-dir input so we can safely overwrite it
@@ -114,7 +116,7 @@ watch(
   },
 )
 
-const canSubmit = computed(() => Boolean(pwd.value.trim() && selectedConfig.value && !starting.value))
+const canSubmit = computed(() => Boolean(pwd.value.trim() && selectedConfig.value && !starting.value && (!cluster.isCluster || (onNode.value && onNode.value !== "_host"))))
 
 async function onSubmit() {
   if (!canSubmit.value) return

--- a/src/kohakuterrarium/api/routes/sessions_v2/active.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/active.py
@@ -102,17 +102,7 @@ async def create_creature_session(
 async def create_terrarium_session(
     req: TerrariumCreate, service: TerrariumService = Depends(get_service)
 ):
-    """Start a multi-creature session from a host-local recipe.
-
-    Remote recipe spawning is rejected rather than silently ignoring the selected
-    worker.
-    """
-    if req.on_node and req.on_node != "_host":
-        raise HTTPException(
-            501,
-            "Recipe spawn on a remote worker is not implemented yet — "
-            "spawn individual creatures via /agents with on_node instead.",
-        )
+    """Start the complete recipe on the explicitly selected runtime node."""
     try:
         session = await lifecycle.start_terrarium(
             service,
@@ -120,6 +110,7 @@ async def create_terrarium_session(
             pwd=req.pwd,
             name=req.name,
             llm=req.llm,
+            on_node=req.on_node or "_host",
         )
         return {**session.to_dict(), "status": "running"}
     except (ValueError, KeyError, FileNotFoundError) as e:
@@ -159,12 +150,6 @@ async def create_agent_compat(
 async def create_terrarium_compat(
     req: TerrariumCreate, service: TerrariumService = Depends(get_service)
 ):
-    if req.on_node and req.on_node != "_host":
-        raise HTTPException(
-            501,
-            "Recipe spawn on a remote worker is not implemented yet — "
-            "spawn individual creatures via /agents with on_node instead.",
-        )
     try:
         session = await lifecycle.start_terrarium(
             service,
@@ -172,6 +157,7 @@ async def create_terrarium_compat(
             pwd=req.pwd,
             name=req.name,
             llm=req.llm,
+            on_node=req.on_node or "_host",
         )
         return {"terrarium_id": session.session_id, "status": "running"}
     except (ValueError, KeyError, FileNotFoundError) as e:

--- a/src/kohakuterrarium/laboratory/adapters/_worker_session.py
+++ b/src/kohakuterrarium/laboratory/adapters/_worker_session.py
@@ -197,6 +197,13 @@ class WorkerSessionAttacher:
                     tee.detach()
             return
 
+    def discard_graph(self, graph_id: str) -> None:
+        """Detach all mirroring state before a recipe store is deleted."""
+        tee = self._graph_tees.pop(graph_id, None)
+        self._graph_refs.pop(graph_id, None)
+        if tee is not None:
+            tee.detach()
+
     def close_all(self) -> None:
         """Detach every tracked event tee."""
         for tee in list(self._graph_tees.values()):

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
@@ -15,6 +15,7 @@ from kohakuterrarium.laboratory.protocols import LabRegistrar
 from kohakuterrarium.llm.backends import set_remote_backend
 from kohakuterrarium.llm.preset_store import preset_from_data, set_remote_preset
 from kohakuterrarium.llm.profile_types import LLMBackend
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.terrarium.creature_ops import (
     agent_command_inventory,
     agent_env,
@@ -42,7 +43,7 @@ from kohakuterrarium.terrarium.creature_ops import (
     session_attach_policies_for,
     wire_creature_on_engine,
 )
-from kohakuterrarium.session.raw_history import UserMessageSelector
+from kohakuterrarium.terrarium.recipe_discard import discard_recipe_graph_shielded
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium.service import (
     LocalTerrariumService,
@@ -340,6 +341,22 @@ class TerrariumRuntimeAdapter:
                     "graph": pack_graph_topology(graph),
                     "creatures": creatures,
                 }
+            case "discard_recipe":
+                graph_id = str(msg.body.get("graph_id") or "")
+                if not graph_id:
+                    raise ValueError("graph_id is required")
+                await discard_recipe_graph_shielded(
+                    self._engine,
+                    graph_id,
+                    before_store_close=(
+                        lambda: (
+                            self._session_attacher.discard_graph(graph_id)
+                            if self._session_attacher is not None
+                            else None
+                        )
+                    ),
+                )
+                return {}
             case "add_creature":
                 config = unpack_creature_build_input(msg.body["config"])
                 # LLM construction needs remote profiles and credentials already cached.

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
@@ -309,18 +309,27 @@ class TerrariumRuntimeAdapter:
                 return {"status": self._engine.status()}
 
             case "apply_recipe":
-                await self._prewarm_llm_identity(msg.body.get("llm"))
+                llm = msg.body.get("llm")
+                if llm is not None and not isinstance(llm, str):
+                    raise ValueError("llm must be a selector string")
+                await self._prewarm_profile_by_selector(llm or "")
                 recipe_path = str(msg.body.get("recipe_path") or "")
                 if not recipe_path:
                     raise ValueError("recipe_path is required")
-                session_path = msg.body.get("session_path")
+                if "session_path" in msg.body:
+                    raise ValueError(
+                        "session_path is worker-owned and cannot be provided"
+                    )
+                persist = msg.body.get("persist", False)
+                if not isinstance(persist, bool):
+                    raise ValueError("persist must be a boolean")
                 graph = await self._engine.apply_recipe(
                     recipe_path,
                     pwd=msg.body.get("pwd"),
-                    llm=msg.body.get("llm"),
+                    llm=llm,
                     strict=bool(msg.body.get("strict", True)),
                     start=bool(msg.body.get("start", True)),
-                    session=session_path or False,
+                    session=True if persist else False,
                 )
                 creatures = [
                     pack_creature_info(creature_to_info(creature))

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
@@ -308,6 +308,29 @@ class TerrariumRuntimeAdapter:
             case "status_snapshot":
                 return {"status": self._engine.status()}
 
+            case "apply_recipe":
+                await self._prewarm_llm_identity(msg.body.get("llm"))
+                recipe_path = str(msg.body.get("recipe_path") or "")
+                if not recipe_path:
+                    raise ValueError("recipe_path is required")
+                session_path = msg.body.get("session_path")
+                graph = await self._engine.apply_recipe(
+                    recipe_path,
+                    pwd=msg.body.get("pwd"),
+                    llm=msg.body.get("llm"),
+                    strict=bool(msg.body.get("strict", True)),
+                    start=bool(msg.body.get("start", True)),
+                    session=session_path or False,
+                )
+                creatures = [
+                    pack_creature_info(creature_to_info(creature))
+                    for creature in self._engine.list_creatures()
+                    if creature.graph_id == graph.graph_id
+                ]
+                return {
+                    "graph": pack_graph_topology(graph),
+                    "creatures": creatures,
+                }
             case "add_creature":
                 config = unpack_creature_build_input(msg.body["config"])
                 # LLM construction needs remote profiles and credentials already cached.

--- a/src/kohakuterrarium/studio/facade_sessions.py
+++ b/src/kohakuterrarium/studio/facade_sessions.py
@@ -73,6 +73,7 @@ class _SessionsNS:
         pwd: str | None = None,
         llm: str | None = None,
         name: str | None = None,
+        on_node: str = "_host",
     ) -> _session_handles.Session:
         return await _session_lifecycle.start_terrarium(
             self._studio._service,
@@ -80,6 +81,7 @@ class _SessionsNS:
             pwd=pwd,
             llm=llm,
             name=name,
+            on_node=on_node,
         )
 
     def list(self) -> list[_session_handles.SessionListing]:

--- a/src/kohakuterrarium/studio/sessions/lifecycle.py
+++ b/src/kohakuterrarium/studio/sessions/lifecycle.py
@@ -11,7 +11,12 @@ from typing import Any
 
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.terrarium.graph_identity import ensure_graph_name_available
-from kohakuterrarium.studio.sessions import cluster_fold, remote_meta, stop as _stop
+from kohakuterrarium.studio.sessions import (
+    cluster_fold,
+    remote_meta,
+    remote_terrarium,
+    stop as _stop,
+)
 from kohakuterrarium.studio.sessions import index_hooks as _index_hooks
 from kohakuterrarium.studio.sessions.find import (
     apply_creature_name,
@@ -37,7 +42,6 @@ from kohakuterrarium.terrarium.config import (
     load_terrarium_config,
 )
 from kohakuterrarium.studio._runtime import as_engine, host_engine_or_none
-from kohakuterrarium.studio.deploy import deploy_creature_to_node
 from kohakuterrarium.terrarium import TerrariumService
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium.multi_node_service import MultiNodeTerrariumService
@@ -367,110 +371,14 @@ async def _start_remote_terrarium(
     llm: str | None,
     on_node: str,
 ) -> Session:
-    """Deploy and apply one complete recipe on one explicitly selected worker."""
-    if on_node == "_host":
-        raise ValueError("Lab recipe deployment requires an explicit worker node")
-    if on_node not in service.connected_nodes():
-        raise KeyError(f"worker node {on_node!r} is not connected")
-    if not config_path:
-        raise ValueError("remote recipe deployment requires config_path")
-
-    source_path = Path(config_path).resolve()
-    if source_path.is_file():
-        allowed = {source_path.name, "system.md", "config.yaml", "config.yml"}
-        unexpected = [
-            item.name
-            for item in source_path.parent.iterdir()
-            if item.is_file() and item.name not in allowed
-        ]
-        if unexpected:
-            raise ValueError(
-                "remote recipe directory contains unrelated files; "
-                f"move the recipe into a dedicated directory: {unexpected[0]!r}"
-            )
-    bundle_path = source_path.parent if source_path.is_file() else source_path
-    remote_root = await deploy_creature_to_node(
-        service.host,
-        on_node,
-        bundle_path,
-        name=f"recipe-{source_path.stem}",
-    )
-    remote_recipe = (
-        str(Path(remote_root) / source_path.name)
-        if source_path.is_file()
-        else str(remote_root)
-    )
-
-    remote_service = service.service_for(on_node)
-    graph, creatures = await remote_service.apply_recipe(
-        remote_recipe,
+    """Delegate remote recipe startup to its worker-specific lifecycle."""
+    return await remote_terrarium.start_remote_terrarium(
+        service,
+        config_path=config_path,
+        name=name,
         pwd=pwd,
         llm=llm,
-        persist=True,
-    )
-    registered_ids: list[str] = []
-    try:
-        collisions = [
-            creature.creature_id
-            for creature in creatures
-            if creature.creature_id in service._home
-            and service._home[creature.creature_id] != on_node
-        ]
-        if collisions:
-            raise ValueError(f"remote recipe creature_id collision: {collisions[0]!r}")
-        for creature in creatures:
-            service._home[creature.creature_id] = on_node
-            registered_ids.append(creature.creature_id)
-        requested_name = name.strip() if name and name.strip() else None
-        base_name = requested_name or load_terrarium_config(config_path).name
-        existing_names = {entry.get("name") for entry in meta_for(service).values()}
-        session_name = base_name
-        suffix = 2
-        while session_name in existing_names:
-            session_name = f"{base_name} #{suffix}"
-            suffix += 1
-        created_at = now_iso()
-    except BaseException:
-        for creature_id in registered_ids:
-            if service._home.get(creature_id) == on_node:
-                service._home.pop(creature_id, None)
-        for creature in reversed(creatures):
-            try:
-                await remote_service.remove_creature(creature.creature_id)
-            except BaseException:
-                logger.exception(
-                    "remote recipe compensation failed",
-                    extra={"creature_id": creature.creature_id},
-                )
-        raise
-    meta_for(service)[graph.graph_id] = {
-        "session_id": graph.graph_id,
-        "name": session_name,
-        "kind": "terrarium",
-        "status": "running",
-        "created_at": created_at,
-        "on_node": on_node,
-        "creature_id": creatures[0].creature_id if creatures else None,
-        "creature_ids": [creature.creature_id for creature in creatures],
-        "creatures": [creature.name for creature in creatures],
-    }
-    return Session(
-        session_id=graph.graph_id,
-        name=session_name,
-        creatures=[
-            {
-                "creature_id": creature.creature_id,
-                "name": creature.name,
-                "home_node": on_node,
-            }
-            for creature in creatures
-        ],
-        channels=[{"name": channel} for channel in sorted(graph.channels)],
-        created_at=created_at,
-        config_path=config_path,
-        pwd=pwd or "",
-        has_root=any(creature.is_privileged for creature in creatures),
-        home_node=on_node,
+        on_node=on_node,
     )
 
 

--- a/src/kohakuterrarium/studio/sessions/lifecycle.py
+++ b/src/kohakuterrarium/studio/sessions/lifecycle.py
@@ -37,8 +37,10 @@ from kohakuterrarium.terrarium.config import (
     load_terrarium_config,
 )
 from kohakuterrarium.studio._runtime import as_engine, host_engine_or_none
+from kohakuterrarium.studio.deploy import deploy_creature_to_node
 from kohakuterrarium.terrarium import TerrariumService
 from kohakuterrarium.terrarium.engine import Terrarium
+from kohakuterrarium.terrarium.multi_node_service import MultiNodeTerrariumService
 from kohakuterrarium.utils.logging import get_logger
 from kohakuterrarium.utils.mobile_sandbox import default_workdir
 
@@ -266,6 +268,7 @@ async def start_terrarium(
     pwd: str | None = None,
     name: str | None = None,
     llm: str | None = None,
+    on_node: str = "_host",
 ) -> Session:
     """Apply a recipe into a fresh graph; start every creature.
 
@@ -282,6 +285,16 @@ async def start_terrarium(
     that engine, and it is gated on the lab-host's explicit
     presence of one.
     """
+    if isinstance(service, MultiNodeTerrariumService):
+        return await _start_remote_terrarium(
+            service,
+            config_path=config_path,
+            name=name,
+            pwd=pwd,
+            llm=llm,
+            on_node=on_node,
+        )
+
     engine = _resolve_engine_for_recipe(service)
     pwd = _normalize_pwd(pwd)
     if config_path:
@@ -343,6 +356,121 @@ async def start_terrarium(
     }
     logger.info("Terrarium session started", session_id=sid)
     return _build_session_handle(engine, sid, meta_for(service))
+
+
+async def _start_remote_terrarium(
+    service: MultiNodeTerrariumService,
+    *,
+    config_path: str | None,
+    name: str | None,
+    pwd: str | None,
+    llm: str | None,
+    on_node: str,
+) -> Session:
+    """Deploy and apply one complete recipe on one explicitly selected worker."""
+    if on_node == "_host":
+        raise ValueError("Lab recipe deployment requires an explicit worker node")
+    if on_node not in service.connected_nodes():
+        raise KeyError(f"worker node {on_node!r} is not connected")
+    if not config_path:
+        raise ValueError("remote recipe deployment requires config_path")
+
+    source_path = Path(config_path).resolve()
+    if source_path.is_file():
+        allowed = {source_path.name, "system.md", "config.yaml", "config.yml"}
+        unexpected = [
+            item.name
+            for item in source_path.parent.iterdir()
+            if item.is_file() and item.name not in allowed
+        ]
+        if unexpected:
+            raise ValueError(
+                "remote recipe directory contains unrelated files; "
+                f"move the recipe into a dedicated directory: {unexpected[0]!r}"
+            )
+    bundle_path = source_path.parent if source_path.is_file() else source_path
+    remote_root = await deploy_creature_to_node(
+        service.host,
+        on_node,
+        bundle_path,
+        name=f"recipe-{source_path.stem}",
+    )
+    remote_recipe = (
+        str(Path(remote_root) / source_path.name)
+        if source_path.is_file()
+        else str(remote_root)
+    )
+
+    remote_service = service.service_for(on_node)
+    graph, creatures = await remote_service.apply_recipe(
+        remote_recipe,
+        pwd=pwd,
+        llm=llm,
+        session_path=f"sessions/{name or source_path.stem}.kohakutr",
+    )
+    registered_ids: list[str] = []
+    try:
+        collisions = [
+            creature.creature_id
+            for creature in creatures
+            if creature.creature_id in service._home
+            and service._home[creature.creature_id] != on_node
+        ]
+        if collisions:
+            raise ValueError(f"remote recipe creature_id collision: {collisions[0]!r}")
+        for creature in creatures:
+            service._home[creature.creature_id] = on_node
+            registered_ids.append(creature.creature_id)
+        base_name = name or load_terrarium_config(config_path).name
+        existing_names = {entry.get("name") for entry in meta_for(service).values()}
+        session_name = base_name
+        suffix = 2
+        while session_name in existing_names:
+            session_name = f"{base_name} #{suffix}"
+            suffix += 1
+        created_at = now_iso()
+    except BaseException:
+        for creature_id in registered_ids:
+            if service._home.get(creature_id) == on_node:
+                service._home.pop(creature_id, None)
+        for creature in reversed(creatures):
+            try:
+                await remote_service.remove_creature(creature.creature_id)
+            except BaseException:
+                logger.exception(
+                    "remote recipe compensation failed",
+                    extra={"creature_id": creature.creature_id},
+                )
+        raise
+    meta_for(service)[graph.graph_id] = {
+        "session_id": graph.graph_id,
+        "name": session_name,
+        "kind": "terrarium",
+        "status": "running",
+        "created_at": created_at,
+        "on_node": on_node,
+        "creature_id": creatures[0].creature_id if creatures else None,
+        "creature_ids": [creature.creature_id for creature in creatures],
+        "creatures": [creature.name for creature in creatures],
+    }
+    return Session(
+        session_id=graph.graph_id,
+        name=session_name,
+        creatures=[
+            {
+                "creature_id": creature.creature_id,
+                "name": creature.name,
+                "home_node": on_node,
+            }
+            for creature in creatures
+        ],
+        channels=[{"name": channel} for channel in sorted(graph.channels)],
+        created_at=created_at,
+        config_path=config_path,
+        pwd=pwd or "",
+        has_root=any(creature.is_privileged for creature in creatures),
+        home_node=on_node,
+    )
 
 
 def list_sessions(service: "TerrariumService") -> list[SessionListing]:

--- a/src/kohakuterrarium/studio/sessions/lifecycle.py
+++ b/src/kohakuterrarium/studio/sessions/lifecycle.py
@@ -406,7 +406,7 @@ async def _start_remote_terrarium(
         remote_recipe,
         pwd=pwd,
         llm=llm,
-        session_path=f"sessions/{name or source_path.stem}.kohakutr",
+        persist=True,
     )
     registered_ids: list[str] = []
     try:
@@ -421,7 +421,8 @@ async def _start_remote_terrarium(
         for creature in creatures:
             service._home[creature.creature_id] = on_node
             registered_ids.append(creature.creature_id)
-        base_name = name or load_terrarium_config(config_path).name
+        requested_name = name.strip() if name and name.strip() else None
+        base_name = requested_name or load_terrarium_config(config_path).name
         existing_names = {entry.get("name") for entry in meta_for(service).values()}
         session_name = base_name
         suffix = 2

--- a/src/kohakuterrarium/studio/sessions/remote_terrarium.py
+++ b/src/kohakuterrarium/studio/sessions/remote_terrarium.py
@@ -1,5 +1,6 @@
 """Start Studio terrarium sessions on a selected laboratory worker."""
 
+import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -89,14 +90,13 @@ async def start_remote_terrarium(
         for creature_id in registered_ids:
             if service._home.get(creature_id) == on_node:
                 service._home.pop(creature_id, None)
-        for creature in reversed(creatures):
-            try:
-                await remote_service.remove_creature(creature.creature_id)
-            except BaseException:
-                logger.exception(
-                    "remote recipe compensation failed",
-                    extra={"creature_id": creature.creature_id},
-                )
+        try:
+            await _discard_remote_recipe(remote_service, graph.graph_id)
+        except BaseException:
+            logger.exception(
+                "remote recipe compensation failed",
+                extra={"graph_id": graph.graph_id},
+            )
         raise
     meta_for(service)[graph.graph_id] = {
         "session_id": graph.graph_id,
@@ -127,3 +127,13 @@ async def start_remote_terrarium(
         has_root=any(creature.is_privileged for creature in creatures),
         home_node=on_node,
     )
+
+
+async def _discard_remote_recipe(remote_service, graph_id: str) -> None:
+    """Finish the worker-side discard even when the caller is cancelled."""
+    cleanup = asyncio.create_task(remote_service.discard_recipe(graph_id))
+    try:
+        await asyncio.shield(cleanup)
+    except asyncio.CancelledError:
+        await cleanup
+        raise

--- a/src/kohakuterrarium/studio/sessions/remote_terrarium.py
+++ b/src/kohakuterrarium/studio/sessions/remote_terrarium.py
@@ -1,0 +1,129 @@
+"""Start Studio terrarium sessions on a selected laboratory worker."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from kohakuterrarium.studio.deploy import deploy_creature_to_node
+from kohakuterrarium.studio.sessions.handles import Session
+from kohakuterrarium.studio.sessions.registry import meta_for
+from kohakuterrarium.terrarium.config import load_terrarium_config
+from kohakuterrarium.terrarium.multi_node_service import MultiNodeTerrariumService
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+async def start_remote_terrarium(
+    service: MultiNodeTerrariumService,
+    *,
+    config_path: str | None,
+    name: str | None,
+    pwd: str | None,
+    llm: str | None,
+    on_node: str,
+) -> Session:
+    """Deploy and apply one complete recipe on one explicitly selected worker."""
+    if on_node == "_host":
+        raise ValueError("Lab recipe deployment requires an explicit worker node")
+    if on_node not in service.connected_nodes():
+        raise KeyError(f"worker node {on_node!r} is not connected")
+    if not config_path:
+        raise ValueError("remote recipe deployment requires config_path")
+
+    source_path = Path(config_path).resolve()
+    if source_path.is_file():
+        allowed = {source_path.name, "system.md", "config.yaml", "config.yml"}
+        unexpected = [
+            item.name
+            for item in source_path.parent.iterdir()
+            if item.is_file() and item.name not in allowed
+        ]
+        if unexpected:
+            raise ValueError(
+                "remote recipe directory contains unrelated files; "
+                f"move the recipe into a dedicated directory: {unexpected[0]!r}"
+            )
+    bundle_path = source_path.parent if source_path.is_file() else source_path
+    remote_root = await deploy_creature_to_node(
+        service.host,
+        on_node,
+        bundle_path,
+        name=f"recipe-{source_path.stem}",
+    )
+    remote_recipe = (
+        str(Path(remote_root) / source_path.name)
+        if source_path.is_file()
+        else str(remote_root)
+    )
+
+    remote_service = service.service_for(on_node)
+    graph, creatures = await remote_service.apply_recipe(
+        remote_recipe,
+        pwd=pwd,
+        llm=llm,
+        persist=True,
+    )
+    registered_ids: list[str] = []
+    try:
+        collisions = [
+            creature.creature_id
+            for creature in creatures
+            if creature.creature_id in service._home
+            and service._home[creature.creature_id] != on_node
+        ]
+        if collisions:
+            raise ValueError(f"remote recipe creature_id collision: {collisions[0]!r}")
+        for creature in creatures:
+            service._home[creature.creature_id] = on_node
+            registered_ids.append(creature.creature_id)
+        requested_name = name.strip() if name and name.strip() else None
+        base_name = requested_name or load_terrarium_config(config_path).name
+        existing_names = {entry.get("name") for entry in meta_for(service).values()}
+        session_name = base_name
+        suffix = 2
+        while session_name in existing_names:
+            session_name = f"{base_name} #{suffix}"
+            suffix += 1
+        created_at = datetime.now(timezone.utc).isoformat()
+    except BaseException:
+        for creature_id in registered_ids:
+            if service._home.get(creature_id) == on_node:
+                service._home.pop(creature_id, None)
+        for creature in reversed(creatures):
+            try:
+                await remote_service.remove_creature(creature.creature_id)
+            except BaseException:
+                logger.exception(
+                    "remote recipe compensation failed",
+                    extra={"creature_id": creature.creature_id},
+                )
+        raise
+    meta_for(service)[graph.graph_id] = {
+        "session_id": graph.graph_id,
+        "name": session_name,
+        "kind": "terrarium",
+        "status": "running",
+        "created_at": created_at,
+        "on_node": on_node,
+        "creature_id": creatures[0].creature_id if creatures else None,
+        "creature_ids": [creature.creature_id for creature in creatures],
+        "creatures": [creature.name for creature in creatures],
+    }
+    return Session(
+        session_id=graph.graph_id,
+        name=session_name,
+        creatures=[
+            {
+                "creature_id": creature.creature_id,
+                "name": creature.name,
+                "home_node": on_node,
+            }
+            for creature in creatures
+        ],
+        channels=[{"name": channel} for channel in sorted(graph.channels)],
+        created_at=created_at,
+        config_path=config_path,
+        pwd=pwd or "",
+        has_root=any(creature.is_privileged for creature in creatures),
+        home_node=on_node,
+    )

--- a/src/kohakuterrarium/terrarium/autosession.py
+++ b/src/kohakuterrarium/terrarium/autosession.py
@@ -225,13 +225,26 @@ async def attach_for_recipe(
     session: SessionArg = None,
 ) -> SessionStore | None:
     """Autosession for ``apply_recipe`` — one terrarium-typed store."""
+    existing = engine._session_stores.get(graph_id)
     if session is False:
-        return engine._session_stores.get(graph_id)
+        return existing
+
+    names = [
+        engine.get_creature(cid).name
+        for cid in sorted(engine.get_graph(graph_id).creature_ids)
+        if cid in engine._creatures
+    ]
     if isinstance(session, SessionStore):
+        register_agents_in_meta(session, names)
         await engine.attach_session(graph_id, session)
         return session
-    if session is None and engine._session_stores.get(graph_id) is not None:
-        return engine._session_stores[graph_id]
+    if existing is not None and recipe_session_reuses_store(existing, session):
+        register_agents_in_meta(existing, names)
+        # The recipe may have just added graph members. Reattaching the same
+        # store wires persistence into every member without replacing the
+        # existing writer.
+        await engine.attach_session(graph_id, existing)
+        return existing
 
     if isinstance(session, (str, Path)):
         path: "str | Path | None" = session
@@ -242,11 +255,6 @@ async def attach_for_recipe(
             return None
         path = None
 
-    names = [
-        engine.get_creature(cid).name
-        for cid in sorted(engine.get_graph(graph_id).creature_ids)
-        if cid in engine._creatures
-    ]
     store = mint_store(
         engine,
         graph_id,
@@ -258,6 +266,27 @@ async def attach_for_recipe(
     engine._owned_sessions.add(graph_id)
     await engine.attach_session(graph_id, store)
     return store
+
+
+def recipe_session_reuses_store(
+    existing: SessionStore,
+    session: SessionArg,
+) -> bool:
+    """Return whether recipe persistence should retain ``existing``.
+
+    ``None`` and ``True`` mean "use persistence for this graph", so an
+    already-attached store satisfies both. An explicit path naming that same
+    file must also reuse the live writer rather than acquire a second writer
+    lock for it.
+    """
+    if session is None or session is True or session is existing:
+        return True
+    if not isinstance(session, (str, Path)):
+        return False
+    try:
+        return Path(existing.path).resolve() == Path(session).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
 
 
 def close_owned_stores(engine: "Terrarium") -> None:

--- a/src/kohakuterrarium/terrarium/engine.py
+++ b/src/kohakuterrarium/terrarium/engine.py
@@ -17,9 +17,12 @@ from typing import TYPE_CHECKING, Any
 import kohakuterrarium.terrarium.autosession as _autosession
 import kohakuterrarium.terrarium.channel_lifecycle as _lifecycle
 import kohakuterrarium.terrarium.channels as _channels
+import kohakuterrarium.terrarium.engine_creature_add as _engine_creature_add
 import kohakuterrarium.terrarium.engine_observability as _observability
 import kohakuterrarium.terrarium.graph_checkpoint as _checkpoint
 import kohakuterrarium.terrarium.recipe as _recipe
+import kohakuterrarium.terrarium.recipe_identity as _recipe_identity
+import kohakuterrarium.terrarium.recipe_transaction as _recipe_transaction
 import kohakuterrarium.terrarium.resume as _resume
 import kohakuterrarium.terrarium.root as _root
 import kohakuterrarium.terrarium.topology as _topo
@@ -30,7 +33,6 @@ from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.terrarium.creature_host import (
     Creature,
     CreatureBuildInput,
-    apply_creature_name,
     build_creature,
 )
 from kohakuterrarium.terrarium.events import (
@@ -109,8 +111,9 @@ class Terrarium:
         )
         self._topology = TopologyState()
         self._creatures: dict[str, Creature] = {}
+        self._recipe_identities = _recipe_identity.RecipeIdentityReservations()
+        self._recipe_graph_locks: dict[str, asyncio.Lock] = {}
         self._environments: dict[str, Environment] = {}
-        # graph_id -> attached SessionStore.
         self._session_stores: dict[str, "SessionStore"] = {}
         # graph_ids whose stores THIS engine minted (closed on shutdown).
         self._owned_sessions: set[str] = set()
@@ -247,201 +250,22 @@ class Terrarium:
             raise RuntimeError("this terrarium has no Drive runtime to reconfigure")
         return self._drive_runtime.reconfigure(drive_registrations)
 
-    # ------------------------------------------------------------------
     # creature CRUD
-    # ------------------------------------------------------------------
 
     async def add_creature(
         self,
-        config: "CreatureBuildInput | Creature",
-        *,
-        graph: GraphRef | None = None,
-        creature_id: str | None = None,
-        llm: Any = None,
-        pwd: str | None = None,
-        start: bool = True,
-        is_privileged: bool = False,
-        parent_creature_id: str | None = None,
-        io: str = "config",
-        strict: bool = True,
-        session: "bool | str | Path | SessionStore | None" = None,
-        name: str | None = None,
-        tools: list[Any] | None = None,
-        plugins: list[Any] | None = None,
+        config: CreatureBuildInput | Creature,
+        **kwargs: Any,
     ) -> Creature:
-        """Add a creature to the engine.
-
-        ``config`` may be a path (or ``@pkg/...`` reference),
-        ``AgentConfig``, ``CreatureConfig``, or a pre-built ``Creature``
-        (tests / advanced callers).  With ``graph=None`` a fresh
-        singleton graph is minted.  ``start`` toggles auto-start of the
-        underlying agent.
-
-        ``llm`` binds the creature's LLM — a provider instance, a
-        selector string, an ``LLMProfile``, or None (resolve from the
-        config).
-
-        ``io`` selects how much of the config's I/O boots:
-        ``"config"`` (as declared), ``"none"`` (input suppressed —
-        Studio / Lab managed spawns driven via the attach WebSocket),
-        or ``"headless"`` (input suppressed AND default output
-        silenced — batch / programmatic runs).
-
-        ``session`` controls persistence without requiring callers to manually
-        create a ``SessionStore``, initialize metadata, and attach it:
-        a path mints the store at exactly that file; ``True`` mints in
-        the default session dir; ``False`` disables persistence even
-        under autosession; a ``SessionStore`` attaches as-is; ``None``
-        (default) follows the engine — autosession when
-        ``Terrarium(session_dir=...)`` was set, joins the graph's
-        existing store otherwise, else no persistence.
-
-        ``name`` is a spawn-time display-name override (the name the
-        user typed in the Studio "new creature" form).  When set it is
-        applied across the creature + its nested objects, so a creature
-        spawned on a worker carries the user's chosen name — not the
-        config file's own ``name``.
-
-        ``tools`` / ``plugins`` are INSTANCES (e.g. ``kt.tool``
-        adapters, ``BasePlugin`` subclass objects) injected into the
-        underlying agent at build time — same contract as
-        ``Agent.build(tools=, plugins=)``.  Not applicable to a
-        pre-built ``Creature`` (raises like the other build kwargs).
-
-        ``is_privileged`` marks the creature as having access to the
-        group_* tool surface — set by direct user actions (solo
-        ``kt run``, Studio "new creature") and by recipe-root assignment
-        (via :meth:`assign_root`). False for tool-spawned workers.
-        **Elevate-only**: passing ``False`` here on a pre-built
-        :class:`Creature` whose ``is_privileged`` is already ``True``
-        (tests, advanced callers) does not demote it. Callers cannot
-        downgrade privilege through this method.
-
-        ``parent_creature_id`` is also additive: it overwrites only when
-        non-None. None means "leave whatever the pre-built creature
-        already has."
-
-        Example: ``alice = await t.add_creature("alice.yaml")``.
-        """
-        if isinstance(config, Creature):
-            # Build-time kwargs cannot apply to an already-built
-            # creature — silently ignoring them hid real caller bugs.
-            ignored = [
-                kw
-                for kw, val in (
-                    ("llm", llm),
-                    ("pwd", pwd),
-                    ("io", io),
-                    ("tools", tools),
-                    ("plugins", plugins),
-                )
-                if val not in (None, "config")
-            ]
-            if ignored:
-                raise ValueError(
-                    f"add_creature received a pre-built Creature; build-time "
-                    f"argument(s) {', '.join(ignored)} cannot be applied. "
-                    f"Pass them to build_creature / the config-based overload."
-                )
-            creature = config
-        else:
-            creature = build_creature(
-                config,
-                creature_id=creature_id,
-                pwd=pwd if pwd is not None else self._pwd,
-                llm=llm,
-                io=io,
-                strict=strict,
-                tools=tools,
-                plugins=plugins,
-            )
-        if creature_id and creature.creature_id != creature_id:
-            creature.creature_id = creature_id
-        _identity.bind_runtime_creature_id(creature)
-        if name and name.strip():
-            apply_creature_name(creature, name.strip())
-        if creature.creature_id in self._creatures:
-            raise ValueError(f"creature_id {creature.creature_id!r} already exists")
-
-        graph_id = self._resolve_graph_id(graph) if graph is not None else None
-        if graph_id is not None:
-            _identity.guard_add_name(self, creature, graph_id)
-            await _checkpoint.preflight_add(
-                self,
-                graph_id,
-                creature,
-                will_persist=session is not False
-                and (session is not None or self._session_dir is not None),
-            )
-        gid = _topo.add_creature(
-            self._topology, creature.creature_id, graph_id=graph_id
+        """Build and insert one creature into the engine."""
+        return await _engine_creature_add.add_creature(
+            self,
+            config,
+            builder=build_creature,
+            register_basic=force_register_basic_tools,
+            register_privileged=force_register_privileged_tools,
+            **kwargs,
         )
-        creature.graph_id = gid
-        # ``is_privileged`` and ``parent_creature_id`` are additive. A
-        # pre-built creature (tests, advanced callers) may already carry
-        # these flags; we never demote them via add_creature.
-        if is_privileged:
-            creature.is_privileged = True
-        if parent_creature_id is not None:
-            creature.parent_creature_id = parent_creature_id
-        # Allocate or reuse the graph's environment, then bind the
-        # creature's agent + executor to it so ToolContext is correct
-        # even when joining a non-empty graph.
-        if gid not in self._environments:
-            self._environments[gid] = Environment(env_id=f"env_{gid}")
-        graph_env = self._environments[gid]
-        _channels.bind_creature_to_environment(creature, graph_env)
-        _channels.register_engine_handle(graph_env, self)
-        self._creatures[creature.creature_id] = creature
-        _wiring.install_output_wiring_resolver(self)
-
-        # Every engine-backed creature gets the basic comm tools
-        # (``send_channel`` / ``group_send``); only privileged creatures
-        # additionally get the graph-mutating ``group_*`` surface.
-        force_register_basic_tools(creature.agent)
-        if creature.is_privileged:
-            force_register_privileged_tools(creature.agent)
-
-        # Drive-enabled engines inject the self-service Drive tools + prompt
-        # and register the Drive service on the graph environment. A
-        # Drive-disabled engine skips this entirely.
-        if self._drive_runtime is not None:
-            await self._drive_runtime.attach_creature(creature, graph_env)
-
-        self._emit(
-            EngineEvent(
-                kind=EventKind.CREATURE_ADDED,
-                creature_id=creature.creature_id,
-                graph_id=gid,
-            )
-        )
-        if start:
-            await creature.start()
-        # Resolve the persistence ``session=`` argument after the
-        # agent starts (matching the Studio attach ordering the turn
-        # viewer depends on).  Minted meta is written BEFORE
-        # ``attach_session`` assigns ``_session_stores`` (the Lab
-        # worker's observing dict snapshots ``load_meta()`` on that
-        # assignment).
-        await _autosession.attach_for_new_creature(
-            self, creature, config=config, session=session
-        )
-        if start:
-            # STARTED fires only when the agent actually started —
-            # ``start=False`` adds used to emit it anyway.
-            self._emit(
-                EngineEvent(
-                    kind=EventKind.CREATURE_STARTED,
-                    creature_id=creature.creature_id,
-                    graph_id=gid,
-                )
-            )
-            # Reconcile this creature's Drives once it crosses the
-            # restoration barrier, rather than immediately on start().
-            if self._drive_runtime is not None:
-                self._drive_runtime.schedule_reconcile(creature)
-        await _checkpoint.checkpoint(self, gid)
-        return creature
 
     async def remove_creature(self, creature: CreatureRef) -> None:
         """Stop and remove a creature.  May split the graph it lived in.
@@ -757,13 +581,8 @@ class Terrarium:
     ) -> GraphTopology:
         """Apply a terrarium recipe into this engine.
 
-        ``session`` follows the same contract as ``add_creature`` but
-        mints ONE terrarium-typed store for the whole graph, with the
-        recipe path recorded as ``config_path`` so resume can rebuild
-        the topology.
-
-        ``created_ids`` collects the id of every creature this call adds
-        (for precise rollback by the resume path).
+        ``session`` follows ``add_creature`` and creates one graph store.
+        ``created_ids`` collects only creatures added by this call.
         """
         kwargs = {
             "graph": graph,
@@ -775,15 +594,21 @@ class Terrarium:
         }
         if llm is not None:
             kwargs["llm"] = llm
+        transaction = _recipe_transaction.RecipeApplyTransaction(self)
+        kwargs["transaction"] = transaction
         topo = None
-        with _checkpoint.suppress(self):
-            topo = await _recipe.apply_recipe(self, recipe, **kwargs)
+        try:
+            with _checkpoint.suppress(self):
+                topo = await _recipe.apply_recipe(self, recipe, **kwargs)
+                if topo is not None:
+                    await _autosession.attach_for_recipe(
+                        self, topo.graph_id, recipe=recipe, session=session
+                    )
             if topo is not None:
-                await _autosession.attach_for_recipe(
-                    self, topo.graph_id, recipe=recipe, session=session
-                )
-        if topo is not None:
-            await _checkpoint.checkpoint(self, topo.graph_id)
+                await _checkpoint.checkpoint(self, topo.graph_id)
+        except BaseException:
+            await _recipe_transaction.rollback_shielded(transaction)
+            raise
         return topo
 
     # ------------------------------------------------------------------

--- a/src/kohakuterrarium/terrarium/engine.py
+++ b/src/kohakuterrarium/terrarium/engine.py
@@ -255,16 +255,43 @@ class Terrarium:
     async def add_creature(
         self,
         config: CreatureBuildInput | Creature,
-        **kwargs: Any,
+        *,
+        graph: GraphRef | None = None,
+        creature_id: str | None = None,
+        llm: Any = None,
+        pwd: str | None = None,
+        start: bool = True,
+        is_privileged: bool = False,
+        parent_creature_id: str | None = None,
+        io: str = "config",
+        strict: bool = True,
+        session: bool | str | Path | SessionStore | None = None,
+        name: str | None = None,
+        tools: list[Any] | None = None,
+        plugins: list[Any] | None = None,
+        _identity_reserved: bool = False,
     ) -> Creature:
         """Build and insert one creature into the engine."""
         return await _engine_creature_add.add_creature(
             self,
             config,
+            graph=graph,
+            creature_id=creature_id,
+            llm=llm,
+            pwd=pwd,
+            start=start,
+            is_privileged=is_privileged,
+            parent_creature_id=parent_creature_id,
+            io=io,
+            strict=strict,
+            session=session,
+            name=name,
+            tools=tools,
+            plugins=plugins,
+            identity_reserved=_identity_reserved,
             builder=build_creature,
             register_basic=force_register_basic_tools,
             register_privileged=force_register_privileged_tools,
-            **kwargs,
         )
 
     async def remove_creature(self, creature: CreatureRef) -> None:
@@ -601,6 +628,15 @@ class Terrarium:
             with _checkpoint.suppress(self):
                 topo = await _recipe.apply_recipe(self, recipe, **kwargs)
                 if topo is not None:
+                    previous_store = self._session_stores.get(topo.graph_id)
+                    if (
+                        previous_store is not None
+                        and session is not False
+                        and not _autosession.recipe_session_reuses_store(
+                            previous_store, session
+                        )
+                    ):
+                        transaction.stage_session_replacement(topo.graph_id)
                     await _autosession.attach_for_recipe(
                         self, topo.graph_id, recipe=recipe, session=session
                     )
@@ -609,6 +645,7 @@ class Terrarium:
         except BaseException:
             await _recipe_transaction.rollback_shielded(transaction)
             raise
+        await transaction.commit()
         return topo
 
     # ------------------------------------------------------------------

--- a/src/kohakuterrarium/terrarium/engine_creature_add.py
+++ b/src/kohakuterrarium/terrarium/engine_creature_add.py
@@ -1,0 +1,200 @@
+"""Creature construction and insertion helpers for the Terrarium engine."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import kohakuterrarium.terrarium.autosession as _autosession
+import kohakuterrarium.terrarium.channels as _channels
+import kohakuterrarium.terrarium.graph_checkpoint as _checkpoint
+import kohakuterrarium.terrarium.graph_identity_engine as _identity
+import kohakuterrarium.terrarium.topology as _topo
+import kohakuterrarium.terrarium.wiring as _wiring
+from kohakuterrarium.core.environment import Environment
+from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.terrarium.creature_host import (
+    Creature,
+    CreatureBuildInput,
+    apply_creature_name,
+    build_creature,
+)
+from kohakuterrarium.terrarium.events import EngineEvent, EventKind
+
+if TYPE_CHECKING:
+    from kohakuterrarium.terrarium.engine import Terrarium
+    from kohakuterrarium.terrarium.topology import GraphTopology
+
+
+async def add_creature(
+    engine: Terrarium,
+    config: CreatureBuildInput | Creature,
+    *,
+    graph: GraphTopology | str | None = None,
+    creature_id: str | None = None,
+    llm: Any = None,
+    pwd: str | None = None,
+    start: bool = True,
+    is_privileged: bool = False,
+    parent_creature_id: str | None = None,
+    io: str = "config",
+    strict: bool = True,
+    session: bool | str | Path | SessionStore | None = None,
+    name: str | None = None,
+    tools: list[Any] | None = None,
+    plugins: list[Any] | None = None,
+    builder=build_creature,
+    register_basic=None,
+    register_privileged=None,
+    identity_reserved: bool = False,
+) -> Creature:
+    """Build, insert, optionally start, persist, and checkpoint one creature."""
+    creature = _prepare_creature(
+        engine,
+        config,
+        creature_id=creature_id,
+        llm=llm,
+        pwd=pwd,
+        io=io,
+        strict=strict,
+        name=name,
+        tools=tools,
+        plugins=plugins,
+        builder=builder,
+    )
+    _identity.bind_runtime_creature_id(creature)
+    claimed_identity = False
+    if not identity_reserved:
+        claimed_identity = await engine._recipe_identities.claim_exact(
+            engine, creature.creature_id
+        )
+        if not claimed_identity:
+            raise ValueError(f"creature_id {creature.creature_id!r} already exists")
+    elif creature.creature_id in engine._creatures:
+        raise ValueError(f"creature_id {creature.creature_id!r} already exists")
+
+    graph_id = engine._resolve_graph_id(graph) if graph is not None else None
+    try:
+        _identity.guard_add_name(engine, creature, graph_id)
+        if graph_id is not None:
+            await _checkpoint.preflight_add(
+                engine,
+                graph_id,
+                creature,
+                will_persist=session is not False
+                and (session is not None or engine._session_dir is not None),
+            )
+        gid = _topo.add_creature(
+            engine._topology, creature.creature_id, graph_id=graph_id
+        )
+    except BaseException:
+        if claimed_identity:
+            await engine._recipe_identities.release_exact(creature.creature_id)
+        raise
+    if claimed_identity:
+        await engine._recipe_identities.release_exact(creature.creature_id)
+    creature.graph_id = gid
+    if is_privileged:
+        creature.is_privileged = True
+    if parent_creature_id is not None:
+        creature.parent_creature_id = parent_creature_id
+    if gid not in engine._environments:
+        engine._environments[gid] = Environment(env_id=f"env_{gid}")
+    graph_env = engine._environments[gid]
+    _channels.bind_creature_to_environment(creature, graph_env)
+    _channels.register_engine_handle(graph_env, engine)
+    engine._creatures[creature.creature_id] = creature
+    _wiring.install_output_wiring_resolver(engine)
+
+    if register_basic is not None:
+        register_basic(creature.agent)
+    if creature.is_privileged and register_privileged is not None:
+        register_privileged(creature.agent)
+    if engine._drive_runtime is not None:
+        await engine._drive_runtime.attach_creature(creature, graph_env)
+
+    engine._emit(
+        EngineEvent(
+            kind=EventKind.CREATURE_ADDED,
+            creature_id=creature.creature_id,
+            graph_id=gid,
+        )
+    )
+    try:
+        if start:
+            await creature.start()
+        await _autosession.attach_for_new_creature(
+            engine, creature, config=config, session=session
+        )
+        if start:
+            engine._emit(
+                EngineEvent(
+                    kind=EventKind.CREATURE_STARTED,
+                    creature_id=creature.creature_id,
+                    graph_id=gid,
+                )
+            )
+            if engine._drive_runtime is not None:
+                engine._drive_runtime.schedule_reconcile(creature)
+        await _checkpoint.checkpoint(engine, gid)
+        return creature
+    except BaseException:
+        cleanup = asyncio.create_task(engine.remove_creature(creature.creature_id))
+        try:
+            await asyncio.shield(cleanup)
+        except asyncio.CancelledError:
+            await cleanup
+            raise
+        raise
+
+
+def _prepare_creature(
+    engine: Terrarium,
+    config: CreatureBuildInput | Creature,
+    *,
+    creature_id: str | None,
+    llm: Any,
+    pwd: str | None,
+    io: str,
+    strict: bool,
+    name: str | None,
+    tools: list[Any] | None,
+    plugins: list[Any] | None,
+    builder,
+) -> Creature:
+    if isinstance(config, Creature):
+        ignored = [
+            key
+            for key, value in (
+                ("llm", llm),
+                ("pwd", pwd),
+                ("io", io),
+                ("tools", tools),
+                ("plugins", plugins),
+            )
+            if value not in (None, "config")
+        ]
+        if ignored:
+            raise ValueError(
+                "add_creature received a pre-built Creature; build-time "
+                f"argument(s) {', '.join(ignored)} cannot be applied. Pass them "
+                "to build_creature / the config-based overload."
+            )
+        creature = config
+    else:
+        creature = builder(
+            config,
+            creature_id=creature_id,
+            pwd=pwd if pwd is not None else engine._pwd,
+            llm=llm,
+            io=io,
+            strict=strict,
+            tools=tools,
+            plugins=plugins,
+        )
+    if creature_id and creature.creature_id != creature_id:
+        creature.creature_id = creature_id
+    if name and name.strip():
+        apply_creature_name(creature, name.strip())
+    return creature

--- a/src/kohakuterrarium/terrarium/recipe.py
+++ b/src/kohakuterrarium/terrarium/recipe.py
@@ -28,12 +28,7 @@ from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
-from kohakuterrarium.core.environment import Environment
-from kohakuterrarium.terrarium.config import (
-    CreatureConfig,
-    TerrariumConfig,
-    load_terrarium_config,
-)
+from kohakuterrarium.terrarium.config import TerrariumConfig, load_terrarium_config
 from kohakuterrarium.terrarium.creature_host import Creature, build_creature
 from kohakuterrarium.terrarium.graph_identity import ensure_graph_name_available
 from kohakuterrarium.terrarium.recipe_apply import apply_resolved_recipe
@@ -167,30 +162,3 @@ def _validate_declared_name_aliases(config: TerrariumConfig) -> list[str]:
             "one graph."
         )
     return sorted(owners)
-
-
-def _build_recipe_creature(
-    builder: CreatureBuilder,
-    cfg: CreatureConfig,
-    *,
-    creature_id: str,
-    pwd: str | None,
-    llm: Any,
-    env: Environment,
-    use_default_builder: bool,
-    strict: bool = True,
-) -> Creature:
-    if use_default_builder:
-        return builder(
-            cfg,
-            creature_id=creature_id,
-            pwd=pwd,
-            llm=llm,
-            environment=env,
-            strict=strict,
-        )
-    creature = builder(cfg, creature_id=creature_id, pwd=pwd)
-    creature.agent.environment = env
-    if getattr(creature.agent, "executor", None) is not None:
-        creature.agent.executor._environment = env
-    return creature

--- a/src/kohakuterrarium/terrarium/recipe.py
+++ b/src/kohakuterrarium/terrarium/recipe.py
@@ -22,13 +22,12 @@ and gives every other creature a send edge on ``report_to_root``.
 agent, so no recipe-side tool injection is needed.
 """
 
+import asyncio
 from collections import Counter
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
-import kohakuterrarium.terrarium.channels as _channels
-import kohakuterrarium.terrarium.topology as _topo
-import kohakuterrarium.terrarium.wiring as _wiring
 from kohakuterrarium.core.environment import Environment
 from kohakuterrarium.terrarium.config import (
     CreatureConfig,
@@ -37,14 +36,11 @@ from kohakuterrarium.terrarium.config import (
 )
 from kohakuterrarium.terrarium.creature_host import Creature, build_creature
 from kohakuterrarium.terrarium.graph_identity import ensure_graph_name_available
+from kohakuterrarium.terrarium.recipe_apply import apply_resolved_recipe
 from kohakuterrarium.terrarium.topology import GraphTopology
-from kohakuterrarium.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from kohakuterrarium.terrarium.engine import Terrarium
-
-logger = get_logger(__name__)
-
 
 CreatureBuilder = Callable[..., Creature]
 
@@ -68,6 +64,7 @@ async def apply_recipe(
     start: bool = True,
     creature_builder: CreatureBuilder | None = None,
     created_ids: list[str] | None = None,
+    transaction=None,
 ) -> GraphTopology:
     """Load a terrarium recipe into ``engine`` and return the resulting
     :class:`GraphTopology`.
@@ -83,232 +80,62 @@ async def apply_recipe(
     task added meanwhile.
     """
     config = _resolve_recipe(recipe)
-    _preflight_recipe_names(engine, config, graph)
+    logical_names = _validate_logical_names(config)
     builder = creature_builder or build_creature
     use_default_builder = creature_builder is None
-
-    # 1. Mint or reuse the graph and its shared environment before building
-    # agents, so recipe-created agents receive the graph Environment in their
-    # ToolContext and can use shared channels.
+    graph_lock = None
     if graph is not None:
         graph_id = engine._resolve_graph_id(graph)
-    else:
-        graph_id = _topo.new_graph_id()
-        engine._topology.graphs[graph_id] = _topo.GraphTopology(graph_id=graph_id)
-        engine._environments[graph_id] = Environment(env_id=f"env_{graph_id}")
-    env = engine._environments[graph_id]
-    _channels.register_engine_handle(env, engine)
+        graph_lock = engine._recipe_graph_locks.setdefault(graph_id, asyncio.Lock())
+    graph_cm = graph_lock if graph_lock is not None else nullcontext()
 
-    # 2. Pre-declare every channel the recipe wants.
-    for ch_cfg in config.channels:
-        await engine.add_channel(
-            graph_id,
-            ch_cfg.name,
-            description=ch_cfg.description,
-        )
-        logger.debug("Recipe channel declared", channel=ch_cfg.name)
-
-    # 3. Auto-direct channels (one per creature) — added even for
-    #    creatures the recipe didn't list as having explicit inbound.
-    for cr_cfg in config.creatures:
-        if cr_cfg.name not in engine.get_graph(graph_id).channels:
-            await engine.add_channel(
-                graph_id,
-                cr_cfg.name,
-                description=f"Direct channel to {cr_cfg.name}",
+    async with graph_cm:
+        if graph is not None:
+            graph_id = engine._resolve_graph_id(graph)
+            for name in logical_names:
+                ensure_graph_name_available(
+                    engine._topology,
+                    engine._creatures,
+                    graph_id=graph_id,
+                    name=name,
+                )
+        async with engine._recipe_identities.reserve(
+            engine, logical_names
+        ) as runtime_ids:
+            return await apply_resolved_recipe(
+                engine,
+                config,
+                runtime_ids=runtime_ids,
+                graph=graph,
+                pwd=pwd,
+                llm=llm,
+                strict=strict,
+                start=start,
+                builder=builder,
+                use_default_builder=use_default_builder,
+                created_ids=created_ids,
+                transaction=transaction,
             )
 
-    # 4. report_to_root when a root is declared.
-    has_root = config.root is not None
-    if has_root and "report_to_root" not in engine.get_graph(graph_id).channels:
-        await engine.add_channel(
-            graph_id,
-            "report_to_root",
-            description="Any creature can report to the root agent",
-        )
 
-    # 5. Add every configured creature.
-    # Back-to-back spawns of the same recipe would collide on
-    # ``creature_id=cr_cfg.name``; suffix with a counter so a second
-    # ``apply_recipe`` against the same engine adds ``intake_2`` /
-    # ``intake_3`` / ... instead of 400ing on ``already exists``.
-    # We track the resolved id per cr_cfg.name so the wiring pass
-    # in step 6 can find the right Creature when names alias.
-    recipe_id_map: dict[str, str] = {}
-    for cr_cfg in config.creatures:
-        cid = _allocate_unique_creature_id(engine, cr_cfg.name)
-        recipe_id_map[cr_cfg.name] = cid
-        creature = _build_recipe_creature(
-            builder,
-            cr_cfg,
-            creature_id=cid,
-            pwd=pwd,
-            llm=llm,
-            env=env,
-            use_default_builder=use_default_builder,
-            strict=strict,
-        )
-        # ``session=False``: per-creature autosession is suppressed —
-        # ``engine.apply_recipe`` mints ONE terrarium-typed store for
-        # the whole graph (config_path = the recipe) after this loop.
-        added = await engine.add_creature(
-            creature, graph=graph_id, start=False, session=False
-        )
-        if created_ids is not None:
-            created_ids.append(added.creature_id)
-
-    root_creature: Creature | None = None
-    if config.root is not None:
-        root_data = dict(config.root.config_data)
-        root_data["name"] = "root"
-        root_cfg = CreatureConfig(
-            name="root",
-            config_data=root_data,
-            base_dir=config.root.base_dir,
-        )
-        root_creature = _build_recipe_creature(
-            builder,
-            root_cfg,
-            creature_id="root",
-            pwd=pwd,
-            llm=llm,
-            env=env,
-            use_default_builder=use_default_builder,
-            strict=strict,
-        )
-        added_root = await engine.add_creature(
-            root_creature, graph=graph_id, start=False, session=False
-        )
-        if created_ids is not None:
-            created_ids.append(added_root.creature_id)
-
-    # 6. Wire listen/send edges + inject triggers.
-    for cr_cfg in config.creatures:
-        creature = engine.get_creature(recipe_id_map[cr_cfg.name])
-        # Always listen to the creature's own direct channel.
-        all_listen = list(cr_cfg.listen_channels)
-        if cr_cfg.name not in all_listen:
-            all_listen.append(cr_cfg.name)
-        for ch in all_listen:
-            try:
-                _topo.set_listen(
-                    engine._topology,
-                    creature.creature_id,
-                    ch,
-                    listening=True,
-                )
-            except KeyError:
-                # Channel not declared — recipe-author error; skip
-                # silently (parity with legacy behaviour).
-                continue
-            _channels.inject_channel_trigger(
-                creature.agent,
-                subscriber_id=cr_cfg.name,
-                channel_name=ch,
-                registry=env.shared_channels,
-                ignore_sender=cr_cfg.name,
-                ignore_sender_id=creature.creature_id,
-            )
-            if ch not in creature.listen_channels:
-                creature.listen_channels.append(ch)
-        # send edges — no trigger needed; the agent emits to the channel
-        # via send_channel / send_message tool.
-        all_send = list(cr_cfg.send_channels)
-        if has_root and "report_to_root" not in all_send:
-            all_send.append("report_to_root")
-        for ch in all_send:
-            try:
-                _topo.set_send(
-                    engine._topology,
-                    creature.creature_id,
-                    ch,
-                    sending=True,
-                )
-            except KeyError:
-                continue
-            if ch not in creature.send_channels:
-                creature.send_channels.append(ch)
-
-    # 7. Designate the root creature: makes it privileged and wires it
-    # as the listener on every channel in the graph.
-    if root_creature is not None:
-        await engine.assign_root(root_creature)
-
-    _wiring.install_output_wiring_resolver(engine)
-
-    # 8. Start every creature now that wiring is complete. Resume
-    # passes ``start=False`` so saved state can be injected BEFORE any
-    # startup trigger or input runs against an empty conversation.
-    if start:
-        for cid in list(engine.get_graph(graph_id).creature_ids):
-            creature = engine.get_creature(cid)
-            await creature.start()
-            # Arm the barrier-gated Drive reconcile/dispatcher start, as every
-            # other creature-start site does (engine.add_creature / engine.start
-            # / resume). Recipe apply starts creatures directly, not via those.
-            if engine._drive_runtime is not None:
-                engine._drive_runtime.schedule_reconcile(creature)
-
-    logger.info(
-        "Recipe applied",
-        terrarium=config.name,
-        creatures=len(config.creatures),
-        channels=len(config.channels),
-        root=has_root,
-    )
-    return engine.get_graph(graph_id)
-
-
-def _preflight_recipe_names(
-    engine: "Terrarium",
-    config: TerrariumConfig,
-    graph: GraphTopology | str | None,
-) -> None:
-    """Reject ambiguous names before recipe application mutates the engine."""
+def _validate_logical_names(config: TerrariumConfig) -> list[str]:
+    """Return recipe logical names, rejecting names that make wiring ambiguous."""
     names = [creature.name for creature in config.creatures]
-    if config.root is not None:
-        names.append("root")
     duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
     if duplicates:
+        formatted = ", ".join(repr(name) for name in duplicates)
         raise ValueError(
-            "Terrarium recipe contains duplicate logical creature name(s): "
-            + ", ".join(repr(name) for name in duplicates)
+            f"Terrarium recipe contains duplicate logical creature name(s): "
+            f"{formatted}. Logical creature names must be unique within one recipe."
         )
-    if graph is None:
-        return
-    graph_id = engine._resolve_graph_id(graph)
-    for name in names:
-        ensure_graph_name_available(
-            engine._topology,
-            engine._creatures,
-            graph_id=graph_id,
-            name=name,
-        )
-
-
-def _allocate_unique_creature_id(engine: "Terrarium", name: str) -> str:
-    """Return a creature_id starting with ``name`` that isn't taken on
-    ``engine``.
-
-    Recipe-spawned creatures historically use ``creature_id == name``;
-    when the same recipe is applied twice (or two recipes share a name
-    in the same engine) the second spawn collided with
-    ``ValueError: creature_id 'X' already exists``.  Suffix with a
-    counter (``X_2``, ``X_3``, ...) so back-to-back ``apply_recipe``
-    calls succeed deterministically.
-    """
-    try:
-        engine.get_creature(name)
-    except KeyError:
-        return name
-    n = 2
-    while True:
-        candidate = f"{name}_{n}"
-        try:
-            engine.get_creature(candidate)
-        except KeyError:
-            return candidate
-        n += 1
+    if config.root is not None:
+        if "root" in names:
+            raise ValueError(
+                "Terrarium recipe cannot declare both a root section and a regular "
+                "creature named 'root'"
+            )
+        names.append("root")
+    return names
 
 
 def _build_recipe_creature(

--- a/src/kohakuterrarium/terrarium/recipe.py
+++ b/src/kohakuterrarium/terrarium/recipe.py
@@ -81,6 +81,7 @@ async def apply_recipe(
     """
     config = _resolve_recipe(recipe)
     logical_names = _validate_logical_names(config)
+    declared_aliases = _validate_declared_name_aliases(config)
     builder = creature_builder or build_creature
     use_default_builder = creature_builder is None
     graph_lock = None
@@ -92,7 +93,7 @@ async def apply_recipe(
     async with graph_cm:
         if graph is not None:
             graph_id = engine._resolve_graph_id(graph)
-            for name in logical_names:
+            for name in declared_aliases:
                 ensure_graph_name_available(
                     engine._topology,
                     engine._creatures,
@@ -136,6 +137,36 @@ def _validate_logical_names(config: TerrariumConfig) -> list[str]:
             )
         names.append("root")
     return names
+
+
+def _validate_declared_name_aliases(config: TerrariumConfig) -> list[str]:
+    """Return every declared graph alias, rejecting cross-member ambiguity."""
+    owners: dict[str, int] = {}
+    duplicates: set[str] = set()
+    for owner, creature in enumerate(config.creatures):
+        aliases = {creature.name}
+        configured_name = creature.config_data.get("name")
+        if isinstance(configured_name, str) and configured_name:
+            aliases.add(configured_name)
+        for alias in aliases:
+            previous_owner = owners.setdefault(alias, owner)
+            if previous_owner != owner:
+                duplicates.add(alias)
+
+    if config.root is not None:
+        root_owner = len(config.creatures)
+        previous_owner = owners.setdefault("root", root_owner)
+        if previous_owner != root_owner:
+            duplicates.add("root")
+
+    if duplicates:
+        formatted = ", ".join(repr(name) for name in sorted(duplicates))
+        raise ValueError(
+            "Terrarium recipe contains duplicate creature name alias(es): "
+            f"{formatted}. Display and configured names must be unique within "
+            "one graph."
+        )
+    return sorted(owners)
 
 
 def _build_recipe_creature(

--- a/src/kohakuterrarium/terrarium/recipe_apply.py
+++ b/src/kohakuterrarium/terrarium/recipe_apply.py
@@ -1,0 +1,312 @@
+"""Transactional mechanics for applying a resolved terrarium recipe."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import kohakuterrarium.terrarium.channels as _channels
+import kohakuterrarium.terrarium.topology as _topo
+import kohakuterrarium.terrarium.wiring as _wiring
+from kohakuterrarium.core.environment import Environment
+from kohakuterrarium.terrarium.config import CreatureConfig, TerrariumConfig
+from kohakuterrarium.terrarium.creature_host import Creature
+from kohakuterrarium.terrarium.recipe_transaction import (
+    RecipeApplyTransaction,
+    rollback_shielded,
+)
+from kohakuterrarium.terrarium.topology import GraphTopology
+from kohakuterrarium.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from kohakuterrarium.terrarium.engine import Terrarium
+
+CreatureBuilder = Callable[..., Creature]
+logger = get_logger(__name__)
+
+
+async def apply_resolved_recipe(
+    engine: Terrarium,
+    config: TerrariumConfig,
+    *,
+    runtime_ids: dict[str, str],
+    graph: GraphTopology | str | None,
+    pwd: str | None,
+    llm: Any,
+    strict: bool,
+    start: bool,
+    builder: CreatureBuilder,
+    use_default_builder: bool,
+    created_ids: list[str] | None,
+    transaction: RecipeApplyTransaction | None = None,
+) -> GraphTopology:
+    """Apply a validated recipe and roll back every owned mutation on failure."""
+    transaction = transaction or RecipeApplyTransaction(engine)
+    try:
+        result = await _apply(
+            engine,
+            config,
+            runtime_ids=runtime_ids,
+            graph=graph,
+            pwd=pwd,
+            llm=llm,
+            strict=strict,
+            start=start,
+            builder=builder,
+            use_default_builder=use_default_builder,
+            transaction=transaction,
+        )
+    except BaseException:
+        await rollback_shielded(transaction)
+        raise
+
+    if created_ids is not None:
+        created_ids.extend(transaction.created_creature_ids)
+    return result
+
+
+async def _apply(
+    engine: Terrarium,
+    config: TerrariumConfig,
+    *,
+    runtime_ids: dict[str, str],
+    graph: GraphTopology | str | None,
+    pwd: str | None,
+    llm: Any,
+    strict: bool,
+    start: bool,
+    builder: CreatureBuilder,
+    use_default_builder: bool,
+    transaction: RecipeApplyTransaction,
+) -> GraphTopology:
+    graph_id, graph_obj = _prepare_graph(engine, graph, transaction)
+    transaction.snapshot_existing_members(graph_id)
+    environment = engine._environments[graph_id]
+    _channels.register_engine_handle(environment, engine)
+    await _declare_channels(engine, config, graph_id, transaction)
+
+    root_creature = await _add_members(
+        engine,
+        config,
+        runtime_ids=runtime_ids,
+        graph_id=graph_id,
+        pwd=pwd,
+        llm=llm,
+        strict=strict,
+        builder=builder,
+        use_default_builder=use_default_builder,
+        transaction=transaction,
+        environment=environment,
+    )
+    await _wire_members(engine, config, runtime_ids, root_creature, environment)
+
+    if start:
+        for creature_id in transaction.created_creature_ids:
+            creature = engine.get_creature(creature_id)
+            await creature.start()
+            if engine._drive_runtime is not None:
+                engine._drive_runtime.schedule_reconcile(creature)
+
+    logger.info(
+        "Applied recipe '%s': %d creatures, %d channels",
+        config.name,
+        len(config.creatures) + (1 if config.root else 0),
+        len(config.channels) + (1 if config.root else 0),
+    )
+    return graph_obj
+
+
+def _prepare_graph(
+    engine: Terrarium,
+    graph: GraphTopology | str | None,
+    transaction: RecipeApplyTransaction,
+) -> tuple[str, GraphTopology]:
+    if graph is not None:
+        graph_id = engine._resolve_graph_id(graph)
+        return graph_id, engine.get_graph(graph_id)
+
+    graph_id = _topo.new_graph_id()
+    graph_obj = _topo.GraphTopology(graph_id=graph_id)
+    engine._topology.graphs[graph_id] = graph_obj
+    engine._environments[graph_id] = Environment(env_id=f"env_{graph_id}")
+    transaction.record_graph(graph_id)
+    return graph_id, graph_obj
+
+
+async def _declare_channels(
+    engine: Terrarium,
+    config: TerrariumConfig,
+    graph_id: str,
+    transaction: RecipeApplyTransaction,
+) -> None:
+    graph = engine.get_graph(graph_id)
+    for channel in config.channels:
+        if channel.name not in graph.channels:
+            await engine.add_channel(
+                graph_id,
+                channel.name,
+                description=channel.description,
+            )
+            transaction.record_channel(graph_id, channel.name)
+
+    for creature in config.creatures:
+        if creature.name not in engine.get_graph(graph_id).channels:
+            await engine.add_channel(
+                graph_id,
+                creature.name,
+                description=f"Direct channel to {creature.name}",
+            )
+            transaction.record_channel(graph_id, creature.name)
+
+    if (
+        config.root is not None
+        and "report_to_root" not in engine.get_graph(graph_id).channels
+    ):
+        await engine.add_channel(
+            graph_id,
+            "report_to_root",
+            description="Any creature can report to the root",
+        )
+        transaction.record_channel(graph_id, "report_to_root")
+
+
+async def _add_members(
+    engine: Terrarium,
+    config: TerrariumConfig,
+    *,
+    runtime_ids: dict[str, str],
+    graph_id: str,
+    pwd: str | None,
+    llm: Any,
+    strict: bool,
+    builder: CreatureBuilder,
+    use_default_builder: bool,
+    transaction: RecipeApplyTransaction,
+    environment: Environment,
+) -> Creature | None:
+    for creature_config in config.creatures:
+        creature = _build_recipe_creature(
+            builder,
+            creature_config,
+            creature_id=runtime_ids[creature_config.name],
+            graph_id=graph_id,
+            pwd=pwd,
+            llm=llm,
+            strict=strict,
+            use_default_builder=use_default_builder,
+            environment=environment,
+        )
+        if creature.creature_id != runtime_ids[creature_config.name]:
+            raise ValueError(
+                f"recipe builder returned creature_id {creature.creature_id!r}; "
+                f"reserved {runtime_ids[creature_config.name]!r}"
+            )
+        transaction.record_creature(creature.creature_id)
+        await engine.add_creature(
+            creature,
+            graph=graph_id,
+            start=False,
+            session=False,
+            identity_reserved=True,
+        )
+
+    if config.root is None:
+        return None
+
+    root_data = dict(config.root.config_data)
+    root_data["name"] = "root"
+    root_config = CreatureConfig(
+        name="root",
+        config_data=root_data,
+        base_dir=config.root.base_dir,
+    )
+    root = _build_recipe_creature(
+        builder,
+        root_config,
+        creature_id=runtime_ids["root"],
+        graph_id=graph_id,
+        pwd=pwd,
+        llm=llm,
+        strict=strict,
+        use_default_builder=use_default_builder,
+        environment=environment,
+    )
+    if root.creature_id != runtime_ids["root"]:
+        raise ValueError(
+            f"recipe builder returned creature_id {root.creature_id!r}; "
+            f"reserved {runtime_ids['root']!r}"
+        )
+    transaction.record_creature(root.creature_id)
+    return await engine.add_creature(
+        root,
+        graph=graph_id,
+        start=False,
+        session=False,
+        identity_reserved=True,
+    )
+
+
+async def _wire_members(
+    engine: Terrarium,
+    config: TerrariumConfig,
+    runtime_ids: dict[str, str],
+    root_creature: Creature | None,
+    environment: Environment,
+) -> None:
+    for creature_config in config.creatures:
+        creature = engine.get_creature(runtime_ids[creature_config.name])
+        listen_channels = list(
+            dict.fromkeys([creature_config.name, *creature_config.listen_channels])
+        )
+        for channel_name in listen_channels:
+            channel = environment.shared_channels.get(channel_name)
+            if channel is None:
+                continue
+            _channels.inject_channel_trigger(
+                creature.agent,
+                subscriber_id=creature.name,
+                channel_name=channel_name,
+                registry=environment.shared_channels,
+                ignore_sender_id=creature.creature_id,
+            )
+            if channel_name not in creature.listen_channels:
+                creature.listen_channels.append(channel_name)
+            graph = engine._topology.graphs[creature.graph_id]
+            graph.listen_edges.setdefault(creature.creature_id, set()).add(channel_name)
+
+        for channel_name in creature_config.send_channels:
+            graph = engine._topology.graphs[creature.graph_id]
+            if channel_name not in graph.channels:
+                continue
+            if channel_name not in creature.send_channels:
+                creature.send_channels.append(channel_name)
+            graph.send_edges.setdefault(creature.creature_id, set()).add(channel_name)
+
+    if root_creature is not None:
+        await engine.assign_root(root_creature)
+
+    _wiring.install_output_wiring_resolver(engine)
+
+
+def _build_recipe_creature(
+    builder: CreatureBuilder,
+    config: CreatureConfig,
+    *,
+    creature_id: str,
+    graph_id: str,
+    pwd: str | None,
+    llm: Any,
+    strict: bool,
+    use_default_builder: bool,
+    environment: Environment,
+) -> Creature:
+    kwargs: dict[str, Any] = {
+        "graph_id": graph_id,
+        "pwd": pwd,
+        "llm": llm,
+        "strict": strict,
+        "environment": environment,
+    }
+    kwargs["creature_id"] = creature_id
+    creature = builder(config, **kwargs)
+    return creature

--- a/src/kohakuterrarium/terrarium/recipe_apply.py
+++ b/src/kohakuterrarium/terrarium/recipe_apply.py
@@ -300,13 +300,18 @@ def _build_recipe_creature(
     use_default_builder: bool,
     environment: Environment,
 ) -> Creature:
-    kwargs: dict[str, Any] = {
-        "graph_id": graph_id,
-        "pwd": pwd,
-        "llm": llm,
-        "strict": strict,
-        "environment": environment,
-    }
-    kwargs["creature_id"] = creature_id
+    kwargs: dict[str, Any] = {"creature_id": creature_id, "pwd": pwd}
+    if use_default_builder:
+        kwargs.update(
+            graph_id=graph_id,
+            llm=llm,
+            strict=strict,
+            environment=environment,
+        )
     creature = builder(config, **kwargs)
+    if not use_default_builder:
+        creature.agent.environment = environment
+        executor = getattr(creature.agent, "executor", None)
+        if executor is not None:
+            executor._environment = environment
     return creature

--- a/src/kohakuterrarium/terrarium/recipe_apply.py
+++ b/src/kohakuterrarium/terrarium/recipe_apply.py
@@ -207,7 +207,7 @@ async def _add_members(
             graph=graph_id,
             start=False,
             session=False,
-            identity_reserved=True,
+            _identity_reserved=True,
         )
 
     if config.root is None:
@@ -242,7 +242,7 @@ async def _add_members(
         graph=graph_id,
         start=False,
         session=False,
-        identity_reserved=True,
+        _identity_reserved=True,
     )
 
 

--- a/src/kohakuterrarium/terrarium/recipe_discard.py
+++ b/src/kohakuterrarium/terrarium/recipe_discard.py
@@ -1,0 +1,162 @@
+"""Discard a worker-owned recipe graph and its persistent session family."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import kohakuterrarium.terrarium.wiring as wiring
+from kohakuterrarium.terrarium import graph_checkpoint
+from kohakuterrarium.terrarium.channels import remove_channel_trigger
+from kohakuterrarium.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from kohakuterrarium.terrarium.engine import Terrarium
+
+logger = get_logger(__name__)
+
+
+async def discard_recipe_graph(
+    engine: Terrarium,
+    graph_id: str,
+    *,
+    before_store_close: Callable[[], None] | None = None,
+) -> None:
+    """Remove one recipe graph and delete the session files minted for it."""
+    graph = engine._topology.graphs.get(graph_id)
+    if graph is None:
+        raise KeyError(f"graph {graph_id!r} not in engine")
+    store = engine._session_stores.get(graph_id)
+    if store is None or graph_id not in engine._owned_sessions:
+        raise ValueError(f"graph {graph_id!r} has no worker-owned session")
+
+    session_path = Path(store.path)
+    creature_ids = sorted(graph.creature_ids)
+    remaining_ids = set(creature_ids)
+    for creature_id in creature_ids:
+        remaining_ids.discard(creature_id)
+        creature = engine._creatures.get(creature_id)
+        if creature is None:
+            continue
+        if creature.is_running:
+            try:
+                await creature.stop(requested=False)
+            except BaseException:
+                logger.exception(
+                    "discard recipe failed to stop creature",
+                    extra={"creature_id": creature_id},
+                )
+        if engine._drive_runtime is not None:
+            try:
+                await engine._drive_runtime.on_creature_removed(
+                    creature_id,
+                    graph_id=graph_id,
+                    graph_member_ids=frozenset(remaining_ids),
+                )
+            except BaseException:
+                logger.exception(
+                    "discard recipe failed to clean Drive assignments",
+                    extra={"creature_id": creature_id},
+                )
+        for channel_name in list(creature.listen_channels):
+            try:
+                remove_channel_trigger(
+                    creature.agent,
+                    subscriber_id=creature.name,
+                    channel_name=channel_name,
+                )
+            except BaseException:
+                logger.exception(
+                    "discard recipe failed to remove channel trigger",
+                    extra={"creature_id": creature_id},
+                )
+        engine._creatures.pop(creature_id, None)
+        engine._topology.creature_to_graph.pop(creature_id, None)
+
+    engine._topology.graphs.pop(graph_id, None)
+    engine._environments.pop(graph_id, None)
+    graph_checkpoint.discard(engine, graph_id)
+    if engine._drive_runtime is not None:
+        engine._drive_runtime.registry.drop_graph(graph_id)
+        await engine._drain_drive_topology()
+    wiring.install_output_wiring_resolver(engine)
+
+    if before_store_close is not None:
+        before_store_close()
+    await _close_store(store)
+    engine._session_stores.pop(graph_id, None)
+    engine._owned_sessions.discard(graph_id)
+    engine._recipe_graph_locks.pop(graph_id, None)
+    _discard_session_family(session_path)
+
+
+async def discard_recipe_graph_shielded(
+    engine: Terrarium,
+    graph_id: str,
+    *,
+    before_store_close: Callable[[], None] | None = None,
+) -> None:
+    """Finish worker cleanup even if the request task is cancelled."""
+    cleanup = asyncio.create_task(
+        discard_recipe_graph(
+            engine,
+            graph_id,
+            before_store_close=before_store_close,
+        )
+    )
+    try:
+        await asyncio.shield(cleanup)
+    except asyncio.CancelledError:
+        await cleanup
+        raise
+
+
+async def _close_store(store) -> None:
+    try:
+        result = store.close(update_status=False)
+    except TypeError:
+        result = store.close()
+    if inspect.isawaitable(result):
+        await result
+
+
+def _discard_session_family(path: Path) -> None:
+    family = [
+        path,
+        path.with_name(path.name + "-wal"),
+        path.with_name(path.name + "-shm"),
+        path.with_name(path.name + ".drives"),
+        path.with_name(path.name + ".drives-wal"),
+        path.with_name(path.name + ".drives-shm"),
+        *path.parent.glob(f"{path.name}.drives.split-intent.json*"),
+    ]
+    detached: list[tuple[Path, Path]] = []
+    try:
+        for source in family:
+            if not source.exists():
+                continue
+            quarantine = source.with_name(f"{source.name}.discard-{uuid4().hex}")
+            source.replace(quarantine)
+            detached.append((source, quarantine))
+    except OSError:
+        for source, quarantine in reversed(detached):
+            if quarantine.exists():
+                quarantine.replace(source)
+        raise
+
+    for original, quarantine in detached:
+        try:
+            quarantine.unlink()
+        except OSError:
+            logger.warning(
+                "Discarded recipe file remains quarantined",
+                original=str(original),
+                quarantine=str(quarantine),
+            )
+
+
+__all__ = ["discard_recipe_graph", "discard_recipe_graph_shielded"]

--- a/src/kohakuterrarium/terrarium/recipe_identity.py
+++ b/src/kohakuterrarium/terrarium/recipe_identity.py
@@ -1,0 +1,101 @@
+"""Atomic runtime identity reservation for recipe applications."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterable
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kohakuterrarium.terrarium.engine import Terrarium
+
+
+class RecipeIdentityReservations:
+    """Reserve a recipe's runtime creature IDs in one short critical section."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._reserved: set[str] = set()
+
+    @asynccontextmanager
+    async def reserve_exact(
+        self, engine: "Terrarium", runtime_ids: Iterable[str]
+    ) -> AsyncIterator[tuple[str, ...]]:
+        """Reserve exact persisted IDs before manifest adoption performs I/O."""
+        requested = tuple(runtime_ids)
+        if len(set(requested)) != len(requested):
+            raise ValueError("duplicate runtime identity in one reservation")
+        async with self._lock:
+            unavailable = set(engine._creatures) | self._reserved
+            collision = next((item for item in requested if item in unavailable), None)
+            if collision is not None:
+                raise ValueError(f"creature_id {collision!r} already exists")
+            self._reserved.update(requested)
+        try:
+            yield requested
+        finally:
+            release = asyncio.create_task(self._release(requested))
+            try:
+                await asyncio.shield(release)
+            except asyncio.CancelledError:
+                await release
+                raise
+
+    @asynccontextmanager
+    async def reserve(
+        self,
+        engine: "Terrarium",
+        logical_names: Iterable[str],
+    ) -> AsyncIterator[dict[str, str]]:
+        """Yield logical-name to runtime-ID mappings and always release them.
+
+        Only ID calculation and publication happen while holding ``_lock``.
+        Recipe building, engine mutation, startup, and cleanup all run outside
+        that critical section.
+        """
+        names = tuple(logical_names)
+        if len(names) != len(set(names)):
+            raise ValueError("logical creature names must be unique")
+
+        async with self._lock:
+            unavailable = set(engine._creatures) | self._reserved
+            reserved = {name: _next_available_id(name, unavailable) for name in names}
+            self._reserved.update(reserved.values())
+        try:
+            yield reserved
+        finally:
+            # Cancellation can arrive before or during lock acquisition. Keep
+            # retrying in a separate task so no reservation can be stranded.
+            release = asyncio.create_task(self._release(reserved.values()))
+            try:
+                await asyncio.shield(release)
+            except asyncio.CancelledError:
+                await release
+                raise
+
+    async def claim_exact(self, engine: "Terrarium", runtime_id: str) -> bool:
+        """Claim an unreserved direct-add ID without holding startup I/O."""
+        async with self._lock:
+            if runtime_id in engine._creatures or runtime_id in self._reserved:
+                return False
+            self._reserved.add(runtime_id)
+            return True
+
+    async def release_exact(self, runtime_id: str) -> None:
+        """Release one direct-add claim after insertion succeeds or fails."""
+        await self._release([runtime_id])
+
+    async def _release(self, runtime_ids: Iterable[str]) -> None:
+        async with self._lock:
+            self._reserved.difference_update(runtime_ids)
+
+
+def _next_available_id(name: str, unavailable: set[str]) -> str:
+    candidate = name
+    suffix = 2
+    while candidate in unavailable:
+        candidate = f"{name}_{suffix}"
+        suffix += 1
+    unavailable.add(candidate)
+    return candidate

--- a/src/kohakuterrarium/terrarium/recipe_transaction.py
+++ b/src/kohakuterrarium/terrarium/recipe_transaction.py
@@ -1,0 +1,178 @@
+"""Cancellation-safe transaction state for applying one recipe."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from kohakuterrarium.terrarium.channels import remove_channel_trigger
+from kohakuterrarium.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from kohakuterrarium.terrarium.engine import Terrarium
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class RecipeApplyTransaction:
+    """Track resources owned by one recipe application and roll them back."""
+
+    engine: Terrarium
+    created_creature_ids: list[str] = field(default_factory=list)
+    created_graph_ids: set[str] = field(default_factory=set)
+    created_channels: list[tuple[str, str]] = field(default_factory=list)
+    existing_member_edges: dict[str, tuple[list[str], list[str]]] = field(
+        default_factory=dict
+    )
+    existing_graph_id: str | None = None
+    external_compensations: list[Callable[[], Awaitable[Any]]] = field(
+        default_factory=list
+    )
+    _rolled_back: bool = False
+
+    def record_creature(self, creature_id: str) -> None:
+        """Record a creature after the engine has accepted it."""
+        self.created_creature_ids.append(creature_id)
+
+    def record_graph(self, graph_id: str) -> None:
+        """Record an empty graph created before the first creature was added."""
+        self.created_graph_ids.add(graph_id)
+
+    def record_channel(self, graph_id: str, channel_name: str) -> None:
+        """Record a channel created in a graph that may predate this apply."""
+        self.created_channels.append((graph_id, channel_name))
+
+    def snapshot_existing_members(self, graph_id: str) -> None:
+        """Snapshot pre-apply edges for members the transaction does not own."""
+        graph = self.engine._topology.graphs[graph_id]
+        if graph_id not in self.created_graph_ids:
+            self.existing_graph_id = graph_id
+        for creature_id in graph.creature_ids:
+            if creature_id in self.created_creature_ids:
+                continue
+            creature = self.engine._creatures.get(creature_id)
+            if creature is None:
+                continue
+            self.existing_member_edges[creature_id] = (
+                list(creature.listen_channels),
+                list(creature.send_channels),
+            )
+
+    async def _remove_from_existing_graph(self) -> None:
+        """Remove owned members without invoking split/merge topology logic."""
+        graph = self.engine._topology.graphs.get(self.existing_graph_id)
+        if graph is None:
+            return
+        for creature_id in reversed(self.created_creature_ids):
+            creature = self.engine._creatures.pop(creature_id, None)
+            if creature is None:
+                continue
+            try:
+                await creature.stop()
+            except BaseException:
+                logger.exception(
+                    "recipe rollback failed to stop creature",
+                    extra={"creature_id": creature_id},
+                )
+            for channel_name in list(creature.listen_channels):
+                try:
+                    remove_channel_trigger(creature.agent, channel_name)
+                except BaseException:
+                    logger.exception(
+                        "recipe rollback failed to remove trigger",
+                        extra={"creature_id": creature_id},
+                    )
+            graph.creature_ids.discard(creature_id)
+            graph.listen_edges.pop(creature_id, None)
+            graph.send_edges.pop(creature_id, None)
+            self.engine._topology.creature_to_graph.pop(creature_id, None)
+
+    def record_external_compensation(
+        self, compensation: Callable[[], Awaitable[Any]]
+    ) -> None:
+        """Register a best-effort cleanup for an external side effect."""
+        self.external_compensations.append(compensation)
+
+    async def rollback(self) -> None:
+        """Remove only resources created by this application, exactly once."""
+        if self._rolled_back:
+            return
+        self._rolled_back = True
+        for creature_id, (
+            listen_channels,
+            send_channels,
+        ) in self.existing_member_edges.items():
+            creature = self.engine._creatures.get(creature_id)
+            if creature is None:
+                continue
+            creature.listen_channels = list(listen_channels)
+            creature.send_channels = list(send_channels)
+            graph = self.engine._topology.graphs.get(creature.graph_id)
+            if graph is not None:
+                graph.listen_edges[creature_id] = set(listen_channels)
+                graph.send_edges[creature_id] = set(send_channels)
+
+        if self.existing_graph_id is not None:
+            await self._remove_from_existing_graph()
+        else:
+            for creature_id in reversed(self.created_creature_ids):
+                if creature_id not in self.engine._creatures:
+                    continue
+                try:
+                    await self.engine.remove_creature(creature_id)
+                except BaseException:
+                    logger.exception(
+                        "recipe rollback failed to remove creature",
+                        extra={"creature_id": creature_id},
+                    )
+
+        for graph_id, channel_name in reversed(self.created_channels):
+            graph = self.engine._topology.graphs.get(graph_id)
+            if graph is None or channel_name not in graph.channels:
+                continue
+            try:
+                await self.engine.remove_channel(graph_id, channel_name)
+            except BaseException:
+                logger.exception(
+                    "recipe rollback failed to remove channel",
+                    extra={"graph_id": graph_id, "channel_name": channel_name},
+                )
+
+        for graph_id in self.created_graph_ids:
+            graph = self.engine._topology.graphs.get(graph_id)
+            if graph is not None and graph.creature_ids:
+                continue
+            self.engine._topology.graphs.pop(graph_id, None)
+            self.engine._environments.pop(graph_id, None)
+            store = self.engine._session_stores.pop(graph_id, None)
+            if store is not None and graph_id in self.engine._owned_sessions:
+                self.engine._owned_sessions.discard(graph_id)
+                try:
+                    result = store.close()
+                    if inspect.isawaitable(result):
+                        await result
+                except BaseException:
+                    logger.exception(
+                        "recipe rollback failed to close session store",
+                        extra={"graph_id": graph_id},
+                    )
+
+        for compensation in reversed(self.external_compensations):
+            try:
+                await compensation()
+            except BaseException:
+                logger.exception("recipe external compensation failed")
+
+
+async def rollback_shielded(transaction: RecipeApplyTransaction) -> None:
+    """Finish rollback even when the calling task is already cancelled."""
+    cleanup_task = asyncio.create_task(transaction.rollback())
+    try:
+        await asyncio.shield(cleanup_task)
+    except asyncio.CancelledError:
+        await cleanup_task
+        raise

--- a/src/kohakuterrarium/terrarium/recipe_transaction.py
+++ b/src/kohakuterrarium/terrarium/recipe_transaction.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from kohakuterrarium.terrarium.channels import remove_channel_trigger
 from kohakuterrarium.utils.logging import get_logger
@@ -19,7 +18,7 @@ logger = get_logger(__name__)
 
 @dataclass
 class RecipeApplyTransaction:
-    """Track resources owned by one recipe application and roll them back."""
+    """Track engine resources owned by one recipe application and roll them back."""
 
     engine: Terrarium
     created_creature_ids: list[str] = field(default_factory=list)
@@ -29,9 +28,6 @@ class RecipeApplyTransaction:
         default_factory=dict
     )
     existing_graph_id: str | None = None
-    external_compensations: list[Callable[[], Awaitable[Any]]] = field(
-        default_factory=list
-    )
     _rolled_back: bool = False
 
     def record_creature(self, creature_id: str) -> None:
@@ -90,12 +86,6 @@ class RecipeApplyTransaction:
             graph.listen_edges.pop(creature_id, None)
             graph.send_edges.pop(creature_id, None)
             self.engine._topology.creature_to_graph.pop(creature_id, None)
-
-    def record_external_compensation(
-        self, compensation: Callable[[], Awaitable[Any]]
-    ) -> None:
-        """Register a best-effort cleanup for an external side effect."""
-        self.external_compensations.append(compensation)
 
     async def rollback(self) -> None:
         """Remove only resources created by this application, exactly once."""
@@ -160,12 +150,6 @@ class RecipeApplyTransaction:
                         "recipe rollback failed to close session store",
                         extra={"graph_id": graph_id},
                     )
-
-        for compensation in reversed(self.external_compensations):
-            try:
-                await compensation()
-            except BaseException:
-                logger.exception("recipe external compensation failed")
 
 
 async def rollback_shielded(transaction: RecipeApplyTransaction) -> None:

--- a/src/kohakuterrarium/terrarium/recipe_transaction.py
+++ b/src/kohakuterrarium/terrarium/recipe_transaction.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from kohakuterrarium.terrarium.channels import remove_channel_trigger
 from kohakuterrarium.utils.logging import get_logger
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from kohakuterrarium.terrarium.engine import Terrarium
 
 logger = get_logger(__name__)
+_NO_STORE = object()
 
 
 @dataclass
@@ -28,6 +30,11 @@ class RecipeApplyTransaction:
         default_factory=dict
     )
     existing_graph_id: str | None = None
+    existing_session_store: Any = field(default=_NO_STORE, init=False, repr=False)
+    existing_session_owned: bool = field(default=False, init=False)
+    existing_session_meta: dict[str, Any] = field(default_factory=dict, init=False)
+    existing_agent_stores: dict[str, Any] = field(default_factory=dict, init=False)
+    _session_replacement_staged: bool = field(default=False, init=False)
     _rolled_back: bool = False
 
     def record_creature(self, creature_id: str) -> None:
@@ -47,6 +54,18 @@ class RecipeApplyTransaction:
         graph = self.engine._topology.graphs[graph_id]
         if graph_id not in self.created_graph_ids:
             self.existing_graph_id = graph_id
+            self.existing_session_store = self.engine._session_stores.get(
+                graph_id, _NO_STORE
+            )
+            self.existing_session_owned = graph_id in self.engine._owned_sessions
+            if self.existing_session_store is not _NO_STORE and hasattr(
+                self.existing_session_store, "meta"
+            ):
+                meta = self.existing_session_store.meta
+                for key in ("agents", "config_type"):
+                    self.existing_session_meta[key] = (
+                        copy.deepcopy(meta[key]) if key in meta else _NO_STORE
+                    )
         for creature_id in graph.creature_ids:
             if creature_id in self.created_creature_ids:
                 continue
@@ -57,35 +76,162 @@ class RecipeApplyTransaction:
                 list(creature.listen_channels),
                 list(creature.send_channels),
             )
+            agent = getattr(creature, "agent", None)
+            if agent is not None:
+                self.existing_agent_stores[creature_id] = getattr(
+                    agent, "session_store", _NO_STORE
+                )
+
+    def stage_session_replacement(self, graph_id: str) -> None:
+        """Keep the previous store alive until the recipe commits.
+
+        ``Terrarium.attach_session`` normally closes a replaced store
+        immediately. A recipe still has a fallible final checkpoint after
+        attachment, so temporarily removing the old mapping lets rollback
+        restore the same live writer if that checkpoint fails.
+        """
+        previous = self.existing_session_store
+        if (
+            self.existing_graph_id != graph_id
+            or previous is _NO_STORE
+            or self.engine._session_stores.get(graph_id) is not previous
+        ):
+            return
+        self.engine._session_stores.pop(graph_id, None)
+        self.engine._owned_sessions.discard(graph_id)
+        self._session_replacement_staged = True
+
+    async def commit(self) -> None:
+        """Release a replaced store only after the recipe checkpoint succeeds."""
+        if not self._session_replacement_staged:
+            return
+        self._session_replacement_staged = False
+        await _close_store(self.existing_session_store, self.existing_graph_id or "")
 
     async def _remove_from_existing_graph(self) -> None:
         """Remove owned members without invoking split/merge topology logic."""
         graph = self.engine._topology.graphs.get(self.existing_graph_id)
         if graph is None:
             return
+        surviving_ids = frozenset(graph.creature_ids).difference(
+            self.created_creature_ids
+        )
         for creature_id in reversed(self.created_creature_ids):
-            creature = self.engine._creatures.pop(creature_id, None)
-            if creature is None:
-                continue
-            try:
-                await creature.stop()
-            except BaseException:
-                logger.exception(
-                    "recipe rollback failed to stop creature",
-                    extra={"creature_id": creature_id},
-                )
-            for channel_name in list(creature.listen_channels):
+            creature = self.engine._creatures.get(creature_id)
+            if creature is not None:
                 try:
-                    remove_channel_trigger(creature.agent, channel_name)
+                    await creature.stop()
                 except BaseException:
                     logger.exception(
-                        "recipe rollback failed to remove trigger",
+                        "recipe rollback failed to stop creature",
                         extra={"creature_id": creature_id},
                     )
+                drive_runtime = getattr(self.engine, "_drive_runtime", None)
+                if drive_runtime is not None:
+                    try:
+                        await drive_runtime.on_creature_removed(
+                            creature_id,
+                            graph_id=self.existing_graph_id,
+                            graph_member_ids=surviving_ids,
+                        )
+                    except BaseException:
+                        logger.exception(
+                            "recipe rollback failed to clean Drive assignments",
+                            extra={"creature_id": creature_id},
+                        )
+                for channel_name in list(creature.listen_channels):
+                    try:
+                        remove_channel_trigger(
+                            creature.agent,
+                            subscriber_id=creature.name,
+                            channel_name=channel_name,
+                        )
+                    except BaseException:
+                        logger.exception(
+                            "recipe rollback failed to remove trigger",
+                            extra={"creature_id": creature_id},
+                        )
+                self.engine._creatures.pop(creature_id, None)
             graph.creature_ids.discard(creature_id)
             graph.listen_edges.pop(creature_id, None)
             graph.send_edges.pop(creature_id, None)
             self.engine._topology.creature_to_graph.pop(creature_id, None)
+
+    async def _restore_existing_session(self) -> None:
+        """Detach a store minted/replaced by the failed recipe application."""
+        graph_id = self.existing_graph_id
+        if graph_id is None:
+            return
+        previous = self.existing_session_store
+        current = self.engine._session_stores.get(graph_id, _NO_STORE)
+        if current is not previous:
+            drive_runtime = getattr(self.engine, "_drive_runtime", None)
+            if drive_runtime is not None:
+                try:
+                    await drive_runtime.detach_graph(graph_id)
+                except BaseException:
+                    logger.exception(
+                        "recipe rollback failed to detach Drive store",
+                        extra={"graph_id": graph_id},
+                    )
+
+            self.engine._session_stores.pop(graph_id, None)
+            current_owned = graph_id in self.engine._owned_sessions
+            self.engine._owned_sessions.discard(graph_id)
+            if current is not _NO_STORE and current_owned:
+                await _close_store(current, graph_id)
+
+            if previous is not _NO_STORE:
+                self.engine._session_stores[graph_id] = previous
+            if self.existing_session_owned:
+                self.engine._owned_sessions.add(graph_id)
+
+            if drive_runtime is not None:
+                try:
+                    if previous is _NO_STORE:
+                        drive_runtime.manager_for(graph_id)
+                    else:
+                        await drive_runtime.bind_graph_store(graph_id, previous)
+                except BaseException:
+                    logger.exception(
+                        "recipe rollback failed to restore Drive store",
+                        extra={"graph_id": graph_id},
+                    )
+
+        if previous is not _NO_STORE and self.existing_session_meta:
+            try:
+                meta = previous.meta
+                for key, value in self.existing_session_meta.items():
+                    if value is _NO_STORE:
+                        if key in meta:
+                            del meta[key]
+                    else:
+                        meta[key] = copy.deepcopy(value)
+            except BaseException:
+                logger.exception(
+                    "recipe rollback failed to restore session metadata",
+                    extra={"graph_id": graph_id},
+                )
+
+        for creature_id, previous_store in self.existing_agent_stores.items():
+            creature = self.engine._creatures.get(creature_id)
+            agent = getattr(creature, "agent", None) if creature is not None else None
+            if agent is None or previous_store is _NO_STORE:
+                continue
+            try:
+                if previous_store is None:
+                    _detach_agent_store(agent)
+                else:
+                    attach = getattr(agent, "attach_session_store", None)
+                    if callable(attach):
+                        attach(previous_store)
+                    else:
+                        agent.session_store = previous_store
+            except BaseException:
+                logger.exception(
+                    "recipe rollback failed to restore agent session store",
+                    extra={"creature_id": creature_id},
+                )
 
     async def rollback(self) -> None:
         """Remove only resources created by this application, exactly once."""
@@ -108,6 +254,7 @@ class RecipeApplyTransaction:
 
         if self.existing_graph_id is not None:
             await self._remove_from_existing_graph()
+            await self._restore_existing_session()
         else:
             for creature_id in reversed(self.created_creature_ids):
                 if creature_id not in self.engine._creatures:
@@ -150,6 +297,45 @@ class RecipeApplyTransaction:
                         "recipe rollback failed to close session store",
                         extra={"graph_id": graph_id},
                     )
+
+
+async def _close_store(store: Any, graph_id: str) -> None:
+    try:
+        try:
+            result = store.close(update_status=False)
+        except TypeError:
+            result = store.close()
+        if inspect.isawaitable(result):
+            await result
+    except BaseException:
+        logger.exception(
+            "recipe rollback failed to close session store",
+            extra={"graph_id": graph_id},
+        )
+
+
+def _detach_agent_store(agent: Any) -> None:
+    """Undo Agent.attach_session_store without constructing a sink for None."""
+    agent.session_store = None
+    controller = getattr(agent, "controller", None)
+    if controller is not None:
+        controller.session_store = None
+    session_output = getattr(agent, "_session_output", None)
+    if session_output is not None:
+        router = getattr(agent, "output_router", None)
+        remove = getattr(router, "remove_secondary", None)
+        if callable(remove):
+            remove(session_output)
+        agent._session_output = None
+    subagent_manager = getattr(agent, "subagent_manager", None)
+    if subagent_manager is not None:
+        subagent_manager._session_store = None
+    trigger_manager = getattr(agent, "trigger_manager", None)
+    if trigger_manager is not None:
+        trigger_manager._session_store = None
+    compact_manager = getattr(agent, "compact_manager", None)
+    if compact_manager is not None:
+        compact_manager._session_store = None
 
 
 async def rollback_shielded(transaction: RecipeApplyTransaction) -> None:

--- a/src/kohakuterrarium/terrarium/remote_recipe.py
+++ b/src/kohakuterrarium/terrarium/remote_recipe.py
@@ -1,0 +1,48 @@
+"""Remote recipe operations for :class:`RemoteTerrariumService`."""
+
+from typing import Any
+
+from kohakuterrarium.terrarium.service import CreatureInfo
+from kohakuterrarium.terrarium.topology import GraphTopology
+from kohakuterrarium.terrarium.wire import (
+    unpack_creature_info,
+    unpack_graph_topology,
+)
+
+
+class RemoteRecipeServiceMixin:
+    """Proxy whole-recipe application to one remote worker node."""
+
+    async def _checked_req(
+        self, type_: str, body: dict[str, Any]
+    ) -> dict[str, Any]: ...
+
+    async def apply_recipe(
+        self,
+        recipe_path: str,
+        *,
+        pwd: str | None = None,
+        llm: Any = None,
+        strict: bool = True,
+        start: bool = True,
+        persist: bool = False,
+    ) -> tuple[GraphTopology, list[CreatureInfo]]:
+        """Apply one complete recipe on this worker without cross-node splitting.
+
+        Persistence is worker-owned so display names and controller-provided
+        paths can never select the session file.
+        """
+        body = await self._checked_req(
+            "apply_recipe",
+            {
+                "recipe_path": recipe_path,
+                "pwd": pwd,
+                "llm": llm,
+                "strict": strict,
+                "start": start,
+                "persist": persist,
+            },
+        )
+        graph = unpack_graph_topology(body["graph"])
+        creatures = [unpack_creature_info(item) for item in body["creatures"]]
+        return graph, creatures

--- a/src/kohakuterrarium/terrarium/remote_recipe.py
+++ b/src/kohakuterrarium/terrarium/remote_recipe.py
@@ -46,3 +46,7 @@ class RemoteRecipeServiceMixin:
         graph = unpack_graph_topology(body["graph"])
         creatures = [unpack_creature_info(item) for item in body["creatures"]]
         return graph, creatures
+
+    async def discard_recipe(self, graph_id: str) -> None:
+        """Discard a just-applied recipe and its worker-owned persistence."""
+        await self._checked_req("discard_recipe", {"graph_id": graph_id})

--- a/src/kohakuterrarium/terrarium/remote_service.py
+++ b/src/kohakuterrarium/terrarium/remote_service.py
@@ -49,6 +49,7 @@ from kohakuterrarium.terrarium.events import (
     EngineEvent,
     EventFilter,
 )
+from kohakuterrarium.terrarium.remote_recipe import RemoteRecipeServiceMixin
 from kohakuterrarium.terrarium.service import CreatureInfo
 from kohakuterrarium.terrarium.service_dto import BranchMutationResult
 from kohakuterrarium.terrarium.topology import (
@@ -157,7 +158,11 @@ def _branch_mutation_result(body: dict[str, Any]) -> BranchMutationResult:
         ) from exc
 
 
-class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMixin):
+class RemoteTerrariumService(
+    RemoteRecipeServiceMixin,
+    RemoteDriveServiceMixin,
+    DriveServiceUnsupportedMixin,
+):
     """Controller-side proxy for a worker node's Terrarium engine.
 
     Implements the :class:`TerrariumService` Protocol over Lab APP
@@ -241,38 +246,6 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
-
-    async def apply_recipe(
-        self,
-        recipe_path: str,
-        *,
-        pwd: str | None = None,
-        llm: Any = None,
-        strict: bool = True,
-        start: bool = True,
-        persist: bool = False,
-    ) -> tuple[GraphTopology, list[CreatureInfo]]:
-        """Apply one complete recipe on this worker without cross-node splitting.
-
-        Persistence is worker-owned so display names and controller-provided
-        paths can never select the session file.
-        """
-        body = _maybe_raise(
-            await self._req(
-                "apply_recipe",
-                {
-                    "recipe_path": recipe_path,
-                    "pwd": pwd,
-                    "llm": llm,
-                    "strict": strict,
-                    "start": start,
-                    "persist": persist,
-                },
-            )
-        )
-        graph = unpack_graph_topology(body["graph"])
-        creatures = [unpack_creature_info(item) for item in body["creatures"]]
-        return graph, creatures
 
     async def add_creature(
         self,
@@ -984,6 +957,9 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
             body=body,
             timeout=timeout if timeout is not None else self._timeout,
         )
+
+    async def _checked_req(self, type_: str, body: dict[str, Any]) -> dict[str, Any]:
+        return _maybe_raise(await self._req(type_, body))
 
     async def _req_turn_mutation(self, type_: str, body: dict[str, Any]) -> Any:
         """Turn-length branch mutation (regenerate / edit_message).

--- a/src/kohakuterrarium/terrarium/remote_service.py
+++ b/src/kohakuterrarium/terrarium/remote_service.py
@@ -250,9 +250,13 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
         llm: Any = None,
         strict: bool = True,
         start: bool = True,
-        session_path: str | None = None,
+        persist: bool = False,
     ) -> tuple[GraphTopology, list[CreatureInfo]]:
-        """Apply one complete recipe on this worker without cross-node splitting."""
+        """Apply one complete recipe on this worker without cross-node splitting.
+
+        Persistence is worker-owned so display names and controller-provided
+        paths can never select the session file.
+        """
         body = _maybe_raise(
             await self._req(
                 "apply_recipe",
@@ -262,7 +266,7 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
                     "llm": llm,
                     "strict": strict,
                     "start": start,
-                    "session_path": session_path,
+                    "persist": persist,
                 },
             )
         )

--- a/src/kohakuterrarium/terrarium/remote_service.py
+++ b/src/kohakuterrarium/terrarium/remote_service.py
@@ -242,6 +242,34 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
     # Lifecycle
     # ------------------------------------------------------------------
 
+    async def apply_recipe(
+        self,
+        recipe_path: str,
+        *,
+        pwd: str | None = None,
+        llm: Any = None,
+        strict: bool = True,
+        start: bool = True,
+        session_path: str | None = None,
+    ) -> tuple[GraphTopology, list[CreatureInfo]]:
+        """Apply one complete recipe on this worker without cross-node splitting."""
+        body = _maybe_raise(
+            await self._req(
+                "apply_recipe",
+                {
+                    "recipe_path": recipe_path,
+                    "pwd": pwd,
+                    "llm": llm,
+                    "strict": strict,
+                    "start": start,
+                    "session_path": session_path,
+                },
+            )
+        )
+        graph = unpack_graph_topology(body["graph"])
+        creatures = [unpack_creature_info(item) for item in body["creatures"]]
+        return graph, creatures
+
     async def add_creature(
         self,
         config: Any,

--- a/src/kohakuterrarium/terrarium/resume.py
+++ b/src/kohakuterrarium/terrarium/resume.py
@@ -194,7 +194,7 @@ async def _resume_reserved_manifest(
                 name=item.name,
                 is_privileged=item.is_privileged,
                 parent_creature_id=item.parent_creature_id,
-                identity_reserved=True,
+                _identity_reserved=True,
             )
             creature.injected_runtime = ()
             created.append(creature)

--- a/src/kohakuterrarium/terrarium/resume.py
+++ b/src/kohakuterrarium/terrarium/resume.py
@@ -148,6 +148,22 @@ async def _resume_manifest_into_engine(
     store: SessionStore | None = None,
 ) -> str:
     """Restore a graph exactly from an authoritative manifest."""
+    runtime_ids = [entry.creature_id for entry in manifest.creatures]
+    async with engine._recipe_identities.reserve_exact(engine, runtime_ids):
+        return await _resume_reserved_manifest(
+            engine, path, manifest, pwd=pwd, llm=llm, store=store
+        )
+
+
+async def _resume_reserved_manifest(
+    engine: "Terrarium",
+    path: Path,
+    manifest: _manifest.GraphManifest,
+    *,
+    pwd: str | None,
+    llm: Any,
+    store: SessionStore | None,
+) -> str:
     store = store or _open_store_with_migration(path, writer_lock=True)
     if manifest.graph_id in engine._topology.graphs:
         store.close(update_status=False)
@@ -178,6 +194,7 @@ async def _resume_manifest_into_engine(
                 name=item.name,
                 is_privileged=item.is_privileged,
                 parent_creature_id=item.parent_creature_id,
+                identity_reserved=True,
             )
             creature.injected_runtime = ()
             created.append(creature)

--- a/tests/unit/api/test_sessions_active_route.py
+++ b/tests/unit/api/test_sessions_active_route.py
@@ -110,13 +110,21 @@ class TestCreateTerrariumSession:
         assert body["session_id"] == "s1"
         assert body["name"] == "alice"
 
-    def test_remote_node_not_implemented(self):
+    def test_remote_node_forwarded(self, monkeypatch):
+        seen = {}
+
+        async def fake(service, **kw):
+            seen.update(kw)
+            return _session(session_id="g1")
+
+        monkeypatch.setattr(active_mod.lifecycle, "start_terrarium", fake)
         client = TestClient(self._setup_app())
         resp = client.post(
             "/active/terrarium",
             json={"config_path": "/x", "on_node": "worker-1"},
         )
-        assert resp.status_code == 501
+        assert resp.status_code == 200
+        assert seen["on_node"] == "worker-1"
 
     def test_value_error(self, monkeypatch):
         async def boom(service, **kw):
@@ -185,13 +193,21 @@ class TestLegacyCreateTerrarium:
         assert resp.status_code == 200
         assert resp.json()["terrarium_id"] == "g1"
 
-    def test_remote_node_not_implemented(self):
+    def test_remote_node_forwarded(self, monkeypatch):
+        seen = {}
+
+        async def fake(service, **kw):
+            seen.update(kw)
+            return _session(session_id="g1")
+
+        monkeypatch.setattr(active_mod.lifecycle, "start_terrarium", fake)
         client = TestClient(self._app())
         resp = client.post(
             "/active/terrariums",
             json={"config_path": "/x", "on_node": "worker-1"},
         )
-        assert resp.status_code == 501
+        assert resp.status_code == 200
+        assert seen["on_node"] == "worker-1"
 
     def test_value_error(self, monkeypatch):
         async def boom(service, **kw):

--- a/tests/unit/laboratory/test_terrarium_runtime_adapter.py
+++ b/tests/unit/laboratory/test_terrarium_runtime_adapter.py
@@ -250,6 +250,36 @@ class TestTopologyReads:
 
 
 class TestLifecycleOps:
+    async def test_apply_recipe_persistence_is_worker_owned(self):
+        adapter = await _make_adapter()
+        calls = []
+
+        async def apply(recipe, **kwargs):
+            calls.append({"recipe": recipe, **kwargs})
+            return adapter._engine.list_graphs()[0]
+
+        adapter._engine.apply_recipe = apply
+        try:
+            out = await adapter._dispatch(
+                _msg("apply_recipe", {"recipe_path": "recipe.yaml", "persist": True})
+            )
+            assert out["graph"]["graph_id"]
+            assert calls[0]["session"] is True
+
+            rejected = await adapter._dispatch(
+                _msg(
+                    "apply_recipe",
+                    {
+                        "recipe_path": "recipe.yaml",
+                        "session_path": "../../escape.kohakutr",
+                    },
+                )
+            )
+            assert rejected["error"]["kind"] == "invalid"
+            assert len(calls) == 1
+        finally:
+            await adapter._engine.shutdown()
+
     async def test_remove_creature(self):
         adapter = await _make_adapter()
         try:

--- a/tests/unit/laboratory/test_terrarium_runtime_adapter.py
+++ b/tests/unit/laboratory/test_terrarium_runtime_adapter.py
@@ -10,6 +10,7 @@ from kohakuterrarium.laboratory.adapters.terrarium_runtime import (
     TerrariumRuntimeAdapter,
     _NotHostedHere,
 )
+from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.testing.terrarium import TestTerrariumBuilder
 
 
@@ -289,6 +290,33 @@ class TestLifecycleOps:
             assert out == {}
         finally:
             await adapter._engine.shutdown()
+
+    async def test_discard_recipe_removes_worker_store_and_releases_lock(
+        self, tmp_path
+    ):
+        adapter = await _make_adapter()
+        engine = adapter._engine
+        graph_id = engine.list_graphs()[0].graph_id
+        session_path = tmp_path / "recipe.kohakutr"
+        await engine.attach_session(graph_id, session_path)
+        try:
+            out = await adapter._dispatch(
+                _msg("discard_recipe", {"graph_id": graph_id})
+            )
+
+            assert out == {}
+            assert engine.list_creatures() == []
+            assert engine.list_graphs() == []
+            assert engine._session_stores == {}
+            assert engine._owned_sessions == set()
+            assert not session_path.exists()
+            assert not session_path.with_name(session_path.name + "-wal").exists()
+            assert not session_path.with_name(session_path.name + "-shm").exists()
+            assert not session_path.with_name(session_path.name + ".drives").exists()
+            reopened = SessionStore(session_path, writer_lock=True)
+            reopened.close(update_status=False)
+        finally:
+            await engine.shutdown()
 
     async def test_start_stop_creature(self):
         adapter = await _make_adapter()

--- a/tests/unit/studio/test_lifecycle_full.py
+++ b/tests/unit/studio/test_lifecycle_full.py
@@ -12,7 +12,7 @@ import pytest
 
 from kohakuterrarium.studio.sessions import lifecycle
 from kohakuterrarium.terrarium.engine import Terrarium
-from kohakuterrarium.terrarium.service import LocalTerrariumService
+from kohakuterrarium.terrarium.service import CreatureInfo, LocalTerrariumService
 from kohakuterrarium.testing.terrarium import (
     TestTerrariumBuilder,
     _FakeAgent,
@@ -84,7 +84,6 @@ class TestStartCreatureLocal:
         # When on_node != "_host", takes the remote path.
         engine = Terrarium()
         svc = LocalTerrariumService(engine)
-        from kohakuterrarium.terrarium.service import CreatureInfo
 
         info = CreatureInfo(
             creature_id="cid-r",

--- a/tests/unit/studio/test_lifecycle_more.py
+++ b/tests/unit/studio/test_lifecycle_more.py
@@ -12,10 +12,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from kohakuterrarium.studio.sessions import lifecycle
-from kohakuterrarium.terrarium.engine import Terrarium
-from kohakuterrarium.terrarium.service import LocalTerrariumService, CreatureInfo
-from kohakuterrarium.testing.terrarium import TestTerrariumBuilder, _FakeAgent
 from kohakuterrarium.terrarium.creature_host import Creature
+from kohakuterrarium.terrarium.engine import Terrarium
+from kohakuterrarium.terrarium.service import CreatureInfo, LocalTerrariumService
+from kohakuterrarium.terrarium.topology import GraphTopology
+from kohakuterrarium.testing.terrarium import TestTerrariumBuilder, _FakeAgent
 
 # Session bookkeeping is instance-scoped (studio.sessions.registry) —
 # each test builds its own engine/service, so no module-state reset is
@@ -226,6 +227,83 @@ class TestStartTerrariumPackageRef:
             assert captured["path"] == "@pkg/t"
         finally:
             await engine.shutdown()
+
+    async def test_remote_duplicate_dangerous_names_keep_persistence_worker_owned(
+        self, tmp_path, monkeypatch
+    ):
+        recipe_dir = tmp_path / "remote-recipe"
+        recipe_dir.mkdir()
+        recipe_path = recipe_dir / "terrarium.yaml"
+        recipe_path.write_text("terrarium:\n  name: safe-recipe\n", encoding="utf-8")
+
+        async def deploy(*args, **kwargs):
+            return "C:/worker/recipes/deployed"
+
+        class RemoteRecipeService:
+            def __init__(self):
+                self.calls = []
+
+            async def apply_recipe(self, recipe, **kwargs):
+                self.calls.append({"recipe": recipe, **kwargs})
+                index = len(self.calls)
+                creature_id = f"worker-{index}"
+                graph_id = f"graph-{index}"
+                return (
+                    GraphTopology(graph_id=graph_id, creature_ids={creature_id}),
+                    [
+                        CreatureInfo(
+                            creature_id=creature_id,
+                            name="worker",
+                            graph_id=graph_id,
+                            is_running=True,
+                            is_privileged=True,
+                            parent_creature_id=None,
+                            listen_channels=(),
+                            send_channels=(),
+                        )
+                    ],
+                )
+
+            async def remove_creature(self, creature_id):
+                raise AssertionError(f"unexpected compensation for {creature_id}")
+
+        remote = RemoteRecipeService()
+        service = SimpleNamespace(
+            host=object(),
+            _home={},
+            connected_nodes=lambda: ("worker-1",),
+            service_for=lambda node: remote,
+        )
+        monkeypatch.setattr(lifecycle, "deploy_creature_to_node", deploy)
+        monkeypatch.setattr(
+            lifecycle,
+            "load_terrarium_config",
+            lambda path: SimpleNamespace(name="safe-recipe"),
+        )
+
+        dangerous_name = "../../shared-session"
+        first = await lifecycle._start_remote_terrarium(
+            service,
+            config_path=str(recipe_path),
+            name=dangerous_name,
+            pwd=None,
+            llm=None,
+            on_node="worker-1",
+        )
+        second = await lifecycle._start_remote_terrarium(
+            service,
+            config_path=str(recipe_path),
+            name=dangerous_name,
+            pwd=None,
+            llm=None,
+            on_node="worker-1",
+        )
+
+        assert first.name == dangerous_name
+        assert second.name == f"{dangerous_name} #2"
+        assert first.session_id != second.session_id
+        assert [call["persist"] for call in remote.calls] == [True, True]
+        assert all("session_path" not in call for call in remote.calls)
 
 
 # ── list_sessions filter: on_node None (368) ──────────────────

--- a/tests/unit/studio/test_lifecycle_more.py
+++ b/tests/unit/studio/test_lifecycle_more.py
@@ -15,7 +15,6 @@ from kohakuterrarium.studio.sessions import lifecycle
 from kohakuterrarium.terrarium.creature_host import Creature
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium.service import CreatureInfo, LocalTerrariumService
-from kohakuterrarium.terrarium.topology import GraphTopology
 from kohakuterrarium.testing.terrarium import TestTerrariumBuilder, _FakeAgent
 
 # Session bookkeeping is instance-scoped (studio.sessions.registry) —
@@ -227,83 +226,6 @@ class TestStartTerrariumPackageRef:
             assert captured["path"] == "@pkg/t"
         finally:
             await engine.shutdown()
-
-    async def test_remote_duplicate_dangerous_names_keep_persistence_worker_owned(
-        self, tmp_path, monkeypatch
-    ):
-        recipe_dir = tmp_path / "remote-recipe"
-        recipe_dir.mkdir()
-        recipe_path = recipe_dir / "terrarium.yaml"
-        recipe_path.write_text("terrarium:\n  name: safe-recipe\n", encoding="utf-8")
-
-        async def deploy(*args, **kwargs):
-            return "C:/worker/recipes/deployed"
-
-        class RemoteRecipeService:
-            def __init__(self):
-                self.calls = []
-
-            async def apply_recipe(self, recipe, **kwargs):
-                self.calls.append({"recipe": recipe, **kwargs})
-                index = len(self.calls)
-                creature_id = f"worker-{index}"
-                graph_id = f"graph-{index}"
-                return (
-                    GraphTopology(graph_id=graph_id, creature_ids={creature_id}),
-                    [
-                        CreatureInfo(
-                            creature_id=creature_id,
-                            name="worker",
-                            graph_id=graph_id,
-                            is_running=True,
-                            is_privileged=True,
-                            parent_creature_id=None,
-                            listen_channels=(),
-                            send_channels=(),
-                        )
-                    ],
-                )
-
-            async def remove_creature(self, creature_id):
-                raise AssertionError(f"unexpected compensation for {creature_id}")
-
-        remote = RemoteRecipeService()
-        service = SimpleNamespace(
-            host=object(),
-            _home={},
-            connected_nodes=lambda: ("worker-1",),
-            service_for=lambda node: remote,
-        )
-        monkeypatch.setattr(lifecycle, "deploy_creature_to_node", deploy)
-        monkeypatch.setattr(
-            lifecycle,
-            "load_terrarium_config",
-            lambda path: SimpleNamespace(name="safe-recipe"),
-        )
-
-        dangerous_name = "../../shared-session"
-        first = await lifecycle._start_remote_terrarium(
-            service,
-            config_path=str(recipe_path),
-            name=dangerous_name,
-            pwd=None,
-            llm=None,
-            on_node="worker-1",
-        )
-        second = await lifecycle._start_remote_terrarium(
-            service,
-            config_path=str(recipe_path),
-            name=dangerous_name,
-            pwd=None,
-            llm=None,
-            on_node="worker-1",
-        )
-
-        assert first.name == dangerous_name
-        assert second.name == f"{dangerous_name} #2"
-        assert first.session_id != second.session_id
-        assert [call["persist"] for call in remote.calls] == [True, True]
-        assert all("session_path" not in call for call in remote.calls)
 
 
 # ── list_sessions filter: on_node None (368) ──────────────────

--- a/tests/unit/studio/test_remote_terrarium.py
+++ b/tests/unit/studio/test_remote_terrarium.py
@@ -1,4 +1,7 @@
+import asyncio
 from types import SimpleNamespace
+
+import pytest
 
 from kohakuterrarium.studio.sessions import remote_terrarium
 from kohakuterrarium.terrarium.service import CreatureInfo
@@ -82,3 +85,90 @@ class TestStartRemoteTerrarium:
         assert first.session_id != second.session_id
         assert [call["persist"] for call in remote.calls] == [True, True]
         assert all("session_path" not in call for call in remote.calls)
+
+    async def test_post_apply_failure_discards_complete_worker_recipe(
+        self, tmp_path, monkeypatch
+    ):
+        recipe_dir = tmp_path / "remote-recipe"
+        recipe_dir.mkdir()
+        recipe_path = recipe_dir / "terrarium.yaml"
+        recipe_path.write_text("terrarium:\n  name: safe-recipe\n", encoding="utf-8")
+
+        async def deploy(*args, **kwargs):
+            return "C:/worker/recipes/deployed"
+
+        creature = CreatureInfo(
+            creature_id="worker-1",
+            name="worker",
+            graph_id="graph-1",
+            is_running=True,
+            is_privileged=True,
+            parent_creature_id=None,
+            listen_channels=(),
+            send_channels=(),
+        )
+
+        class RemoteRecipeService:
+            def __init__(self):
+                self.discarded = []
+                self.removed = []
+
+            async def apply_recipe(self, recipe, **kwargs):
+                return (
+                    GraphTopology(graph_id="graph-1", creature_ids={"worker-1"}),
+                    [creature],
+                )
+
+            async def discard_recipe(self, graph_id):
+                self.discarded.append(graph_id)
+
+            async def remove_creature(self, creature_id):
+                self.removed.append(creature_id)
+
+        remote = RemoteRecipeService()
+        service = SimpleNamespace(
+            host=object(),
+            _home={"worker-1": "other-node"},
+            connected_nodes=lambda: ("worker-node",),
+            service_for=lambda node: remote,
+        )
+        monkeypatch.setattr(remote_terrarium, "deploy_creature_to_node", deploy)
+
+        with pytest.raises(ValueError, match="creature_id collision"):
+            await remote_terrarium.start_remote_terrarium(
+                service,
+                config_path=str(recipe_path),
+                name=None,
+                pwd=None,
+                llm=None,
+                on_node="worker-node",
+            )
+
+        assert remote.discarded == ["graph-1"]
+        assert remote.removed == []
+        assert service._home == {"worker-1": "other-node"}
+
+    async def test_remote_discard_finishes_under_cancellation(self):
+        started = asyncio.Event()
+        release = asyncio.Event()
+        discarded = []
+
+        class RemoteRecipeService:
+            async def discard_recipe(self, graph_id):
+                started.set()
+                await release.wait()
+                discarded.append(graph_id)
+
+        task = asyncio.create_task(
+            remote_terrarium._discard_remote_recipe(
+                RemoteRecipeService(),
+                "graph-1",
+            )
+        )
+        await started.wait()
+        task.cancel()
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert discarded == ["graph-1"]

--- a/tests/unit/studio/test_remote_terrarium.py
+++ b/tests/unit/studio/test_remote_terrarium.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+from kohakuterrarium.studio.sessions import remote_terrarium
+from kohakuterrarium.terrarium.service import CreatureInfo
+from kohakuterrarium.terrarium.topology import GraphTopology
+
+
+class TestStartRemoteTerrarium:
+    async def test_duplicate_dangerous_names_keep_persistence_worker_owned(
+        self, tmp_path, monkeypatch
+    ):
+        recipe_dir = tmp_path / "remote-recipe"
+        recipe_dir.mkdir()
+        recipe_path = recipe_dir / "terrarium.yaml"
+        recipe_path.write_text("terrarium:\n  name: safe-recipe\n", encoding="utf-8")
+
+        async def deploy(*args, **kwargs):
+            return "C:/worker/recipes/deployed"
+
+        class RemoteRecipeService:
+            def __init__(self):
+                self.calls = []
+
+            async def apply_recipe(self, recipe, **kwargs):
+                self.calls.append({"recipe": recipe, **kwargs})
+                index = len(self.calls)
+                creature_id = f"worker-{index}"
+                graph_id = f"graph-{index}"
+                return (
+                    GraphTopology(graph_id=graph_id, creature_ids={creature_id}),
+                    [
+                        CreatureInfo(
+                            creature_id=creature_id,
+                            name="worker",
+                            graph_id=graph_id,
+                            is_running=True,
+                            is_privileged=True,
+                            parent_creature_id=None,
+                            listen_channels=(),
+                            send_channels=(),
+                        )
+                    ],
+                )
+
+            async def remove_creature(self, creature_id):
+                raise AssertionError(f"unexpected compensation for {creature_id}")
+
+        remote = RemoteRecipeService()
+        service = SimpleNamespace(
+            host=object(),
+            _home={},
+            connected_nodes=lambda: ("worker-1",),
+            service_for=lambda node: remote,
+        )
+        monkeypatch.setattr(remote_terrarium, "deploy_creature_to_node", deploy)
+        monkeypatch.setattr(
+            remote_terrarium,
+            "load_terrarium_config",
+            lambda path: SimpleNamespace(name="safe-recipe"),
+        )
+
+        dangerous_name = "../../shared-session"
+        first = await remote_terrarium.start_remote_terrarium(
+            service,
+            config_path=str(recipe_path),
+            name=dangerous_name,
+            pwd=None,
+            llm=None,
+            on_node="worker-1",
+        )
+        second = await remote_terrarium.start_remote_terrarium(
+            service,
+            config_path=str(recipe_path),
+            name=dangerous_name,
+            pwd=None,
+            llm=None,
+            on_node="worker-1",
+        )
+
+        assert first.name == dangerous_name
+        assert second.name == f"{dangerous_name} #2"
+        assert first.session_id != second.session_id
+        assert [call["persist"] for call in remote.calls] == [True, True]
+        assert all("session_path" not in call for call in remote.calls)

--- a/tests/unit/studio/test_studio_class.py
+++ b/tests/unit/studio/test_studio_class.py
@@ -140,11 +140,19 @@ class TestClassmethodConstructors:
         captured = {}
 
         async def fake_start_terrarium(
-            service, *, config_path=None, config=None, pwd=None, name=None, llm=None
+            service,
+            *,
+            config_path=None,
+            config=None,
+            pwd=None,
+            name=None,
+            llm=None,
+            on_node="_host",
         ):
             captured["config_path"] = config_path
             captured["llm"] = llm
             captured["name"] = name
+            captured["on_node"] = on_node
             return SimpleNamespace(session_id="g1")
 
         monkeypatch.setattr(_lifecycle, "start_terrarium", fake_start_terrarium)
@@ -153,6 +161,7 @@ class TestClassmethodConstructors:
         assert captured["config_path"] == "/x"
         assert captured["llm"] == "profile-x"
         assert captured["name"] == "team"
+        assert captured["on_node"] == "_host"
         await studio.shutdown()
 
 

--- a/tests/unit/terrarium/test_engine.py
+++ b/tests/unit/terrarium/test_engine.py
@@ -135,6 +135,26 @@ class TestAddRemoveCreature:
             await t.shutdown()
             await other.shutdown()
 
+    async def test_add_binds_final_runtime_id_to_executor(self):
+        t = Terrarium()
+        creature = Creature(
+            creature_id="configured-id",
+            name="worker",
+            agent=_FakeAgent(name="worker"),
+        )
+        creature.agent.executor = SimpleNamespace(_creature_id="configured-id")
+        try:
+            added = await t.add_creature(
+                creature,
+                creature_id="runtime-id",
+                start=False,
+                session=False,
+            )
+            assert added.creature_id == "runtime-id"
+            assert creature.agent.executor._creature_id == "runtime-id"
+        finally:
+            await t.shutdown()
+
     async def test_remove_unknown_raises(self):
         t = Terrarium()
         with pytest.raises(KeyError):

--- a/tests/unit/terrarium/test_engine.py
+++ b/tests/unit/terrarium/test_engine.py
@@ -64,6 +64,45 @@ class TestAddRemoveCreature:
         finally:
             await t.shutdown()
 
+    async def test_start_failure_removes_inserted_creature(self):
+        t = Terrarium()
+        creature = Creature(
+            creature_id="alice", name="alice", agent=_FakeAgent("alice")
+        )
+
+        async def fail_start():
+            raise RuntimeError("start failed")
+
+        creature.agent.start = fail_start
+        try:
+            with pytest.raises(RuntimeError, match="start failed"):
+                await t.add_creature(creature)
+            assert t.list_creatures() == []
+            assert t.list_graphs() == []
+        finally:
+            await t.shutdown()
+
+    async def test_session_attach_failure_removes_inserted_creature(self, monkeypatch):
+        t = Terrarium()
+        creature = Creature(
+            creature_id="alice", name="alice", agent=_FakeAgent("alice")
+        )
+
+        async def fail_attach(*args, **kwargs):
+            raise RuntimeError("attach failed")
+
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.autosession.attach_for_new_creature",
+            fail_attach,
+        )
+        try:
+            with pytest.raises(RuntimeError, match="attach failed"):
+                await t.add_creature(creature, start=False)
+            assert t.list_creatures() == []
+            assert t.list_graphs() == []
+        finally:
+            await t.shutdown()
+
     async def test_persisted_graph_rejects_duplicate_name_before_add(self):
         t = await TestTerrariumBuilder().with_creature("alice").build()
         graph_id = t.get_creature("alice").graph_id
@@ -604,6 +643,7 @@ class TestApplyRecipe:
             start=True,
             creature_builder=None,
             created_ids=None,
+            transaction=None,
         ):
             captured["recipe"] = recipe
             captured["pwd"] = pwd

--- a/tests/unit/terrarium/test_engine_branches.py
+++ b/tests/unit/terrarium/test_engine_branches.py
@@ -19,6 +19,7 @@ from kohakuterrarium.terrarium import channel_lifecycle as cl
 from kohakuterrarium.terrarium import config as config_mod
 from kohakuterrarium.terrarium import creature_ops as co
 from kohakuterrarium.terrarium import recipe as recipe_mod
+from kohakuterrarium.terrarium import recipe_apply as recipe_apply_mod
 from kohakuterrarium.terrarium import resume as resume_mod
 from kohakuterrarium.terrarium import root as root_mod
 from kohakuterrarium.terrarium import wire as wire_mod
@@ -265,13 +266,15 @@ class TestRecipeBranches:
         cfg = CreatureConfig(
             name="alice", config_data={"name": "alice"}, base_dir=Path(".")
         )
-        out = recipe_mod._build_recipe_creature(
+        out = recipe_apply_mod._build_recipe_creature(
             _builder,
             cfg,
             creature_id="alice",
+            graph_id="graph",
             pwd=None,
             llm=None,
-            env=env,
+            strict=True,
+            environment=env,
             use_default_builder=False,
         )
         assert out is creature

--- a/tests/unit/terrarium/test_manifest_resume.py
+++ b/tests/unit/terrarium/test_manifest_resume.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -80,7 +81,12 @@ class TestManifestResume:
             if not isinstance(config, AgentConfig):
                 return await original_add(config, **kwargs)
             creature = engine._creature_for_restore(config, kwargs)
-            return await original_add(creature, start=False, graph=kwargs["graph"])
+            return await original_add(
+                creature,
+                start=False,
+                graph=kwargs["graph"],
+                identity_reserved=kwargs.get("identity_reserved", False),
+            )
 
         engine.add_creature = _wrapped_add
         try:
@@ -93,3 +99,44 @@ class TestManifestResume:
             assert graph.send_edges["alice_id"] == {"tasks"}
         finally:
             await engine.shutdown()
+
+    async def test_manifest_ids_are_reserved_before_restore_io(
+        self, monkeypatch, tmp_path
+    ):
+        manifest_data = _manifest()
+        manifest = resume_mod._manifest.parse_manifest(manifest_data)
+        engine = await TestTerrariumBuilder().build()
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        calls = 0
+
+        async def blocked_restore(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            first_started.set()
+            await release_first.wait()
+            return "graph_saved"
+
+        monkeypatch.setattr(resume_mod, "_resume_reserved_manifest", blocked_restore)
+        first = asyncio.create_task(
+            resume_mod._resume_manifest_into_engine(
+                engine,
+                tmp_path / "run.kohakutr",
+                manifest,
+                pwd=None,
+                store=object(),
+            )
+        )
+        await first_started.wait()
+        with pytest.raises(ValueError, match="already exists"):
+            await resume_mod._resume_manifest_into_engine(
+                engine,
+                tmp_path / "run.kohakutr",
+                manifest,
+                pwd=None,
+                store=object(),
+            )
+        release_first.set()
+        assert await first == "graph_saved"
+        assert calls == 1
+        await engine.shutdown()

--- a/tests/unit/terrarium/test_manifest_resume.py
+++ b/tests/unit/terrarium/test_manifest_resume.py
@@ -85,7 +85,7 @@ class TestManifestResume:
                 creature,
                 start=False,
                 graph=kwargs["graph"],
-                identity_reserved=kwargs.get("identity_reserved", False),
+                _identity_reserved=kwargs.get("_identity_reserved", False),
             )
 
         engine.add_creature = _wrapped_add

--- a/tests/unit/terrarium/test_recipe.py
+++ b/tests/unit/terrarium/test_recipe.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from kohakuterrarium.terrarium import recipe as recipe_mod
+from kohakuterrarium.terrarium import graph_checkpoint as checkpoint_mod
 from kohakuterrarium.terrarium.config import (
     ChannelConfig,
     CreatureConfig,
@@ -413,6 +414,32 @@ class TestApplyRecipe:
         finally:
             await engine.shutdown()
 
+    async def test_existing_persisted_graph_attaches_store_to_new_members(
+        self, tmp_path
+    ):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+        try:
+            added = await engine.add_creature(
+                existing,
+                start=False,
+                session=tmp_path / "existing.kohakutr",
+            )
+            store = engine._session_stores[added.graph_id]
+
+            await engine.apply_recipe(
+                _recipe(creatures=[_creature_cfg("new")]),
+                graph=added.graph_id,
+                start=False,
+                creature_builder=_fake_builder,
+            )
+
+            assert engine.get_creature("new").agent.session_store is store
+            assert store.meta["agents"] == ["existing", "new"]
+            assert store.meta["config_type"] == "terrarium"
+        finally:
+            await engine.shutdown()
+
 
 class TestRecipeRollback:
     async def test_builder_cannot_return_preexisting_creature_id(self):
@@ -439,11 +466,13 @@ class TestRecipeRollback:
     async def test_start_failure_rolls_back_only_new_members(self):
         engine = Terrarium()
         existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+        built = {}
 
         def failing_builder(config, **kwargs):
             creature = _fake_builder(config, **kwargs)
             if config.name == "bad":
                 creature.agent = _StartFailAgent("bad")
+            built[config.name] = creature
             return creature
 
         try:
@@ -464,6 +493,8 @@ class TestRecipeRollback:
             assert graph.channels == {}
             assert existing.send_channels == []
             assert graph.send_edges.get("existing", set()) == set()
+            assert built["good"].agent.trigger_manager._triggers == {}
+            assert built["bad"].agent.trigger_manager._triggers == {}
         finally:
             await engine.shutdown()
 
@@ -511,6 +542,114 @@ class TestRecipeRollback:
         assert engine.list_graphs() == []
         assert engine._session_stores == {}
         assert engine._owned_sessions == set()
+        await engine.shutdown()
+
+    async def test_existing_graph_checkpoint_failure_removes_stale_membership(
+        self, monkeypatch, tmp_path
+    ):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+        added = await engine.add_creature(existing, start=False, session=False)
+        await engine.add_channel(added.graph_id, "worker")
+
+        real_checkpoint = checkpoint_mod.checkpoint
+
+        async def fail_checkpoint(engine_arg, graph_id):
+            if checkpoint_mod._suppression.get(engine_arg, 0):
+                return await real_checkpoint(engine_arg, graph_id)
+            raise RuntimeError("checkpoint failed")
+
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.graph_checkpoint.checkpoint",
+            fail_checkpoint,
+        )
+        with pytest.raises(RuntimeError, match="checkpoint failed"):
+            await engine.apply_recipe(
+                _recipe(creatures=[_creature_cfg("worker")]),
+                graph=added.graph_id,
+                start=False,
+                session=tmp_path / "run.kohakutr",
+                creature_builder=_fake_builder,
+            )
+
+        graph = engine.get_graph(added.graph_id)
+        assert graph.creature_ids == {"existing"}
+        assert set(engine._creatures) == {"existing"}
+        assert set(graph.channels) == {"worker"}
+        assert engine._session_stores == {}
+        assert engine._owned_sessions == set()
+        assert existing.agent.session_store is None
+        await engine.shutdown()
+
+    async def test_failed_store_replacement_restores_open_previous_store(
+        self, monkeypatch, tmp_path
+    ):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+        added = await engine.add_creature(
+            existing,
+            start=False,
+            session=tmp_path / "previous.kohakutr",
+        )
+        previous = engine._session_stores[added.graph_id]
+        real_checkpoint = checkpoint_mod.checkpoint
+
+        async def fail_checkpoint(engine_arg, graph_id):
+            if checkpoint_mod._suppression.get(engine_arg, 0):
+                return await real_checkpoint(engine_arg, graph_id)
+            raise RuntimeError("checkpoint failed")
+
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.graph_checkpoint.checkpoint",
+            fail_checkpoint,
+        )
+        with pytest.raises(RuntimeError, match="checkpoint failed"):
+            await engine.apply_recipe(
+                _recipe(creatures=[_creature_cfg("new")]),
+                graph=added.graph_id,
+                start=False,
+                session=tmp_path / "replacement.kohakutr",
+                creature_builder=_fake_builder,
+            )
+
+        assert engine._session_stores[added.graph_id] is previous
+        assert getattr(previous, "_closed", False) is False
+        assert existing.agent.session_store is previous
+        assert set(engine._creatures) == {"existing"}
+        await engine.shutdown()
+
+    async def test_failed_existing_store_reuse_restores_session_meta(
+        self, monkeypatch, tmp_path
+    ):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+        added = await engine.add_creature(
+            existing,
+            start=False,
+            session=tmp_path / "existing.kohakutr",
+        )
+        store = engine._session_stores[added.graph_id]
+
+        async def fail_checkpoint(*args, **kwargs):
+            raise RuntimeError("checkpoint failed")
+
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.graph_checkpoint.checkpoint",
+            fail_checkpoint,
+        )
+        with pytest.raises(RuntimeError, match="checkpoint failed"):
+            await engine.apply_recipe(
+                _recipe(creatures=[_creature_cfg("new")]),
+                graph=added.graph_id,
+                start=False,
+                creature_builder=_fake_builder,
+            )
+
+        assert engine._session_stores[added.graph_id] is store
+        assert store.meta["agents"] == ["existing"]
+        assert store.meta["config_type"] == "agent"
+        assert existing.agent.session_store is store
+        assert set(engine._creatures) == {"existing"}
         await engine.shutdown()
 
     async def test_cancelled_start_finishes_rollback_and_releases_identity(self):

--- a/tests/unit/terrarium/test_recipe.py
+++ b/tests/unit/terrarium/test_recipe.py
@@ -393,6 +393,59 @@ class TestApplyRecipe:
         finally:
             await engine.shutdown()
 
+    async def test_existing_graph_rejects_declared_agent_alias_before_mutation(
+        self, monkeypatch
+    ):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+        existing.agent.config.name = "shared"
+        candidate = _creature_cfg("new-member")
+        candidate.config_data["name"] = "shared"
+
+        async def unexpected_add_channel(*_args, **_kwargs):
+            raise AssertionError("recipe mutation began before alias preflight")
+
+        try:
+            added = await engine.add_creature(existing, start=False, session=False)
+            monkeypatch.setattr(engine, "add_channel", unexpected_add_channel)
+            with pytest.raises(ValueError, match="already contains creature name"):
+                await recipe_mod.apply_recipe(
+                    engine,
+                    _recipe(creatures=[candidate]),
+                    graph=added.graph_id,
+                    creature_builder=_fake_builder,
+                )
+            graph = engine.get_graph(added.graph_id)
+            assert graph.creature_ids == {"existing"}
+            assert graph.channels == {}
+        finally:
+            await engine.shutdown()
+
+    async def test_duplicate_declared_agent_aliases_fail_before_mutation(
+        self, monkeypatch
+    ):
+        engine = Terrarium()
+        alice = _creature_cfg("alice")
+        bob = _creature_cfg("bob")
+        alice.config_data["name"] = "shared"
+        bob.config_data["name"] = "shared"
+
+        async def unexpected_add_channel(*_args, **_kwargs):
+            raise AssertionError("recipe mutation began before alias validation")
+
+        monkeypatch.setattr(engine, "add_channel", unexpected_add_channel)
+        try:
+            with pytest.raises(ValueError, match="duplicate creature name alias"):
+                await recipe_mod.apply_recipe(
+                    engine,
+                    _recipe(creatures=[alice, bob]),
+                    creature_builder=_fake_builder,
+                )
+            assert engine.list_graphs() == []
+            assert engine.list_creatures() == []
+        finally:
+            await engine.shutdown()
+
     async def test_existing_graph_starts_only_new_members(self):
         engine = Terrarium()
         existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")

--- a/tests/unit/terrarium/test_recipe.py
+++ b/tests/unit/terrarium/test_recipe.py
@@ -12,6 +12,7 @@ import pytest
 
 from kohakuterrarium.terrarium import recipe as recipe_mod
 from kohakuterrarium.terrarium import graph_checkpoint as checkpoint_mod
+from kohakuterrarium.terrarium import recipe_apply as recipe_apply_mod
 from kohakuterrarium.terrarium.config import (
     ChannelConfig,
     CreatureConfig,
@@ -751,13 +752,24 @@ class TestBuildRecipeCreature:
     def test_use_default_builder_passes_kwargs(self):
         called = {}
 
-        def default(cfg, *, creature_id, pwd, llm, environment, strict=True):
+        def default(
+            cfg,
+            *,
+            creature_id,
+            graph_id,
+            pwd,
+            llm,
+            environment,
+            strict=True,
+        ):
             called.update(
                 {
                     "creature_id": creature_id,
+                    "graph_id": graph_id,
                     "pwd": pwd,
                     "llm": llm,
                     "environment": environment,
+                    "strict": strict,
                 }
             )
             return Creature(
@@ -768,32 +780,46 @@ class TestBuildRecipeCreature:
 
         cfg = _creature_cfg("x")
         env = object()
-        recipe_mod._build_recipe_creature(
+        recipe_apply_mod._build_recipe_creature(
             default,
             cfg,
             creature_id="cid",
+            graph_id="gid",
             pwd="/wd",
             llm="model",
-            env=env,
+            strict=False,
+            environment=env,
             use_default_builder=True,
         )
         assert called == {
             "creature_id": "cid",
+            "graph_id": "gid",
             "pwd": "/wd",
             "llm": "model",
             "environment": env,
+            "strict": False,
         }
 
-    def test_stub_builder_injects_env(self):
+    def test_custom_builder_keeps_public_contract_and_injects_env(self):
         cfg = _creature_cfg("x")
         env = object()
-        out = recipe_mod._build_recipe_creature(
-            _fake_builder,
+
+        def strict_custom_builder(config, *, creature_id, pwd=None):
+            return Creature(
+                creature_id=creature_id,
+                name=config.name,
+                agent=_FakeAgent(name=config.name),
+            )
+
+        out = recipe_apply_mod._build_recipe_creature(
+            strict_custom_builder,
             cfg,
             creature_id="cid",
-            pwd=None,
-            llm=None,
-            env=env,
+            graph_id="gid",
+            pwd="/wd",
+            llm="model",
+            strict=True,
+            environment=env,
             use_default_builder=False,
         )
         assert out.agent.environment is env

--- a/tests/unit/terrarium/test_recipe.py
+++ b/tests/unit/terrarium/test_recipe.py
@@ -512,6 +512,7 @@ class TestRecipeRollback:
             await engine.apply_recipe(
                 _recipe(creatures=[_creature_cfg("worker")]),
                 start=False,
+                creature_builder=_fake_builder,
             )
 
         assert engine.list_creatures() == []

--- a/tests/unit/terrarium/test_recipe.py
+++ b/tests/unit/terrarium/test_recipe.py
@@ -5,9 +5,11 @@ instances — the engine layer only cares about ``Creature.agent``
 shape, which our fake satisfies.
 """
 
+import asyncio
 from pathlib import Path
 
 import pytest
+
 from kohakuterrarium.terrarium import recipe as recipe_mod
 from kohakuterrarium.terrarium.config import (
     ChannelConfig,
@@ -36,6 +38,20 @@ def _creature_cfg(name, listen=None, send=None):
         listen_channels=list(listen or []),
         send_channels=list(send or []),
     )
+
+
+class _StartFailAgent(_FakeAgent):
+    async def start(self) -> None:
+        raise RuntimeError("start failed")
+
+
+class _BlockingStartAgent(_FakeAgent):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def start(self) -> None:
+        self.started.set()
+        await self.release.wait()
 
 
 def _recipe(creatures=None, channels=None, root=None):
@@ -194,6 +210,343 @@ class TestApplyRecipe:
             assert g1.graph_id == g2.graph_id
             assert "alice" in g2.creature_ids
             assert "bob" in g2.creature_ids
+        finally:
+            await engine.shutdown()
+
+    async def test_concurrent_applies_reserve_distinct_id_sets(self):
+        engine = Terrarium()
+        both_applies_entered = asyncio.Event()
+        release_applies = asyncio.Event()
+        entered = 0
+
+        original_add = engine.add_creature
+
+        async def blocked_add(*args, **kwargs):
+            nonlocal entered
+            entered += 1
+            if entered == 2:
+                both_applies_entered.set()
+            await release_applies.wait()
+            return await original_add(*args, **kwargs)
+
+        engine.add_creature = blocked_add
+        first_ids: list[str] = []
+        second_ids: list[str] = []
+        recipe = _recipe(creatures=[_creature_cfg("alice"), _creature_cfg("bob")])
+        try:
+            first = asyncio.create_task(
+                recipe_mod.apply_recipe(
+                    engine,
+                    recipe,
+                    creature_builder=_fake_builder,
+                    created_ids=first_ids,
+                )
+            )
+            second = asyncio.create_task(
+                recipe_mod.apply_recipe(
+                    engine,
+                    recipe,
+                    creature_builder=_fake_builder,
+                    created_ids=second_ids,
+                )
+            )
+            await asyncio.wait_for(both_applies_entered.wait(), timeout=1)
+            release_applies.set()
+            await asyncio.gather(first, second)
+
+            assert first_ids == ["alice", "bob"]
+            assert second_ids == ["alice_2", "bob_2"]
+            assert set(first_ids).isdisjoint(second_ids)
+        finally:
+            release_applies.set()
+            await engine.shutdown()
+
+    async def test_existing_id_uses_next_available_suffix(self):
+        engine = Terrarium()
+        try:
+            existing = _fake_builder(_creature_cfg("alice"), creature_id="alice")
+            await engine.add_creature(existing, start=False, session=False)
+            created_ids: list[str] = []
+
+            await recipe_mod.apply_recipe(
+                engine,
+                _recipe(creatures=[_creature_cfg("alice")]),
+                start=False,
+                creature_builder=_fake_builder,
+                created_ids=created_ids,
+            )
+
+            assert created_ids == ["alice_2"]
+        finally:
+            await engine.shutdown()
+
+    async def test_builder_error_releases_reservation_and_does_not_deadlock(self):
+        engine = Terrarium()
+
+        def failing_builder(*args, **kwargs):
+            raise RuntimeError("build failed")
+
+        try:
+            recipe = _recipe(creatures=[_creature_cfg("alice")])
+            with pytest.raises(RuntimeError, match="build failed"):
+                await recipe_mod.apply_recipe(
+                    engine, recipe, creature_builder=failing_builder
+                )
+
+            created_ids: list[str] = []
+            await asyncio.wait_for(
+                recipe_mod.apply_recipe(
+                    engine,
+                    recipe,
+                    start=False,
+                    creature_builder=_fake_builder,
+                    created_ids=created_ids,
+                ),
+                timeout=1,
+            )
+            assert created_ids == ["alice"]
+        finally:
+            await engine.shutdown()
+
+    async def test_cancellation_releases_reservation(self):
+        engine = Terrarium()
+        add_entered = asyncio.Event()
+        never_release = asyncio.Event()
+        original_add = engine.add_creature
+
+        async def blocked_add(*args, **kwargs):
+            add_entered.set()
+            await never_release.wait()
+            return await original_add(*args, **kwargs)
+
+        engine.add_creature = blocked_add
+        recipe = _recipe(creatures=[_creature_cfg("alice")])
+        task = asyncio.create_task(
+            recipe_mod.apply_recipe(engine, recipe, creature_builder=_fake_builder)
+        )
+        try:
+            await asyncio.wait_for(add_entered.wait(), timeout=1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            engine.add_creature = original_add
+            created_ids: list[str] = []
+            await asyncio.wait_for(
+                recipe_mod.apply_recipe(
+                    engine,
+                    recipe,
+                    start=False,
+                    creature_builder=_fake_builder,
+                    created_ids=created_ids,
+                ),
+                timeout=1,
+            )
+            assert created_ids == ["alice"]
+        finally:
+            task.cancel()
+            await engine.shutdown()
+
+    async def test_rejects_duplicate_logical_names_before_mutation(self):
+        engine = Terrarium()
+        recipe = _recipe(creatures=[_creature_cfg("alice"), _creature_cfg("alice")])
+        try:
+            with pytest.raises(ValueError, match="duplicate logical creature name"):
+                await recipe_mod.apply_recipe(
+                    engine, recipe, creature_builder=_fake_builder
+                )
+            assert engine.list_graphs() == []
+            assert engine.list_creatures() == []
+        finally:
+            await engine.shutdown()
+
+    async def test_rejects_root_section_and_regular_root_name(self):
+        engine = Terrarium()
+        recipe = _recipe(
+            creatures=[_creature_cfg("root")],
+            root=RootConfig(config_data={"name": "root"}, base_dir=Path(".")),
+        )
+        try:
+            with pytest.raises(ValueError, match="regular creature named 'root'"):
+                await recipe_mod.apply_recipe(
+                    engine, recipe, creature_builder=_fake_builder
+                )
+            assert engine.list_graphs() == []
+            assert engine.list_creatures() == []
+        finally:
+            await engine.shutdown()
+
+    async def test_existing_graph_rejects_duplicate_logical_name(self):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("alice"), creature_id="existing")
+        try:
+            added = await engine.add_creature(existing, start=False, session=False)
+            with pytest.raises(ValueError, match="already contains creature name"):
+                await recipe_mod.apply_recipe(
+                    engine,
+                    _recipe(creatures=[_creature_cfg("alice")]),
+                    graph=added.graph_id,
+                    creature_builder=_fake_builder,
+                )
+            assert engine.get_graph(added.graph_id).creature_ids == {"existing"}
+        finally:
+            await engine.shutdown()
+
+    async def test_existing_graph_starts_only_new_members(self):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+        try:
+            added = await engine.add_creature(existing, start=False, session=False)
+            created_ids: list[str] = []
+
+            await recipe_mod.apply_recipe(
+                engine,
+                _recipe(creatures=[_creature_cfg("new")]),
+                graph=added.graph_id,
+                creature_builder=_fake_builder,
+                created_ids=created_ids,
+            )
+
+            assert existing.agent.start_calls == 0
+            assert engine.get_creature("new").agent.start_calls == 1
+            assert created_ids == ["new"]
+        finally:
+            await engine.shutdown()
+
+
+class TestRecipeRollback:
+    async def test_builder_cannot_return_preexisting_creature_id(self):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+
+        def bad_builder(config, **kwargs):
+            return _fake_builder(config, creature_id="existing")
+
+        try:
+            await engine.add_creature(existing, start=False, session=False)
+            with pytest.raises(ValueError, match="reserved"):
+                await recipe_mod.apply_recipe(
+                    engine,
+                    _recipe(creatures=[_creature_cfg("worker")]),
+                    creature_builder=bad_builder,
+                )
+            assert [creature.creature_id for creature in engine.list_creatures()] == [
+                "existing"
+            ]
+        finally:
+            await engine.shutdown()
+
+    async def test_start_failure_rolls_back_only_new_members(self):
+        engine = Terrarium()
+        existing = _fake_builder(_creature_cfg("existing"), creature_id="existing")
+
+        def failing_builder(config, **kwargs):
+            creature = _fake_builder(config, **kwargs)
+            if config.name == "bad":
+                creature.agent = _StartFailAgent("bad")
+            return creature
+
+        try:
+            added = await engine.add_creature(existing, start=False, session=False)
+            with pytest.raises(RuntimeError, match="start failed"):
+                await recipe_mod.apply_recipe(
+                    engine,
+                    _recipe(creatures=[_creature_cfg("good"), _creature_cfg("bad")]),
+                    graph=added.graph_id,
+                    creature_builder=failing_builder,
+                )
+
+            assert [creature.creature_id for creature in engine.list_creatures()] == [
+                "existing"
+            ]
+            graph = engine.get_graph(added.graph_id)
+            assert graph.creature_ids == {"existing"}
+            assert graph.channels == {}
+            assert existing.send_channels == []
+            assert graph.send_edges.get("existing", set()) == set()
+        finally:
+            await engine.shutdown()
+
+    async def test_engine_session_failure_rolls_back_created_graph(self, monkeypatch):
+        engine = Terrarium()
+
+        async def fail_attach(*args, **kwargs):
+            raise RuntimeError("session attach failed")
+
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.autosession.attach_for_recipe",
+            fail_attach,
+        )
+        with pytest.raises(RuntimeError, match="session attach failed"):
+            await engine.apply_recipe(
+                _recipe(creatures=[_creature_cfg("worker")]),
+                start=False,
+            )
+
+        assert engine.list_creatures() == []
+        assert engine.list_graphs() == []
+        await engine.shutdown()
+
+    async def test_checkpoint_failure_closes_owned_recipe_store(
+        self, monkeypatch, tmp_path
+    ):
+        engine = Terrarium()
+
+        async def fail_checkpoint(*args, **kwargs):
+            raise RuntimeError("checkpoint failed")
+
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.graph_checkpoint.checkpoint",
+            fail_checkpoint,
+        )
+        session_path = tmp_path / "run.kohakutr"
+        with pytest.raises(RuntimeError, match="checkpoint failed"):
+            await engine.apply_recipe(
+                _recipe(creatures=[_creature_cfg("worker")]),
+                start=False,
+                session=session_path,
+            )
+
+        assert engine.list_creatures() == []
+        assert engine.list_graphs() == []
+        assert engine._session_stores == {}
+        assert engine._owned_sessions == set()
+        await engine.shutdown()
+
+    async def test_cancelled_start_finishes_rollback_and_releases_identity(self):
+        engine = Terrarium()
+        _BlockingStartAgent.started = asyncio.Event()
+        _BlockingStartAgent.release = asyncio.Event()
+
+        def blocking_builder(config, **kwargs):
+            creature = _fake_builder(config, **kwargs)
+            creature.agent = _BlockingStartAgent(config.name)
+            return creature
+
+        task = asyncio.create_task(
+            recipe_mod.apply_recipe(
+                engine,
+                _recipe(creatures=[_creature_cfg("worker")]),
+                creature_builder=blocking_builder,
+            )
+        )
+        await _BlockingStartAgent.started.wait()
+        task.cancel()
+        _BlockingStartAgent.release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert engine.list_graphs() == []
+        assert engine.list_creatures() == []
+        graph = await recipe_mod.apply_recipe(
+            engine,
+            _recipe(creatures=[_creature_cfg("worker")]),
+            creature_builder=_fake_builder,
+            start=False,
+        )
+        try:
+            assert graph.creature_ids == {"worker"}
         finally:
             await engine.shutdown()
 

--- a/tests/unit/terrarium/test_recipe_transaction.py
+++ b/tests/unit/terrarium/test_recipe_transaction.py
@@ -1,0 +1,111 @@
+"""Unit tests for recipe apply transaction rollback."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from kohakuterrarium.terrarium.recipe_transaction import (
+    RecipeApplyTransaction,
+    rollback_shielded,
+)
+
+
+class _Engine:
+    def __init__(self, creature_ids: list[str]) -> None:
+        self._creatures = {creature_id: object() for creature_id in creature_ids}
+        self.removed: list[str] = []
+        self.remove_started = asyncio.Event()
+        self.allow_remove = asyncio.Event()
+        self.block_remove = False
+
+    async def remove_creature(self, creature_id: str) -> None:
+        self.remove_started.set()
+        if self.block_remove:
+            await self.allow_remove.wait()
+        self.removed.append(creature_id)
+        self._creatures.pop(creature_id)
+
+
+@pytest.mark.asyncio
+async def test_recipe_transaction_removes_only_owned_resources_in_reverse_order() -> (
+    None
+):
+    engine = _Engine(["existing", "new-a", "new-b"])
+    transaction = RecipeApplyTransaction(engine)  # type: ignore[arg-type]
+    transaction.record_creature("new-a")
+    transaction.record_creature("new-b")
+
+    await transaction.rollback()
+
+    assert engine.removed == ["new-b", "new-a"]
+    assert set(engine._creatures) == {"existing"}
+
+
+@pytest.mark.asyncio
+async def test_recipe_transaction_rollback_is_idempotent() -> None:
+    engine = _Engine(["new-a"])
+    transaction = RecipeApplyTransaction(engine)  # type: ignore[arg-type]
+    transaction.record_creature("new-a")
+
+    await transaction.rollback()
+    await transaction.rollback()
+
+    assert engine.removed == ["new-a"]
+
+
+@pytest.mark.asyncio
+async def test_recipe_transaction_skips_owned_resource_removed_elsewhere() -> None:
+    engine = _Engine(["existing", "new-a"])
+    transaction = RecipeApplyTransaction(engine)  # type: ignore[arg-type]
+    transaction.record_creature("new-a")
+    transaction.record_creature("missing")
+
+    await transaction.rollback()
+
+    assert engine.removed == ["new-a"]
+    assert set(engine._creatures) == {"existing"}
+
+
+@pytest.mark.asyncio
+async def test_recipe_transaction_external_compensation_is_best_effort(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    engine = _Engine([])
+    transaction = RecipeApplyTransaction(engine)  # type: ignore[arg-type]
+    calls: list[str] = []
+
+    async def succeeds() -> None:
+        calls.append("succeeds")
+
+    async def fails() -> None:
+        calls.append("fails")
+        raise RuntimeError("external cleanup failed")
+
+    transaction.record_external_compensation(succeeds)
+    transaction.record_external_compensation(fails)
+
+    await transaction.rollback()
+
+    assert calls == ["fails", "succeeds"]
+    assert "recipe external compensation failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_recipe_transaction_rollback_survives_caller_cancellation() -> None:
+    engine = _Engine(["new-a"])
+    engine.block_remove = True
+    transaction = RecipeApplyTransaction(engine)  # type: ignore[arg-type]
+    transaction.record_creature("new-a")
+
+    rollback_task = asyncio.create_task(rollback_shielded(transaction))
+    await engine.remove_started.wait()
+    rollback_task.cancel()
+    engine.allow_remove.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await rollback_task
+
+    assert engine.removed == ["new-a"]
+    assert engine._creatures == {}

--- a/tests/unit/terrarium/test_recipe_transaction.py
+++ b/tests/unit/terrarium/test_recipe_transaction.py
@@ -69,30 +69,6 @@ async def test_recipe_transaction_skips_owned_resource_removed_elsewhere() -> No
 
 
 @pytest.mark.asyncio
-async def test_recipe_transaction_external_compensation_is_best_effort(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    engine = _Engine([])
-    transaction = RecipeApplyTransaction(engine)  # type: ignore[arg-type]
-    calls: list[str] = []
-
-    async def succeeds() -> None:
-        calls.append("succeeds")
-
-    async def fails() -> None:
-        calls.append("fails")
-        raise RuntimeError("external cleanup failed")
-
-    transaction.record_external_compensation(succeeds)
-    transaction.record_external_compensation(fails)
-
-    await transaction.rollback()
-
-    assert calls == ["fails", "succeeds"]
-    assert "recipe external compensation failed" in caplog.text
-
-
-@pytest.mark.asyncio
 async def test_recipe_transaction_rollback_survives_caller_cancellation() -> None:
     engine = _Engine(["new-a"])
     engine.block_remove = True

--- a/tests/unit/terrarium/test_recipe_transaction.py
+++ b/tests/unit/terrarium/test_recipe_transaction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -85,3 +86,58 @@ async def test_recipe_transaction_rollback_survives_caller_cancellation() -> Non
 
     assert engine.removed == ["new-a"]
     assert engine._creatures == {}
+
+
+@pytest.mark.asyncio
+async def test_existing_graph_rollback_cleans_drive_assignments() -> None:
+    class _Creature:
+        def __init__(self, creature_id: str) -> None:
+            self.creature_id = creature_id
+            self.graph_id = "g"
+            self.name = creature_id
+            self.listen_channels = []
+            self.send_channels = []
+            self.agent = SimpleNamespace(
+                trigger_manager=SimpleNamespace(_triggers={}, _created_at={})
+            )
+
+        async def stop(self) -> None:
+            return None
+
+    class _DriveRuntime:
+        def __init__(self) -> None:
+            self.removed = []
+
+        async def on_creature_removed(
+            self, creature_id, *, graph_id, graph_member_ids
+        ) -> None:
+            self.removed.append((creature_id, graph_id, graph_member_ids))
+
+    graph = SimpleNamespace(
+        creature_ids={"existing", "new"},
+        listen_edges={},
+        send_edges={},
+        channels={},
+    )
+    drive = _DriveRuntime()
+    engine = SimpleNamespace(
+        _creatures={
+            "existing": _Creature("existing"),
+            "new": _Creature("new"),
+        },
+        _topology=SimpleNamespace(
+            graphs={"g": graph},
+            creature_to_graph={"existing": "g", "new": "g"},
+        ),
+        _drive_runtime=drive,
+        _environments={},
+        _session_stores={},
+        _owned_sessions=set(),
+    )
+    transaction = RecipeApplyTransaction(engine)
+    transaction.snapshot_existing_members("g")
+    transaction.record_creature("new")
+
+    await transaction.rollback()
+
+    assert drive.removed == [("new", "g", frozenset({"existing"}))]

--- a/tests/unit/terrarium/test_remote_service.py
+++ b/tests/unit/terrarium/test_remote_service.py
@@ -260,6 +260,16 @@ class TestLifecycle:
             },
         )
 
+    async def test_discard_recipe_targets_worker_graph(self):
+        svc = _make_service({"discard_recipe": {}})
+
+        await svc.discard_recipe("g1")
+
+        assert svc._sender.calls[-1][1:] == (
+            "discard_recipe",
+            {"graph_id": "g1"},
+        )
+
     async def test_add_creature_with_agent_config(self):
         from pathlib import Path
 

--- a/tests/unit/terrarium/test_remote_service.py
+++ b/tests/unit/terrarium/test_remote_service.py
@@ -228,6 +228,38 @@ class TestReadRPCs:
 
 
 class TestLifecycle:
+    async def test_apply_recipe_targets_one_worker(self):
+        graph = {
+            "graph_id": "g1",
+            "creature_ids": ["alice", "bob"],
+            "channels": {},
+            "listen_edges": {},
+            "send_edges": {},
+        }
+        info_a = _packed_creature_info()
+        info_b = {**info_a, "creature_id": "bob", "name": "bob"}
+        svc = _make_service(
+            {"apply_recipe": {"graph": graph, "creatures": [info_a, info_b]}}
+        )
+
+        out_graph, creatures = await svc.apply_recipe(
+            "recipe://team/config.yaml", start=False
+        )
+
+        assert out_graph.creature_ids == {"alice", "bob"}
+        assert [creature.creature_id for creature in creatures] == ["cid", "bob"]
+        assert svc._sender.calls[-1][1:] == (
+            "apply_recipe",
+            {
+                "recipe_path": "recipe://team/config.yaml",
+                "pwd": None,
+                "llm": None,
+                "strict": True,
+                "start": False,
+                "session_path": None,
+            },
+        )
+
     async def test_add_creature_with_agent_config(self):
         from pathlib import Path
 

--- a/tests/unit/terrarium/test_remote_service.py
+++ b/tests/unit/terrarium/test_remote_service.py
@@ -243,7 +243,7 @@ class TestLifecycle:
         )
 
         out_graph, creatures = await svc.apply_recipe(
-            "recipe://team/config.yaml", start=False
+            "recipe://team/config.yaml", start=False, persist=True
         )
 
         assert out_graph.creature_ids == {"alice", "bob"}
@@ -256,7 +256,7 @@ class TestLifecycle:
                 "llm": None,
                 "strict": True,
                 "start": False,
-                "session_path": None,
+                "persist": True,
             },
         )
 


### PR DESCRIPTION
## Summary

Make recipe application atomic across local and remote terrarium paths, including strict custom-builder compatibility and complete worker-owned compensation.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

A failed recipe could leave created creatures, channels, persisted Studio state, graph ownership, or an open session writer behind. The live helper also passed default-builder-only keywords to custom builders.

## Changes

- Reserve recipe identities before mutation and validate aliases before creating graph resources.
- Track and compensate only resources owned by the current apply operation.
- Call custom builders with their documented minimal contract while preserving the richer default-builder path.
- Roll back creatures, channels, persisted metadata, graph ownership, stores, Drive repositories, writer state, and session files.
- Use one cancellation-safe worker-owned `discard_recipe` operation for remote compensation.
- Keep whole-recipe worker placement and persistence worker-owned.
- Split oversized recipe, remote-service, and Studio lifecycle responsibilities into focused modules.
- Add negative regressions for strict custom builders and remote persisted rollback.
- Document remote recipe placement semantics.

## Validation

Final local validation on exact head `8b4a2d3f01ffc12ae3ffe66d83474c362042684e`:

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
pytest tests/integration/ -q
pytest tests/e2e/ -q

cd src/kohakuterrarium-frontend
npm test -- --maxWorkers=2 --testTimeout=20000
npm run lint
npm run format:check
npm run build
```

- Ruff and Black passed; Black reported 1,461 files unchanged.
- Unit: 11,685 passed and 9 skipped. The sole Windows `EDITOR=true` environment miss passed when rerun with Git's `true.exe` on `PATH`.
- File-size and dependency-graph guards: 1,660 passed.
- Integration: 170 passed and 1 skipped.
- Frontend: 887 passed across 85 files; ESLint, Prettier, and the production build passed.
- Focused M-002/M-003 regressions: 3 passed.
- E2E: 77 passed. The same two regenerate-status timing assertions and one Windows subprocess-worker timeout recorded on the clean baseline remained; no new failure appeared.
- `git diff --check` passed.
- All 10 `range-diff` entries against the reviewed remediation branch are unchanged (`=`), and the final tree is identical to the locally rehearsed tree.
- Fork CI passed all 13 jobs on the exact head:
  https://github.com/VVittgenstein/KohakuTerrarium/actions/runs/30604159319
- Upstream PR CI passed all 13 jobs on the exact head:
  https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/30604066318

## Checklist

- [x] I read `CONTRIBUTING.md`
- [ ] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

2026-07-30

## Notes for Reviewers

- Please focus on the strict custom-builder call contract and the post-persistence remote compensation boundary.
- Remote recipe deployment intentionally places the complete recipe on one worker; it does not introduce automatic cross-worker splitting.
- `studio/sessions/lifecycle.py` is 936 lines and `terrarium/remote_service.py` is 997 lines, both below the 1,000-line hard cap.
- This head contains 10 commits across 33 files and is rebased directly onto merged PR #93 at `7355731f9c96e22f7dedd26606b8368dafde3eb5`.

## Screenshots / Logs (if applicable)

Historical screenshots and full rehearsal evidence remain in the review packages. Post-fix behavior is pinned by automated tests.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The first Windows unit invocation could not resolve the POSIX `true` command selected by `TestSettings::test_edit_config_with_editor`. That exact test passed after adding Git's `true.exe` to `PATH`; both exact-head CI matrices passed the complete unit suite.
- The three local E2E failures are unchanged clean-baseline differences: two synchronous regenerate-status expectations (`regenerating` versus already `completed`) and one Windows subprocess-worker read timeout.
