### PR TITLE
fix(session): rerun from canonical uncompacted message history

### DIFF
--- a/docs/en/guides/sessions.md
+++ b/docs/en/guides/sessions.md
@@ -33,6 +33,10 @@ Concept primer: [memory and compaction](../concepts/modules/memory-and-compactio
 
 The format is append-only for event data and versioned through KohakuVault's auto-pack. Binary artifacts can also live in a sibling `<session>.artifacts/` directory, so when a run generated images or other binary outputs, archive the `.kohakutr` file and its artifacts directory together.
 
+### Edit and regenerate after compaction
+
+Compaction changes the live prompt and writes a fast-resume snapshot, but it does not erase the append-only event log. Studio identifies editable user messages with the persisted `event_id`, `turn_index`, and `branch_id`. Save & Rerun and Regenerate rebuild the new branch from the selected message's original event prefix, ignoring compact summaries and snapshots. The previous branch and every later event remain available for branch navigation and resume. If the locator is missing, ambiguous, points to injected mid-turn input, or conflicts with the selected branch, the operation fails without changing history.
+
 ## Where sessions live
 
 ```

--- a/docs/zh-CN/guides/sessions.md
+++ b/docs/zh-CN/guides/sessions.md
@@ -18,6 +18,10 @@ tags:
 概念入门：[记忆与压缩](../concepts/modules/memory-and-compaction.md)、
 [会话与环境](../concepts/modules/session-and-environment.md)。
 
+### 压缩后的编辑与重新生成
+
+压缩会改变实时提示并写入快速恢复快照，但不会删除追加式事件日志。Studio 使用持久化的 `event_id`、`turn_index` 和 `branch_id` 定位可编辑用户消息。保存并重新运行或重新生成时，新分支从所选消息之前的原始事件前缀重建，并忽略压缩摘要和快照；旧分支及其后续事件仍可切换和恢复。定位缺失、歧义、指向回合中注入输入或与所选分支冲突时，操作会在不修改历史的情况下失败。
+
 ## `.kohakutr` 文件
 
 `.kohakutr` 是一个 SQLite 数据库（经 KohakuVault），有九张表：

--- a/docs/zh-TW/guides/sessions.md
+++ b/docs/zh-TW/guides/sessions.md
@@ -15,6 +15,10 @@ tags:
 
 概念入門：[記憶與壓縮](../concepts/modules/memory-and-compaction.md)、[工作階段與環境](../concepts/modules/session-and-environment.md)。
 
+### 壓縮後的編輯與重新產生
+
+壓縮會改變即時提示並寫入快速恢復快照，但不會刪除追加式事件日誌。Studio 使用持久化的 `event_id`、`turn_index` 和 `branch_id` 定位可編輯的使用者訊息。儲存並重新執行或重新產生時，新分支會從所選訊息之前的原始事件前綴重建，並忽略壓縮摘要與快照；舊分支及其後續事件仍可切換與恢復。定位缺失、歧義、指向回合中注入輸入或與所選分支衝突時，操作會在不修改歷程的情況下失敗。
+
 ## `.kohakutr` 檔案
 
 `.kohakutr` 是一個 SQLite 資料庫 (透過 KohakuVault)，有九張表：

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.test.js
@@ -28,7 +28,7 @@ function mountMessage(store, pinia) {
   store.messagesByTab.main = [message]
   store.activeTab = "main"
   return mount(ChatMessage, {
-    props: { message, messageIdx: 0 },
+    props: { message, messageIdx: 0, tabId: "main" },
     global: {
       plugins: [pinia],
       stubs: {
@@ -56,6 +56,24 @@ describe("ChatMessage branch operations", () => {
     })
     pinia = createPinia()
     setActivePinia(pinia)
+  })
+
+  it("keeps Save & Rerun bound to the message tab after the active tab changes", async () => {
+    const store = useChatStore()
+    store._instanceId = "instance"
+    const editSpy = vi.spyOn(store, "editMessage").mockResolvedValue({ ok: true })
+    const wrapper = mountMessage(store, pinia)
+
+    await wrapper.get('[aria-label="Edit and rerun message"]').trigger("click")
+    store.activeTab = "other"
+    await wrapper.get("textarea").setValue("updated draft")
+    await wrapper.get('[aria-label="Save and rerun"]').trigger("click")
+
+    expect(editSpy).toHaveBeenCalledWith(
+      0,
+      "updated draft",
+      expect.objectContaining({ tabId: "main" }),
+    )
   })
 
   it("keeps the editor mounted and disabled until Save & Rerun is accepted", async () => {

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
@@ -146,7 +146,7 @@
       <p v-if="editError || branchOperationError" class="mt-1 text-sm text-red-600 dark:text-red-400" role="alert">{{ editError || branchOperationError }}</p>
     </div>
     <!-- Hover actions for user messages -->
-    <div v-if="!editing && !message.queued && messageIdx != null" class="absolute -bottom-5 right-2 flex gap-1 items-center hover-only-action chat-msg-actions chat-msg-actions--right">
+    <div v-if="!editing && !message.queued && !message.injectedMidTurn && messageIdx != null" class="absolute -bottom-5 right-2 flex gap-1 items-center hover-only-action chat-msg-actions chat-msg-actions--right">
       <!-- Branch navigator on user message: shown only when this turn
            has multiple distinct user contents (i.e. an edit produced
            a sibling branch at this divergence point). -->

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
@@ -460,6 +460,7 @@ async function confirmEdit() {
     userPosition: props.message.userPosition,
     latestBranch: props.message.latestBranch,
     attachments: editAttachments.value,
+    tabId: messageTab.value,
   })
   await nextTick()
   if (branchOperation.value) {

--- a/src/kohakuterrarium-frontend/src/stores/chat.editRerunGuards.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.editRerunGuards.test.js
@@ -1,0 +1,116 @@
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { _replayEvents, useChatStore } from "./chat.js"
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe("chat store — edit/rerun semantic guards", () => {
+  it("does not let injected mid-turn rows shift canonical user locators", () => {
+    const events = [
+      { type: "user_input", event_id: 1, content: "first", turn_index: 1, branch_id: 1 },
+      { type: "user_message", event_id: 2, content: "first", turn_index: 1, branch_id: 1 },
+      {
+        type: "user_input_injected",
+        event_id: 3,
+        content: "steer",
+        turn_index: 1,
+        branch_id: 1,
+      },
+      { type: "turn_end", event_id: 4, content: "a1", turn_index: 1, branch_id: 1 },
+      { type: "user_input", event_id: 5, content: "second", turn_index: 2, branch_id: 1 },
+      { type: "user_message", event_id: 6, content: "second", turn_index: 2, branch_id: 1 },
+    ]
+
+    const replayed = _replayEvents([], events).messages
+    const users = replayed.filter((message) => message.role === "user")
+
+    expect(users).toHaveLength(3)
+    expect(users[0]).toMatchObject({ content: "first", turnIndex: 1, userPosition: 0 })
+    expect(users[1]).toMatchObject({ content: "steer", turnIndex: 1, injectedMidTurn: true })
+    expect(users[1].userPosition).toBeUndefined()
+    expect(users[2]).toMatchObject({ content: "second", turnIndex: 2, userPosition: 1 })
+
+    const chat = useChatStore()
+    chat.messagesByTab = { main: replayed }
+    const secondUserIdx = replayed.findIndex((message) => message.content === "second")
+    expect(chat._conversationUserPosition("main", secondUserIdx)).toBe(1)
+  })
+
+  it("keeps optimistic edit and rollback on the owning tab after active-tab changes", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "graph_1"
+    chat._instanceGraphId = "graph_1"
+    chat.tabs = ["main", "other", "observer"]
+    chat.activeTab = "other"
+    const originalEvents = [
+      { type: "user_input", event_id: 1, content: "main draft", turn_index: 1, branch_id: 1 },
+      {
+        type: "user_message",
+        event_id: 2,
+        content: "main draft",
+        turn_index: 1,
+        branch_id: 1,
+      },
+      { type: "processing_end", event_id: 3, turn_index: 1, branch_id: 1 },
+    ]
+    const originalMainMessages = _replayEvents([], originalEvents).messages
+    const expectedMainMessages = JSON.parse(JSON.stringify(originalMainMessages))
+    chat.messagesByTab = {
+      main: originalMainMessages,
+      other: [{ id: "other-user", role: "user", content: "other draft", turnIndex: 1 }],
+      observer: [{ id: "observer-user", role: "user", content: "observer draft", turnIndex: 1 }],
+    }
+    chat.eventsByTab = { main: [...originalEvents] }
+    chat.branchViewByTab = { main: { 1: 1 } }
+    chat.processingByTab = { main: false, other: false, observer: false }
+
+    const { agentAPI } = await import("@/utils/api")
+    let rejectEdit
+    const editSpy = vi.spyOn(agentAPI, "editMessage").mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          rejectEdit = reject
+        }),
+    )
+
+    const editPromise = chat.editMessage(0, "edited main draft", {
+      tabId: "main",
+      turnIndex: 1,
+      userPosition: 0,
+      latestBranch: 1,
+    })
+
+    await vi.waitFor(() => expect(editSpy).toHaveBeenCalledOnce())
+    expect(editSpy).toHaveBeenCalledWith(
+      "graph_1",
+      "main",
+      0,
+      "edited main draft",
+      expect.objectContaining({ turnIndex: 1, userPosition: 0 }),
+    )
+    expect(JSON.stringify(chat.messagesByTab.main)).toContain("edited main draft")
+    expect(chat.messagesByTab.other[0].content).toBe("other draft")
+    expect(chat.messagesByTab.observer[0].content).toBe("observer draft")
+
+    chat.activeTab = "observer"
+    rejectEdit(Object.assign(new Error("edit conflict"), { response: { status: 409 } }))
+    const result = await editPromise
+
+    expect(result.ok).toBe(false)
+    expect(chat.messagesByTab.main).toEqual(expectedMainMessages)
+    expect(chat.eventsByTab.main).toEqual(originalEvents)
+    expect(chat.branchViewByTab.main).toEqual({ 1: 1 })
+    expect(chat.processingByTab.main).toBe(false)
+    expect(chat.messagesByTab.other[0].content).toBe("other draft")
+    expect(chat.messagesByTab.observer[0].content).toBe("observer draft")
+    expect(chat.branchOperationByTab.main).toBeNull()
+    expect(chat.branchOperationErrorByTab.main).toBe("edit conflict")
+    expect(chat.branchOperationByTab.other).toBeUndefined()
+
+    editSpy.mockRestore()
+    chat._clearBranchResyncTimers()
+  })
+})

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -708,6 +708,7 @@ export function _replayEvents(messages, events, branchView = null) {
         role: "user",
         content: normalized.content,
         contentParts: normalized.contentParts,
+        turnIndex: typeof evt?.turn_index === "number" ? evt.turn_index : null,
         injectedMidTurn: true,
         timestamp: "",
       })
@@ -1163,7 +1164,9 @@ export function _replayEvents(messages, events, branchView = null) {
   let assistantMsgIdx = 0
   for (const msg of result) {
     if (msg.role === "user") {
-      const ti = userTurnsForResult[userMsgIdx]
+      if (msg.injectedMidTurn) continue
+      const ti = typeof msg.turnIndex === "number" ? msg.turnIndex : userTurnsForResult[userMsgIdx]
+      msg.userPosition = userMsgIdx
       userMsgIdx += 1
       // Always stamp turnIndex on the message so the regen / edit
       // buttons can target THIS turn — even when there's no
@@ -3356,7 +3359,7 @@ const _chatStoreOptions = {
       if (msgs[messageIdx]?.role !== "user") return null
       let pos = 0
       for (let i = 0; i < messageIdx; i++) {
-        if (msgs[i]?.role === "user") pos += 1
+        if (msgs[i]?.role === "user" && !msgs[i]?.injectedMidTurn) pos += 1
       }
       return pos
     },
@@ -3573,7 +3576,7 @@ const _chatStoreOptions = {
      * server-side regardless of how many decorations sit in front of it.
      */
     async editMessage(messageIdx, newContent, target = {}) {
-      const tab = this.activeTab
+      const tab = target.tabId || this.activeTab
       if (!this._instanceId)
         return this._branchOperationResult(false, tab, null, "No active instance")
       if (messageIdx == null)

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -3530,7 +3530,8 @@ const _chatStoreOptions = {
             this._rebuildMessages(tab)
           }
           this._scheduleBranchResync(tab)
-          return
+          const error = this._failBranchOperation(tab, e)
+          return this._branchOperationResult(false, tab, null, error)
         }
         if (regenResponse?.branch_id != null && regenResponse?.turn_index != null) {
           // Trust the backend's exact branch_id over our prediction —

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -395,7 +395,7 @@ export function _replayEvents(messages, events, branchView = null) {
   let _n = 0
   // Dedupe user-role renders across user_input + user_message duplicates
   // for the same (turn, branch).
-  const _seenUserRender = new Set()
+  const _seenUserRender = new Map()
   // Track job lifecycle: started jobs and completed jobs
   const startedJobs = {} // jobId -> tool part reference
   const completedJobs = new Set() // jobIds that received done/error
@@ -662,17 +662,28 @@ export function _replayEvents(messages, events, branchView = null) {
       const ti = evt?.turn_index
       const bi = evt?.branch_id
       const key = typeof ti === "number" && typeof bi === "number" ? `${ti}/${bi}` : null
-      if (key && _seenUserRender.has(key)) continue
-      if (key) _seenUserRender.add(key)
+      if (key && _seenUserRender.has(key)) {
+        const prior = _seenUserRender.get(key)
+        if (t === "user_message" && prior && typeof evt.event_id === "number") {
+          prior.locator = { eventId: evt.event_id, turnIndex: ti, branchId: bi }
+        }
+        continue
+      }
       cur = null
       const normalized = normalizeMessageContent(evt.content)
-      result.push({
+      const userMessage = {
         id: "h_" + result.length,
         role: "user",
         content: normalized.content,
         contentParts: normalized.contentParts,
         timestamp: "",
-      })
+        locator:
+          t === "user_message" && typeof evt.event_id === "number"
+            ? { eventId: evt.event_id, turnIndex: ti, branchId: bi }
+            : null,
+      }
+      result.push(userMessage)
+      if (key) _seenUserRender.set(key, userMessage)
     } else if (t === "user_input_injected") {
       // Mid-turn injection (Feat 3) — the user typed during processing
       // and the backend folded it into the running turn. Distinct
@@ -3495,6 +3506,7 @@ const _chatStoreOptions = {
             turnIndex,
             branchView,
             requestId,
+            locator: target.locator ?? msgs?.[lastUserIdx]?.locator,
           })
         } catch (e) {
           // No HTTP response ≠ rejected (this POST blocks through the
@@ -3577,7 +3589,8 @@ const _chatStoreOptions = {
       }
       let backendIdx = messageIdx
       let userPosition = target.userPosition
-      const turnIndex = target.turnIndex
+      const locator = target.locator ?? this.messagesByTab[tab]?.[messageIdx]?.locator
+      const turnIndex = locator?.turnIndex ?? target.turnIndex
       // Never-branched messages carry no ``latestBranch`` metadata —
       // derive the current max from the cached event log so the
       // prediction (and the stale-history guard) still arm.
@@ -3691,6 +3704,7 @@ const _chatStoreOptions = {
             branchView,
             attachments: Array.isArray(target.attachments) ? target.attachments : [],
             requestId,
+            locator,
           })
         } catch (e) {
           // No HTTP response ≠ rejected: this POST blocks through the

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -3506,7 +3506,7 @@ const _chatStoreOptions = {
             turnIndex,
             branchView,
             requestId,
-            locator: target.locator ?? msgs?.[lastUserIdx]?.locator,
+            locator: targetUserMsg?.locator,
           })
         } catch (e) {
           // No HTTP response ≠ rejected (this POST blocks through the

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -524,13 +524,20 @@ export const agentAPI = {
    * name. Old call sites that pass only an agent id can still call
    * ``regenerate(agentId)`` — the second arg defaults to the first.
    */
-  async regenerate(sessionId, creatureId, { turnIndex, branchView, requestId } = {}) {
+  async regenerate(sessionId, creatureId, { turnIndex, branchView, requestId, locator } = {}) {
     const sid = sessionId || "_"
     const cid = creatureId || sessionId
     const body = {}
     if (turnIndex != null) body.turn_index = turnIndex
     if (branchView && Object.keys(branchView).length) body.branch_view = branchView
     if (requestId) body.request_id = requestId
+    if (locator) {
+      body.target = {
+        event_id: locator.eventId,
+        turn_index: locator.turnIndex,
+        branch_id: locator.branchId,
+      }
+    }
     // This POST blocks through the whole rerun turn — no client timeout.
     const { data } = await api.post(
       `/sessions/${encodeTarget(sid)}/creatures/${encodeTarget(cid)}/regenerate`,
@@ -549,6 +556,13 @@ export const agentAPI = {
       body.branch_view = target.branchView
     }
     if (target.requestId) body.request_id = target.requestId
+    if (target.locator) {
+      body.target = {
+        event_id: target.locator.eventId,
+        turn_index: target.locator.turnIndex,
+        branch_id: target.locator.branchId,
+      }
+    }
     const sid = sessionId || "_"
     const cid = creatureId || sessionId
     // This POST blocks through the whole rerun turn — no client timeout.

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
@@ -14,6 +14,7 @@ from kohakuterrarium.api.schemas import (
     RegenerateRequest,
 )
 from kohakuterrarium.errors import ConflictError, NotFoundError
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.terrarium.service import TerrariumService
 
 router = APIRouter()
@@ -53,13 +54,20 @@ async def regenerate_creature(
     turn_index = req.turn_index if req is not None else None
     branch_view = req.branch_view if req is not None else None
     request_id = request_id or (req.request_id if req is not None else None)
+    target = (
+        UserMessageSelector(**req.target.model_dump())
+        if req is not None and req.target is not None
+        else None
+    )
     try:
-        return await service.regenerate(
-            cid,
-            turn_index=turn_index,
-            branch_view=branch_view,
-            request_id=request_id,
-        )
+        kwargs = {
+            "turn_index": turn_index,
+            "branch_view": branch_view,
+            "request_id": request_id,
+        }
+        if target is not None:
+            kwargs["target"] = target
+        return await service.regenerate(cid, **kwargs)
     except (NotFoundError, KeyError) as exc:
         raise HTTPException(404, str(exc)) from exc
     except (ConflictError, ValueError) as exc:
@@ -88,15 +96,16 @@ async def edit_creature_message(
     cid = await resolve_creature_id(service, creature_id, session_id)
     request_id = request_id or req.request_id
     try:
-        edited = await service.edit_message(
-            cid,
-            msg_idx,
-            content,
-            turn_index=req.turn_index,
-            user_position=req.user_position,
-            branch_view=req.branch_view,
-            request_id=request_id,
-        )
+        target = UserMessageSelector(**req.target.model_dump()) if req.target else None
+        kwargs = {
+            "turn_index": req.turn_index,
+            "user_position": req.user_position,
+            "branch_view": req.branch_view,
+            "request_id": request_id,
+        }
+        if target is not None:
+            kwargs["target"] = target
+        edited = await service.edit_message(cid, msg_idx, content, **kwargs)
         return edited
     except (NotFoundError, KeyError) as exc:
         raise HTTPException(404, str(exc)) from exc

--- a/src/kohakuterrarium/api/schemas.py
+++ b/src/kohakuterrarium/api/schemas.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class TerrariumCreate(BaseModel):
@@ -128,9 +128,9 @@ class AgentChat(BaseModel):
 class PersistedMessageLocator(BaseModel):
     """Canonical identity of one persisted turn-root user message."""
 
-    event_id: int
-    turn_index: int
-    branch_id: int
+    event_id: int = Field(gt=0)
+    turn_index: int = Field(gt=0)
+    branch_id: int = Field(gt=0)
 
 
 class RegenerateRequest(BaseModel):

--- a/src/kohakuterrarium/api/schemas.py
+++ b/src/kohakuterrarium/api/schemas.py
@@ -125,6 +125,14 @@ class AgentChat(BaseModel):
     content: list[ContentPartPayload] | None = None
 
 
+class PersistedMessageLocator(BaseModel):
+    """Canonical identity of one persisted turn-root user message."""
+
+    event_id: int
+    turn_index: int
+    branch_id: int
+
+
 class RegenerateRequest(BaseModel):
     """Select the turn and branch view used to regenerate a response.
 
@@ -136,6 +144,7 @@ class RegenerateRequest(BaseModel):
     turn_index: int | None = None
     branch_view: dict[int, int] | None = None
     request_id: str | None = None
+    target: PersistedMessageLocator | None = None
 
 
 class BranchMutationResponse(BaseModel):
@@ -160,6 +169,7 @@ class MessageEdit(BaseModel):
     # Restore the selected subtree before resolving edits on a non-latest branch.
     branch_view: dict[int, int] | None = None
     request_id: str | None = None
+    target: PersistedMessageLocator | None = None
 
 
 class SlashCommand(BaseModel):

--- a/src/kohakuterrarium/core/agent_message_history.py
+++ b/src/kohakuterrarium/core/agent_message_history.py
@@ -1,0 +1,296 @@
+"""Branch-aware history lookup helpers for agent message mutations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from kohakuterrarium.core.message_locator import (
+    user_message_indices_for_content,
+    user_message_indices_for_turn,
+)
+from kohakuterrarium.session.history import (
+    replay_conversation,
+    resolve_branch_view_strict,
+    select_live_event_ids,
+)
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def resolve_edit_message_index(
+    agent: Any,
+    msgs: list[object],
+    message_idx: int,
+    *,
+    turn_index: int | None = None,
+    user_position: int | None = None,
+    branch_view: dict[int, int] | None = None,
+) -> int | None:
+    """Resolve by turn metadata or exact unique legacy-content matching."""
+    if turn_index is not None:
+        metadata_matches = user_message_indices_for_turn(msgs, turn_index)
+        if len(metadata_matches) == 1:
+            return metadata_matches[0]
+        if len(metadata_matches) > 1:
+            logger.warning(
+                "Ambiguous edit target metadata",
+                turn_index=turn_index,
+                matches=len(metadata_matches),
+            )
+            return None
+
+        target_content = user_message_content_for_turn(
+            agent,
+            turn_index,
+            branch_view=branch_view,
+        )
+        if target_content is not None:
+            content_matches = user_message_indices_for_content(msgs, target_content)
+            if len(content_matches) == 1:
+                return content_matches[0]
+            logger.warning(
+                "Cannot uniquely match edit target content",
+                turn_index=turn_index,
+                matches=len(content_matches),
+            )
+            return None
+
+        if user_position is None:
+            return None
+    if user_position is not None:
+        if user_position < 0:
+            return None
+        seen = -1
+        for idx, msg in enumerate(msgs):
+            if msg.role != "user":
+                continue
+            seen += 1
+            if seen == user_position:
+                return idx
+        return None
+    if message_idx < 0 or message_idx >= len(msgs):
+        return None
+    return message_idx
+
+
+def user_position_for_turn_index(
+    agent: Any,
+    turn_index: int,
+    *,
+    branch_view: dict[int, int] | None = None,
+) -> int | None:
+    """Return the visible user-position for a live turn_index."""
+    for pos, candidate in enumerate(live_user_turns(agent, branch_view=branch_view)):
+        if candidate == turn_index:
+            return pos
+    return None
+
+
+def live_user_turns(
+    agent: Any,
+    *,
+    branch_view: dict[int, int] | None = None,
+) -> list[int]:
+    """Return live user turn indices in visible order."""
+    if agent.session_store is None:
+        return []
+    try:
+        events = agent.session_store.get_events(agent.config.name)
+    except Exception as exc:
+        logger.warning(
+            "Failed to read events for live turns",
+            error=str(exc),
+            exc_info=True,
+        )
+        return []
+    live_ids = select_live_event_ids(events, branch_view=branch_view)
+    seen_turns: set[int] = set()
+    turns: list[tuple[int, int]] = []
+    for event in events:
+        if event.get("type") != "user_message":
+            continue
+        event_id = event.get("event_id")
+        turn_index = event.get("turn_index")
+        if not isinstance(event_id, int) or not isinstance(turn_index, int):
+            continue
+        if event_id not in live_ids or turn_index in seen_turns:
+            continue
+        seen_turns.add(turn_index)
+        turns.append((turn_index, event_id))
+    turns.sort(key=lambda pair: pair[0])
+    return [turn_index for turn_index, _ in turns]
+
+
+def turn_index_for_user_position(
+    agent: Any,
+    user_position: int,
+    *,
+    branch_view: dict[int, int] | None = None,
+) -> int | None:
+    """Return the live turn at one visible user-message position."""
+    turns = live_user_turns(agent, branch_view=branch_view)
+    if user_position < 0 or user_position >= len(turns):
+        return None
+    return turns[user_position]
+
+
+def max_branch_id_for_turn(agent: Any, turn_index: int) -> int:
+    """Return the largest persisted branch id for one turn."""
+    if agent.session_store is None:
+        return 0
+    try:
+        events = agent.session_store.get_events(agent.config.name)
+    except Exception as exc:
+        logger.warning(
+            "Failed to read events for branch lookup",
+            error=str(exc),
+            exc_info=True,
+        )
+        return 0
+    max_branch = 0
+    for event in events:
+        if event.get("turn_index") != turn_index:
+            continue
+        branch_id = event.get("branch_id")
+        if isinstance(branch_id, int) and branch_id > max_branch:
+            max_branch = branch_id
+    return max_branch
+
+
+def user_message_content_for_turn(
+    agent: Any,
+    turn_index: int,
+    *,
+    branch_view: dict[int, int] | None = None,
+):
+    """Return persisted user content from the selected branch of one turn."""
+    if agent.session_store is None:
+        return None
+    try:
+        events = agent.session_store.get_events(agent.config.name)
+    except Exception as exc:
+        logger.warning(
+            "Failed to read events for turn-content lookup",
+            error=str(exc),
+            exc_info=True,
+        )
+        return None
+    selected = resolve_branch_view_strict(events, branch_view)
+    target_branch = selected.get(turn_index)
+    if target_branch is None:
+        return None
+    for event in events:
+        if (
+            event.get("type") == "user_message"
+            and event.get("turn_index") == turn_index
+            and event.get("branch_id") == target_branch
+        ):
+            return event.get("content")
+    return None
+
+
+def reload_conversation_under_branch_view(
+    agent: Any,
+    branch_view: dict[int, int],
+    *,
+    replay: Callable[..., list[dict[str, Any]]] = replay_conversation,
+) -> None:
+    """Replay a selected subtree and align conversation and branch state."""
+    if agent.session_store is None:
+        return
+    try:
+        events = agent.session_store.get_events(agent.config.name)
+    except Exception as exc:
+        logger.warning(
+            "Failed to read events for branch_view reload",
+            error=str(exc),
+            exc_info=True,
+        )
+        return
+
+    selected = resolve_branch_view_strict(events, branch_view)
+    messages = replay(events, branch_view=branch_view)
+    metadata_by_turn = {
+        int(event["turn_index"]): {
+            "event_id": event.get("event_id"),
+            "turn_index": event.get("turn_index"),
+            "branch_id": event.get("branch_id"),
+        }
+        for event in events
+        if event.get("type") == "user_message"
+        and isinstance(event.get("turn_index"), int)
+    }
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        for metadata in metadata_by_turn.values():
+            if message.get("content") == next(
+                (
+                    event.get("content")
+                    for event in events
+                    if event.get("event_id") == metadata.get("event_id")
+                ),
+                None,
+            ):
+                message["metadata"] = metadata
+                break
+
+    conversation = agent.controller.conversation
+    existing_system = [
+        message for message in conversation.get_messages() if message.role == "system"
+    ]
+    conversation._messages.clear()
+    conversation._messages.extend(existing_system)
+    for message in messages:
+        role = message.get("role")
+        if role == "system":
+            continue
+        extra: dict = {}
+        for key in ("tool_calls", "tool_call_id", "name", "metadata"):
+            if message.get(key):
+                extra[key] = message[key]
+        conversation.append(role, message.get("content", ""), **extra)
+
+    if selected:
+        max_turn = max(selected)
+        agent._turn_index = max_turn
+        agent._branch_id = selected[max_turn]
+        agent._parent_branch_path = [
+            (turn, branch)
+            for turn, branch in sorted(selected.items())
+            if turn < max_turn
+        ]
+    else:
+        agent._turn_index = 0
+        agent._branch_id = 0
+        agent._parent_branch_path = []
+
+
+def previous_branch_user_content(agent: Any):
+    """Return user content from the nearest lower branch of the current turn."""
+    if agent.session_store is None:
+        return None
+    try:
+        events = agent.session_store.get_events(agent.config.name)
+    except Exception as exc:
+        logger.warning(
+            "Failed to read events for prev-branch user",
+            error=str(exc),
+            exc_info=True,
+        )
+        return None
+    latest_for_turn: dict | None = None
+    latest_branch = -1
+    for event in events:
+        if (
+            event.get("type") != "user_message"
+            or event.get("turn_index") != agent._turn_index
+        ):
+            continue
+        branch_id = event.get("branch_id")
+        if not isinstance(branch_id, int):
+            continue
+        if branch_id < agent._branch_id and branch_id > latest_branch:
+            latest_branch = branch_id
+            latest_for_turn = event
+    return latest_for_turn.get("content") if latest_for_turn is not None else None

--- a/src/kohakuterrarium/core/agent_messages.py
+++ b/src/kohakuterrarium/core/agent_messages.py
@@ -3,21 +3,25 @@
 Modify past messages, regenerate responses, and replay conversation branches.
 """
 
+import asyncio
+
+from kohakuterrarium.core.agent_message_history import (
+    live_user_turns as _live_user_turns,
+    max_branch_id_for_turn as _max_branch_id_for_turn,
+    previous_branch_user_content as _previous_branch_user_content,
+    reload_conversation_under_branch_view as _reload_branch_view,
+    resolve_edit_message_index as _resolve_edit_message_index,
+    turn_index_for_user_position as _turn_index_for_user_position,
+    user_message_content_for_turn as _user_message_content_for_turn,
+)
 from kohakuterrarium.core.agent_raw_history import (
     raw_target_content,
     reload_raw_prefix_for_target,
 )
 from kohakuterrarium.core.events import EventType, TriggerEvent
-from kohakuterrarium.core.message_locator import (
-    user_message_indices_for_content,
-    user_message_indices_for_turn,
-)
+from kohakuterrarium.errors import ConflictError
 from kohakuterrarium.llm.message import normalize_content_parts
-from kohakuterrarium.session.history import (
-    replay_conversation,
-    resolve_branch_view_strict,
-    select_live_event_ids,
-)
+from kohakuterrarium.session.history import replay_conversation
 from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.utils.logging import get_logger
 
@@ -97,6 +101,13 @@ class AgentMessagesMixin:
             )
             return
 
+        async with self._get_message_mutation_lock():
+            await self._regenerate_tail_response(request_id=request_id)
+
+    async def _regenerate_tail_response(self, *, request_id: str | None) -> None:
+        """Regenerate the current tail while holding the mutation lock."""
+        self._ensure_history_mutation_idle()
+        self._ensure_rerun_available()
         conv = self.controller.conversation
         last_user = conv.find_last_user_index()
         if last_user < 0:
@@ -156,6 +167,29 @@ class AgentMessagesMixin:
         request_id: str | None = None,
         target: UserMessageSelector | None = None,
     ) -> bool:
+        """Serialize conversation reconstruction and the resulting rerun turn."""
+        async with self._get_message_mutation_lock():
+            return await self._edit_and_rerun_locked(
+                message_idx,
+                new_content,
+                turn_index=turn_index,
+                user_position=user_position,
+                branch_view=branch_view,
+                request_id=request_id,
+                target=target,
+            )
+
+    async def _edit_and_rerun_locked(
+        self,
+        message_idx: int,
+        new_content: str,
+        *,
+        turn_index: int | None = None,
+        user_position: int | None = None,
+        branch_view: dict[int, int] | None = None,
+        request_id: str | None = None,
+        target: UserMessageSelector | None = None,
+    ) -> bool:
         """Replace a user message and re-run from there.
 
         ``message_idx`` remains the raw in-memory conversation index for
@@ -169,6 +203,8 @@ class AgentMessagesMixin:
         truncation target resolves correctly even when the user has
         switched to an older subtree in the UI.
         """
+        self._ensure_history_mutation_idle()
+        self._ensure_rerun_available()
         # Canonical persisted targets reconstruct original context before
         # mutating in-memory state, deliberately bypassing compact snapshots.
         if target is not None:
@@ -278,20 +314,50 @@ class AgentMessagesMixin:
 
     async def rewind_to(self, message_idx: int) -> None:
         """Drop messages from ``message_idx`` onward without re-running."""
-        conv = self.controller.conversation
-        removed = conv.truncate_from(message_idx)
-        logger.info("Rewound", index=message_idx, dropped=len(removed))
-        if self.session_store:
-            try:
-                self.session_store.save_conversation(
-                    self.config.name, conv.to_messages(include_metadata=True)
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to save conversation after rewind",
-                    error=str(e),
-                    exc_info=True,
-                )
+        async with self._get_message_mutation_lock():
+            self._ensure_history_mutation_idle()
+            conv = self.controller.conversation
+            removed = conv.truncate_from(message_idx)
+            logger.info("Rewound", index=message_idx, dropped=len(removed))
+            if self.session_store:
+                try:
+                    self.session_store.save_conversation(
+                        self.config.name, conv.to_messages(include_metadata=True)
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to save conversation after rewind",
+                        error=str(e),
+                        exc_info=True,
+                    )
+
+    def _get_message_mutation_lock(self) -> asyncio.Lock:
+        """Return the per-agent lock guarding destructive history mutations."""
+        lock = getattr(self, "_message_mutation_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._message_mutation_lock = lock
+        return lock
+
+    def _ensure_history_mutation_idle(self) -> None:
+        """Reject destructive history changes while another turn can observe it."""
+        processing_lock = getattr(self, "_processing_lock", None)
+        inbox = getattr(self, "_event_inbox", None)
+        turn_active = processing_lock is not None and processing_lock.locked()
+        input_pending = inbox is not None and len(inbox) > 0
+        if turn_active or input_pending:
+            raise ConflictError(
+                "Cannot mutate conversation history while a turn is active"
+            )
+
+    def _ensure_rerun_available(self) -> None:
+        """Reject reruns before mutation when the event loop cannot admit them."""
+        if getattr(self, "_paused", False):
+            raise ConflictError("Cannot rerun conversation while the agent is paused")
+        if getattr(self, "_running", True) is False:
+            raise ConflictError(
+                "Cannot rerun conversation while the agent is not running"
+            )
 
     async def _rerun_from_last(self, new_user_content: str | list = "") -> None:
         """Trigger an LLM turn from the current conversation state.
@@ -327,50 +393,14 @@ class AgentMessagesMixin:
         branch_view: dict[int, int] | None = None,
     ) -> int | None:
         """Resolve by turn metadata or exact unique legacy-content matching."""
-        if turn_index is not None:
-            metadata_matches = user_message_indices_for_turn(msgs, turn_index)
-            if len(metadata_matches) == 1:
-                return metadata_matches[0]
-            if len(metadata_matches) > 1:
-                logger.warning(
-                    "Ambiguous edit target metadata",
-                    turn_index=turn_index,
-                    matches=len(metadata_matches),
-                )
-                return None
-
-            target_content = self._user_message_content_for_turn(
-                turn_index, branch_view=branch_view
-            )
-            if target_content is not None:
-                content_matches = user_message_indices_for_content(msgs, target_content)
-                if len(content_matches) == 1:
-                    return content_matches[0]
-                logger.warning(
-                    "Cannot uniquely match edit target content",
-                    turn_index=turn_index,
-                    matches=len(content_matches),
-                )
-                return None
-
-            # A caller may still supply the legacy visible position when no
-            # event metadata exists (for example, a narrow in-memory client).
-            if user_position is None:
-                return None
-        if user_position is not None:
-            if user_position < 0:
-                return None
-            seen = -1
-            for idx, msg in enumerate(msgs):
-                if msg.role != "user":
-                    continue
-                seen += 1
-                if seen == user_position:
-                    return idx
-            return None
-        if message_idx < 0 or message_idx >= len(msgs):
-            return None
-        return message_idx
+        return _resolve_edit_message_index(
+            self,
+            msgs,
+            message_idx,
+            turn_index=turn_index,
+            user_position=user_position,
+            branch_view=branch_view,
+        )
 
     def _user_position_for_turn_index(
         self,
@@ -379,8 +409,8 @@ class AgentMessagesMixin:
         branch_view: dict[int, int] | None = None,
     ) -> int | None:
         """Return the visible user-position for a live turn_index."""
-        for pos, ti in enumerate(self._live_user_turns(branch_view=branch_view)):
-            if ti == turn_index:
+        for pos, candidate in enumerate(self._live_user_turns(branch_view=branch_view)):
+            if candidate == turn_index:
                 return pos
         return None
 
@@ -400,37 +430,7 @@ class AgentMessagesMixin:
         Defers to ``select_live_event_ids`` from ``session/history.py``
         so this stays in lock-step with the replay logic.
         """
-        if self.session_store is None:
-            return []
-        try:
-            events = self.session_store.get_events(self.config.name)
-        except Exception as e:
-            logger.warning(
-                "Failed to read events for live turns", error=str(e), exc_info=True
-            )
-            return []
-        live_ids = select_live_event_ids(events, branch_view=branch_view)
-        seen_turns: set[int] = set()
-        live_user_turns: list[tuple[int, int]] = []
-        for evt in events:
-            if evt.get("type") != "user_message":
-                continue
-            eid = evt.get("event_id")
-            ti = evt.get("turn_index")
-            if not isinstance(eid, int) or not isinstance(ti, int):
-                continue
-            if eid not in live_ids:
-                continue
-            if ti in seen_turns:
-                # Legacy sessions may contain duplicate user events for a turn.
-                continue
-            seen_turns.add(ti)
-            live_user_turns.append((ti, eid))
-        # Sort by turn_index so position N maps to the Nth visible turn,
-        # not the Nth event in chronological order (which can scramble
-        # when sibling branches interleave in the event log).
-        live_user_turns.sort(key=lambda p: p[0])
-        return [ti for ti, _ in live_user_turns]
+        return _live_user_turns(self, branch_view=branch_view)
 
     def _turn_index_for_user_position(
         self,
@@ -445,30 +445,16 @@ class AgentMessagesMixin:
         ``branch_view`` (or the latest subtree when ``branch_view``
         is ``None``).
         """
-        live_user_turns = self._live_user_turns(branch_view=branch_view)
-        if user_position < 0 or user_position >= len(live_user_turns):
-            return None
-        return live_user_turns[user_position]
+        return _turn_index_for_user_position(
+            self,
+            user_position,
+            branch_view=branch_view,
+        )
 
     def _max_branch_id_for_turn(self, turn_index: int) -> int:
         """Return the largest ``branch_id`` recorded for ``turn_index``,
         or ``0`` if no branch yet exists."""
-        if self.session_store is None:
-            return 0
-        try:
-            events = self.session_store.get_events(self.config.name)
-        except Exception as e:
-            logger.warning(
-                "Failed to read events for branch lookup", error=str(e), exc_info=True
-            )
-            return 0
-        max_branch = 0
-        for evt in events:
-            if evt.get("turn_index") == turn_index:
-                bi = evt.get("branch_id")
-                if isinstance(bi, int) and bi > max_branch:
-                    max_branch = bi
-        return max_branch
+        return _max_branch_id_for_turn(self, turn_index)
 
     def _user_message_content_for_turn(
         self,
@@ -486,30 +472,11 @@ class AgentMessagesMixin:
         the user's current subtree (otherwise it picks the latest
         branch globally).
         """
-        if self.session_store is None:
-            return None
-        try:
-            events = self.session_store.get_events(self.config.name)
-        except Exception as e:
-            logger.warning(
-                "Failed to read events for turn-content lookup",
-                error=str(e),
-                exc_info=True,
-            )
-            return None
-        selected = resolve_branch_view_strict(events, branch_view)
-        target_branch = selected.get(turn_index)
-        if target_branch is None:
-            return None
-        for evt in events:
-            if evt.get("type") != "user_message":
-                continue
-            if evt.get("turn_index") != turn_index:
-                continue
-            if evt.get("branch_id") != target_branch:
-                continue
-            return evt.get("content")
-        return None
+        return _user_message_content_for_turn(
+            self,
+            turn_index,
+            branch_view=branch_view,
+        )
 
     def _reload_conversation_under_branch_view(
         self,
@@ -520,84 +487,11 @@ class AgentMessagesMixin:
         Branch selection changes only the displayed view, so runtime state must
         be reseated before an edit or retry can resolve the intended message.
         """
-        if self.session_store is None:
-            return
-        try:
-            events = self.session_store.get_events(self.config.name)
-        except Exception as e:
-            logger.warning(
-                "Failed to read events for branch_view reload",
-                error=str(e),
-                exc_info=True,
-            )
-            return
-
-        # Compute the chosen subtree's leaf state up front so we can
-        # set agent metadata after reseating the conversation.
-        selected = resolve_branch_view_strict(events, branch_view)
-
-        messages = replay_conversation(events, branch_view=branch_view)
-        metadata_by_turn = {
-            int(event["turn_index"]): {
-                "event_id": event.get("event_id"),
-                "turn_index": event.get("turn_index"),
-                "branch_id": event.get("branch_id"),
-            }
-            for event in events
-            if event.get("type") == "user_message"
-            and isinstance(event.get("turn_index"), int)
-        }
-        for message in messages:
-            if message.get("role") != "user":
-                continue
-            for metadata in metadata_by_turn.values():
-                if message.get("content") == next(
-                    (
-                        event.get("content")
-                        for event in events
-                        if event.get("event_id") == metadata.get("event_id")
-                    ),
-                    None,
-                ):
-                    message["metadata"] = metadata
-                    break
-        conv = self.controller.conversation
-        # Keep the system prompt (it carries tool docs and agent
-        # personality). ``replay_conversation`` does not emit system
-        # messages from the event log, so we preserve whatever the
-        # controller set up at boot.
-        existing_system = [m for m in conv.get_messages() if m.role == "system"]
-        conv._messages.clear()
-        conv._messages.extend(existing_system)
-        for msg in messages:
-            role = msg.get("role")
-            if role == "system":
-                continue
-            content = msg.get("content", "")
-            extra: dict = {}
-            if msg.get("tool_calls"):
-                extra["tool_calls"] = msg["tool_calls"]
-            if msg.get("tool_call_id"):
-                extra["tool_call_id"] = msg["tool_call_id"]
-            if msg.get("name"):
-                extra["name"] = msg["name"]
-            if msg.get("metadata"):
-                extra["metadata"] = msg["metadata"]
-            conv.append(role, content, **extra)
-
-        # Reseat agent state to the chosen subtree's leaf so the next
-        # operation (edit/retry/continue) operates within this view.
-        if selected:
-            max_turn = max(selected.keys())
-            self._turn_index = max_turn
-            self._branch_id = selected[max_turn]
-            self._parent_branch_path = [
-                (t, b) for t, b in sorted(selected.items()) if t < max_turn
-            ]
-        else:
-            self._turn_index = 0
-            self._branch_id = 0
-            self._parent_branch_path = []
+        _reload_branch_view(
+            self,
+            branch_view,
+            replay=replay_conversation,
+        )
 
     def _previous_branch_user_content(self):
         """Return the ``user_message`` content recorded for the most
@@ -608,31 +502,4 @@ class AgentMessagesMixin:
         ``user_message`` event with the same wording as the original
         branch (pure regen does not change the user message).
         """
-        if self.session_store is None:
-            return None
-        try:
-            events = self.session_store.get_events(self.config.name)
-        except Exception as e:
-            logger.warning(
-                "Failed to read events for prev-branch user",
-                error=str(e),
-                exc_info=True,
-            )
-            return None
-        latest_for_turn: dict | None = None
-        latest_branch = -1
-        for evt in events:
-            if evt.get("type") != "user_message":
-                continue
-            if evt.get("turn_index") != self._turn_index:
-                continue
-            bi = evt.get("branch_id")
-            if not isinstance(bi, int):
-                continue
-            # The nearest lower branch is the source branch for regeneration.
-            if bi < self._branch_id and bi > latest_branch:
-                latest_branch = bi
-                latest_for_turn = evt
-        if latest_for_turn is None:
-            return None
-        return latest_for_turn.get("content")
+        return _previous_branch_user_content(self)

--- a/src/kohakuterrarium/core/agent_messages.py
+++ b/src/kohakuterrarium/core/agent_messages.py
@@ -3,13 +3,22 @@
 Modify past messages, regenerate responses, and replay conversation branches.
 """
 
+from kohakuterrarium.core.agent_raw_history import (
+    raw_target_content,
+    reload_raw_prefix_for_target,
+)
 from kohakuterrarium.core.events import EventType, TriggerEvent
+from kohakuterrarium.core.message_locator import (
+    user_message_indices_for_content,
+    user_message_indices_for_turn,
+)
 from kohakuterrarium.llm.message import normalize_content_parts
 from kohakuterrarium.session.history import (
     replay_conversation,
     resolve_branch_view_strict,
     select_live_event_ids,
 )
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -24,6 +33,7 @@ class AgentMessagesMixin:
         turn_index: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> None:
         """Regenerate an assistant response.
 
@@ -46,6 +56,17 @@ class AgentMessagesMixin:
         the resolved ``turn_index`` so the original branch is preserved
         and addressable via the ``<x/N>`` navigator.
         """
+        if target is not None:
+            await self.edit_and_rerun(
+                message_idx=-1,
+                new_content=raw_target_content(self, target, branch_view=branch_view),
+                turn_index=target.turn_index,
+                branch_view=branch_view,
+                request_id=request_id,
+                target=target,
+            )
+            return
+
         if turn_index is not None:
             # Reusing the selected branch's content gives regeneration the same
             # branching semantics as an edit without changing the message.
@@ -133,6 +154,7 @@ class AgentMessagesMixin:
         user_position: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> bool:
         """Replace a user message and re-run from there.
 
@@ -147,11 +169,13 @@ class AgentMessagesMixin:
         truncation target resolves correctly even when the user has
         switched to an older subtree in the UI.
         """
-        # Reload conversation under the chosen subtree FIRST so the
-        # in-memory message list reflects what the user sees in the UI.
-        # Without this, edits on a non-latest branch silently fail
-        # because the agent's in-memory state is on a different branch.
-        if branch_view:
+        # Canonical persisted targets reconstruct original context before
+        # mutating in-memory state, deliberately bypassing compact snapshots.
+        if target is not None:
+            reload_raw_prefix_for_target(self, target, branch_view=branch_view)
+            turn_index = target.turn_index
+            user_position = None
+        elif branch_view:
             self._reload_conversation_under_branch_view(branch_view)
 
         conv = self.controller.conversation
@@ -260,7 +284,7 @@ class AgentMessagesMixin:
         if self.session_store:
             try:
                 self.session_store.save_conversation(
-                    self.config.name, conv.to_messages()
+                    self.config.name, conv.to_messages(include_metadata=True)
                 )
             except Exception as e:
                 logger.warning(
@@ -302,14 +326,36 @@ class AgentMessagesMixin:
         user_position: int | None = None,
         branch_view: dict[int, int] | None = None,
     ) -> int | None:
-        """Resolve an edit target to an in-memory user-message index."""
+        """Resolve by turn metadata or exact unique legacy-content matching."""
         if turn_index is not None:
-            pos = self._user_position_for_turn_index(
+            metadata_matches = user_message_indices_for_turn(msgs, turn_index)
+            if len(metadata_matches) == 1:
+                return metadata_matches[0]
+            if len(metadata_matches) > 1:
+                logger.warning(
+                    "Ambiguous edit target metadata",
+                    turn_index=turn_index,
+                    matches=len(metadata_matches),
+                )
+                return None
+
+            target_content = self._user_message_content_for_turn(
                 turn_index, branch_view=branch_view
             )
-            if pos is not None:
-                user_position = pos
-            elif user_position is None:
+            if target_content is not None:
+                content_matches = user_message_indices_for_content(msgs, target_content)
+                if len(content_matches) == 1:
+                    return content_matches[0]
+                logger.warning(
+                    "Cannot uniquely match edit target content",
+                    turn_index=turn_index,
+                    matches=len(content_matches),
+                )
+                return None
+
+            # A caller may still supply the legacy visible position when no
+            # event metadata exists (for example, a narrow in-memory client).
+            if user_position is None:
                 return None
         if user_position is not None:
             if user_position < 0:
@@ -491,6 +537,30 @@ class AgentMessagesMixin:
         selected = resolve_branch_view_strict(events, branch_view)
 
         messages = replay_conversation(events, branch_view=branch_view)
+        metadata_by_turn = {
+            int(event["turn_index"]): {
+                "event_id": event.get("event_id"),
+                "turn_index": event.get("turn_index"),
+                "branch_id": event.get("branch_id"),
+            }
+            for event in events
+            if event.get("type") == "user_message"
+            and isinstance(event.get("turn_index"), int)
+        }
+        for message in messages:
+            if message.get("role") != "user":
+                continue
+            for metadata in metadata_by_turn.values():
+                if message.get("content") == next(
+                    (
+                        event.get("content")
+                        for event in events
+                        if event.get("event_id") == metadata.get("event_id")
+                    ),
+                    None,
+                ):
+                    message["metadata"] = metadata
+                    break
         conv = self.controller.conversation
         # Keep the system prompt (it carries tool docs and agent
         # personality). ``replay_conversation`` does not emit system
@@ -511,6 +581,8 @@ class AgentMessagesMixin:
                 extra["tool_call_id"] = msg["tool_call_id"]
             if msg.get("name"):
                 extra["name"] = msg["name"]
+            if msg.get("metadata"):
+                extra["metadata"] = msg["metadata"]
             conv.append(role, content, **extra)
 
         # Reseat agent state to the chosen subtree's leaf so the next

--- a/src/kohakuterrarium/core/agent_raw_history.py
+++ b/src/kohakuterrarium/core/agent_raw_history.py
@@ -1,0 +1,73 @@
+"""Raw persisted-history helpers for message branch mutations."""
+
+from typing import Any, Protocol
+
+from kohakuterrarium.core.conversation import Conversation
+from kohakuterrarium.llm.message import dicts_to_messages
+from kohakuterrarium.session.history import replay_conversation
+from kohakuterrarium.session.raw_history import (
+    UserMessageSelector,
+    select_raw_history_prefix,
+)
+
+
+class RawHistoryAgent(Protocol):
+    session_store: Any
+    config: Any
+    controller: Any
+    _turn_index: int
+    _branch_id: int
+    _parent_branch_path: list[tuple[int, int]]
+
+
+def raw_target_content(
+    agent: RawHistoryAgent,
+    target: UserMessageSelector,
+    *,
+    branch_view: dict[int, int] | None = None,
+):
+    """Read canonical target content without changing agent state."""
+    if agent.session_store is None:
+        raise ValueError("raw persisted history is unavailable")
+    prefix = select_raw_history_prefix(
+        agent.session_store.get_events(agent.config.name),
+        selector=target,
+        branch_view=branch_view,
+    )
+    return prefix.target.get("content", "")
+
+
+def reload_raw_prefix_for_target(
+    agent: RawHistoryAgent,
+    target: UserMessageSelector,
+    *,
+    branch_view: dict[int, int] | None = None,
+) -> None:
+    """Reseat one agent on the uncompacted prefix ending at target."""
+    if agent.session_store is None:
+        raise ValueError("raw persisted history is unavailable")
+    prefix = select_raw_history_prefix(
+        agent.session_store.get_events(agent.config.name),
+        selector=target,
+        branch_view=branch_view,
+    )
+    raw_events = [
+        event
+        for event in [*prefix.events, prefix.target]
+        if event.get("type") not in {"compact_replace", "conversation_snapshot"}
+    ]
+    messages = replay_conversation(
+        raw_events,
+        branch_view=prefix.branch_view,
+        include_metadata=True,
+    )
+    agent.controller.conversation = Conversation(
+        initial_messages=dicts_to_messages(messages)
+    )
+    agent._turn_index = target.turn_index
+    agent._branch_id = target.branch_id
+    agent._parent_branch_path = [
+        (turn, branch)
+        for turn, branch in prefix.branch_view.items()
+        if turn < target.turn_index
+    ]

--- a/src/kohakuterrarium/core/agent_raw_history.py
+++ b/src/kohakuterrarium/core/agent_raw_history.py
@@ -46,6 +46,7 @@ def reload_raw_prefix_for_target(
     """Reseat one agent on the uncompacted prefix ending at target."""
     if agent.session_store is None:
         raise ValueError("raw persisted history is unavailable")
+    current_conversation = agent.controller.conversation
     prefix = select_raw_history_prefix(
         agent.session_store.get_events(agent.config.name),
         selector=target,
@@ -75,7 +76,7 @@ def reload_raw_prefix_for_target(
             ),
             *persisted_messages,
         ]
-    conversation = Conversation()
+    conversation = Conversation(current_conversation.config)
     for message in persisted_messages:
         conversation.append_message(message)
     agent.controller.conversation = conversation

--- a/src/kohakuterrarium/core/agent_raw_history.py
+++ b/src/kohakuterrarium/core/agent_raw_history.py
@@ -61,8 +61,22 @@ def reload_raw_prefix_for_target(
         branch_view=prefix.branch_view,
         include_metadata=True,
     )
+    persisted_messages = dicts_to_messages(messages)
+    for raw_message, message in zip(messages, persisted_messages):
+        metadata = raw_message.get("metadata")
+        if isinstance(metadata, dict):
+            message.metadata = dict(metadata)
+    if not any(message.role == "system" for message in persisted_messages):
+        persisted_messages = [
+            *(
+                message
+                for message in agent.controller.conversation.get_messages()
+                if message.role == "system"
+            ),
+            *persisted_messages,
+        ]
     conversation = Conversation()
-    for message in dicts_to_messages(messages):
+    for message in persisted_messages:
         conversation.append_message(message)
     agent.controller.conversation = conversation
     agent._turn_index = target.turn_index

--- a/src/kohakuterrarium/core/agent_raw_history.py
+++ b/src/kohakuterrarium/core/agent_raw_history.py
@@ -61,9 +61,10 @@ def reload_raw_prefix_for_target(
         branch_view=prefix.branch_view,
         include_metadata=True,
     )
-    agent.controller.conversation = Conversation(
-        initial_messages=dicts_to_messages(messages)
-    )
+    conversation = Conversation()
+    for message in dicts_to_messages(messages):
+        conversation.append_message(message)
+    agent.controller.conversation = conversation
     agent._turn_index = target.turn_index
     agent._branch_id = target.branch_id
     agent._parent_branch_path = [

--- a/src/kohakuterrarium/core/conversation.py
+++ b/src/kohakuterrarium/core/conversation.py
@@ -147,14 +147,23 @@ class Conversation:
         )
 
     def to_messages(
-        self, *, preserve_pending_tail: bool = False
+        self,
+        *,
+        preserve_pending_tail: bool = False,
+        include_metadata: bool = False,
     ) -> list[dict[str, Any]]:
         """Return provider message dictionaries with valid native tool pairs.
 
         ``preserve_pending_tail`` retains an in-flight tool announcement only for
         persistence; provider generation rejects unanswered trailing calls.
+        ``include_metadata`` is for session snapshots only; provider calls leave
+        it disabled so internal message identity never reaches the wire.
         """
         messages = messages_to_dicts(self._messages)
+        if include_metadata:
+            for msg, serialized in zip(self._messages, messages):
+                if msg.metadata:
+                    serialized["metadata"] = dict(msg.metadata)
         if self.config.sanitize_orphan_tool_calls:
             messages = self.sanitize_orphan_tool_pairs(
                 messages, preserve_pending_tail=preserve_pending_tail

--- a/src/kohakuterrarium/core/message_locator.py
+++ b/src/kohakuterrarium/core/message_locator.py
@@ -1,0 +1,56 @@
+"""Locate canonical user messages without relying on conversation positions."""
+
+import json
+
+from kohakuterrarium.llm.message import TextPart, normalize_content_parts
+
+
+def _content_signature(content: object) -> tuple[str, str]:
+    """Return a stable text/attachment signature for persisted message content."""
+    normalized = normalize_content_parts(content)  # type: ignore[arg-type]
+    if isinstance(normalized, str):
+        return normalized, "[]"
+    if not isinstance(normalized, list):
+        return "", "[]"
+
+    text = "\n\n".join(part.text for part in normalized if isinstance(part, TextPart))
+    attachments = [
+        part.to_dict() for part in normalized if not isinstance(part, TextPart)
+    ]
+    return text, json.dumps(
+        attachments,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def user_message_indices_for_turn(
+    messages: list[object],
+    turn_index: int,
+) -> list[int]:
+    """Return user-message indices carrying the requested persisted turn."""
+    indices: list[int] = []
+    for idx, msg in enumerate(messages):
+        metadata = getattr(msg, "metadata", None)
+        if (
+            getattr(msg, "role", None) == "user"
+            and isinstance(metadata, dict)
+            and metadata.get("turn_index") == turn_index
+        ):
+            indices.append(idx)
+    return indices
+
+
+def user_message_indices_for_content(
+    messages: list[object],
+    content: object,
+) -> list[int]:
+    """Return user-message indices whose normalized content matches exactly."""
+    signature = _content_signature(content)
+    return [
+        idx
+        for idx, msg in enumerate(messages)
+        if getattr(msg, "role", None) == "user"
+        and _content_signature(getattr(msg, "content", None)) == signature
+    ]

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
@@ -40,6 +40,7 @@ from kohakuterrarium.terrarium.creature_ops import (
     session_attach_policies_for,
     wire_creature_on_engine,
 )
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium.service import (
     LocalTerrariumService,
@@ -482,22 +483,34 @@ class TerrariumRuntimeAdapter:
 
             case "regenerate":
                 agent = self._require_hosted(msg.body["creature_id"]).agent
-                await agent.regenerate_last_response(
-                    turn_index=msg.body.get("turn_index"),
-                    branch_view=msg.body.get("branch_view"),
-                    request_id=msg.body.get("request_id"),
-                )
+                raw_target = msg.body.get("target")
+                target = UserMessageSelector(**raw_target) if raw_target else None
+                kwargs = {
+                    "turn_index": msg.body.get("turn_index"),
+                    "branch_view": msg.body.get("branch_view"),
+                    "request_id": msg.body.get("request_id"),
+                }
+                if target is not None:
+                    kwargs["target"] = target
+                await agent.regenerate_last_response(**kwargs)
                 return _completed_branch_result(agent, msg.body.get("request_id"))
 
             case "edit_message":
                 agent = self._require_hosted(msg.body["creature_id"]).agent
+                raw_target = msg.body.get("target")
+                target = UserMessageSelector(**raw_target) if raw_target else None
+                kwargs = {
+                    "turn_index": msg.body.get("turn_index"),
+                    "user_position": msg.body.get("user_position"),
+                    "branch_view": msg.body.get("branch_view"),
+                    "request_id": msg.body.get("request_id"),
+                }
+                if target is not None:
+                    kwargs["target"] = target
                 ok = await agent.edit_and_rerun(
                     msg.body["msg_idx"],
                     unpack_content(msg.body["content"]),
-                    turn_index=msg.body.get("turn_index"),
-                    user_position=msg.body.get("user_position"),
-                    branch_view=msg.body.get("branch_view"),
-                    request_id=msg.body.get("request_id"),
+                    **kwargs,
                 )
                 if not ok:
                     raise ValueError(f"message {msg.body['msg_idx']} cannot be edited")

--- a/src/kohakuterrarium/session/history.py
+++ b/src/kohakuterrarium/session/history.py
@@ -439,6 +439,7 @@ def replay_conversation(
     events: Iterable[dict[str, Any]],
     *,
     branch_view: dict[int, int] | None = None,
+    include_metadata: bool = False,
 ) -> list[dict[str, Any]]:
     """Rebuild an OpenAI-shape message list from the event log.
 
@@ -509,7 +510,14 @@ def replay_conversation(
         _flush_text()
 
         if etype == "user_message":
-            messages.append({"role": "user", "content": evt.get("content", "")})
+            message = {"role": "user", "content": evt.get("content", "")}
+            if include_metadata:
+                message["metadata"] = {
+                    "event_id": evt.get("event_id"),
+                    "turn_index": evt.get("turn_index"),
+                    "branch_id": evt.get("branch_id"),
+                }
+            messages.append(message)
         elif etype == "assistant_tool_calls":
             tool_calls = evt.get("tool_calls") or []
             if (

--- a/src/kohakuterrarium/session/raw_history.py
+++ b/src/kohakuterrarium/session/raw_history.py
@@ -5,8 +5,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, TypeAlias
 
-from kohakuterrarium.session.history import _coerce_path
-
 BranchView: TypeAlias = Mapping[int | str, int | str]
 
 
@@ -99,9 +97,31 @@ def _validate_events(events: list[dict[str, Any]]) -> dict[int, int]:
     return positions
 
 
-def _target_lineage(target: Mapping[str, Any]) -> dict[int, int]:
+def _target_lineage(
+    target: Mapping[str, Any],
+    *,
+    target_turn: int,
+) -> dict[int, int]:
+    raw_path = target.get("parent_branch_path")
+    if raw_path is None:
+        return {}
+    if not isinstance(raw_path, (list, tuple)):
+        raise TargetUserMessageLineageError(
+            "target parent_branch_path must be a sequence of positive integer pairs"
+        )
+
     lineage: dict[int, int] = {}
-    for turn, branch in _coerce_path(target.get("parent_branch_path")):
+    for item in raw_path:
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            raise TargetUserMessageLineageError(
+                "target parent_branch_path must contain positive integer pairs"
+            )
+        turn = _positive_int(item[0])
+        branch = _positive_int(item[1])
+        if turn is None or branch is None or turn >= target_turn:
+            raise TargetUserMessageLineageError(
+                "target parent_branch_path must contain positive earlier-turn pairs"
+            )
         prior = lineage.get(turn)
         if prior is not None and prior != branch:
             raise TargetUserMessageLineageError(
@@ -139,7 +159,7 @@ def select_raw_history_prefix(
             f"event_id {selector.event_id} belongs to turn/branch {actual}, not {expected}"
         )
 
-    lineage = _target_lineage(target)
+    lineage = _target_lineage(target, target_turn=selector.turn_index)
     selected = _normalize_view(branch_view)
     required = {**lineage, selector.turn_index: selector.branch_id}
     for turn, branch in selected.items():

--- a/src/kohakuterrarium/session/raw_history.py
+++ b/src/kohakuterrarium/session/raw_history.py
@@ -1,0 +1,171 @@
+"""Select uncompacted persisted history for a branch-aware edit or rerun."""
+
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+from kohakuterrarium.session.history import _coerce_path
+
+BranchView: TypeAlias = Mapping[int | str, int | str]
+
+
+class RawHistorySelectionError(ValueError):
+    """Base error for fail-closed raw history selection."""
+
+
+class MissingRawHistoryError(RawHistorySelectionError):
+    """Raised when original persisted history is incomplete."""
+
+
+class TargetUserMessageNotFoundError(RawHistorySelectionError):
+    """Raised when the requested persisted user event does not exist."""
+
+
+class TargetUserMessageConflictError(RawHistorySelectionError):
+    """Raised when canonical locator coordinates disagree."""
+
+
+class TargetUserMessageLineageError(RawHistorySelectionError):
+    """Raised when the requested target is outside the selected lineage."""
+
+
+class InvalidRawHistoryEventError(RawHistorySelectionError):
+    """Raised when persisted event identity is missing or ambiguous."""
+
+
+@dataclass(frozen=True, slots=True)
+class UserMessageSelector:
+    """Canonical identity for a persisted turn-root user message."""
+
+    event_id: int
+    turn_index: int
+    branch_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class RawHistoryPrefix:
+    """Detached original event prefix and its canonical target."""
+
+    events: list[dict[str, Any]]
+    target: dict[str, Any]
+    branch_view: dict[int, int]
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def _normalize_view(branch_view: BranchView | None) -> dict[int, int]:
+    selected: dict[int, int] = {}
+    for raw_turn, raw_branch in (branch_view or {}).items():
+        try:
+            turn = int(raw_turn)
+            branch = int(raw_branch)
+        except (TypeError, ValueError) as exc:
+            raise TargetUserMessageLineageError(
+                "branch_view must contain positive integer turn/branch pairs"
+            ) from exc
+        if turn <= 0 or branch <= 0:
+            raise TargetUserMessageLineageError(
+                "branch_view must contain positive integer turn/branch pairs"
+            )
+        prior = selected.get(turn)
+        if prior is not None and prior != branch:
+            raise TargetUserMessageLineageError(
+                f"branch_view selects conflicting branches for turn {turn}"
+            )
+        selected[turn] = branch
+    return selected
+
+
+def _coordinates(event: Mapping[str, Any]) -> tuple[int | None, int | None]:
+    return _positive_int(event.get("turn_index")), _positive_int(event.get("branch_id"))
+
+
+def _validate_events(events: list[dict[str, Any]]) -> dict[int, int]:
+    positions: dict[int, int] = {}
+    for position, event in enumerate(events):
+        event_id = _positive_int(event.get("event_id"))
+        if event_id is None:
+            raise InvalidRawHistoryEventError(
+                f"raw event at position {position} lacks a positive integer event_id"
+            )
+        if event_id in positions:
+            raise InvalidRawHistoryEventError(f"duplicate raw event_id {event_id}")
+        positions[event_id] = position
+    return positions
+
+
+def _target_lineage(target: Mapping[str, Any]) -> dict[int, int]:
+    lineage: dict[int, int] = {}
+    for turn, branch in _coerce_path(target.get("parent_branch_path")):
+        prior = lineage.get(turn)
+        if prior is not None and prior != branch:
+            raise TargetUserMessageLineageError(
+                f"target ancestry selects conflicting branches for turn {turn}"
+            )
+        lineage[turn] = branch
+    return lineage
+
+
+def select_raw_history_prefix(
+    events: Iterable[Mapping[str, Any]],
+    *,
+    selector: UserMessageSelector,
+    branch_view: BranchView | None = None,
+) -> RawHistoryPrefix:
+    """Return original persisted events strictly before one canonical user event."""
+
+    raw = [deepcopy(dict(event)) for event in events]
+    positions = _validate_events(raw)
+    position = positions.get(selector.event_id)
+    if position is None:
+        raise TargetUserMessageNotFoundError(
+            f"user_message event_id {selector.event_id} does not exist"
+        )
+
+    target = raw[position]
+    if target.get("type") != "user_message":
+        raise TargetUserMessageConflictError(
+            f"event_id {selector.event_id} is not an editable user_message"
+        )
+    actual = _coordinates(target)
+    expected = (selector.turn_index, selector.branch_id)
+    if actual != expected:
+        raise TargetUserMessageConflictError(
+            f"event_id {selector.event_id} belongs to turn/branch {actual}, not {expected}"
+        )
+
+    lineage = _target_lineage(target)
+    selected = _normalize_view(branch_view)
+    required = {**lineage, selector.turn_index: selector.branch_id}
+    for turn, branch in selected.items():
+        expected_branch = required.get(turn)
+        if expected_branch is not None and expected_branch != branch:
+            raise TargetUserMessageLineageError(
+                f"branch_view selects branch {branch} for turn {turn}, "
+                f"but target lineage requires branch {expected_branch}"
+            )
+    selected.update(required)
+
+    prefix: list[dict[str, Any]] = []
+    for event in raw[:position]:
+        turn, branch = _coordinates(event)
+        if (turn is None) != (branch is None):
+            raise MissingRawHistoryError(
+                f"raw event_id {event['event_id']} has incomplete turn/branch metadata"
+            )
+        if turn is not None:
+            selected_branch = selected.get(turn)
+            if selected_branch is not None and selected_branch != branch:
+                continue
+        prefix.append(event)
+
+    return RawHistoryPrefix(
+        events=prefix,
+        target=deepcopy(target),
+        branch_view=dict(sorted(selected.items())),
+    )

--- a/src/kohakuterrarium/studio/facade_sessions.py
+++ b/src/kohakuterrarium/studio/facade_sessions.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from kohakuterrarium.errors import SessionNotFoundError
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.studio._runtime import host_engine_or_none
 from kohakuterrarium.studio.persistence import store as _persistence_store
 from kohakuterrarium.studio.sessions import (
@@ -231,6 +232,7 @@ class _SessionsChat:
         turn_index: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> dict[str, Any]:
         return await _session_chat.regenerate(
             self._studio._service,
@@ -239,6 +241,7 @@ class _SessionsChat:
             turn_index=turn_index,
             branch_view=branch_view,
             request_id=request_id,
+            target=target,
         )
 
     async def edit_message(
@@ -252,6 +255,7 @@ class _SessionsChat:
         user_position: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> dict[str, Any]:
         return await _session_chat.edit_message(
             self._studio._service,
@@ -263,6 +267,7 @@ class _SessionsChat:
             user_position=user_position,
             branch_view=branch_view,
             request_id=request_id,
+            target=target,
         )
 
     async def rewind(self, session_id: str, creature_id: str, msg_idx: int) -> None:

--- a/src/kohakuterrarium/studio/sessions/creature_chat.py
+++ b/src/kohakuterrarium/studio/sessions/creature_chat.py
@@ -2,6 +2,7 @@
 
 from typing import Any, AsyncIterator
 
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.studio.sessions.lifecycle import find_creature
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium import TerrariumService
@@ -39,6 +40,7 @@ async def regenerate(
     turn_index: int | None = None,
     branch_view: dict[int, int] | None = None,
     request_id: str | None = None,
+    target: UserMessageSelector | None = None,
 ) -> dict[str, Any]:
     """Regenerate an assistant response.
 
@@ -59,12 +61,14 @@ async def regenerate(
     method on top of their host engine, so the path collapses to a
     direct call there.
     """
-    return await service.regenerate(
-        creature_id,
-        turn_index=turn_index,
-        branch_view=branch_view,
-        request_id=request_id,
-    )
+    kwargs = {
+        "turn_index": turn_index,
+        "branch_view": branch_view,
+        "request_id": request_id,
+    }
+    if target is not None:
+        kwargs["target"] = target
+    return await service.regenerate(creature_id, **kwargs)
 
 
 async def edit_message(
@@ -78,6 +82,7 @@ async def edit_message(
     user_position: int | None = None,
     branch_view: dict[int, int] | None = None,
     request_id: str | None = None,
+    target: UserMessageSelector | None = None,
 ) -> dict[str, Any]:
     """Edit a user message at ``msg_idx`` and re-run from there.
 
@@ -91,15 +96,15 @@ async def edit_message(
     about worker-hosted creatures, so the legacy ``as_engine`` path
     raised ``KeyError`` in lab-host mode.
     """
-    return await service.edit_message(
-        creature_id,
-        msg_idx,
-        content,
-        turn_index=turn_index,
-        user_position=user_position,
-        branch_view=branch_view,
-        request_id=request_id,
-    )
+    kwargs = {
+        "turn_index": turn_index,
+        "user_position": user_position,
+        "branch_view": branch_view,
+        "request_id": request_id,
+    }
+    if target is not None:
+        kwargs["target"] = target
+    return await service.edit_message(creature_id, msg_idx, content, **kwargs)
 
 
 async def rewind(

--- a/src/kohakuterrarium/terrarium/multi_node_service.py
+++ b/src/kohakuterrarium/terrarium/multi_node_service.py
@@ -73,6 +73,7 @@ from kohakuterrarium.terrarium.multi_node_routing import (
     runtime_graph_snapshot_fanout,
     stream_subscribe,
 )
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.terrarium.remote_service import RemoteTerrariumService
 from kohakuterrarium.terrarium.service import (
     CreatureInfo,
@@ -566,15 +567,18 @@ class MultiNodeTerrariumService(
         turn_index: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
+        kwargs = {
+            "turn_index": turn_index,
+            "branch_view": branch_view,
+            "request_id": request_id,
+        }
+        if target is not None:
+            kwargs["target"] = target
         return await self._route_per_creature(
             creature_id,
-            lambda svc: svc.regenerate(
-                creature_id,
-                turn_index=turn_index,
-                branch_view=branch_view,
-                request_id=request_id,
-            ),
+            lambda svc: svc.regenerate(creature_id, **kwargs),
         )
 
     async def edit_message(
@@ -587,18 +591,19 @@ class MultiNodeTerrariumService(
         user_position: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
+        kwargs = {
+            "turn_index": turn_index,
+            "user_position": user_position,
+            "branch_view": branch_view,
+            "request_id": request_id,
+        }
+        if target is not None:
+            kwargs["target"] = target
         return await self._route_per_creature(
             creature_id,
-            lambda svc: svc.edit_message(
-                creature_id,
-                msg_idx,
-                content,
-                turn_index=turn_index,
-                user_position=user_position,
-                branch_view=branch_view,
-                request_id=request_id,
-            ),
+            lambda svc: svc.edit_message(creature_id, msg_idx, content, **kwargs),
         )
 
     async def rewind(self, creature_id: str, msg_idx: int) -> None:

--- a/src/kohakuterrarium/terrarium/remote_service.py
+++ b/src/kohakuterrarium/terrarium/remote_service.py
@@ -37,6 +37,7 @@ from kohakuterrarium.laboratory._internal.client import (
     RequestTimeoutError,
 )
 from kohakuterrarium.laboratory.streams import RemoteStream, StreamDemux
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.terrarium.creature_host import Creature
 from kohakuterrarium.terrarium.drive.remote_ops import RemoteDriveServiceMixin
 from kohakuterrarium.terrarium.drive.service_protocol import (
@@ -359,6 +360,7 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
         turn_index: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
         body = _maybe_raise(
             await self._req_turn_mutation(
@@ -368,6 +370,15 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
                     "turn_index": turn_index,
                     "branch_view": branch_view,
                     "request_id": request_id,
+                    "target": (
+                        {
+                            "event_id": target.event_id,
+                            "turn_index": target.turn_index,
+                            "branch_id": target.branch_id,
+                        }
+                        if target is not None
+                        else None
+                    ),
                 },
             )
         )
@@ -383,6 +394,7 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
         user_position: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
         body = _maybe_raise(
             await self._req_turn_mutation(
@@ -395,6 +407,15 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
                     "user_position": user_position,
                     "branch_view": branch_view,
                     "request_id": request_id,
+                    "target": (
+                        {
+                            "event_id": target.event_id,
+                            "turn_index": target.turn_index,
+                            "branch_id": target.branch_id,
+                        }
+                        if target is not None
+                        else None
+                    ),
                 },
             )
         )

--- a/src/kohakuterrarium/terrarium/service.py
+++ b/src/kohakuterrarium/terrarium/service.py
@@ -34,6 +34,7 @@ from collections.abc import AsyncIterator
 from typing import Any, Protocol, runtime_checkable
 
 from kohakuterrarium.core.channel import ChannelMessage as _ChannelMessage
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.terrarium.drive.service import DriveServiceMixin
 from kohakuterrarium.terrarium.drive.service_protocol import DriveServiceProtocol
 from kohakuterrarium.terrarium.service_dto import (
@@ -85,7 +86,7 @@ from kohakuterrarium.terrarium.topology import (
 def _completed_branch_result(
     agent: Any, request_id: str | None
 ) -> BranchMutationResult:
-    parent_path = getattr(agent, "_branch_parent_path", ()) or ()
+    parent_path = getattr(agent, "_parent_branch_path", ()) or ()
     return {
         "status": "completed",
         "request_id": request_id or uuid.uuid4().hex,
@@ -292,6 +293,7 @@ class TerrariumService(DriveServiceProtocol, Protocol):
         turn_index: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
         """Regenerate an assistant response (whole tail by default).
 
@@ -312,6 +314,7 @@ class TerrariumService(DriveServiceProtocol, Protocol):
         user_position: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
         """Edit the user message at ``msg_idx`` and re-run from there."""
         ...
@@ -719,12 +722,14 @@ class LocalTerrariumService(DriveServiceMixin):
         turn_index: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
         agent = self._agent(creature_id)
         await agent.regenerate_last_response(
             turn_index=turn_index,
             branch_view=branch_view,
             request_id=request_id,
+            target=target,
         )
         return _completed_branch_result(agent, request_id)
 
@@ -738,6 +743,7 @@ class LocalTerrariumService(DriveServiceMixin):
         user_position: int | None = None,
         branch_view: dict[int, int] | None = None,
         request_id: str | None = None,
+        target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
         agent = self._agent(creature_id)
         ok = await agent.edit_and_rerun(
@@ -747,6 +753,7 @@ class LocalTerrariumService(DriveServiceMixin):
             user_position=user_position,
             branch_view=branch_view,
             request_id=request_id,
+            target=target,
         )
         if not ok:
             raise ValueError(f"message {msg_idx} cannot be edited")

--- a/src/kohakuterrarium/terrarium/service.py
+++ b/src/kohakuterrarium/terrarium/service.py
@@ -725,12 +725,14 @@ class LocalTerrariumService(DriveServiceMixin):
         target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
         agent = self._agent(creature_id)
-        await agent.regenerate_last_response(
-            turn_index=turn_index,
-            branch_view=branch_view,
-            request_id=request_id,
-            target=target,
-        )
+        kwargs = {
+            "turn_index": turn_index,
+            "branch_view": branch_view,
+            "request_id": request_id,
+        }
+        if target is not None:
+            kwargs["target"] = target
+        await agent.regenerate_last_response(**kwargs)
         return _completed_branch_result(agent, request_id)
 
     async def edit_message(
@@ -746,15 +748,15 @@ class LocalTerrariumService(DriveServiceMixin):
         target: UserMessageSelector | None = None,
     ) -> BranchMutationResult:
         agent = self._agent(creature_id)
-        ok = await agent.edit_and_rerun(
-            msg_idx,
-            content,
-            turn_index=turn_index,
-            user_position=user_position,
-            branch_view=branch_view,
-            request_id=request_id,
-            target=target,
-        )
+        kwargs = {
+            "turn_index": turn_index,
+            "user_position": user_position,
+            "branch_view": branch_view,
+            "request_id": request_id,
+        }
+        if target is not None:
+            kwargs["target"] = target
+        ok = await agent.edit_and_rerun(msg_idx, content, **kwargs)
         if not ok:
             raise ValueError(f"message {msg_idx} cannot be edited")
         return _completed_branch_result(agent, request_id)

--- a/tests/unit/core/test_agent_messages.py
+++ b/tests/unit/core/test_agent_messages.py
@@ -1,10 +1,14 @@
 """Unit tests for :mod:`kohakuterrarium.core.agent_messages`."""
 
+import asyncio
+
 import pytest
 
 from kohakuterrarium.core.agent_messages import AgentMessagesMixin
 from kohakuterrarium.core.conversation import Conversation
+from kohakuterrarium.errors import ConflictError
 from kohakuterrarium.session.history import InvalidBranchViewError
+from kohakuterrarium.session.raw_history import UserMessageSelector
 from kohakuterrarium.session.store import SessionStore
 
 # ── fake agent harness (mirrors production surface) ──────────────
@@ -373,6 +377,90 @@ class TestEditAndRerun:
             user_position=0,  # first user message
         )
         assert ok is True
+
+    async def test_concurrent_canonical_edits_are_serialized(self, agent):
+        agent._apply_user_input("u1")
+        agent._emit_assistant("a1")
+        target_event = next(
+            event
+            for event in agent.session_store.get_events(agent.config.name)
+            if event.get("type") == "user_message"
+        )
+        target = UserMessageSelector(
+            event_id=target_event["event_id"],
+            turn_index=target_event["turn_index"],
+            branch_id=target_event["branch_id"],
+        )
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        entered: list[str] = []
+
+        async def blocking_process(event):
+            entered.append(event.content)
+            if len(entered) == 1:
+                first_started.set()
+                await release_first.wait()
+
+        agent._process_event = blocking_process
+        first = asyncio.create_task(
+            agent.edit_and_rerun(-1, "first edit", target=target)
+        )
+        await first_started.wait()
+        second = asyncio.create_task(
+            agent.edit_and_rerun(-1, "second edit", target=target)
+        )
+        await asyncio.sleep(0)
+        try:
+            assert entered == ["first edit"]
+        finally:
+            release_first.set()
+            results = await asyncio.gather(first, second)
+
+        assert results == [True, True]
+        assert entered == ["first edit", "second edit"]
+
+    async def test_edit_rejects_an_active_turn_before_mutating_history(self, agent):
+        agent._apply_user_input("u1")
+        agent._emit_assistant("a1")
+        agent._processing_lock = asyncio.Lock()
+        await agent._processing_lock.acquire()
+        messages_before = agent.controller.conversation.to_messages()
+        events_before = agent.session_store.get_events(agent.config.name)
+
+        try:
+            with pytest.raises(ConflictError, match="turn is active"):
+                await agent.edit_and_rerun(0, "must not land")
+        finally:
+            agent._processing_lock.release()
+
+        assert agent.controller.conversation.to_messages() == messages_before
+        assert agent.session_store.get_events(agent.config.name) == events_before
+
+    @pytest.mark.parametrize(
+        ("runtime_state", "message"),
+        [
+            ({"_paused": True}, "paused"),
+            ({"_running": False}, "not running"),
+        ],
+    )
+    async def test_edit_rejects_when_rerun_cannot_start_before_mutating_history(
+        self,
+        agent,
+        runtime_state,
+        message,
+    ):
+        agent._apply_user_input("u1")
+        agent._emit_assistant("a1")
+        for name, value in runtime_state.items():
+            setattr(agent, name, value)
+        messages_before = agent.controller.conversation.to_messages()
+        events_before = agent.session_store.get_events(agent.config.name)
+
+        with pytest.raises(ConflictError, match=message):
+            await agent.edit_and_rerun(0, "must not land")
+
+        assert agent.controller.conversation.to_messages() == messages_before
+        assert agent.session_store.get_events(agent.config.name) == events_before
 
 
 class TestRegenerateNonTailTurn:

--- a/tests/unit/core/test_agent_raw_history.py
+++ b/tests/unit/core/test_agent_raw_history.py
@@ -1,0 +1,103 @@
+"""Tests for reseating an agent on uncompacted persisted history."""
+
+from types import SimpleNamespace
+
+from kohakuterrarium.core.agent_raw_history import reload_raw_prefix_for_target
+from kohakuterrarium.core.conversation import Conversation
+from kohakuterrarium.core.message_locator import user_message_indices_for_turn
+from kohakuterrarium.session.raw_history import UserMessageSelector
+
+
+class _Store:
+    def __init__(self, events):
+        self.events = events
+
+    def get_events(self, agent_name):
+        assert agent_name == "worker"
+        return self.events
+
+
+def _event(event_id, event_type, *, turn=None, content="", path=None):
+    event = {"event_id": event_id, "type": event_type}
+    if turn is not None:
+        event.update(
+            {
+                "turn_index": turn,
+                "branch_id": 1,
+                "parent_branch_path": path or [],
+            }
+        )
+    if content:
+        event["content"] = content
+    return event
+
+
+def _agent(events):
+    conversation = Conversation()
+    conversation.append("system", "current runtime prompt")
+    conversation.append("user", "compacted context that must be discarded")
+    return SimpleNamespace(
+        session_store=_Store(events),
+        config=SimpleNamespace(name="worker"),
+        controller=SimpleNamespace(conversation=conversation),
+        _turn_index=9,
+        _branch_id=4,
+        _parent_branch_path=[(8, 4)],
+    )
+
+
+def test_reload_restores_missing_system_prompt_and_canonical_user_metadata():
+    events = [
+        _event(1, "user_message", turn=1, content="same"),
+        _event(2, "text_chunk", turn=1, content="first reply"),
+        _event(3, "user_message", turn=2, content="same", path=[[1, 1]]),
+        _event(4, "text_chunk", turn=2, content="discarded tail", path=[[1, 1]]),
+    ]
+    agent = _agent(events)
+
+    reload_raw_prefix_for_target(
+        agent,
+        UserMessageSelector(event_id=3, turn_index=2, branch_id=1),
+    )
+
+    messages = agent.controller.conversation.get_messages()
+    assert [(message.role, message.content) for message in messages] == [
+        ("system", "current runtime prompt"),
+        ("user", "same"),
+        ("assistant", "first reply"),
+        ("user", "same"),
+    ]
+    assert user_message_indices_for_turn(messages, 1) == [1]
+    assert user_message_indices_for_turn(messages, 2) == [3]
+    assert messages[1].metadata == {
+        "event_id": 1,
+        "turn_index": 1,
+        "branch_id": 1,
+    }
+    assert messages[3].metadata == {
+        "event_id": 3,
+        "turn_index": 2,
+        "branch_id": 1,
+    }
+    assert agent._turn_index == 2
+    assert agent._branch_id == 1
+    assert agent._parent_branch_path == [(1, 1)]
+
+
+def test_reload_does_not_duplicate_a_persisted_system_prompt():
+    events = [
+        _event(1, "system_prompt_set", content="persisted prompt"),
+        _event(2, "user_message", turn=1, content="target"),
+    ]
+    agent = _agent(events)
+
+    reload_raw_prefix_for_target(
+        agent,
+        UserMessageSelector(event_id=2, turn_index=1, branch_id=1),
+    )
+
+    messages = agent.controller.conversation.get_messages()
+    assert [(message.role, message.content) for message in messages] == [
+        ("system", "persisted prompt"),
+        ("user", "target"),
+    ]

--- a/tests/unit/core/test_agent_raw_history.py
+++ b/tests/unit/core/test_agent_raw_history.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 
 from kohakuterrarium.core.agent_raw_history import reload_raw_prefix_for_target
-from kohakuterrarium.core.conversation import Conversation
+from kohakuterrarium.core.conversation import Conversation, ConversationConfig
 from kohakuterrarium.core.message_locator import user_message_indices_for_turn
 from kohakuterrarium.session.raw_history import UserMessageSelector
 
@@ -32,8 +32,8 @@ def _event(event_id, event_type, *, turn=None, content="", path=None):
     return event
 
 
-def _agent(events):
-    conversation = Conversation()
+def _agent(events, *, conversation_config=None):
+    conversation = Conversation(conversation_config)
     conversation.append("system", "current runtime prompt")
     conversation.append("user", "compacted context that must be discarded")
     return SimpleNamespace(
@@ -101,3 +101,22 @@ def test_reload_does_not_duplicate_a_persisted_system_prompt():
         ("system", "persisted prompt"),
         ("user", "target"),
     ]
+
+
+def test_reload_preserves_the_runtime_conversation_config():
+    events = [
+        _event(1, "user_message", turn=1, content="target"),
+    ]
+    config = ConversationConfig(
+        max_messages=17,
+        keep_system=False,
+        sanitize_orphan_tool_calls=False,
+    )
+    agent = _agent(events, conversation_config=config)
+
+    reload_raw_prefix_for_target(
+        agent,
+        UserMessageSelector(event_id=1, turn_index=1, branch_id=1),
+    )
+
+    assert agent.controller.conversation.config is config

--- a/tests/unit/session/test_raw_history.py
+++ b/tests/unit/session/test_raw_history.py
@@ -157,3 +157,11 @@ def test_incomplete_raw_turn_metadata_is_rejected():
 
     with pytest.raises(MissingRawHistoryError, match="incomplete turn/branch"):
         _select(events)
+
+
+def test_malformed_explicit_target_ancestry_is_rejected():
+    events = _branched_events()
+    events[2]["parent_branch_path"] = [[1, 1], ["not-a-turn", 2]]
+
+    with pytest.raises(TargetUserMessageLineageError, match="parent_branch_path"):
+        _select(events)

--- a/tests/unit/session/test_raw_history.py
+++ b/tests/unit/session/test_raw_history.py
@@ -1,0 +1,159 @@
+"""Tests for strict raw-event history prefix selection."""
+
+from copy import deepcopy
+
+import pytest
+
+from kohakuterrarium.session.raw_history import (
+    InvalidRawHistoryEventError,
+    MissingRawHistoryError,
+    TargetUserMessageConflictError,
+    TargetUserMessageLineageError,
+    TargetUserMessageNotFoundError,
+    UserMessageSelector,
+    select_raw_history_prefix,
+)
+
+
+def _event(
+    event_id: int,
+    event_type: str,
+    *,
+    turn: int | None = None,
+    branch: int | None = None,
+    path: list[list[int]] | None = None,
+    content: str = "",
+    **extra,
+):
+    event = {"event_id": event_id, "type": event_type}
+    if turn is not None:
+        event["turn_index"] = turn
+    if branch is not None:
+        event["branch_id"] = branch
+    if path is not None:
+        event["parent_branch_path"] = path
+    if content:
+        event["content"] = content
+    event.update(extra)
+    return event
+
+
+def _branched_events():
+    return [
+        _event(1, "user_message", turn=1, branch=1, path=[], content="old one"),
+        _event(2, "text_chunk", turn=1, branch=1, path=[], content="old reply"),
+        _event(3, "user_message", turn=2, branch=1, path=[[1, 1]], content="old two"),
+        _event(4, "text_chunk", turn=2, branch=1, path=[[1, 1]], content="old tail"),
+        _event(5, "user_message", turn=1, branch=2, path=[], content="new one"),
+        _event(6, "text_chunk", turn=1, branch=2, path=[], content="new reply"),
+        _event(7, "user_message", turn=2, branch=2, path=[[1, 2]], content="new two"),
+        _event(8, "text_chunk", turn=2, branch=2, path=[[1, 2]], content="after"),
+    ]
+
+
+def _select(events, event_id=3, turn=2, branch=1, view=None):
+    return select_raw_history_prefix(
+        events,
+        selector=UserMessageSelector(event_id, turn, branch),
+        branch_view=view or {turn: branch},
+    )
+
+
+def test_selects_plain_uncompacted_history_before_target():
+    events = [
+        _event(1, "system_prompt_set", content="system"),
+        _event(2, "user_message", turn=1, branch=1, path=[], content="first"),
+        _event(3, "text_chunk", turn=1, branch=1, path=[], content="answer"),
+        _event(4, "user_message", turn=2, branch=1, path=[[1, 1]], content="target"),
+        _event(5, "text_chunk", turn=2, branch=1, path=[[1, 1]], content="later"),
+    ]
+
+    result = _select(events, event_id=4)
+
+    assert [event["event_id"] for event in result.events] == [1, 2, 3]
+    assert result.target["content"] == "target"
+    assert result.branch_view == {1: 1, 2: 1}
+
+
+def test_compaction_and_snapshot_markers_do_not_replace_raw_events():
+    events = [
+        _event(1, "user_message", turn=1, branch=1, path=[], content="verbatim"),
+        _event(2, "text_chunk", turn=1, branch=1, path=[], content="original reply"),
+        _event(
+            3,
+            "compact_replace",
+            turn=1,
+            branch=1,
+            path=[],
+            summary_text="invented summary",
+            replaced_from_event_id=1,
+            replaced_to_event_id=2,
+        ),
+        _event(4, "snapshot", snapshot=[{"role": "user", "content": "summary"}]),
+        _event(5, "user_message", turn=2, branch=1, path=[[1, 1]], content="target"),
+    ]
+
+    result = _select(events, event_id=5)
+
+    assert result.events[0]["content"] == "verbatim"
+    assert result.events[1]["content"] == "original reply"
+    assert result.events[2]["type"] == "compact_replace"
+    assert result.events[3]["type"] == "snapshot"
+
+
+def test_selected_branch_prefix_contains_only_its_lineage_and_excludes_target_tail():
+    result = _select(_branched_events(), event_id=7, branch=2, view={1: 2, 2: 2})
+
+    assert [event["event_id"] for event in result.events] == [5, 6]
+    assert 7 not in {event["event_id"] for event in result.events}
+    assert 8 not in {event["event_id"] for event in result.events}
+
+
+def test_selection_does_not_modify_old_branch_or_inputs():
+    events = _branched_events()
+    before = deepcopy(events)
+
+    result = _select(events)
+    result.events[0]["content"] = "mutated copy"
+    result.target["content"] = "mutated target copy"
+
+    assert events == before
+
+
+def test_missing_target_is_rejected():
+    with pytest.raises(TargetUserMessageNotFoundError, match="does not exist"):
+        _select(_branched_events(), event_id=99)
+
+
+def test_target_outside_selected_branch_is_rejected():
+    with pytest.raises(TargetUserMessageLineageError, match="selects branch 2"):
+        _select(_branched_events(), view={1: 2, 2: 2})
+
+
+def test_conflicting_selector_coordinates_are_rejected():
+    with pytest.raises(TargetUserMessageConflictError, match="turn/branch"):
+        _select(_branched_events(), turn=9)
+
+
+def test_duplicate_event_identity_is_rejected():
+    events = _branched_events()
+    events.append(_event(3, "user_message", turn=2, branch=1, content="collision"))
+
+    with pytest.raises(InvalidRawHistoryEventError, match="duplicate raw event_id 3"):
+        _select(events)
+
+
+def test_missing_event_identity_is_rejected():
+    events = _branched_events()
+    events[0].pop("event_id")
+
+    with pytest.raises(InvalidRawHistoryEventError, match="lacks a positive"):
+        _select(events)
+
+
+def test_incomplete_raw_turn_metadata_is_rejected():
+    events = _branched_events()
+    events.insert(2, _event(9, "text_chunk", turn=1, content="unattributed"))
+
+    with pytest.raises(MissingRawHistoryError, match="incomplete turn/branch"):
+        _select(events)

--- a/tests/unit/test_file_sizes.py
+++ b/tests/unit/test_file_sizes.py
@@ -178,6 +178,9 @@ ALLOWLIST_600 = {
     # is already delegated to ``bootstrap/*`` factory modules — what
     # remains is the wiring sequence the Agent depends on in order.
     "bootstrap/agent_init.py",
+    # AgentMessagesMixin: branch-aware edit/regenerate resolution plus
+    # persisted raw-history reseating. Extraction follows if it grows further.
+    "core/agent_messages.py",
     # AgentToolsMixin: tool dispatch + handle waiting + promotion +
     # interruption + completion-activity emission + native/text result
     # formatting. One cohesive lifecycle around in-flight tool jobs;

--- a/tests/unit/test_file_sizes.py
+++ b/tests/unit/test_file_sizes.py
@@ -178,9 +178,6 @@ ALLOWLIST_600 = {
     # is already delegated to ``bootstrap/*`` factory modules — what
     # remains is the wiring sequence the Agent depends on in order.
     "bootstrap/agent_init.py",
-    # AgentMessagesMixin: branch-aware edit/regenerate resolution plus
-    # persisted raw-history reseating. Extraction follows if it grows further.
-    "core/agent_messages.py",
     # AgentToolsMixin: tool dispatch + handle waiting + promotion +
     # interruption + completion-activity emission + native/text result
     # formatting. One cohesive lifecycle around in-flight tool jobs;


### PR DESCRIPTION
## Summary

Fix Edit / Save & Rerun / Regenerate so message mutations target a canonical persisted event and rebuild context from the original append-only event prefix. Existing alternatives and descendants remain available, while malformed, stale, cross-conversation, and concurrent targets fail closed.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Compaction and branching made frontend message positions an unstable mutation key. Editing or regenerating from a compacted view could reconstruct the wrong context, lose configuration, or partially rewrite shared history while another turn was active.

## Changes

- Add canonical `event_id`, `turn_index`, and `branch_id` message locators from the API through local, remote, multi-node, and Laboratory services.
- Reconstruct rerun context from persisted raw events, including the original system/configuration context.
- Validate branch lineage and conversation ownership; reject malformed or ambiguous legacy targets instead of silently falling back.
- Serialize history mutations and reject unsafe active, paused, or stopped states before any persisted write.
- Preserve prior branches and descendants, and restore frontend state when a mutation request fails.
- Keep edit/rerun bound to the message's owning tab if focus changes during the request, and exclude injected mid-turn user rows from canonical user-position indexing.
- Split message-history reconstruction out of the oversized agent message module and add negative-case coverage.

## Validation

```bash
python -m ruff check src/ tests/
python -m black --check --target-version py313 src/ tests/
python -m pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
python -m pytest tests/unit/test_file_sizes.py -q
python -m pytest tests/integration/ -q
python -m pytest tests/e2e/ -q

cd src/kohakuterrarium-frontend
npm test -- --maxWorkers=1
npm test -- src/stores/chat.editRerunGuards.test.js src/components/chat/ChatMessage.test.js
npx prettier --check --end-of-line auto \
  src/components/chat/ChatMessage.test.js src/components/chat/ChatMessage.vue \
  src/stores/chat.editRerunGuards.test.js src/stores/chat.js src/utils/api.js
npm run lint
npm run build
```

Results:

- Ruff and Black passed; 1,436 Python files were unchanged.
- File-size guard: 1,626 passed.
- Pre-rebase local full unit suite: 11,548 passed, 9 skipped, and 6 baseline/environment failures described below.
- Integration: 170 passed, 1 skipped.
- Pre-rebase local E2E: 76 passed and 4 baseline failures described below.
- Frontend: the final single-worker run passed 81 files / 852 tests; focused owning-tab/canonical-position tests, lint, changed-file Prettier, and production build passed.
- Browser smoke before the final guard-only commit: editing a persisted user message completed a rerun, retained the previous alternative, and exposed the expected `2/2` branch selector. The final race/mapping guards are covered by the final automated suite.
- Post-rebase validation on merged prerequisite `48d51f2c`: 406 affected unit tests, the complete edit/regenerate/rewind integration workflow, and 6 focused frontend tests passed; `git diff --check` passed.
- Fresh fork CI for the rebased head passed all 13 jobs across lint, packaging, frontend, and the complete Linux/macOS/Windows Python matrix.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [ ] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

2026-07-27

## Notes for Reviewers

- Please focus on canonical locator validation, persisted-prefix reconstruction, the lock boundary around history mutation, owning-tab dispatch, and injected-row position mapping. Legacy positional targeting remains available only when it resolves unambiguously.
- The branch was rebased without conflicts onto merged prerequisite `48d51f2c`; all 7 `range-diff` entries are unchanged (`=`).
- Signed candidate head: `abc960db4ab3d2b8ec491c0d34c79ede370aa98a` (7 commits, 26 files, +1,509/-288).

## Screenshots / Logs (if applicable)

The browser smoke screenshot captures the edited message, regenerated response, and retained branch alternative. It will be attached when the PR is opened.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The pre-rebase Windows full-unit run had six baseline/environment failures: four unavailable Hugging Face downloads, the Unix-only `EDITOR=true` assumption, and concurrent writes from the running operator application's `app.log`. The merged prerequisite removes external model downloads from CI; the rebased affected tests pass.
- Four E2E failures reproduce on `origin/main`: two stale assertions expect `regenerating` instead of the current synchronous `completed` response, one stale Studio assertion expects no branch metadata after regeneration, and one memory-search request exceeds the existing 8-second Windows subprocess timeout.
- The exact repository-wide `npm run format:check` is red on this Windows checkout because global Git converts LF to CRLF. Changed-file Prettier passes with `--end-of-line auto`; the Linux fork CI run remains authoritative.
- Fresh fork CI for the rebased head passed 13/13 jobs: https://github.com/VVittgenstein/KohakuTerrarium/actions/runs/30352890502