### PR TITLE
feat(web): add slash command and skill completion

### DIFF
--- a/docs/en/guides/web-chat-slash-commands.md
+++ b/docs/en/guides/web-chat-slash-commands.md
@@ -1,0 +1,31 @@
+# Web Chat slash commands and skills
+
+Type `/` at the start of an empty Web Chat composer to open the live command and skill menu for the selected creature. Continue typing to filter by command name, command alias, or skill name. Use Up/Down to move, Enter or Tab to select, Escape to close, or click an item.
+
+Commands are listed before skills. A command name or alias always wins if it collides with a skill name. Disabled skills are omitted and rejected by the server. A skill with model invocation blocked still appears for explicit user selection: that flag only prevents automatic model invocation.
+
+Selecting a command uses the command endpoint and surfaces its typed result. Selecting a skill sends an explicit skill input through the normal creature turn queue with source `web:skill`, so the resulting answer streams and is recorded like other chat input.
+
+The menu inventory is cached briefly per session tab and refreshed after expiry. Changing sessions or tabs cannot apply a stale response to the new composer.
+
+## API
+
+- `GET /api/sessions/{session_id}/creatures/{creature_id}/command-inventory`
+- `POST /api/sessions/{session_id}/creatures/{creature_id}/skill-input`
+
+The skill request body uses the existing slash payload shape:
+
+```json
+{"command": "review", "args": "focus on security"}
+```
+
+## Screenshot instructions
+
+No private/local screenshot file should be committed. For release notes or documentation screenshots:
+
+1. Start Web Chat with a creature that has at least one command and one enabled skill.
+2. Select the creature tab and type `/` in an empty composer.
+3. Capture the grouped Commands and Skills menu, with one keyboard-selected option visible.
+4. Type a filtering prefix and capture the narrowed menu.
+5. Select a skill and capture the streamed response in the same tab.
+6. Remove account names, tokens, filesystem paths, and private conversation content before publishing.

--- a/docs/zh-CN/guides/web-chat-slash-commands.md
+++ b/docs/zh-CN/guides/web-chat-slash-commands.md
@@ -1,0 +1,14 @@
+# Web Chat 斜杠命令与技能
+
+在空的 Web Chat 输入框开头输入 `/`，即可打开当前 Creature 的实时命令/技能菜单。继续输入可按命令名、别名或技能名过滤；使用上下方向键移动，Enter 或 Tab 选择，Escape 关闭，也可以点击条目。
+
+命令始终排在技能之前。命令名或别名与技能名冲突时，命令优先。已禁用技能不会显示，服务端也会拒绝执行。`invocation_blocked` 仅禁止模型自动调用，不会阻止用户显式选择技能。
+
+选择命令会调用命令接口并显示结构化结果。选择技能会以 `web:skill` 来源注入正常 Creature turn 队列，因此回复会像普通聊天一样流式显示并写入会话记录。
+
+接口：
+
+- `GET /api/sessions/{session_id}/creatures/{creature_id}/command-inventory`
+- `POST /api/sessions/{session_id}/creatures/{creature_id}/skill-input`
+
+截图请按英文文档所列步骤操作；不要提交包含私人账号、令牌、路径或聊天内容的本地截图文件。

--- a/docs/zh-TW/guides/web-chat-slash-commands.md
+++ b/docs/zh-TW/guides/web-chat-slash-commands.md
@@ -1,0 +1,14 @@
+# Web Chat 斜線命令與技能
+
+在空的 Web Chat 輸入框開頭輸入 `/`，即可開啟目前 Creature 的即時命令／技能選單。繼續輸入可依命令名稱、別名或技能名稱篩選；使用上下方向鍵移動，Enter 或 Tab 選取，Escape 關閉，也可以點擊項目。
+
+命令一律排在技能之前。命令名稱或別名與技能名稱衝突時，命令優先。已停用技能不會顯示，伺服器也會拒絕執行。`invocation_blocked` 只禁止模型自動呼叫，不會阻止使用者明確選取技能。
+
+選取命令會呼叫命令 API 並顯示結構化結果。選取技能會以 `web:skill` 來源注入正常 Creature turn 佇列，因此回覆會像一般聊天一樣串流顯示並寫入工作階段紀錄。
+
+API：
+
+- `GET /api/sessions/{session_id}/creatures/{creature_id}/command-inventory`
+- `POST /api/sessions/{session_id}/creatures/{creature_id}/skill-input`
+
+截圖請依英文文件列出的步驟操作；不要提交含有私人帳號、權杖、路徑或聊天內容的本機截圖檔。

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
@@ -127,4 +127,207 @@ describe("ChatPanel command results", () => {
     expect(invoke).not.toHaveBeenCalled()
     invoke.mockRestore()
   })
+
+  it.each([
+    [
+      "instance generation",
+      (chat) => {
+        chat._instanceGeneration += 1
+      },
+    ],
+    [
+      "session id",
+      (chat) => {
+        chat._instanceId = "session_2"
+      },
+    ],
+    [
+      "graph id",
+      (chat) => {
+        chat._instanceGraphId = "graph_2"
+      },
+    ],
+  ])(
+    "does not dispatch to a same-named tab when the %s changes during slash lookup",
+    async (_field, changeContext) => {
+      let resolveTarget
+      const chat = useChatStore("session_1")
+      chat._instanceGeneration = 4
+      chat._instanceId = "session_1"
+      chat._instanceGraphId = "graph_1"
+      chat.activeTab = "kohaku"
+      chat.tabs = ["kohaku"]
+      chat.messagesByTab = { kohaku: [] }
+      vi.spyOn(chat, "prepareSlashSend").mockReturnValue(
+        new Promise((resolve) => {
+          resolveTarget = resolve
+        }),
+      )
+      const invoke = vi
+        .spyOn(terrariumAPI, "invokeCreatureSkill")
+        .mockResolvedValue({ accepted: true })
+      const execute = vi
+        .spyOn(terrariumAPI, "executeCreatureCommand")
+        .mockResolvedValue({ output: "unexpected" })
+      const wrapper = mount(ChatPanel, {
+        props: {
+          instance: {
+            id: "session_1",
+            graph_id: "graph_1",
+            creatures: [{ name: "kohaku", status: "idle" }],
+          },
+        },
+        global: {
+          provide: { chatStore: chat },
+          stubs: {
+            ChatMessage: true,
+            ModelSwitcher: true,
+            SiteChip: true,
+            StatusDot: true,
+          },
+        },
+      })
+      const textarea = wrapper.find("textarea")
+      await textarea.setValue("/review focus")
+      chat.markSlashTarget("kohaku", { type: "skill", name: "old-review" })
+      const staleTarget = chat._slashTargetByTab.kohaku
+      await wrapper.find('button[aria-label="Send message"]').trigger("click")
+
+      changeContext(chat)
+      chat.activeTab = "kohaku"
+      resolveTarget({ type: "skill", name: "review" })
+      await flushPromises()
+
+      expect(invoke).not.toHaveBeenCalled()
+      expect(execute).not.toHaveBeenCalled()
+      expect(chat._slashTargetByTab.kohaku).toBeUndefined()
+      expect(staleTarget).toMatchObject({ type: "skill", name: "old-review" })
+      expect(textarea.element.value).toBe("/review focus")
+      invoke.mockRestore()
+      execute.mockRestore()
+      wrapper.unmount()
+    },
+  )
+
+  it("does not dispatch when another chat group takes focus during slash lookup", async () => {
+    let resolveTarget
+    const chat = useChatStore("graph_1")
+    chat._instanceId = "graph_1"
+    chat._instanceGraphId = "graph_1"
+    chat.activeTab = "kohaku"
+    chat.tabs = ["kohaku", "reviewer"]
+    chat.messagesByTab = { kohaku: [], reviewer: [] }
+    const sourceGroup = chat.enableGroups()
+    const otherGroup = chat.splitGroup(sourceGroup, "horizontal", "after", "reviewer")
+    chat.setFocusedGroup(sourceGroup)
+    vi.spyOn(chat, "prepareSlashSend").mockReturnValue(
+      new Promise((resolve) => {
+        resolveTarget = resolve
+      }),
+    )
+    const invoke = vi
+      .spyOn(terrariumAPI, "invokeCreatureSkill")
+      .mockResolvedValue({ accepted: true })
+    const execute = vi
+      .spyOn(terrariumAPI, "executeCreatureCommand")
+      .mockResolvedValue({ output: "unexpected" })
+    const wrapper = mount(ChatPanel, {
+      props: {
+        instance: {
+          id: "graph_1",
+          graph_id: "graph_1",
+          creatures: [
+            { name: "kohaku", status: "idle" },
+            { name: "reviewer", status: "idle" },
+          ],
+        },
+        groupId: sourceGroup,
+      },
+      global: {
+        provide: { chatStore: chat },
+        stubs: {
+          ChatMessage: true,
+          ModelSwitcher: true,
+          SiteChip: true,
+          StatusDot: true,
+        },
+      },
+    })
+    const textarea = wrapper.find("textarea")
+    await textarea.setValue("/review focus")
+    await wrapper.find('button[aria-label="Send message"]').trigger("click")
+
+    chat.setFocusedGroup(otherGroup)
+    expect(chat.activeTab).toBe("reviewer")
+    expect(chat.groups[sourceGroup].activeTab).toBe("kohaku")
+    resolveTarget({ type: "skill", name: "review" })
+    await flushPromises()
+
+    expect(invoke).not.toHaveBeenCalled()
+    expect(execute).not.toHaveBeenCalled()
+    expect(textarea.element.value).toBe("/review focus")
+    invoke.mockRestore()
+    execute.mockRestore()
+    wrapper.unmount()
+  })
+
+  it("dismisses the slash menu without interrupting an active turn", async () => {
+    const chat = useChatStore("graph_1")
+    chat._instanceId = "graph_1"
+    chat._instanceGraphId = "graph_1"
+    chat.activeTab = "kohaku"
+    chat.tabs = ["kohaku"]
+    chat.messagesByTab = { kohaku: [] }
+    chat.processingByTab = { kohaku: true }
+    chat.commandInventoryByTab = {
+      kohaku: {
+        commands: [{ name: "help", aliases: [], description: "Show help" }],
+        skills: [],
+      },
+    }
+    chat._commandInventoryFetchedAtByTab = { kohaku: Date.now() }
+    const interrupt = vi.spyOn(chat, "interrupt").mockResolvedValue(undefined)
+    const wrapper = mount(ChatPanel, {
+      props: {
+        instance: {
+          id: "graph_1",
+          graph_id: "graph_1",
+          creatures: [{ name: "kohaku", status: "running" }],
+        },
+      },
+      global: {
+        provide: { chatStore: chat },
+        stubs: {
+          ChatMessage: true,
+          ModelSwitcher: true,
+          SiteChip: true,
+          StatusDot: true,
+        },
+      },
+    })
+    const textarea = wrapper.find("textarea")
+    await textarea.setValue("/")
+    await flushPromises()
+    expect(wrapper.find("#slash-command-menu").exists()).toBe(true)
+
+    await textarea.trigger("keydown", { key: "Escape" })
+    await flushPromises()
+
+    expect(wrapper.find("#slash-command-menu").exists()).toBe(false)
+    expect(textarea.attributes("aria-expanded")).toBe("false")
+    expect(interrupt).not.toHaveBeenCalled()
+
+    await textarea.trigger("blur")
+    await textarea.trigger("focus")
+    await flushPromises()
+    expect(wrapper.find("#slash-command-menu").exists()).toBe(true)
+
+    await textarea.trigger("keydown", { key: "Escape" })
+    await textarea.setValue("/h")
+    await flushPromises()
+    expect(wrapper.find("#slash-command-menu").exists()).toBe(true)
+    expect(interrupt).not.toHaveBeenCalled()
+    interrupt.mockRestore()
+    wrapper.unmount()
+  })
 })

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
@@ -77,4 +77,54 @@ describe("ChatPanel command results", () => {
     command.mockRestore()
     confirm.mockRestore()
   })
+
+  it("does not send a slash target to a tab selected during inventory lookup", async () => {
+    let resolveTarget
+    const chat = useChatStore("graph_1")
+    chat._instanceId = "graph_1"
+    chat._instanceGraphId = "graph_1"
+    chat.activeTab = "kohaku"
+    chat.tabs = ["kohaku", "reviewer"]
+    chat.messagesByTab = { kohaku: [], reviewer: [] }
+    localStorage.setItem("kt.chat.draft.graph_1.reviewer", "/review")
+    vi.spyOn(chat, "prepareSlashSend").mockReturnValue(
+      new Promise((resolve) => {
+        resolveTarget = resolve
+      }),
+    )
+    const invoke = vi
+      .spyOn(terrariumAPI, "invokeCreatureSkill")
+      .mockResolvedValue({ accepted: true })
+    const wrapper = mount(ChatPanel, {
+      props: {
+        instance: {
+          id: "graph_1",
+          graph_id: "graph_1",
+          creatures: [
+            { name: "kohaku", status: "idle" },
+            { name: "reviewer", status: "idle" },
+          ],
+        },
+      },
+      global: {
+        provide: { chatStore: chat },
+        stubs: {
+          ChatMessage: true,
+          ModelSwitcher: true,
+          SiteChip: true,
+          StatusDot: true,
+        },
+      },
+    })
+    await wrapper.find("textarea").setValue("/review")
+    await wrapper.find('button[aria-label="Send message"]').trigger("click")
+    chat.activeTab = "reviewer"
+    await flushPromises()
+
+    resolveTarget({ type: "skill", name: "review" })
+    await flushPromises()
+
+    expect(invoke).not.toHaveBeenCalled()
+    invoke.mockRestore()
+  })
 })

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
@@ -44,6 +44,8 @@ describe("ChatPanel command results", () => {
     chat.activeTab = "kohaku"
     chat.tabs = ["kohaku"]
     chat.messagesByTab = { kohaku: [] }
+    chat.commandInventoryByTab = { kohaku: { commands: [], skills: [] } }
+    chat._commandInventoryFetchedAtByTab = { kohaku: Date.now() }
     const wrapper = mount(ChatPanel, {
       props: {
         instance: {

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -1,17 +1,5 @@
 <template>
-  <!--
-    Panel bg = recessed surface (warm-100 / warm-900)
-    Bubble bg = header-level surface (white / warm-800)
-    Tab bar sits on panel bg, active tab = bubble bg
-    Bubble has equal margin left/right/bottom
-  -->
   <div class="h-full flex flex-col bg-warm-100 dark:bg-[#211F1D]" :class="showFocusRing ? 'ring-1 ring-inset ring-iolite/40 dark:ring-iolite-light/30' : ''" @focusin="onGroupFocus" @mousedown="onGroupFocus">
-    <!-- Tab bar on panel bg.  The tabs themselves live in their own
-         ``overflow-x-auto`` scroller so on narrow viewports (and when
-         the user opens many channel tabs) the bar scrolls horizontally
-         within its own box instead of pushing the whole page sideways.
-         Model switcher + token-usage chips stay outside that scroller
-         so they remain visible. -->
     <div role="tablist" class="flex items-end gap-0 px-4 pt-2 shrink-0 min-w-0">
       <div class="flex items-end overflow-x-auto scrollbar-none min-w-0">
         <div v-for="tab in viewTabs" :key="tab" role="tab" tabindex="0" :draggable="!!props.groupId" :aria-selected="viewActiveTab === tab" class="relative flex items-center gap-1.5 px-3.5 py-2 text-xs font-medium cursor-pointer select-none rounded-t-lg -mb-px transition-colors shrink-0" :class="viewActiveTab === tab ? 'bg-white dark:bg-warm-900 text-warm-800 dark:text-warm-200 border border-warm-200 dark:border-warm-700 border-b-white dark:border-b-warm-900 z-10' : 'text-warm-400 dark:text-warm-500 hover:text-warm-600 dark:hover:text-warm-400 border border-transparent'" @click="onTabClick(tab)" @keydown.enter="onTabClick(tab)" @keydown.space.prevent="onTabClick(tab)" @dragstart="onTabDragStart($event, tab)" @dragend="onTabDragEnd" @dragover.prevent="onTabStripDragOver($event)" @drop.prevent.stop="onTabStripDrop($event, viewTabs.indexOf(tab))">
@@ -36,21 +24,10 @@
         </div>
       </div>
 
-      <!-- Model switcher — only mounted on compact density. The
-           regular shell shows the switcher in StatusBar at the
-           bottom of the workspace, so a duplicate in the chat
-           header would be redundant (and the variation summary
-           overflows badly in this narrow slot anyway). On compact
-           StatusBar isn't rendered, so this is the user's primary
-           access point for changing model. -->
       <div v-if="isCompact && props.instance?.id && !readOnly" class="flex items-center px-2 py-1 -mb-px chat-model-switcher">
         <ModelSwitcher :instance-id="props.instance.id" />
       </div>
 
-      <!-- Token usage + session info for active tab. The model name
-           text remains for non-compact contexts (where the
-           StatusBar handles model switching) and for read-only
-           viewers (no instance id). -->
       <div v-if="activeTokens > 0 || (!isCompact && viewModelDisplay) || (!props.instance?.id && viewModelDisplay) || readOnly" class="flex items-center gap-2 px-2 py-2 -mb-px text-[10px] text-warm-400 font-mono">
         <template v-if="(!isCompact || !props.instance?.id || readOnly) && viewModelDisplay">
           <span class="text-warm-500 dark:text-warm-400">{{ viewModelDisplay }}</span>
@@ -68,17 +45,10 @@
         </template>
       </div>
 
-      <!-- Tab bar bottom border (bubble top border) -->
       <div class="flex-1 border-b border-b-warm-200 dark:border-b-warm-700" />
     </div>
 
-    <!-- Chat bubble: surface-level bg, equal margin left/right/bottom -->
     <div ref="bubbleEl" class="flex-1 mx-4 mb-4 bg-white dark:bg-warm-900 rounded-b-xl rounded-tr-xl border border-warm-200 dark:border-warm-700 border-t-0 overflow-hidden flex flex-col shadow-sm relative" :class="{ 'ring-2 ring-iolite/40 ring-inset': dragOver }" @dragenter.prevent="onDragEnter" @dragleave.prevent="onDragLeave" @dragover.prevent="onBubbleDragOver" @drop.prevent="onDrop">
-      <!-- Drop-zone edge overlays (Option E drag-to-split) — visible
-           only when a chat tab is being dragged over THIS group's
-           bubble. Each overlay shows when the cursor is in the
-           corresponding 25% edge zone; the center 50% surfaces a
-           full-bubble "move tab here" tint. -->
       <template v-if="props.groupId && tabDragHoverEdge">
         <div v-if="tabDragHoverEdge === 'left'" class="absolute inset-y-0 left-0 w-1/4 bg-iolite/15 dark:bg-iolite-light/12 border-r-2 border-iolite/50 pointer-events-none z-20" />
         <div v-if="tabDragHoverEdge === 'right'" class="absolute inset-y-0 right-0 w-1/4 bg-iolite/15 dark:bg-iolite-light/12 border-l-2 border-iolite/50 pointer-events-none z-20" />
@@ -86,21 +56,17 @@
         <div v-if="tabDragHoverEdge === 'bottom'" class="absolute inset-x-0 bottom-0 h-1/4 bg-iolite/15 dark:bg-iolite-light/12 border-t-2 border-iolite/50 pointer-events-none z-20" />
         <div v-if="tabDragHoverEdge === 'center'" class="absolute inset-0 bg-iolite/8 dark:bg-iolite-light/8 border-2 border-iolite/40 rounded pointer-events-none z-20" />
       </template>
-      <!-- Decorative top accent: subtle gem gradient -->
       <div class="h-0.5 w-full bg-gradient-to-r from-iolite/30 via-taaffeite/20 to-aquamarine/30" />
 
-      <!-- Reconnect banner: surface when WS is attempting to reconnect -->
       <div v-if="chat.wsStatus === 'reconnecting'" class="flex items-center gap-2 px-4 py-1.5 text-xs bg-amber/10 dark:bg-amber/12 border-b border-amber/25 text-amber-shadow dark:text-amber-light">
         <span class="i-carbon-renew kohaku-pulse shrink-0" />
         <span>{{ t("chat.disconnected") }}</span>
       </div>
 
-      <!-- Drag-over hint -->
       <div v-if="dragOver && !readOnly" class="absolute inset-0 z-10 flex items-center justify-center bg-iolite/5 dark:bg-iolite/10 backdrop-blur-sm pointer-events-none">
         <div class="px-4 py-2 rounded-lg bg-white dark:bg-warm-900 border border-iolite/40 shadow-lg text-sm text-iolite dark:text-iolite-light font-medium"><span class="i-carbon-upload mr-1" /> {{ t("chat.dropToAttach") }}</div>
       </div>
 
-      <!-- Messages -->
       <div ref="messagesEl" class="chat-messages-viewport flex-1 overflow-y-auto px-5 py-4" @scroll="onMessagesScroll">
         <div class="flex flex-col gap-3">
           <template v-if="viewMessages.length === 0">
@@ -120,9 +86,6 @@
         </div>
       </div>
 
-      <!-- Queued messages: shown above input, not in main chat.
-           Capped to QUEUE_VISIBLE items; overflow collapses into a "+N more"
-           toggle so the input doesn't get pushed off-screen. -->
       <div v-if="!readOnly && activeQueue.length" class="px-4 pt-2 flex flex-col gap-1.5">
         <div v-for="qm in visibleQueued" :key="qm.id" class="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-amber/5 dark:bg-amber/5 border border-amber/20 text-sm" :class="{ 'opacity-50': qm.cancelling }">
           <span class="i-carbon-time text-amber/60 text-xs flex-shrink-0" />
@@ -143,12 +106,7 @@
         </button>
       </div>
 
-      <!-- Input: sits inside bubble, with subtle top border -->
       <div v-if="!readOnly" class="px-4 pb-4 pt-2 border-t border-t-warm-100 dark:border-t-warm-800">
-        <!-- Pending UI events banner: shown when the user starts typing
-             with one or more interactive bus events still awaiting a
-             reply. Acts as a soft nudge — clicking scrolls to the most
-             recent unreplied event. -->
         <div v-if="showPendingBanner" class="mb-2 flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-amber/10 dark:bg-amber/15 border border-amber/30 text-xs">
           <span class="i-carbon-warning-alt text-amber" />
           <span class="text-amber-shadow dark:text-amber-light">
@@ -169,11 +127,6 @@
           <input ref="imageInputEl" type="file" accept="image/*" class="hidden" @change="(e) => onFileChange(e, 'image')" />
           <input ref="fileInputEl" type="file" class="hidden" @change="(e) => onFileChange(e, 'file')" />
 
-          <!-- LEFT cluster
-               desktop: always inline [+ file] [image]
-               mobile resting: inline [+ file] [image]
-               mobile active (focus or content): collapsed to a single
-               [+] that toggles an inline popover above the input. -->
           <button v-if="isCompact && inputActive" class="kt-input-pill-btn shrink-0 mb-0.5 text-warm-400 hover:text-iolite hover:bg-iolite/10" :title="t('chat.moreActions')" :aria-label="t('chat.moreActions')" @click="toggleSecondaryMenu">
             <span class="i-carbon-add" />
           </button>
@@ -186,12 +139,9 @@
             </button>
           </div>
 
-          <textarea ref="inputEl" v-model="inputText" rows="1" class="chat-input-textarea flex-1 bg-transparent border-none outline-none kt-text-body text-warm-800 dark:text-warm-200 placeholder-warm-400 dark:placeholder-warm-500 resize-none max-h-32 leading-relaxed py-1 min-w-0" style="min-height: 2em" :placeholder="inputPlaceholder" @keydown="onInputKeydown" @input="autoResize" @paste="onPaste" @focus="onInputFocus" @blur="onInputBlur" />
+          <SlashCommandMenu :open="slashMenuOpen" :loading="slashInventoryLoading" :entries="slashMatches" :selected-index="slashSelectedIndex" @choose="chooseSlashEntry" @select-index="slashSelectedIndex = $event" />
+          <textarea ref="inputEl" v-model="inputText" rows="1" class="chat-input-textarea flex-1 bg-transparent border-none outline-none kt-text-body text-warm-800 dark:text-warm-200 placeholder-warm-400 dark:placeholder-warm-500 resize-none max-h-32 leading-relaxed py-1 min-w-0" style="min-height: 2em" :placeholder="inputPlaceholder" aria-autocomplete="list" :aria-expanded="slashMenuOpen" aria-controls="slash-command-menu" :aria-activedescendant="slashActiveDescendant" role="combobox" @keydown="onInputKeydown" @input="onInputChanged" @paste="onPaste" @focus="onInputFocus" @blur="onInputBlur" />
 
-          <!-- RIGHT cluster
-               desktop / mobile resting: [compact] [clean] [send/stop]
-               mobile active: [send/stop] only — compact/clean are in
-               the popover triggered by [+]. -->
           <div class="flex items-center gap-1 shrink-0 mb-0.5">
             <button v-if="!(isCompact && inputActive)" class="kt-input-pill-btn text-warm-400 hover:text-iolite hover:bg-iolite/10" :title="t('chat.compactContext')" :aria-label="t('chat.compactContext')" @click="triggerCompact">
               <span class="i-carbon-collapse-all" />
@@ -207,8 +157,6 @@
             </button>
           </div>
 
-          <!-- Secondary actions popover (mobile-active only). Anchored
-               just above the input shell; backdrop closes on tap. -->
           <template v-if="isCompact && secondaryMenuOpen">
             <div class="fixed inset-0 z-40" @click="secondaryMenuOpen = false" />
             <div class="absolute left-0 right-0 bottom-full mb-2 z-50 flex items-center gap-1 px-2 py-2 rounded-xl bg-white dark:bg-warm-800 border border-warm-200 dark:border-warm-700 shadow-lg" @click.stop>
@@ -241,9 +189,11 @@ import { inject } from "vue"
 
 import StatusDot from "@/components/common/StatusDot.vue"
 import ChatMessage from "@/components/chat/ChatMessage.vue"
+import SlashCommandMenu from "@/components/chat/SlashCommandMenu.vue"
 import ModelSwitcher from "@/components/chrome/ModelSwitcher.vue"
 import SiteChip from "@/components/cluster/SiteChip.vue"
 import { useDensity } from "@/composables/useDensity"
+import { useSlashCommandCompletion } from "@/composables/useSlashCommandCompletion"
 import { useChatStore } from "@/stores/chat"
 import { useChatTabDrag } from "@/composables/useChatTabDrag"
 import { useI18n } from "@/utils/i18n"
@@ -251,7 +201,6 @@ import { terrariumAPI, agentAPI } from "@/utils/api"
 import { buildMessageParts, formatBytes, MAX_ATTACHMENT_BYTES, MAX_IMAGE_BYTES } from "@/utils/chatAttachments"
 import { readLocalPref, writeLocalPref } from "@/utils/uiPrefs"
 import { shouldSendOnEnter } from "@/utils/chatInput"
-// How many queued-while-processing messages to show before collapsing.
 const QUEUE_VISIBLE = 5
 
 const props = defineProps({
@@ -259,39 +208,14 @@ const props = defineProps({
   readOnly: { type: Boolean, default: false },
   emptyTitle: { type: String, default: "" },
   emptySubtitle: { type: String, default: "" },
-  // ── Multi-chat-panel additions (Option E) ──
-  // When ``groupId`` is set, this panel reads its ``tabs``/``activeTab``
-  // from ``chat.groups[groupId]`` instead of the scope-singleton
-  // legacy state. The container (``ChatPanelContainer``) passes this
-  // prop down to every leaf in the chat-internal split tree. When
-  // ``groupId`` is null (back-compat / SessionHistoryViewer), the
-  // panel behaves exactly as today.
   groupId: { type: String, default: null },
-  // When the parent has already resolved the scoped chat store
-  // (``ChatPanelContainer`` does this once via ``useChatStore`` +
-  // ``provide``), prefer reading via ``inject('chatStore')``. This
-  // closes the scope-mismatch hazard documented in the
-  // ``SessionHistoryViewer.vue`` precedent: descendants must NOT
-  // re-resolve ``useChatStore()`` with a potentially-different scope.
 })
 
 const emit = defineEmits(["focus-group"])
 
-// SCOPE INVARIANT — read order:
-//   1. Injected (preferred): ``ChatPanelContainer`` provided the
-//      scoped store. Use it verbatim; do NOT call ``useChatStore``
-//      with a fallback that might land on the "default" singleton.
-//   2. Fallback (back-compat): legacy callers (``SessionHistoryViewer``,
-//      direct mounts in tests) instantiate ``ChatPanel`` without a
-//      container, so we resolve our own scope here. Same call signature
-//      as before so v1 paths keep working.
 const injectedChat = inject("chatStore", null)
 const chat = injectedChat || useChatStore(props.instance?.id || props.instance?.graph_id || undefined)
 const { t } = useI18n()
-// Compact density renders the chat header model pill (since the
-// StatusBar — which has its own ModelSwitcher — is hidden in the
-// compact shell). Regular/expansive density already shows the
-// switcher in StatusBar so this header-mounted copy is redundant.
 const { isCompact } = useDensity()
 const inputText = ref("")
 const messagesEl = ref(null)
@@ -304,15 +228,6 @@ const queueExpanded = ref(false)
 const dragOver = ref(false)
 let dragDepth = 0
 
-// ── Per-group view shims (Option E) ──
-//
-// When ``groupId`` is set we read tabs/activeTab/messages/queue from
-// the group bucket; otherwise we fall through to the legacy
-// scope-singleton fields exactly as today. ``isFocusedGroup`` drives
-// the iolite focus ring + which group "owns" the global ``chat.send``
-// dispatch (we focus the group on composer focus so ``chat.activeTab``
-// — kept synced by ``_syncLegacyFromGroups`` — matches what the
-// composer is visually pointing at).
 const viewGroup = computed(() => (props.groupId ? chat.groups?.[props.groupId] || null : null))
 const viewTabs = computed(() => (viewGroup.value ? viewGroup.value.tabs : chat.tabs))
 const viewActiveTab = computed(() => (viewGroup.value ? viewGroup.value.activeTab : chat.activeTab))
@@ -324,9 +239,6 @@ const viewProcessing = computed(() => {
   const t = viewActiveTab.value
   return t ? !!chat.processingByTab[t] : false
 })
-// Model info for THIS panel's active tab. In group mode the panel's
-// tab can differ from the store's global activeTab, so resolve the
-// per-tab entry locally instead of using ``chat.activeModelInfo``.
 const viewModelInfo = computed(() => {
   const t = viewActiveTab.value
   const info = (t && chat.modelByTab[t]) || {}
@@ -340,15 +252,8 @@ const viewModelInfo = computed(() => {
 const viewModelDisplay = computed(() => viewModelInfo.value.llmName || viewModelInfo.value.model || "")
 const isFocusedGroup = computed(() => !!(props.groupId && chat.focusedGroupId === props.groupId))
 
-// Whether the chat-internal tree has more than one leaf — drives
-// the focus ring (single-group layouts don't need disambiguation)
-// AND the close-tab button (closing the only tab in the only
-// group would leave the surface empty).
 const multipleGroupsExist = computed(() => Object.keys(chat.groups || {}).length > 1)
 
-// Show the iolite focus ring ONLY when there are multiple groups.
-// With a single group the ring is just visual noise — there's
-// nothing to disambiguate from.
 const showFocusRing = computed(() => isFocusedGroup.value && multipleGroupsExist.value)
 
 function onTabClick(tab) {
@@ -369,12 +274,8 @@ function onGroupFocus() {
   emit("focus-group", props.groupId)
 }
 
-// ── Drag-and-drop (Option E) ──
-//
-// Drag composable is wired only when this panel is rendered inside a
-// group (``groupId`` set). Legacy single-panel mode keeps the original
-// file-drop semantics on the bubble and does not participate in
-// tab-drag-to-split.
+const { activeDescendant: slashActiveDescendant, choose: chooseSlashEntry, clearTarget: clearSlashTarget, entries: slashMatches, loading: slashInventoryLoading, move: moveSlashSelection, open: slashMenuOpen, selectedIndex: slashSelectedIndex } = useSlashCommandCompletion({ chat, inputText, activeTabKey: viewActiveTab })
+
 const tabDrag = useChatTabDrag(chat)
 const tabDragHoverEdge = computed(() => (props.groupId ? tabDrag.isHoveringEdgeOf(props.groupId) : null))
 
@@ -394,19 +295,9 @@ function onTabStripDrop(ev, dstIndex) {
   tabDrag.onTabStripDrop(ev, props.groupId, dstIndex)
 }
 function onBubbleDragOver(ev) {
-  // The bubble already handles file drag-over for attachment intake;
-  // file drags carry ``Files`` in ``dataTransfer.types``, tab drags
-  // carry ``application/x-kt-tab``. The two paths are mutually
-  // exclusive — onDragEnter handles files, the composable handles
-  // tab drags. Falling through to the composable is safe because it
-  // ignores non-tab drags.
   if (props.groupId) tabDrag.onBubbleDragOver(ev, props.groupId)
 }
 
-// Active tab's queue — the chat store keeps queues per tab so the
-// "queued" banner only appears on the tab that owns the queued
-// message, never on a sibling tab the user happens to be looking at.
-// In group mode, route through the per-group activeTab.
 const activeQueue = computed(() => {
   const t = viewActiveTab.value
   return t ? chat.queuedMessagesByTab[t] || [] : []
@@ -418,8 +309,6 @@ const visibleQueued = computed(() => {
 })
 const hiddenQueuedCount = computed(() => Math.max(0, activeQueue.value.length - QUEUE_VISIBLE))
 
-// Inline edit of a still-queued message (UXI-08a). Text-only: editing a
-// queued multimodal message keeps just its text.
 const editingQueueId = ref(null)
 const editQueueText = ref("")
 function startEditQueue(qm) {
@@ -441,19 +330,10 @@ function draftKey() {
   const instanceId = props.instance?.id || chat._instanceId || ""
   const tab = viewActiveTab.value || ""
   if (!instanceId || !tab || props.readOnly) return ""
-  // Drafts are keyed by (instance, tab, groupId?). In legacy mode
-  // (no groupId) the key stays compatible with prior versions so
-  // existing localStorage drafts survive the upgrade. In group mode
-  // we suffix the groupId so two groups viewing the same tab can
-  // have independent drafts.
   const suffix = props.groupId ? `.${props.groupId}` : ""
   return `kt.chat.draft.${instanceId}.${tab}${suffix}`
 }
 
-// Drafts are keystroke-frequency state, so they live in localStorage
-// ONLY — never the backend ui-prefs store. The synchronous read also
-// removes the async restore/typing race the old hybrid path had to
-// generation-guard against.
 function restoreDraft() {
   const key = draftKey()
   if (!key) {
@@ -467,7 +347,6 @@ function restoreDraft() {
 function persistDraft() {
   const key = draftKey()
   if (!key) return
-  // writeLocalPref(key, null) removes the entry.
   writeLocalPref(key, inputText.value || null)
 }
 
@@ -503,9 +382,6 @@ const inputPlaceholder = computed(() => {
 const resolvedEmptyTitle = computed(() => props.emptyTitle || t("chat.noMessagesYet"))
 const resolvedEmptySubtitle = computed(() => props.emptySubtitle || t("chat.getStarted"))
 
-// Phase B: count interactive bus events that haven't been replied to
-// or superseded yet, scoped to the active tab. Banner appears when
-// the user starts typing while there are pending requests.
 const pendingCount = computed(() => {
   const tab = viewActiveTab.value
   if (!tab) return 0
@@ -515,17 +391,6 @@ const pendingCount = computed(() => {
 
 const showPendingBanner = computed(() => pendingCount.value > 0 && inputText.value.length > 0)
 
-// KohakUwUing label binds to the running branch, not to the tab — when
-// the user clicks <1/2> to peek at the previous branch while a regen
-// is still streaming branch 2, the label belongs to branch 2 and must
-// disappear from the branch-1 view. ``chat.viewingRunningBranch``
-// returns true only when the viewed branch IS the one generating; a
-// background tool with no associated stream still surfaces the
-// indicator (running job state is tab-scoped, not branch-scoped).
-// In group mode, ``viewingRunningBranch`` still tracks the global
-// chat.activeTab — which equals THIS group's activeTab only when this
-// group is focused. Unfocused groups fall back to the per-tab
-// processing flag alone (no branch-anchor narrowing).
 const viewRunningJobCount = computed(() => chat.runningJobCountForTab(viewActiveTab.value))
 
 const showKohakUwUingIndicator = computed(() => {
@@ -536,9 +401,6 @@ const showKohakUwUingIndicator = computed(() => {
   return viewProcessing.value
 })
 
-// State-aware label: distinguish an active main stream from "only
-// background tools/sub-agents are alive" so a paused stream doesn't
-// read as still generating.
 const kohakuwuingLabel = computed(() => {
   const streaming = !props.groupId || isFocusedGroup.value ? chat.processing && chat.viewingRunningBranch : viewProcessing.value
   const bgCount = viewRunningJobCount.value
@@ -556,10 +418,6 @@ function scrollToPending() {
   if (!target) return
   const el = messagesEl.value
   if (!el) return
-  // Find the rendered message by id; ChatMessage components don't
-  // expose an explicit id attribute, so we use querySelector by
-  // ``data-message-id`` if present, falling back to scrolling to the
-  // bottom of the list.
   const node = el.querySelector(`[data-message-id="${target.id}"]`)
   if (node && typeof node.scrollIntoView === "function") {
     node.scrollIntoView({ behavior: "smooth", block: "center" })
@@ -585,11 +443,26 @@ function closeTab(tab) {
 
 function onInputKeydown(e) {
   if (props.readOnly) return
-  // The send-vs-newline decision lives in ``shouldSendOnEnter`` (pure +
-  // unit-tested): it skips IME composition, never sends on the touch /
-  // compact shell (mobile soft keyboards have no Shift+Enter; the send
-  // button is used instead — fixes iOS Safari fire-on-Enter), and
-  // otherwise sends only on an unmodified Enter.
+  if (slashMenuOpen.value) {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault()
+      moveSlashSelection(e.key === "ArrowDown" ? 1 : -1)
+      return
+    }
+    if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
+      const selected = slashMatches.value[slashSelectedIndex.value]
+      if (selected) {
+        e.preventDefault()
+        chooseSlashEntry(selected)
+        return
+      }
+    }
+    if (e.key === "Escape") {
+      e.preventDefault()
+      clearSlashTarget()
+      return
+    }
+  }
   if (shouldSendOnEnter(e, { isCompact: isCompact.value })) {
     e.preventDefault()
     send()
@@ -603,17 +476,14 @@ function autoResize() {
   el.style.height = Math.min(el.scrollHeight, 128) + "px"
 }
 
-// Mobile chat-input collapse pattern (Discord-style).  On the touch
-// shell (``isCompact``), once the textarea takes focus OR contains
-// any content, the secondary toolbar buttons (attach file, attach
-// image, compact, clean) collapse into a single ``[+]`` trigger so
-// the textarea + send button take the full bar width.  The collapsed
-// buttons re-appear behind a tap-to-open popover anchored above the
-// shell.  Desktop never engages the collapse — pointer:fine has no
-// real-estate problem.
 const inputFocused = ref(false)
 const secondaryMenuOpen = ref(false)
 const inputActive = computed(() => inputFocused.value || inputText.value.length > 0)
+
+function onInputChanged(event) {
+  autoResize(event)
+  clearSlashTarget()
+}
 
 function onInputFocus() {
   inputFocused.value = true
@@ -621,9 +491,6 @@ function onInputFocus() {
 
 function onInputBlur() {
   inputFocused.value = false
-  // If the user blurs by tapping the [+] popover, keep it open —
-  // the click on a popover button (which calls onSecondaryAction)
-  // will close it explicitly.
 }
 
 function toggleSecondaryMenu() {
@@ -635,15 +502,12 @@ function onSecondaryAction(fn) {
   if (typeof fn === "function") fn()
 }
 
-// Auto-scroll: only when new visible content arrives and the user is already near bottom.
 const isNearBottom = ref(true)
 const forceScrollOnNextMessageUpdate = ref(true)
 const scrollPositions = new Map()
 
 function getScrollKey(instanceId = props.instance?.id || chat._instanceId, tab = viewActiveTab.value) {
   if (!instanceId || !tab) return ""
-  // Suffix the groupId in group mode so two groups viewing the same
-  // tab can each restore their own scrolltop on focus / re-render.
   const suffix = props.groupId ? `:${props.groupId}` : ""
   return `${instanceId}:${tab}${suffix}`
 }
@@ -766,7 +630,6 @@ async function onFileChange(e, kind = "file") {
   e.target.value = ""
 }
 
-// ── Drag-and-drop: routes dropped files through the same validation. ──
 function onDragEnter(e) {
   if (props.readOnly) return
   if (!e.dataTransfer || !Array.from(e.dataTransfer.types).includes("Files")) return
@@ -779,14 +642,6 @@ function onDragLeave() {
   if (dragDepth === 0) dragOver.value = false
 }
 function onDrop(e) {
-  // Dispatch by payload type: a chat tab drag carries
-  // ``application/x-kt-tab`` and is routed to the multi-group
-  // composable for move/split. Anything else (file drag for
-  // attachments) falls through to the existing file-intake path.
-  // Without this dispatch the tab payload would land in the
-  // attachment intake — which silently does nothing because the
-  // tab payload has no ``files`` entry — and the multi-group
-  // composable would never fire for bubble drops.
   if (props.groupId && e.dataTransfer?.types) {
     const types = Array.from(e.dataTransfer.types)
     if (types.includes("application/x-kt-tab")) {
@@ -804,25 +659,15 @@ function onDrop(e) {
   }
 }
 
-// ── Paste: clipboard image / file → attachment.  Lets users
-// Ctrl-V a screenshot (Win+Shift+S buffer, "copy image"
-// from a browser, etc.) or any file copied from the OS file
-// manager.  Text paste falls through untouched — we only
-// preventDefault when at least one file item was consumed.
 function onPaste(e) {
   if (props.readOnly) return
   const cd = e.clipboardData
   if (!cd) return
 
-  // 1. Some browsers (Chromium on file copy from Explorer) populate
-  //    ``clipboardData.files`` directly.
   const direct = Array.from(cd.files || [])
   const collected = []
   for (const file of direct) collected.push(file)
 
-  // 2. Screenshots / copied images surface via ``items`` with
-  //    ``kind === "file"`` but no ``files`` entry on some
-  //    browsers — fall through to that path too.
   if (collected.length === 0 && cd.items) {
     for (const item of cd.items) {
       if (item.kind !== "file") continue
@@ -830,11 +675,8 @@ function onPaste(e) {
       if (file) collected.push(file)
     }
   }
-  if (collected.length === 0) return // nothing pasted — let the textarea handle text
+  if (collected.length === 0) return // nothing pasted 閳?let the textarea handle text
 
-  // Synthesise a friendlier name for the clipboard's anonymous
-  // ``image.png`` blobs so the attachment chip + the backend log
-  // both carry a unique stem.  Existing files keep their name.
   let any = false
   for (const file of collected) {
     const kind = (file.type || "").startsWith("image/") ? "image" : "file"
@@ -846,11 +688,8 @@ function onPaste(e) {
 
 function _renameClipboardBlob(file, kind) {
   const ts = new Date().toISOString().replace(/[:.]/g, "-").replace(/T/, "_").replace(/Z$/, "")
-  const ext = (file.type.split("/")[1] || (kind === "image" ? "png" : "bin")).split("+")[0] // image/svg+xml → svg
+  const ext = (file.type.split("/")[1] || (kind === "image" ? "png" : "bin")).split("+")[0] // image/svg+xml 閳?svg
   const stem = kind === "image" ? `pasted-image-${ts}` : `pasted-file-${ts}`
-  // The File constructor accepts the underlying blob + a new name,
-  // preserving size / type / lastModified.  Falls back to the raw
-  // file when File isn't constructible (older Safari).
   try {
     return new File([file], `${stem}.${ext}`, {
       type: file.type,
@@ -867,12 +706,20 @@ function removeAttachment(index) {
 
 async function send() {
   if (props.readOnly || (!inputText.value.trim() && attachments.value.length === 0)) return
-  // Group mode: focus this group BEFORE ``chat.send`` so the
-  // legacy-synced ``chat.activeTab`` matches this group's activeTab.
-  // ``chat.send`` dispatches on ``chat.activeTab`` under the hood;
-  // without this focus the message would route to whichever group is
-  // currently focused instead of the one whose composer was used.
+  if (slashMenuOpen.value && slashMatches.value.length) {
+    chooseSlashEntry(slashMatches.value[slashSelectedIndex.value] || slashMatches.value[0])
+    return
+  }
   if (props.groupId) onGroupFocus()
+  const slashTarget = await chat.prepareSlashSend(
+    {
+      key: viewActiveTab.value,
+      creature: viewActiveTab.value,
+      type: viewActiveTab.value?.startsWith("ch:") ? "channel" : "creature",
+    },
+    inputText.value,
+  )
+  chat.markSlashTarget(viewActiveTab.value, slashTarget)
   const parts = await buildMessageParts(inputText.value, attachments.value)
   const commandTarget = {
     sessionId: chat._instanceGraphId || chat._instanceId,
@@ -903,10 +750,6 @@ async function triggerCompact() {
     const sid = chat._instanceGraphId || chat._instanceId
     const tab = viewActiveTab.value || "root"
     const response = await terrariumAPI.executeCreatureCommand(sid, tab, "compact")
-    // ``/compact`` returns a ``ui_notify`` payload describing one of
-    // four outcomes: triggered, no-controller, too-short, busy. Without
-    // surfacing it the user has no signal that the click did anything
-    // — the compact runs (or doesn't) silently in the background.
     await surfaceCommandResult(response)
   } catch (err) {
     console.error("Compact failed:", err)
@@ -914,16 +757,6 @@ async function triggerCompact() {
   }
 }
 
-/**
- * Render a ``UserCommandResult`` payload as a toast / inline message.
- *
- * Backend command results carry a ``data`` block built by ``ui_notify``
- * (and friends) in ``modules/user_command/base.py``. CLI/TUI commit
- * ``output`` to their own surfaces; the web frontend is responsible
- * for translating the typed payload into UI. Notifications surface as
- * toasts; confirmations execute the payload's follow-up command only after
- * the user accepts the dialog.
- */
 async function surfaceCommandResult(response, target = null) {
   if (!response) return
   if (response.error) {
@@ -953,8 +786,6 @@ async function surfaceCommandResult(response, target = null) {
     await surfaceCommandResult(confirmed, { sessionId: sid, creatureId: tab })
     return
   }
-  // Fall back to plain ``output`` text when no structured payload —
-  // mirrors how CLI / TUI render unspecified results.
   if (response.output) {
     ElMessage({ message: response.output, type: "info" })
   }
@@ -988,9 +819,6 @@ async function stopTask(jobId, jobName) {
     const tab = viewActiveTab.value
     const sid = chat._instanceGraphId || chat._instanceId
     await terrariumAPI.stopCreatureTask(sid, tab || "root", jobId)
-    // Don't eagerly remove from runningJobs — the backend will send a
-    // subagent_done/subagent_error or tool_done/tool_error event which
-    // handles the removal properly. Just mark as cancelling for visual feedback.
     const job = chat.runningJobs[jobId]
     if (job) job.cancelling = true
   } catch (err) {
@@ -998,9 +826,6 @@ async function stopTask(jobId, jobName) {
   }
 }
 
-// Escape key interrupt — only the FOCUSED group (or legacy single
-// panel) handles the global keystroke. Otherwise N panels would all
-// react to one Escape and call chat.interrupt() N times.
 function onGlobalKeydown(e) {
   if (props.readOnly) return
   if (props.groupId && !isFocusedGroup.value) return
@@ -1012,69 +837,4 @@ onMounted(() => window.addEventListener("keydown", onGlobalKeydown))
 onUnmounted(() => window.removeEventListener("keydown", onGlobalKeydown))
 </script>
 
-<style scoped>
-.chat-messages-viewport {
-  container-type: size;
-}
-
-/* ModelSwitcher's pill defaults to min-width: 12rem which is too
-   wide for the chat tab-bar header on compact viewports. Shrink
-   here without touching the global StatusBar usage. The variation
-   summary is hidden in this context — it overflows badly in the
-   narrow slot, and the user can still see/change variations from
-   the picker popover itself. */
-.chat-model-switcher :deep(.model-pill) {
-  min-width: 0;
-  max-width: 14rem;
-  padding: 0.15rem 0.45rem;
-  min-height: 24px;
-  gap: 0.35rem;
-}
-.chat-model-switcher :deep(.model-pill-variation) {
-  display: none;
-}
-.chat-model-switcher :deep(.target-select) {
-  width: 7rem;
-}
-
-/* Pill button sizing for the chat input row.  Single source of
- * truth so [+], [attach], [image], [compact], [clean] all match.
- * Coarse pointer bumps to 40×40 for tap-target compliance. */
-.kt-input-pill-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 0.375rem;
-  transition:
-    background-color 0.15s ease,
-    color 0.15s ease;
-  flex-shrink: 0;
-}
-@media (pointer: coarse) {
-  .kt-input-pill-btn {
-    width: 2.5rem;
-    height: 2.5rem;
-  }
-}
-
-/* Send / stop button — slightly bigger + rounded-lg to anchor the
- * right side of the input row.  Coarse pointer = 44×44 tap target. */
-.kt-input-send-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.5rem;
-  transition: all 0.15s ease;
-  flex-shrink: 0;
-}
-@media (pointer: coarse) {
-  .kt-input-send-btn {
-    width: 2.75rem;
-    height: 2.75rem;
-  }
-}
-</style>
+<style scoped src="./chat-panel.css"></style>

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -274,7 +274,7 @@ function onGroupFocus() {
   emit("focus-group", props.groupId)
 }
 
-const { activeDescendant: slashActiveDescendant, choose: chooseSlashEntry, clearTarget: clearSlashTarget, entries: slashMatches, loading: slashInventoryLoading, move: moveSlashSelection, open: slashMenuOpen, selectedIndex: slashSelectedIndex } = useSlashCommandCompletion({ chat, inputText, activeTabKey: viewActiveTab })
+const { activeDescendant: slashActiveDescendant, choose: chooseSlashEntry, dismiss: dismissSlashMenu, entries: slashMatches, loading: slashInventoryLoading, move: moveSlashSelection, open: slashMenuOpen, reopen: reopenSlashMenu, selectedIndex: slashSelectedIndex } = useSlashCommandCompletion({ chat, inputText, activeTabKey: viewActiveTab })
 
 const tabDrag = useChatTabDrag(chat)
 const tabDragHoverEdge = computed(() => (props.groupId ? tabDrag.isHoveringEdgeOf(props.groupId) : null))
@@ -459,7 +459,8 @@ function onInputKeydown(e) {
     }
     if (e.key === "Escape") {
       e.preventDefault()
-      clearSlashTarget()
+      e.stopPropagation()
+      dismissSlashMenu()
       return
     }
   }
@@ -482,11 +483,12 @@ const inputActive = computed(() => inputFocused.value || inputText.value.length 
 
 function onInputChanged(event) {
   autoResize(event)
-  clearSlashTarget()
+  chat.markSlashTarget(viewActiveTab.value, null)
 }
 
 function onInputFocus() {
   inputFocused.value = true
+  reopenSlashMenu()
 }
 
 function onInputBlur() {
@@ -709,7 +711,18 @@ async function send() {
   const sendTab = viewActiveTab.value
   const sendText = inputText.value
   const sendAttachments = [...attachments.value]
-  const contextChanged = () => viewActiveTab.value !== sendTab || inputText.value !== sendText || attachments.value.length !== sendAttachments.length || attachments.value.some((attachment, index) => attachment !== sendAttachments[index])
+  const sendInstanceGeneration = chat._instanceGeneration
+  const sendInstanceId = chat._instanceId
+  const sendGraphId = chat._instanceGraphId
+  const sendPropInstanceId = props.instance?.id
+  const sendPropGraphId = props.instance?.graph_id
+  let ownedSlashTarget = chat._slashTargetByTab?.[sendTab]
+  const contextChanged = () => chat._instanceGeneration !== sendInstanceGeneration || chat._instanceId !== sendInstanceId || chat._instanceGraphId !== sendGraphId || props.instance?.id !== sendPropInstanceId || props.instance?.graph_id !== sendPropGraphId || chat.activeTab !== sendTab || viewActiveTab.value !== sendTab || inputText.value !== sendText || attachments.value.length !== sendAttachments.length || attachments.value.some((attachment, index) => attachment !== sendAttachments[index])
+  const clearOwnedSlashTarget = () => {
+    if (chat._slashTargetByTab?.[sendTab] === ownedSlashTarget) {
+      chat.markSlashTarget(sendTab, null)
+    }
+  }
   if (slashMenuOpen.value && slashMatches.value.length) {
     chooseSlashEntry(slashMatches.value[slashSelectedIndex.value] || slashMatches.value[0])
     return
@@ -728,11 +741,21 @@ async function send() {
   } catch (err) {
     console.warn("Slash inventory lookup failed; using command fallback:", err)
   }
-  if (contextChanged()) return
-  chat.markSlashTarget(sendTab, slashTarget)
-  const parts = await buildMessageParts(sendText, sendAttachments)
   if (contextChanged()) {
-    chat.markSlashTarget(sendTab, null)
+    clearOwnedSlashTarget()
+    return
+  }
+  chat.markSlashTarget(sendTab, slashTarget)
+  ownedSlashTarget = chat._slashTargetByTab?.[sendTab]
+  let parts
+  try {
+    parts = await buildMessageParts(sendText, sendAttachments)
+  } catch (err) {
+    clearOwnedSlashTarget()
+    throw err
+  }
+  if (contextChanged()) {
+    clearOwnedSlashTarget()
     return
   }
   const commandTarget = {
@@ -842,6 +865,7 @@ async function stopTask(jobId, jobName) {
 
 function onGlobalKeydown(e) {
   if (props.readOnly) return
+  if (e.defaultPrevented) return
   if (props.groupId && !isFocusedGroup.value) return
   if (e.key === "Escape" && viewProcessing.value) {
     chat.interrupt(viewActiveTab.value)

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -706,24 +706,38 @@ function removeAttachment(index) {
 
 async function send() {
   if (props.readOnly || (!inputText.value.trim() && attachments.value.length === 0)) return
+  const sendTab = viewActiveTab.value
+  const sendText = inputText.value
+  const sendAttachments = [...attachments.value]
+  const contextChanged = () => viewActiveTab.value !== sendTab || inputText.value !== sendText || attachments.value.length !== sendAttachments.length || attachments.value.some((attachment, index) => attachment !== sendAttachments[index])
   if (slashMenuOpen.value && slashMatches.value.length) {
     chooseSlashEntry(slashMatches.value[slashSelectedIndex.value] || slashMatches.value[0])
     return
   }
   if (props.groupId) onGroupFocus()
-  const slashTarget = await chat.prepareSlashSend(
-    {
-      key: viewActiveTab.value,
-      creature: viewActiveTab.value,
-      type: viewActiveTab.value?.startsWith("ch:") ? "channel" : "creature",
-    },
-    inputText.value,
-  )
-  chat.markSlashTarget(viewActiveTab.value, slashTarget)
-  const parts = await buildMessageParts(inputText.value, attachments.value)
+  let slashTarget = null
+  try {
+    slashTarget = await chat.prepareSlashSend(
+      {
+        key: sendTab,
+        creature: sendTab,
+        type: sendTab?.startsWith("ch:") ? "channel" : "creature",
+      },
+      sendText,
+    )
+  } catch (err) {
+    console.warn("Slash inventory lookup failed; using command fallback:", err)
+  }
+  if (contextChanged()) return
+  chat.markSlashTarget(sendTab, slashTarget)
+  const parts = await buildMessageParts(sendText, sendAttachments)
+  if (contextChanged()) {
+    chat.markSlashTarget(sendTab, null)
+    return
+  }
   const commandTarget = {
     sessionId: chat._instanceGraphId || chat._instanceId,
-    creatureId: viewActiveTab.value || "root",
+    creatureId: sendTab || "root",
   }
   const outcomePromise = chat.send(parts)
   inputText.value = ""

--- a/src/kohakuterrarium-frontend/src/components/chat/SlashCommandMenu.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/SlashCommandMenu.test.js
@@ -1,0 +1,54 @@
+import { createPinia, setActivePinia } from "pinia"
+import { mount } from "@vue/test-utils"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import SlashCommandMenu from "./SlashCommandMenu.vue"
+
+describe("SlashCommandMenu", () => {
+  beforeEach(() => setActivePinia(createPinia()))
+  it("groups commands and skills and emits the selected item", async () => {
+    const entries = [
+      { kind: "command", name: "help", description: "Show help", source: "builtin" },
+      { kind: "skill", name: "research", description: "Research a topic", source: "project" },
+    ]
+    const wrapper = mount(SlashCommandMenu, {
+      props: { open: true, entries, selectedIndex: 1 },
+    })
+
+    expect(wrapper.text()).toContain("Commands")
+    expect(wrapper.text()).toContain("Skills")
+    expect(wrapper.text()).toContain("/help")
+    expect(wrapper.text()).toContain("/research")
+
+    await wrapper.findAll('button[role="option"]')[1].trigger("click")
+    expect(wrapper.emitted("choose")?.[0]?.[0]).toMatchObject({
+      kind: "skill",
+      name: "research",
+    })
+  })
+
+  it("keeps aria selection aligned with grouped visual order", () => {
+    const wrapper = mount(SlashCommandMenu, {
+      props: {
+        open: true,
+        selectedIndex: 1,
+        entries: [
+          { kind: "skill", name: "research" },
+          { kind: "command", name: "help" },
+        ],
+      },
+    })
+    const buttons = wrapper.findAll('button[role="option"]')
+    expect(buttons[0].text()).toContain("/help")
+    expect(buttons[0].attributes("aria-selected")).toBe("false")
+    expect(buttons[1].text()).toContain("/research")
+    expect(buttons[1].attributes("aria-selected")).toBe("true")
+  })
+
+  it("renders an empty result state", () => {
+    const wrapper = mount(SlashCommandMenu, {
+      props: { open: true, entries: [] },
+    })
+    expect(wrapper.text()).toContain("No matching commands or skills")
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/chat/SlashCommandMenu.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/SlashCommandMenu.vue
@@ -1,0 +1,46 @@
+<template>
+  <div v-if="open" id="slash-command-menu" class="absolute inset-x-0 bottom-full z-40 mb-2 overflow-hidden rounded-xl border border-warm-200 bg-white shadow-xl dark:border-warm-700 dark:bg-warm-850" role="listbox" :aria-label="t('chat.slash.available')">
+    <div v-if="loading" class="px-3 py-2 text-xs text-warm-500">{{ t("chat.slash.loading") }}</div>
+    <div v-else-if="!visualEntries.length" class="px-3 py-2 text-xs text-warm-500">{{ t("chat.slash.empty") }}</div>
+    <template v-for="item in visualEntries" :key="item.key">
+      <div v-if="item.heading" class="bg-warm-50 px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-warm-500 dark:bg-warm-900/60">
+        {{ item.type === "command" ? t("chat.slash.commands") : t("chat.slash.skills") }}
+      </div>
+      <button v-else :id="`slash-option-${item.visualIndex}`" type="button" role="option" :aria-selected="item.visualIndex === selectedIndex" class="flex w-full items-start gap-3 px-3 py-2 text-left hover:bg-primary-50 dark:hover:bg-primary-950/30" :class="item.visualIndex === selectedIndex ? 'bg-primary-50 dark:bg-primary-950/30' : ''" @mouseenter="$emit('select-index', item.visualIndex)" @click="$emit('choose', item.entry)" @mousedown.prevent>
+        <code class="shrink-0 text-xs font-semibold text-primary-700 dark:text-primary-300">/{{ item.entry.name }}</code>
+        <span class="min-w-0 text-xs text-warm-600 dark:text-warm-300">{{ item.entry.description || t("chat.slash.noDescription") }}</span>
+      </button>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue"
+
+import { useI18n } from "@/utils/i18n"
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  loading: { type: Boolean, default: false },
+  entries: { type: Array, default: () => [] },
+  selectedIndex: { type: Number, default: 0 },
+})
+
+defineEmits(["choose", "select-index"])
+
+const { t } = useI18n()
+const visualEntries = computed(() => {
+  const items = []
+  let visualIndex = 0
+  for (const type of ["command", "skill"]) {
+    const entries = props.entries.filter((entry) => (entry.type || entry.kind) === type)
+    if (!entries.length) continue
+    items.push({ heading: true, type, key: `heading:${type}` })
+    for (const entry of entries) {
+      items.push({ entry, type, visualIndex, key: `${type}:${entry.name}` })
+      visualIndex += 1
+    }
+  }
+  return items
+})
+</script>

--- a/src/kohakuterrarium-frontend/src/components/chat/chat-panel.css
+++ b/src/kohakuterrarium-frontend/src/components/chat/chat-panel.css
@@ -1,0 +1,55 @@
+.chat-messages-viewport {
+  container-type: size;
+}
+
+.chat-model-switcher :deep(.model-pill) {
+  min-width: 0;
+  max-width: 14rem;
+  padding: 0.15rem 0.45rem;
+  min-height: 24px;
+  gap: 0.35rem;
+}
+
+.chat-model-switcher :deep(.model-pill-variation) {
+  display: none;
+}
+
+.chat-model-switcher :deep(.target-select) {
+  width: 7rem;
+}
+
+.kt-input-pill-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.375rem;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.kt-input-send-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  transition: all 0.15s ease;
+  flex-shrink: 0;
+}
+
+@media (pointer: coarse) {
+  .kt-input-pill-btn {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .kt-input-send-btn {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
+}

--- a/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.js
@@ -24,8 +24,14 @@ export function useSlashCommandCompletion({ chat, inputText, activeTabKey }) {
       ...entry,
       type: "command",
     }))
+    const commandNamespace = new Set(
+      commands.flatMap((entry) => [
+        entry.name.toLowerCase(),
+        ...(entry.aliases || []).map((alias) => alias.toLowerCase()),
+      ]),
+    )
     const skills = (inventory.value.skills || [])
-      .filter((entry) => entry.enabled)
+      .filter((entry) => entry.enabled && !commandNamespace.has(entry.name.toLowerCase()))
       .map((entry) => ({ ...entry, type: "skill" }))
     return [...commands, ...skills]
       .filter(

--- a/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.js
@@ -5,6 +5,7 @@ const SLASH_QUERY_RE = /^\/([^\s]*)$/
 export function useSlashCommandCompletion({ chat, inputText, activeTabKey }) {
   const loading = ref(false)
   const selectedIndex = ref(0)
+  const dismissed = ref(false)
   const tab = computed(() => {
     const key = activeTabKey.value
     return key ? { key, creature: key, type: key.startsWith("ch:") ? "channel" : "creature" } : null
@@ -47,7 +48,7 @@ export function useSlashCommandCompletion({ chat, inputText, activeTabKey }) {
       })
       .map((entry, flatIndex) => ({ ...entry, flatIndex }))
   })
-  const open = computed(() => query.value != null)
+  const open = computed(() => query.value != null && !dismissed.value)
   const activeDescendant = computed(() =>
     open.value && entries.value.length ? `slash-option-${selectedIndex.value}` : undefined,
   )
@@ -80,7 +81,17 @@ export function useSlashCommandCompletion({ chat, inputText, activeTabKey }) {
     chat.markSlashTarget(tab.value, null)
   }
 
+  function dismiss() {
+    dismissed.value = true
+    clearTarget()
+  }
+
+  function reopen() {
+    dismissed.value = false
+  }
+
   watch(query, (value) => {
+    dismissed.value = false
     selectedIndex.value = 0
     if (value != null && activeTabKey.value) void ensureLoaded()
   })
@@ -88,6 +99,7 @@ export function useSlashCommandCompletion({ chat, inputText, activeTabKey }) {
     if (selectedIndex.value >= value.length) selectedIndex.value = 0
   })
   watch(activeTabKey, () => {
+    dismissed.value = false
     selectedIndex.value = 0
     if (query.value != null && activeTabKey.value) void ensureLoaded()
   })
@@ -96,11 +108,13 @@ export function useSlashCommandCompletion({ chat, inputText, activeTabKey }) {
     activeDescendant,
     choose,
     clearTarget,
+    dismiss,
     ensureLoaded,
     entries,
     loading,
     move,
     open,
+    reopen,
     selectedIndex,
   }
 }

--- a/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.js
@@ -1,0 +1,100 @@
+import { computed, ref, watch } from "vue"
+
+const SLASH_QUERY_RE = /^\/([^\s]*)$/
+
+export function useSlashCommandCompletion({ chat, inputText, activeTabKey }) {
+  const loading = ref(false)
+  const selectedIndex = ref(0)
+  const tab = computed(() => {
+    const key = activeTabKey.value
+    return key ? { key, creature: key, type: key.startsWith("ch:") ? "channel" : "creature" } : null
+  })
+  const inventory = computed(
+    () => chat.commandInventoryByTab[tab.value?.key] || { commands: [], skills: [] },
+  )
+  const query = computed(() => {
+    if (tab.value?.type === "channel") return null
+    const match = inputText.value.match(SLASH_QUERY_RE)
+    return match ? match[1].toLowerCase() : null
+  })
+  const entries = computed(() => {
+    if (query.value == null) return []
+    const needle = query.value
+    const commands = (inventory.value.commands || []).map((entry) => ({
+      ...entry,
+      type: "command",
+    }))
+    const skills = (inventory.value.skills || [])
+      .filter((entry) => entry.enabled)
+      .map((entry) => ({ ...entry, type: "skill" }))
+    return [...commands, ...skills]
+      .filter(
+        (entry) =>
+          entry.name.toLowerCase().includes(needle) ||
+          entry.aliases?.some((alias) => alias.toLowerCase().includes(needle)),
+      )
+      .sort((left, right) => {
+        if (left.type !== right.type) return left.type === "command" ? -1 : 1
+        const leftPrefix = left.name.toLowerCase().startsWith(needle) ? 0 : 1
+        const rightPrefix = right.name.toLowerCase().startsWith(needle) ? 0 : 1
+        return leftPrefix - rightPrefix || left.name.localeCompare(right.name)
+      })
+      .map((entry, flatIndex) => ({ ...entry, flatIndex }))
+  })
+  const open = computed(() => query.value != null && (loading.value || entries.value.length > 0))
+  const activeDescendant = computed(() =>
+    open.value && entries.value.length ? `slash-option-${selectedIndex.value}` : undefined,
+  )
+
+  async function ensureLoaded({ force = false } = {}) {
+    if (!tab.value || tab.value.type === "channel") return
+    loading.value = true
+    try {
+      await chat.loadCommandInventory(tab.value, { force })
+    } catch (error) {
+      console.warn("Failed to load command inventory", error)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function choose(entry) {
+    if (!entry) return
+    inputText.value = `/${entry.name} `
+    chat.markSlashTarget(tab.value, entry)
+  }
+
+  function move(delta) {
+    if (!entries.value.length) return
+    selectedIndex.value =
+      (selectedIndex.value + delta + entries.value.length) % entries.value.length
+  }
+
+  function clearTarget() {
+    chat.markSlashTarget(tab.value, null)
+  }
+
+  watch(query, (value) => {
+    selectedIndex.value = 0
+    if (value != null && activeTabKey.value) void ensureLoaded()
+  })
+  watch(entries, (value) => {
+    if (selectedIndex.value >= value.length) selectedIndex.value = 0
+  })
+  watch(activeTabKey, () => {
+    selectedIndex.value = 0
+    if (query.value != null && activeTabKey.value) void ensureLoaded()
+  })
+
+  return {
+    activeDescendant,
+    choose,
+    clearTarget,
+    ensureLoaded,
+    entries,
+    loading,
+    move,
+    open,
+    selectedIndex,
+  }
+}

--- a/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.js
@@ -41,7 +41,7 @@ export function useSlashCommandCompletion({ chat, inputText, activeTabKey }) {
       })
       .map((entry, flatIndex) => ({ ...entry, flatIndex }))
   })
-  const open = computed(() => query.value != null && (loading.value || entries.value.length > 0))
+  const open = computed(() => query.value != null)
   const activeDescendant = computed(() =>
     open.value && entries.value.length ? `slash-option-${selectedIndex.value}` : undefined,
   )

--- a/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.test.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.test.js
@@ -28,4 +28,31 @@ describe("useSlashCommandCompletion", () => {
     expect(completion.entries.value).toEqual([])
     expect(completion.open.value).toBe(true)
   })
+
+  it("hides skills shadowed by command names or aliases", async () => {
+    const chat = reactive({
+      commandInventoryByTab: {
+        kohaku: {
+          commands: [{ name: "review", aliases: ["r"], description: "Review command" }],
+          skills: [
+            { name: "review", enabled: true },
+            { name: "R", enabled: true },
+            { name: "standalone", enabled: true },
+          ],
+        },
+      },
+      loadCommandInventory: vi.fn().mockResolvedValue(undefined),
+      markSlashTarget: vi.fn(),
+    })
+    const inputText = ref("/")
+    const activeTabKey = ref("kohaku")
+    const completion = useSlashCommandCompletion({ chat, inputText, activeTabKey })
+
+    await nextTick()
+
+    expect(completion.entries.value.map((entry) => `${entry.type}:${entry.name}`)).toEqual([
+      "command:review",
+      "skill:standalone",
+    ])
+  })
 })

--- a/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.test.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.test.js
@@ -1,0 +1,31 @@
+import { flushPromises } from "@vue/test-utils"
+import { nextTick, reactive, ref } from "vue"
+import { describe, expect, it, vi } from "vitest"
+
+import { useSlashCommandCompletion } from "./useSlashCommandCompletion"
+
+describe("useSlashCommandCompletion", () => {
+  it("keeps the menu open for a loaded slash query with no matches", async () => {
+    const chat = reactive({
+      commandInventoryByTab: {
+        kohaku: {
+          commands: [{ name: "help", aliases: [], description: "Show help" }],
+          skills: [],
+        },
+      },
+      loadCommandInventory: vi.fn().mockResolvedValue(undefined),
+      markSlashTarget: vi.fn(),
+    })
+    const inputText = ref("")
+    const activeTabKey = ref("kohaku")
+    const completion = useSlashCommandCompletion({ chat, inputText, activeTabKey })
+
+    inputText.value = "/missing"
+    await nextTick()
+    await flushPromises()
+
+    expect(completion.loading.value).toBe(false)
+    expect(completion.entries.value).toEqual([])
+    expect(completion.open.value).toBe(true)
+  })
+})

--- a/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.test.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSlashCommandCompletion.test.js
@@ -55,4 +55,40 @@ describe("useSlashCommandCompletion", () => {
       "skill:standalone",
     ])
   })
+
+  it("dismisses the current query until the input changes or the menu is reopened", async () => {
+    const chat = reactive({
+      commandInventoryByTab: {
+        kohaku: {
+          commands: [{ name: "help", aliases: [], description: "Show help" }],
+          skills: [],
+        },
+      },
+      loadCommandInventory: vi.fn().mockResolvedValue(undefined),
+      markSlashTarget: vi.fn(),
+    })
+    const inputText = ref("/")
+    const activeTabKey = ref("kohaku")
+    const completion = useSlashCommandCompletion({ chat, inputText, activeTabKey })
+
+    await nextTick()
+    expect(completion.open.value).toBe(true)
+
+    completion.dismiss()
+    await nextTick()
+    expect(completion.open.value).toBe(false)
+    expect(chat.markSlashTarget).toHaveBeenLastCalledWith(
+      { key: "kohaku", creature: "kohaku", type: "creature" },
+      null,
+    )
+
+    inputText.value = "/h"
+    await nextTick()
+    expect(completion.open.value).toBe(true)
+
+    completion.dismiss()
+    expect(completion.open.value).toBe(false)
+    completion.reopen()
+    expect(completion.open.value).toBe(true)
+  })
 })

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -2055,13 +2055,15 @@ const _chatStoreOptions = {
       const parsed = _parseSlashCommand(content)
       if (!parsed || !tab || tab.type === "channel") return null
       const marked = this._slashTargetByTab[tab.key]
-      if (marked && marked.name === parsed.command) return marked
+      if (marked && marked.name.toLowerCase() === parsed.command) return marked
       const inventory = await this.loadCommandInventory(tab)
       const command = inventory.commands?.find(
-        (entry) => entry.name === parsed.command || entry.aliases?.includes(parsed.command),
+        (entry) =>
+          entry.name.toLowerCase() === parsed.command ||
+          entry.aliases?.some((alias) => alias.toLowerCase() === parsed.command),
       )
       if (command) return { type: "command", name: command.name }
-      const skill = inventory.skills?.find((entry) => entry.name === parsed.command)
+      const skill = inventory.skills?.find((entry) => entry.name.toLowerCase() === parsed.command)
       return skill ? { type: "skill", name: skill.name } : null
     },
 
@@ -2075,7 +2077,7 @@ const _chatStoreOptions = {
         const tabInfo = this.tabs[tab]
         const target = this._slashTargetByTab[tab]
         delete this._slashTargetByTab[tab]
-        if (target?.type === "skill" && target.name === slashCommand.command) {
+        if (target?.type === "skill" && target.name.toLowerCase() === slashCommand.command) {
           const result = await terrariumAPI.invokeCreatureSkill(
             this._instanceGraphId || this._instanceId,
             tabInfo?.creature || tab,

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -15,6 +15,7 @@ import { readLocalJsonPref, writeLocalJsonPref } from "@/utils/uiPrefs"
 import { wsUrl } from "@/utils/wsUrl"
 
 const BRANCH_RESYNC_DELAY_MS = 350
+const COMMAND_INVENTORY_TTL_MS = 30_000
 // A pending branch op whose expected branch never lands (e.g. the edit
 // request was lost before dispatch) must not keep the stale-history
 // guard alive forever — after this many incomplete retries the guard is
@@ -1398,6 +1399,12 @@ const _chatStoreOptions = {
     branchOperationByTab: {},
     /** Last branch operation error, keyed by tab. */
     branchOperationErrorByTab: {},
+    commandInventoryByTab: {},
+    commandInventoryRevisionByTab: {},
+    _commandInventoryFetchedAtByTab: {},
+    _commandInventoryRequestByTab: {},
+    _slashTargetByTab: {},
+
     /** @type {{sessionId: string, model: string, llmName: string, agentName: string, compactThreshold: number, homeNode: string}} Session metadata */
     sessionInfo: {
       sessionId: "",
@@ -1715,6 +1722,11 @@ const _chatStoreOptions = {
       this._recentUserInputs = {}
       this._branchResyncPendingByTab = {}
       this._streamingBranchByTab = {}
+      this.commandInventoryByTab = {}
+      this.commandInventoryRevisionByTab = {}
+      this._commandInventoryFetchedAtByTab = {}
+      this._commandInventoryRequestByTab = {}
+      this._slashTargetByTab = {}
       this._clearBranchResyncTimers()
       // Reset multi-group state — group tree is per-scope, so a
       // different ``_instanceId`` means a different layout to load.
@@ -1954,6 +1966,74 @@ const _chatStoreOptions = {
       }
     },
 
+    async loadCommandInventory(tab, { force = false } = {}) {
+      if (!tab || tab.type === "channel") return { commands: [], skills: [] }
+      const tabKey = tab.key
+      const cached = this.commandInventoryByTab[tabKey]
+      const fetchedAt = this._commandInventoryFetchedAtByTab[tabKey] || 0
+      if (!force && cached && Date.now() - fetchedAt < COMMAND_INVENTORY_TTL_MS) return cached
+      if (!force && this._commandInventoryRequestByTab[tabKey]) {
+        return this._commandInventoryRequestByTab[tabKey]
+      }
+      const sessionId = this._instanceGraphId || this._instanceId
+      const creature = tab.creature || tabKey
+      const request = terrariumAPI
+        .getCreatureCommandInventory(sessionId, creature)
+        .then((inventory) => {
+          const tabStillOpen =
+            this.tabs.includes(tabKey) ||
+            Object.values(this.groups).some((group) => group.tabs.includes(tabKey))
+          if ((this._instanceGraphId || this._instanceId) !== sessionId || !tabStillOpen) {
+            return inventory
+          }
+          this.commandInventoryByTab[tabKey] = inventory
+          this._commandInventoryFetchedAtByTab[tabKey] = Date.now()
+          this.commandInventoryRevisionByTab[tabKey] =
+            (this.commandInventoryRevisionByTab[tabKey] || 0) + 1
+          return inventory
+        })
+        .finally(() => {
+          if (this._commandInventoryRequestByTab[tabKey] === request) {
+            delete this._commandInventoryRequestByTab[tabKey]
+          }
+        })
+      this._commandInventoryRequestByTab[tabKey] = request
+      return request
+    },
+
+    invalidateCommandInventory(tab = null) {
+      if (tab) {
+        delete this._commandInventoryFetchedAtByTab[tab.key]
+        return
+      }
+      this._commandInventoryFetchedAtByTab = {}
+    },
+
+    markSlashTarget(tab, entry) {
+      if (!tab) return
+      const tabKey = typeof tab === "string" ? tab : tab.key
+      if (entry) {
+        this._slashTargetByTab[tabKey] = {
+          type: entry.type || entry.kind,
+          name: entry.name,
+        }
+      } else delete this._slashTargetByTab[tabKey]
+    },
+
+    async prepareSlashSend(tab, content) {
+      const parsed = _parseSlashCommand(content)
+      if (!parsed || !tab || tab.type === "channel") return null
+      const marked = this._slashTargetByTab[tab.key]
+      if (marked && marked.name === parsed.command) return marked
+      const inventory = await this.loadCommandInventory(tab)
+      const command = inventory.commands?.find(
+        (entry) => entry.name === parsed.command || entry.aliases?.includes(parsed.command),
+      )
+      if (command) return { type: "command", name: command.name }
+      const skill = inventory.skills?.find((entry) => entry.name === parsed.command)
+      return skill ? { type: "skill", name: skill.name } : null
+    },
+
     async send(text) {
       if (!this.activeTab) return
       if (typeof text === "string" ? !text.trim() : !text.length) return
@@ -1961,10 +2041,22 @@ const _chatStoreOptions = {
       const tab = this.activeTab
       const slashCommand = _parseSlashCommand(text)
       if (slashCommand && !tab.startsWith("ch:")) {
+        const tabInfo = this.tabs[tab]
+        const target = this._slashTargetByTab[tab]
+        delete this._slashTargetByTab[tab]
+        if (target?.type === "skill" && target.name === slashCommand.command) {
+          const result = await terrariumAPI.invokeCreatureSkill(
+            this._instanceGraphId || this._instanceId,
+            tabInfo?.creature || tab,
+            target.name,
+            slashCommand.args,
+          )
+          return { handled: "skill", result }
+        }
         const result = await terrariumAPI.executeCreatureCommand(
           this._instanceGraphId || this._instanceId,
-          tab,
-          slashCommand.command,
+          tabInfo?.creature || tab,
+          target?.type === "command" ? target.name : slashCommand.command,
           slashCommand.args,
         )
         return { handled: "command", result }

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -1402,6 +1402,7 @@ const _chatStoreOptions = {
     commandInventoryByTab: {},
     commandInventoryRevisionByTab: {},
     _commandInventoryFetchedAtByTab: {},
+    _commandInventoryGenerationByTab: {},
     _commandInventoryRequestByTab: {},
     _slashTargetByTab: {},
 
@@ -1725,6 +1726,7 @@ const _chatStoreOptions = {
       this.commandInventoryByTab = {}
       this.commandInventoryRevisionByTab = {}
       this._commandInventoryFetchedAtByTab = {}
+      this._commandInventoryGenerationByTab = {}
       this._commandInventoryRequestByTab = {}
       this._slashTargetByTab = {}
       this._clearBranchResyncTimers()
@@ -1975,6 +1977,12 @@ const _chatStoreOptions = {
       if (!force && this._commandInventoryRequestByTab[tabKey]) {
         return this._commandInventoryRequestByTab[tabKey]
       }
+      if (force) {
+        this._commandInventoryGenerationByTab[tabKey] =
+          (this._commandInventoryGenerationByTab[tabKey] || 0) + 1
+      }
+      const generation = this._commandInventoryGenerationByTab[tabKey] || 0
+      const instanceGeneration = this._instanceGeneration
       const sessionId = this._instanceGraphId || this._instanceId
       const creature = tab.creature || tabKey
       const request = terrariumAPI
@@ -1983,7 +1991,16 @@ const _chatStoreOptions = {
           const tabStillOpen =
             this.tabs.includes(tabKey) ||
             Object.values(this.groups).some((group) => group.tabs.includes(tabKey))
-          if ((this._instanceGraphId || this._instanceId) !== sessionId || !tabStillOpen) {
+          const sessionStillOpen =
+            this._instanceGeneration === instanceGeneration &&
+            (this._instanceGraphId || this._instanceId) === sessionId
+          if ((this._commandInventoryGenerationByTab[tabKey] || 0) !== generation) {
+            const replacement = this._commandInventoryRequestByTab[tabKey]
+            if (replacement && replacement !== request) return replacement
+            if (sessionStillOpen && tabStillOpen) return this.loadCommandInventory(tab)
+            return inventory
+          }
+          if (!sessionStillOpen || !tabStillOpen) {
             return inventory
           }
           this.commandInventoryByTab[tabKey] = inventory
@@ -2002,11 +2019,25 @@ const _chatStoreOptions = {
     },
 
     invalidateCommandInventory(tab = null) {
+      const invalidate = (tabKey) => {
+        this._commandInventoryGenerationByTab[tabKey] =
+          (this._commandInventoryGenerationByTab[tabKey] || 0) + 1
+        delete this._commandInventoryFetchedAtByTab[tabKey]
+        delete this._commandInventoryRequestByTab[tabKey]
+      }
       if (tab) {
-        delete this._commandInventoryFetchedAtByTab[tab.key]
+        invalidate(typeof tab === "string" ? tab : tab.key)
         return
       }
+      const tabKeys = new Set([
+        ...Object.keys(this.commandInventoryByTab),
+        ...Object.keys(this._commandInventoryFetchedAtByTab),
+        ...Object.keys(this._commandInventoryGenerationByTab),
+        ...Object.keys(this._commandInventoryRequestByTab),
+      ])
+      for (const tabKey of tabKeys) invalidate(tabKey)
       this._commandInventoryFetchedAtByTab = {}
+      this._commandInventoryRequestByTab = {}
     },
 
     markSlashTarget(tab, entry) {
@@ -2059,6 +2090,7 @@ const _chatStoreOptions = {
           target?.type === "command" ? target.name : slashCommand.command,
           slashCommand.args,
         )
+        this.invalidateCommandInventory(tab)
         return { handled: "command", result }
       }
       if (!this._ws) return

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -14,6 +14,7 @@ describe("chat store — slash commands", () => {
     chat._instanceGraphId = "graph_1"
     chat.activeTab = "kohaku"
     chat.messagesByTab = { kohaku: [] }
+    chat._commandInventoryFetchedAtByTab = { kohaku: Date.now() }
     const wsSend = vi.fn()
     chat._ws = { readyState: WebSocket.OPEN, send: wsSend }
 
@@ -29,7 +30,100 @@ describe("chat store — slash commands", () => {
     expect(outcome).toEqual({ handled: "command", result })
     expect(wsSend).not.toHaveBeenCalled()
     expect(chat.messagesByTab.kohaku).toEqual([])
+    expect(chat._commandInventoryFetchedAtByTab.kohaku).toBeUndefined()
+    expect(chat._commandInventoryGenerationByTab.kohaku).toBe(1)
     commandSpy.mockRestore()
+  })
+
+  it("keeps the newest forced inventory when an older request resolves last", async () => {
+    const chat = useChatStore()
+    chat._instanceGraphId = "graph_1"
+    chat.tabs = ["kohaku"]
+    const tab = { key: "kohaku", creature: "kohaku", type: "creature" }
+    let resolveOld
+    let resolveNew
+    const oldRequest = new Promise((resolve) => {
+      resolveOld = resolve
+    })
+    const newRequest = new Promise((resolve) => {
+      resolveNew = resolve
+    })
+    const importActual = await vi.importActual("@/utils/api")
+    const inventorySpy = vi
+      .spyOn(importActual.terrariumAPI, "getCreatureCommandInventory")
+      .mockReturnValueOnce(oldRequest)
+      .mockReturnValueOnce(newRequest)
+
+    const first = chat.loadCommandInventory(tab, { force: true })
+    const second = chat.loadCommandInventory(tab, { force: true })
+    const newest = { commands: [{ name: "new" }], skills: [] }
+    resolveNew(newest)
+    await expect(second).resolves.toEqual(newest)
+    resolveOld({ commands: [{ name: "old" }], skills: [] })
+
+    await expect(first).resolves.toEqual(newest)
+    expect(chat.commandInventoryByTab.kohaku).toEqual(newest)
+    expect(chat.commandInventoryRevisionByTab.kohaku).toBe(1)
+    expect(inventorySpy).toHaveBeenCalledTimes(2)
+    inventorySpy.mockRestore()
+  })
+
+  it("refetches instead of caching a request invalidated while in flight", async () => {
+    const chat = useChatStore()
+    chat._instanceGraphId = "graph_1"
+    chat.tabs = ["kohaku"]
+    const tab = { key: "kohaku", creature: "kohaku", type: "creature" }
+    let resolveStale
+    let resolveFresh
+    const staleRequest = new Promise((resolve) => {
+      resolveStale = resolve
+    })
+    const freshRequest = new Promise((resolve) => {
+      resolveFresh = resolve
+    })
+    const importActual = await vi.importActual("@/utils/api")
+    const inventorySpy = vi
+      .spyOn(importActual.terrariumAPI, "getCreatureCommandInventory")
+      .mockReturnValueOnce(staleRequest)
+      .mockReturnValueOnce(freshRequest)
+
+    const pending = chat.loadCommandInventory(tab)
+    chat.invalidateCommandInventory(tab)
+    resolveStale({ commands: [{ name: "stale" }], skills: [] })
+    await vi.waitFor(() => expect(inventorySpy).toHaveBeenCalledTimes(2))
+    const fresh = { commands: [{ name: "fresh" }], skills: [] }
+    resolveFresh(fresh)
+
+    await expect(pending).resolves.toEqual(fresh)
+    expect(chat.commandInventoryByTab.kohaku).toEqual(fresh)
+    expect(chat.commandInventoryRevisionByTab.kohaku).toBe(1)
+    inventorySpy.mockRestore()
+  })
+
+  it("does not cache a request from an earlier instance generation", async () => {
+    const chat = useChatStore()
+    chat._instanceGraphId = "graph_1"
+    chat.tabs = ["kohaku"]
+    const tab = { key: "kohaku", creature: "kohaku", type: "creature" }
+    let resolveInventory
+    const request = new Promise((resolve) => {
+      resolveInventory = resolve
+    })
+    const importActual = await vi.importActual("@/utils/api")
+    const inventorySpy = vi
+      .spyOn(importActual.terrariumAPI, "getCreatureCommandInventory")
+      .mockReturnValueOnce(request)
+
+    const pending = chat.loadCommandInventory(tab)
+    chat._instanceGeneration += 1
+    chat._commandInventoryGenerationByTab = {}
+    const stale = { commands: [{ name: "stale" }], skills: [] }
+    resolveInventory(stale)
+
+    await expect(pending).resolves.toEqual(stale)
+    expect(chat.commandInventoryByTab.kohaku).toBeUndefined()
+    expect(chat.commandInventoryRevisionByTab.kohaku).toBeUndefined()
+    inventorySpy.mockRestore()
   })
 
   it("routes a menu-selected skill to the explicit skill endpoint", async () => {

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -32,6 +32,29 @@ describe("chat store — slash commands", () => {
     commandSpy.mockRestore()
   })
 
+  it("routes a menu-selected skill to the explicit skill endpoint", async () => {
+    const chat = useChatStore()
+    chat._instanceGraphId = "graph_1"
+    chat.activeTab = "kohaku"
+    chat.tabs = ["kohaku"]
+    chat.messagesByTab = { kohaku: [] }
+    chat.markSlashTarget("kohaku", { type: "skill", name: "review" })
+    const importActual = await vi.importActual("@/utils/api")
+    const result = { accepted: true }
+    const skillSpy = vi
+      .spyOn(importActual.terrariumAPI, "invokeCreatureSkill")
+      .mockResolvedValue(result)
+    const commandSpy = vi.spyOn(importActual.terrariumAPI, "executeCreatureCommand")
+
+    const outcome = await chat.send([{ type: "text", text: "/review diff" }])
+
+    expect(skillSpy).toHaveBeenCalledWith("graph_1", "kohaku", "review", "diff")
+    expect(commandSpy).not.toHaveBeenCalled()
+    expect(outcome).toEqual({ handled: "skill", result })
+    skillSpy.mockRestore()
+    commandSpy.mockRestore()
+  })
+
   it("continues sending normal text over the websocket", async () => {
     const chat = useChatStore()
     chat._instanceGraphId = "graph_1"

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -8,6 +8,38 @@ beforeEach(() => {
 })
 
 describe("chat store — slash commands", () => {
+  it("resolves a mixed-case inventory skill from normalized slash input", async () => {
+    const chat = useChatStore()
+    chat.commandInventoryByTab.kohaku = {
+      commands: [],
+      skills: [{ name: "CodeReview", enabled: true }],
+    }
+    chat._commandInventoryFetchedAtByTab.kohaku = Date.now()
+
+    const target = await chat.prepareSlashSend(
+      { key: "kohaku", creature: "kohaku", type: "creature" },
+      "/codereview focus",
+    )
+
+    expect(target).toEqual({ type: "skill", name: "CodeReview" })
+  })
+
+  it("keeps a selected mixed-case skill without refreshing inventory", async () => {
+    const chat = useChatStore()
+    chat.markSlashTarget("kohaku", { type: "skill", name: "CodeReview" })
+    const load = vi
+      .spyOn(chat, "loadCommandInventory")
+      .mockRejectedValue(new Error("inventory unavailable"))
+
+    const target = await chat.prepareSlashSend(
+      { key: "kohaku", creature: "kohaku", type: "creature" },
+      "/CodeReview focus",
+    )
+
+    expect(target).toEqual({ type: "skill", name: "CodeReview" })
+    expect(load).not.toHaveBeenCalled()
+  })
+
   it("executes a pure-text /goal command without sending websocket input", async () => {
     const chat = useChatStore()
     chat._instanceId = "session_1"

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -406,6 +406,23 @@ export const terrariumAPI = {
     return data
   },
 
+  /** Fetch live commands and skills for a terrarium creature */
+  async getCreatureCommandInventory(id, name) {
+    const { data } = await api.get(
+      `/sessions/${id}/creatures/${encodeTarget(name)}/command-inventory`,
+    )
+    return data
+  },
+
+  /** Inject a user-selected skill into a terrarium creature */
+  async invokeCreatureSkill(id, name, skill, args = "") {
+    const { data } = await api.post(`/sessions/${id}/creatures/${encodeTarget(name)}/skill-input`, {
+      command: skill,
+      args,
+    })
+    return data
+  },
+
   /** Execute a slash command on a terrarium creature */
   async executeCreatureCommand(id, name, command, args = "") {
     const { data } = await api.post(`/sessions/${id}/creatures/${encodeTarget(name)}/command`, {

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -396,6 +396,12 @@ export default {
   "settings.account.resetFailed": "Failed to redeem reset credit",
 
   "chat.noMessagesYet": "No messages yet",
+  "chat.slash.available": "Available commands and skills",
+  "chat.slash.loading": "Loading commands and skills…",
+  "chat.slash.empty": "No matching commands or skills",
+  "chat.slash.commands": "Commands",
+  "chat.slash.skills": "Skills",
+  "chat.slash.noDescription": "No description",
   "chat.getStarted": "Send a message to get started",
   "chat.subagent.conversation": "Conversation",
   "chat.subagent.empty": "(no messages)",

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
@@ -340,6 +340,12 @@ export default {
   "settings.account.inMinutes": "{minutes} 分后",
 
   "chat.noMessagesYet": "尚无消息",
+  "chat.slash.available": "可用命令和技能",
+  "chat.slash.loading": "正在加载命令和技能…",
+  "chat.slash.empty": "没有匹配的命令或技能",
+  "chat.slash.commands": "命令",
+  "chat.slash.skills": "技能",
+  "chat.slash.noDescription": "暂无说明",
   "chat.getStarted": "发送消息开始使用",
   "chat.processing": "KohakUwUing...",
   "chat.bgResultTool": "后台工具结果已送达：{label}",

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-TW.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-TW.js
@@ -340,6 +340,12 @@ export default {
   "settings.account.inMinutes": "{minutes} 分後",
 
   "chat.noMessagesYet": "尚無訊息",
+  "chat.slash.available": "可用命令和技能",
+  "chat.slash.loading": "正在載入命令和技能…",
+  "chat.slash.empty": "沒有符合的命令或技能",
+  "chat.slash.commands": "命令",
+  "chat.slash.skills": "技能",
+  "chat.slash.noDescription": "暫無說明",
   "chat.getStarted": "傳送訊息開始使用",
   "chat.processing": "KohakUwUing...",
   "chat.bgResultTool": "背景工具結果已送達：{label}",

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_command.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_command.py
@@ -1,4 +1,4 @@
-"""Per-creature slash command execution route."""
+"""Per-creature slash command, inventory, and explicit skill routes."""
 
 from fastapi import APIRouter, Depends, HTTPException
 from starlette.requests import HTTPConnection
@@ -6,46 +6,85 @@ from starlette.requests import HTTPConnection
 from kohakuterrarium.api.auth.dependencies import get_auth_config, get_optional_user
 from kohakuterrarium.api.auth.models import User
 from kohakuterrarium.api.deps import get_service
-from kohakuterrarium.api.routes.sessions_v2._helpers import resolve_creature_id
 from kohakuterrarium.api.schemas import SlashCommand
+from kohakuterrarium.terrarium.command_inventory import InvocationResolutionError
 from kohakuterrarium.terrarium.service import TerrariumService
+
+from ._helpers import resolve_creature_id
 
 router = APIRouter()
 
 
-def _command_principal(
-    conn_info: HTTPConnection, user: User | None
+def _command_authority(
+    connection: HTTPConnection,
+    user: User | None,
 ) -> tuple[str, bool]:
-    """Derive the slash-command principal and operator flag.
-
-    The single-tenant console is trusted, anonymous multi-user callers remain
-    unprivileged, and only authenticated administrators receive operator authority.
-    """
-    cfg = get_auth_config(conn_info)
-    if user is None:
-        if cfg.multi_user_enabled:
-            return "user:anonymous", False
+    """Derive command authority from authenticated request context."""
+    config = get_auth_config(connection)
+    if not config.multi_user_enabled:
         return "user:local", True
-    is_admin = user.role == "admin"
-    return f"user:{user.id}", is_admin
+    if user is None:
+        return "user:anonymous", False
+    return f"user:{user.id}", user.role == "admin"
+
+
+@router.get("/{session_id}/creatures/{creature_id}/command-inventory")
+async def get_creature_command_inventory(
+    session_id: str,
+    creature_id: str,
+    service: TerrariumService = Depends(get_service),
+) -> dict:
+    """Return live commands and skills for one creature."""
+    resolved = await resolve_creature_id(service, creature_id, session_id)
+    try:
+        return await service.command_inventory(resolved)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Creature not found") from exc
+
+
+@router.post("/{session_id}/creatures/{creature_id}/skill-input")
+async def invoke_creature_skill(
+    session_id: str,
+    creature_id: str,
+    body: SlashCommand,
+    service: TerrariumService = Depends(get_service),
+) -> dict:
+    """Validate and inject a user-selected skill into the creature turn queue."""
+    resolved = await resolve_creature_id(service, creature_id, session_id)
+    try:
+        return await service.invoke_skill(
+            resolved,
+            body.command,
+            body.args,
+            source="web:skill",
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Creature not found") from exc
+    except (InvocationResolutionError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/{session_id}/creatures/{creature_id}/command")
 async def execute_creature_command(
     session_id: str,
     creature_id: str,
-    req: SlashCommand,
-    conn_info: HTTPConnection,
+    body: SlashCommand,
+    connection: HTTPConnection,
     service: TerrariumService = Depends(get_service),
     user: User | None = Depends(get_optional_user),
-):
-    cid = await resolve_creature_id(service, creature_id, session_id)
-    principal, is_operator = _command_principal(conn_info, user)
+) -> dict:
+    """Execute a user command against a creature."""
+    resolved = await resolve_creature_id(service, creature_id, session_id)
+    principal, is_operator = _command_authority(connection, user)
     try:
         return await service.execute_command(
-            cid, req.command, req.args, principal=principal, is_operator=is_operator
+            resolved,
+            body.command,
+            body.args,
+            principal=principal,
+            is_operator=is_operator,
         )
-    except KeyError:
-        raise HTTPException(404, f"creature {creature_id!r} not found")
-    except ValueError as e:
-        raise HTTPException(400, str(e))
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Creature not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
@@ -16,11 +16,13 @@ from kohakuterrarium.llm.backends import set_remote_backend
 from kohakuterrarium.llm.preset_store import preset_from_data, set_remote_preset
 from kohakuterrarium.llm.profile_types import LLMBackend
 from kohakuterrarium.terrarium.creature_ops import (
+    agent_command_inventory,
     agent_env,
     agent_execute_command,
     agent_get_module_options,
     agent_get_native_tool_options,
     agent_list_modules,
+    agent_invoke_skill,
     agent_list_plugins,
     agent_native_tool_inventory,
     agent_patch_scratchpad,
@@ -684,6 +686,41 @@ class TerrariumRuntimeAdapter:
                     creature.agent,
                     msg.body["module_type"],
                     msg.body["module_name"],
+                )
+
+            case "command_inventory":
+                if msg.sender_node != HOST_NODE_ID:
+                    return {
+                        "error": {
+                            "kind": "forbidden",
+                            "message": (
+                                "command_inventory refused from non-host origin "
+                                f"{msg.sender_node!r}"
+                            ),
+                        }
+                    }
+                cid = msg.body["creature_id"]
+                creature = self._require_hosted(cid)
+                return agent_command_inventory(creature.agent)
+
+            case "invoke_skill":
+                if msg.sender_node != HOST_NODE_ID:
+                    return {
+                        "error": {
+                            "kind": "forbidden",
+                            "message": (
+                                "invoke_skill refused from non-host origin "
+                                f"{msg.sender_node!r}"
+                            ),
+                        }
+                    }
+                cid = msg.body["creature_id"]
+                creature = self._require_hosted(cid)
+                return await agent_invoke_skill(
+                    creature.agent,
+                    msg.body["skill"],
+                    msg.body.get("args"),
+                    source=msg.body.get("source", "web:skill"),
                 )
 
             case "execute_command":

--- a/src/kohakuterrarium/terrarium/command_inventory.py
+++ b/src/kohakuterrarium/terrarium/command_inventory.py
@@ -133,19 +133,50 @@ def build_command_inventory(agent: Any) -> RuntimeCommandInventory:
 
 def resolve_explicit_invocation(agent: Any, name: str) -> ExplicitInvocation:
     """Resolve a user-selected slash target, with commands and aliases first."""
-    normalized = name.strip().lower().lstrip("/")
+    requested = name.strip().lstrip("/")
+    normalized = requested.casefold()
     commands = agent.list_user_commands()
-    command = commands.get(normalized)
-    if command is not None:
-        return ExplicitInvocation("command", normalized, normalized, command)
+    for canonical_name in (requested, normalized):
+        command = commands.get(canonical_name)
+        if command is not None:
+            return ExplicitInvocation("command", canonical_name, normalized, command)
+
+    command_matches = [
+        (canonical_name, candidate)
+        for canonical_name, candidate in commands.items()
+        if canonical_name.casefold() == normalized
+    ]
+    if len(command_matches) == 1:
+        canonical_name, command = command_matches[0]
+        return ExplicitInvocation("command", canonical_name, normalized, command)
+    if len(command_matches) > 1:
+        raise UnknownInvocationError(
+            normalized,
+            f"Ambiguous command name: /{normalized}",
+        )
 
     for canonical_name, candidate in commands.items():
-        aliases = {str(alias).lower() for alias in getattr(candidate, "aliases", ())}
+        aliases = {str(alias).casefold() for alias in getattr(candidate, "aliases", ())}
         if normalized in aliases:
             return ExplicitInvocation("command", canonical_name, normalized, candidate)
 
     registry = getattr(agent, "skills", None)
-    skill = registry.get(normalized) if registry is not None else None
+    skill = registry.get(requested) if registry is not None else None
+    if skill is None and registry is not None:
+        skill = registry.get(normalized)
+    if skill is None and registry is not None:
+        matches = [
+            candidate
+            for candidate in registry.all()
+            if candidate.name.casefold() == normalized
+        ]
+        if len(matches) == 1:
+            skill = matches[0]
+        elif len(matches) > 1:
+            raise UnknownInvocationError(
+                normalized,
+                f"Ambiguous skill name: /{normalized}",
+            )
     if skill is None:
         raise UnknownInvocationError(
             normalized,

--- a/src/kohakuterrarium/terrarium/command_inventory.py
+++ b/src/kohakuterrarium/terrarium/command_inventory.py
@@ -1,0 +1,160 @@
+"""Runtime command/skill inventory and explicit invocation resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class RuntimeCommand:
+    """Serializable user command metadata for interactive clients."""
+
+    name: str
+    aliases: tuple[str, ...]
+    description: str
+    source: str
+    origin: str | None
+    type: Literal["command"] = "command"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "aliases": list(self.aliases),
+            "description": self.description,
+            "source": self.source,
+            "origin": self.origin,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeSkill:
+    """Serializable skill metadata for interactive clients."""
+
+    name: str
+    description: str
+    source: str
+    enabled: bool
+    invocation_blocked: bool
+    type: Literal["skill"] = "skill"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "source": self.source,
+            "enabled": self.enabled,
+            "invocation_blocked": self.invocation_blocked,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeCommandInventory:
+    """Point-in-time command and skill inventory for one live creature."""
+
+    commands: tuple[RuntimeCommand, ...]
+    skills: tuple[RuntimeSkill, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "commands": [entry.to_dict() for entry in self.commands],
+            "skills": [entry.to_dict() for entry in self.skills],
+        }
+
+
+@dataclass(frozen=True)
+class ExplicitInvocation:
+    """Resolved explicit slash invocation."""
+
+    kind: Literal["command", "skill"]
+    name: str
+    requested_name: str
+    value: Any
+
+
+class InvocationResolutionError(ValueError):
+    """Base error for explicit command/skill resolution."""
+
+    def __init__(self, name: str, message: str) -> None:
+        self.name = name
+        super().__init__(message)
+
+
+class DisabledSkillError(InvocationResolutionError):
+    """Raised when a user explicitly requests a disabled skill."""
+
+
+class UnknownInvocationError(InvocationResolutionError):
+    """Raised when no command, alias, or skill matches the requested name."""
+
+
+def _command_source(provenance: Any) -> str:
+    if provenance is None:
+        return "runtime"
+    source = getattr(provenance, "source", "runtime")
+    value = getattr(source, "value", source)
+    return str(value or "runtime")
+
+
+def _command_origin(provenance: Any) -> str | None:
+    origin = getattr(provenance, "origin", None)
+    return str(origin) if origin is not None else None
+
+
+def build_command_inventory(agent: Any) -> RuntimeCommandInventory:
+    """Build the live command/skill inventory exposed to interactive clients."""
+    commands = agent.list_user_commands()
+    provenance = getattr(agent, "_user_command_provenance", {}) or {}
+    command_entries = tuple(
+        RuntimeCommand(
+            name=name,
+            aliases=tuple(getattr(command, "aliases", ()) or ()),
+            description=str(getattr(command, "description", "") or ""),
+            source=_command_source(provenance.get(name)),
+            origin=_command_origin(provenance.get(name)),
+        )
+        for name, command in sorted(commands.items())
+    )
+
+    registry = getattr(agent, "skills", None)
+    skills = registry.all() if registry is not None else []
+    skill_entries = tuple(
+        RuntimeSkill(
+            name=skill.name,
+            description=skill.description,
+            source=skill.origin or "runtime",
+            enabled=bool(skill.enabled),
+            invocation_blocked=bool(skill.invocation_blocked),
+        )
+        for skill in sorted(skills, key=lambda item: item.name)
+    )
+    return RuntimeCommandInventory(commands=command_entries, skills=skill_entries)
+
+
+def resolve_explicit_invocation(agent: Any, name: str) -> ExplicitInvocation:
+    """Resolve a user-selected slash target, with commands and aliases first."""
+    normalized = name.strip().lower().lstrip("/")
+    commands = agent.list_user_commands()
+    command = commands.get(normalized)
+    if command is not None:
+        return ExplicitInvocation("command", normalized, normalized, command)
+
+    for canonical_name, candidate in commands.items():
+        aliases = {str(alias).lower() for alias in getattr(candidate, "aliases", ())}
+        if normalized in aliases:
+            return ExplicitInvocation("command", canonical_name, normalized, candidate)
+
+    registry = getattr(agent, "skills", None)
+    skill = registry.get(normalized) if registry is not None else None
+    if skill is None:
+        raise UnknownInvocationError(
+            normalized,
+            f"Unknown command or skill: /{normalized}",
+        )
+    if not skill.enabled:
+        raise DisabledSkillError(
+            normalized,
+            f"Skill is disabled: /{normalized}",
+        )
+
+    return ExplicitInvocation("skill", skill.name, normalized, skill)

--- a/src/kohakuterrarium/terrarium/creature_ops.py
+++ b/src/kohakuterrarium/terrarium/creature_ops.py
@@ -23,11 +23,16 @@ from typing import Any
 
 from kohakuterrarium.builtins.user_commands import get_builtin_user_command
 from kohakuterrarium.core.scratchpad import is_reserved_scratchpad_key
-from kohakuterrarium.session.history import project_branch_metadata
 from kohakuterrarium.modules.user_command.base import UserCommandContext
+from kohakuterrarium.session.history import project_branch_metadata
+from kohakuterrarium.skills.user_slash import build_user_skill_turn
 import kohakuterrarium.terrarium.channels as _terrarium_channels
 import kohakuterrarium.terrarium.topology as _terrarium_topology
 import kohakuterrarium.terrarium.topology_snapshot as _terrarium_topology_snap
+from kohakuterrarium.terrarium.command_inventory import (
+    build_command_inventory,
+    resolve_explicit_invocation,
+)
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium.events import EngineEvent, EventKind
 from kohakuterrarium.terrarium.topology import GraphTopology
@@ -492,6 +497,34 @@ def wire_creature_on_engine(
     )
     # Resume needs the post-mutation snapshot to replay this wire.
     _terrarium_topology_snap.snapshot(engine, graph_id)
+
+
+def agent_command_inventory(agent: Any) -> dict[str, Any]:
+    """Return the live command and skill inventory for one agent."""
+    return build_command_inventory(agent).to_dict()
+
+
+async def agent_invoke_skill(
+    agent: Any,
+    name: str,
+    args: str | dict[str, Any] | None = None,
+    *,
+    source: str = "web:skill",
+) -> dict[str, Any]:
+    """Validate and inject one explicit user skill invocation."""
+    invocation = resolve_explicit_invocation(agent, name)
+    if invocation.kind != "skill":
+        raise ValueError(f"/{name} resolves to a command, not a skill")
+    arguments = normalize_command_args(args)
+    await agent.inject_input(
+        build_user_skill_turn(invocation.value, arguments),
+        source=source,
+    )
+    return {
+        "skill": invocation.name,
+        "accepted": True,
+        "source": source,
+    }
 
 
 async def agent_execute_command(

--- a/src/kohakuterrarium/terrarium/multi_node_service.py
+++ b/src/kohakuterrarium/terrarium/multi_node_service.py
@@ -606,6 +606,30 @@ class MultiNodeTerrariumService(
             creature_id, lambda svc: svc.rewind(creature_id, msg_idx)
         )
 
+    async def command_inventory(self, creature_id: str) -> dict[str, Any]:
+        return await self._route_per_creature(
+            creature_id,
+            lambda svc: svc.command_inventory(creature_id),
+        )
+
+    async def invoke_skill(
+        self,
+        creature_id: str,
+        skill: str,
+        args: str | dict[str, Any] | None = None,
+        *,
+        source: str = "web:skill",
+    ) -> dict[str, Any]:
+        return await self._route_per_creature(
+            creature_id,
+            lambda svc: svc.invoke_skill(
+                creature_id,
+                skill,
+                args,
+                source=source,
+            ),
+        )
+
     async def execute_command(
         self,
         creature_id: str,

--- a/src/kohakuterrarium/terrarium/remote_service.py
+++ b/src/kohakuterrarium/terrarium/remote_service.py
@@ -589,6 +589,36 @@ class RemoteTerrariumService(RemoteDriveServiceMixin, DriveServiceUnsupportedMix
         )
         return body
 
+    async def command_inventory(self, creature_id: str) -> dict[str, Any]:
+        body = _maybe_raise(
+            await self._req(
+                "command_inventory",
+                {"creature_id": creature_id},
+            )
+        )
+        return body
+
+    async def invoke_skill(
+        self,
+        creature_id: str,
+        skill: str,
+        args: str | dict[str, Any] | None = None,
+        *,
+        source: str = "web:skill",
+    ) -> dict[str, Any]:
+        body = _maybe_raise(
+            await self._req(
+                "invoke_skill",
+                {
+                    "creature_id": creature_id,
+                    "skill": skill,
+                    "args": args,
+                    "source": source,
+                },
+            )
+        )
+        return body
+
     async def execute_command(
         self,
         creature_id: str,

--- a/src/kohakuterrarium/terrarium/service.py
+++ b/src/kohakuterrarium/terrarium/service.py
@@ -43,11 +43,13 @@ from kohakuterrarium.terrarium.service_dto import (
     creature_to_info,
 )
 from kohakuterrarium.terrarium.creature_ops import (
+    agent_command_inventory as _agent_command_inventory,
     agent_env as _agent_env,
     agent_execute_command as _agent_execute_command,
     agent_get_module_options as _agent_get_module_options,
     agent_get_native_tool_options as _agent_get_native_tool_options,
     agent_list_modules as _agent_list_modules,
+    agent_invoke_skill as _agent_invoke_skill,
     agent_list_plugins as _agent_list_plugins,
     agent_native_tool_inventory as _agent_native_tool_inventory,
     agent_patch_scratchpad as _agent_patch_scratchpad,
@@ -396,11 +398,22 @@ class TerrariumService(DriveServiceProtocol, Protocol):
         module_name: str,
     ) -> dict[str, Any]: ...
 
+    async def command_inventory(self, creature_id: str) -> dict[str, Any]: ...
+
+    async def invoke_skill(
+        self,
+        creature_id: str,
+        skill: str,
+        args: str | dict[str, Any] | None = None,
+        *,
+        source: str = "web:skill",
+    ) -> dict[str, Any]: ...
+
     async def execute_command(
         self,
         creature_id: str,
         command: str,
-        args: dict[str, Any] | None = None,
+        args: str | dict[str, Any] | None = None,
         *,
         principal: str = "user:local",
         is_operator: bool = False,
@@ -855,6 +868,24 @@ class LocalTerrariumService(DriveServiceMixin):
     ) -> dict[str, Any]:
         return await _agent_toggle_module(
             self._agent(creature_id), module_type, module_name
+        )
+
+    async def command_inventory(self, creature_id: str) -> dict[str, Any]:
+        return _agent_command_inventory(self._agent(creature_id))
+
+    async def invoke_skill(
+        self,
+        creature_id: str,
+        skill: str,
+        args: str | dict[str, Any] | None = None,
+        *,
+        source: str = "web:skill",
+    ) -> dict[str, Any]:
+        return await _agent_invoke_skill(
+            self._agent(creature_id),
+            skill,
+            args,
+            source=source,
         )
 
     async def execute_command(

--- a/tests/unit/api/routes/sessions_v2/test_creatures_command.py
+++ b/tests/unit/api/routes/sessions_v2/test_creatures_command.py
@@ -1,0 +1,78 @@
+"""Tests for per-creature command inventory and skill routes."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from kohakuterrarium.api.routes.sessions_v2 import creatures_command
+from kohakuterrarium.api.schemas import SlashCommand
+from kohakuterrarium.terrarium.command_inventory import DisabledSkillError
+
+
+@pytest.fixture
+def service(monkeypatch):
+    stub = AsyncMock()
+    monkeypatch.setattr(
+        creatures_command,
+        "resolve_creature_id",
+        AsyncMock(return_value="creature-1"),
+    )
+    return stub
+
+
+@pytest.mark.asyncio
+async def test_command_inventory_delegates_to_service(service):
+    service.command_inventory.return_value = {"commands": [], "skills": []}
+
+    result = await creatures_command.get_creature_command_inventory(
+        "session-1",
+        "root",
+        service,
+    )
+
+    assert result == {"commands": [], "skills": []}
+    service.command_inventory.assert_awaited_once_with("creature-1")
+
+
+@pytest.mark.asyncio
+async def test_skill_input_uses_explicit_web_source(service):
+    service.invoke_skill.return_value = {
+        "skill": "review",
+        "accepted": True,
+        "source": "web:skill",
+    }
+
+    result = await creatures_command.invoke_creature_skill(
+        "session-1",
+        "root",
+        SlashCommand(command="review", args="diff"),
+        service,
+    )
+
+    assert result["accepted"] is True
+    service.invoke_skill.assert_awaited_once_with(
+        "creature-1",
+        "review",
+        "diff",
+        source="web:skill",
+    )
+
+
+@pytest.mark.asyncio
+async def test_skill_input_rejects_disabled_skill(service):
+    service.invoke_skill.side_effect = DisabledSkillError(
+        "review",
+        "Skill is disabled: /review",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await creatures_command.invoke_creature_skill(
+            "session-1",
+            "root",
+            SlashCommand(command="review", args=""),
+            service,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Skill is disabled: /review"

--- a/tests/unit/terrarium/test_command_inventory.py
+++ b/tests/unit/terrarium/test_command_inventory.py
@@ -125,3 +125,24 @@ def test_unknown_name_raises_typed_error():
         resolve_explicit_invocation(_FakeAgent(), "missing")
 
     assert error.value.name == "missing"
+
+
+def test_mixed_case_skill_name_resolves_from_slash_normalization():
+    skill = _FakeSkill("CodeReview")
+    agent = _FakeAgent(skills=_FakeSkillRegistry(skill))
+
+    invocation = resolve_explicit_invocation(agent, "codereview")
+
+    assert invocation.kind == "skill"
+    assert invocation.name == "CodeReview"
+    assert invocation.value is skill
+
+
+def test_exact_skill_case_wins_when_registry_has_casefold_variants():
+    mixed = _FakeSkill("CodeReview")
+    lower = _FakeSkill("codereview")
+    agent = _FakeAgent(skills=_FakeSkillRegistry(mixed, lower))
+
+    invocation = resolve_explicit_invocation(agent, "CodeReview")
+
+    assert invocation.value is mixed

--- a/tests/unit/terrarium/test_command_inventory.py
+++ b/tests/unit/terrarium/test_command_inventory.py
@@ -1,0 +1,127 @@
+"""Tests for the live command and skill inventory boundary."""
+
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from kohakuterrarium.terrarium.command_inventory import (
+    DisabledSkillError,
+    UnknownInvocationError,
+    build_command_inventory,
+    resolve_explicit_invocation,
+)
+
+
+@dataclass
+class _FakeCommand:
+    description: str = "Run the command"
+    aliases: tuple[str, ...] = ()
+
+
+@dataclass
+class _FakeSkill:
+    name: str
+    description: str = "Use the skill"
+    origin: str = "project"
+    enabled: bool = True
+    invocation_blocked: bool = False
+
+
+class _FakeSkillRegistry:
+    def __init__(self, *skills: _FakeSkill) -> None:
+        self._skills = {skill.name: skill for skill in skills}
+
+    def all(self) -> list[_FakeSkill]:
+        return list(self._skills.values())
+
+    def get(self, name: str) -> _FakeSkill | None:
+        return self._skills.get(name)
+
+
+class _FakeAgent:
+    def __init__(
+        self,
+        commands: dict[str, _FakeCommand] | None = None,
+        skills: _FakeSkillRegistry | None = None,
+    ) -> None:
+        self._commands = commands or {}
+        self.skills = skills or _FakeSkillRegistry()
+        self._user_command_provenance = {
+            name: SimpleNamespace(source="plugin", origin="demo")
+            for name in self._commands
+        }
+
+    def list_user_commands(self) -> dict[str, _FakeCommand]:
+        return dict(self._commands)
+
+
+def test_inventory_is_serializable_and_describes_commands_aliases_and_skills():
+    agent = _FakeAgent(
+        commands={"status": _FakeCommand(aliases=("info",))},
+        skills=_FakeSkillRegistry(_FakeSkill("review")),
+    )
+
+    inventory = build_command_inventory(agent).to_dict()
+
+    assert inventory == {
+        "commands": [
+            {
+                "name": "status",
+                "aliases": ["info"],
+                "description": "Run the command",
+                "source": "plugin",
+                "origin": "demo",
+            }
+        ],
+        "skills": [
+            {
+                "name": "review",
+                "description": "Use the skill",
+                "source": "project",
+                "enabled": True,
+                "invocation_blocked": False,
+            }
+        ],
+    }
+    json.dumps(inventory)
+
+
+@pytest.mark.parametrize("requested", ["review", "r"])
+def test_command_name_or_alias_wins_over_same_named_skill(requested):
+    commands = {"review": _FakeCommand(aliases=("r",))}
+    skills = _FakeSkillRegistry(_FakeSkill(requested))
+
+    result = resolve_explicit_invocation(_FakeAgent(commands, skills), requested)
+
+    assert result.kind == "command"
+    assert result.name == "review"
+    assert result.requested_name == requested
+
+
+def test_disabled_skill_cannot_be_explicitly_invoked():
+    agent = _FakeAgent(skills=_FakeSkillRegistry(_FakeSkill("lint", enabled=False)))
+
+    with pytest.raises(DisabledSkillError, match="disabled") as error:
+        resolve_explicit_invocation(agent, "lint")
+
+    assert error.value.name == "lint"
+
+
+def test_invocation_blocked_does_not_block_explicit_user_invocation():
+    skill = _FakeSkill("manual", invocation_blocked=True)
+
+    result = resolve_explicit_invocation(
+        _FakeAgent(skills=_FakeSkillRegistry(skill)), "manual"
+    )
+
+    assert result.kind == "skill"
+    assert result.name == "manual"
+
+
+def test_unknown_name_raises_typed_error():
+    with pytest.raises(UnknownInvocationError, match="/missing") as error:
+        resolve_explicit_invocation(_FakeAgent(), "missing")
+
+    assert error.value.name == "missing"

--- a/tests/unit/terrarium/test_creature_ops.py
+++ b/tests/unit/terrarium/test_creature_ops.py
@@ -7,6 +7,7 @@ Pure-function helpers — exercised against minimal stand-ins for
 import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -473,6 +474,38 @@ class TestModuleCatalog:
 
 
 # ── execute_command ────────────────────────────────────────────
+
+
+class TestCommandInventoryAndSkillInput:
+    @pytest.mark.asyncio
+    async def test_agent_invoke_skill_injects_explicit_web_turn(self):
+        skill = SimpleNamespace(
+            name="review",
+            description="Review changes",
+            body="Inspect carefully",
+            origin="test",
+            enabled=True,
+            invocation_blocked=True,
+        )
+        agent = SimpleNamespace(
+            list_user_commands=lambda: {},
+            skills=SimpleNamespace(
+                get=lambda name: skill if name == "review" else None
+            ),
+            inject_input=AsyncMock(),
+        )
+
+        result = await co.agent_invoke_skill(agent, "review", "diff")
+
+        assert result == {
+            "skill": "review",
+            "accepted": True,
+            "source": "web:skill",
+        }
+        content = agent.inject_input.await_args.args[0]
+        assert "Inspect carefully" in content
+        assert "diff" in content
+        agent.inject_input.assert_awaited_once_with(content, source="web:skill")
 
 
 class TestExecuteCommand:

--- a/tests/unit/terrarium/test_multi_node_service.py
+++ b/tests/unit/terrarium/test_multi_node_service.py
@@ -118,6 +118,14 @@ class _FakeService:
     async def inject_input(self, cid, msg, *, source="chat"):
         self.calls.append(("inject_input", cid, msg, source))
 
+    async def command_inventory(self, cid):
+        self.calls.append(("command_inventory", cid))
+        return {"commands": [], "skills": []}
+
+    async def invoke_skill(self, cid, skill, args=None, *, source="web:skill"):
+        self.calls.append(("invoke_skill", cid, skill, args, source))
+        return {"accepted": True}
+
     async def shutdown(self):
         self.calls.append(("shutdown",))
 
@@ -392,6 +400,24 @@ class TestPerCreatureReads:
     async def test_creature_status_missing_returns_none(self):
         svc = _make_service()
         assert await svc.creature_status("ghost") is None
+
+    async def test_command_inventory_and_skill_route_to_home_worker(self):
+        svc = _make_service(remote_specs={"w1": [_info("c1")]})
+        await svc.list_creatures()
+
+        inventory = await svc.command_inventory("c1")
+        result = await svc.invoke_skill("c1", "review", "diff")
+
+        assert inventory == {"commands": [], "skills": []}
+        assert result == {"accepted": True}
+        assert ("command_inventory", "c1") in svc._remotes["w1"].calls
+        assert (
+            "invoke_skill",
+            "c1",
+            "review",
+            "diff",
+            "web:skill",
+        ) in svc._remotes["w1"].calls
 
 
 # ── lifecycle ──────────────────────────────────────────────────

--- a/tests/unit/terrarium/test_remote_service.py
+++ b/tests/unit/terrarium/test_remote_service.py
@@ -526,6 +526,20 @@ class TestModulesAndCommands:
         out = await svc.toggle_module("cid", "plugin", "n")
         assert out == {"toggled": True}
 
+    async def test_command_inventory_and_skill_input(self):
+        svc = _make_service(
+            {
+                "command_inventory": {"commands": [], "skills": []},
+                "invoke_skill": {"accepted": True},
+            }
+        )
+
+        inventory = await svc.command_inventory("cid")
+        skill = await svc.invoke_skill("cid", "review", "diff")
+
+        assert inventory == {"commands": [], "skills": []}
+        assert skill == {"accepted": True}
+
     async def test_execute_command(self):
         svc = _make_service({"execute_command": {"ok": True}})
         out = await svc.execute_command("cid", "status")


### PR DESCRIPTION
## Summary

Add live slash completion for Web Chat commands, aliases, and explicitly invokable skills. The same inventory and dispatch contract now works across Local, Remote, Multi-node, and Laboratory runtimes, with command precedence, disabled-skill rejection, stale generation/session/graph/tab/group protection, and non-interrupting Escape dismissal.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Web Chat previously treated every leading slash expression as a command and did not expose the selected creature's live skills. Users could not discover or explicitly invoke skills from the composer, and remote or multi-node services did not have a consistent inventory/skill-input contract.

## Changes

- Add a live command/alias/skill inventory with command and canonical-alias priority over colliding skill names.
- Reject disabled skills authoritatively while keeping `invocation_blocked` limited to automatic model invocation.
- Dispatch explicit skill input through the normal turn queue with source `web:skill`.
- Forward the same inventory and skill-input behavior through Local, Remote, Multi-node, and Laboratory services.
- Add grouped filtering, keyboard and mouse selection, and ARIA combobox/listbox behavior to Web Chat.
- Serialize inventory refreshes, deduplicate in-flight requests, and abort stale sends after asynchronous inventory or attachment work when the instance generation, session, graph, active tab, group focus, draft, or attachments change.
- Make Escape dismiss the slash menu without also interrupting an active turn; input, tab, or focus changes can reopen completion.
- Clear only the slash target owned by the abandoned send so a newer session's target is preserved.
- Add English, Simplified Chinese, and Traditional Chinese documentation and regression coverage.

## Validation

```powershell
$env:PYTHONPATH='Z:\KohakuTerrarium-PRs\pr2-slash-skills\src'
& 'Z:\KohakuTerrarium\.venv\Scripts\python.exe' -m ruff check src/ tests/
& 'Z:\KohakuTerrarium\.venv\Scripts\python.exe' -m black --check src/ tests/
& 'Z:\KohakuTerrarium\.venv\Scripts\python.exe' -m pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
& 'Z:\KohakuTerrarium\.venv\Scripts\python.exe' -m pytest tests/unit/test_file_sizes.py -q
& 'Z:\KohakuTerrarium\.venv\Scripts\python.exe' -m pytest tests/integration/ -q
& 'Z:\KohakuTerrarium\.venv\Scripts\python.exe' -m pytest tests/e2e/ -q

Set-Location src/kohakuterrarium-frontend
npm ci
npm run format:check
npx prettier --check src/components/chat/ChatPanel.test.js src/components/chat/ChatPanel.vue src/components/chat/SlashCommandMenu.test.js src/components/chat/SlashCommandMenu.vue src/components/chat/chat-panel.css src/composables/useSlashCommandCompletion.js src/composables/useSlashCommandCompletion.test.js src/stores/chat.js src/stores/chat.test.js src/utils/api.js src/utils/i18n/locales/en.js src/utils/i18n/locales/zh-CN.js src/utils/i18n/locales/zh-TW.js
npm test -- --run --fileParallelism=false
npm test -- --run --fileParallelism=false src/components/chat/ChatPanel.test.js src/composables/useSlashCommandCompletion.test.js src/stores/chat.test.js src/stores/chat.groups.test.js
npm run lint -- --quiet
npm run build
```

Results:

- Ruff passed; Black reported 1,433 files unchanged.
- File-size guard: 1,620 passed.
- Pre-rebase local full unit suite: 11,544 passed, 9 skipped, and 6 baseline/environment failures explained below.
- Integration: 170 passed, 1 skipped.
- Pre-rebase local E2E: 76 passed and 4 baseline failures explained below.
- Final frontend suite: 82 files / 867 tests passed.
- Focused dispatch/race selection: 4 files / 182 tests passed.
- Frontend lint passed; production build passed with 3,572 modules transformed.
- Every changed frontend file passes the focused Prettier command.
- Browser smoke on signed head `ee7c621e` passed: the grouped command/skill menu appeared, keyboard selection dispatched `/ui-smoke`, and the deterministic reply completed. Final stale-send and Escape guards were validated by the full Vitest suite and production build.
- Post-rebase validation on merged prerequisite `48d51f2c`: 184 affected Python tests and 185 focused frontend tests passed; `git diff --check` passed.
- Fresh fork CI for the rebased head passed all 13 jobs across lint, packaging, frontend, and the complete Linux/macOS/Windows Python matrix.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [ ] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

2026-07-27

## Notes for Reviewers

- Please focus on command/alias collision precedence, disabled versus `invocation_blocked` semantics, Remote/Multi-node/Laboratory error envelopes, stale dispatch after generation/session/graph/tab/group changes, owned-target cleanup, and Escape dismissal without active-turn interruption.
- The branch was rebased without conflicts onto merged prerequisite `48d51f2c`; all 4 `range-diff` entries are unchanged (`=`).
- Signed candidate head: `d3289a584ef3feb8a9878a7b242954e79939ec17` (4 commits, 28 files, +1,793/-318).

## Screenshots / Logs (if applicable)

Local screenshots show the grouped slash menu and a completed deterministic skill dispatch. They will be attached when the PR is opened.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The pre-rebase full-unit run had six baseline/environment failures: four unavailable Hugging Face downloads, the Unix-only `EDITOR=true` assumption, and concurrent writes from the running operator application's `app.log`. The merged prerequisite removes external model downloads from CI; the rebased affected tests pass.
- Four E2E failures reproduce on clean `origin/main`: two stale assertions expect `regenerating` instead of the current synchronous `completed` result, one stale Studio assertion expects no branch metadata, and one Windows multi-node memory-search subprocess times out.
- The final sequential frontend suite completed with all 82 files / 867 tests passing.
- Repository-wide `npm run format:check` reports 422 files on this branch and 430 on clean `origin/main` in this Windows checkout. All 13 changed frontend files pass the focused Prettier command.
- Fresh fork CI for the rebased head passed 13/13 jobs: https://github.com/VVittgenstein/KohakuTerrarium/actions/runs/30352890709