### PR TITLE
fix(frontend): remove stopped creatures from live views

### DIFF
--- a/docs/en/guides/sessions.md
+++ b/docs/en/guides/sessions.md
@@ -124,35 +124,34 @@ This means small config drift is fine (swapping an LLM, changing a prompt). Stru
 
 ## Open conversations in the web UI
 
-The Conversations rail tracks a user's intent to continue a conversation, not
-whether its runtime is currently running. These are separate lifecycle axes:
+The Conversations rail lists only conversations whose runtime is currently
+attached. The persisted conversation lifecycle remains a separate concern:
 
-- **Live and open:** a runtime is attached, and the conversation remains in the rail.
-- **Dormant and open:** no runtime is attached, but the saved conversation remains
-  in the rail after a tab closes, a runtime stops, or the app exits.
-- **Ended:** the user explicitly ended the conversation. It leaves the rail, while
-  its saved history remains available from Sessions.
+- **Live and open:** a runtime is attached, so the conversation appears in the rail.
+- **Dormant and open:** no runtime is attached. The saved conversation remains
+  available from Sessions but is not rendered in the rail.
+- **Ended:** the user explicitly ended the conversation. Its saved history remains
+  available from Sessions.
 
 Closing a Chat or Inspector tab only detaches that view. It never stops or ends
-the conversation. A dormant row resumes lazily when you click it; simply opening
-the app does not resume every saved runtime. Chat and Inspector then target the
-new runtime ID. The existing Sessions history page remains read-only and keeps
-its existing **View** and **Resume** actions; the rail does not add a second
-history-specific Continue action.
+the conversation, so a still-live runtime remains in the rail. After the backend
+reports a stopped or disconnected creature as inactive, the row disappears on
+the next refresh. The Sessions history page remains read-only and keeps its
+existing **View** and **Resume** actions.
 
 Every newly persisted conversation has a stable `conversation_id`. Runtime graph
 IDs may change after restart or resume, and filenames may be moved or renamed,
-but those changes do not create duplicate rail rows. `GET /api/sessions/open`
+but those changes do not create duplicate records. `GET /api/sessions/open`
 merges live runtimes with saved open markers using this identity and lets the
-live row win. Session indexes and lookups are scoped to the authenticated
-session directory, so one user's index cannot supply another user's rows.
+live row win; the rail renders only rows with `is_live: true`. Session indexes
+and lookups are scoped to the authenticated session directory, so one user's
+index cannot supply another user's rows.
 
 The saved lifecycle marker is explicit. Sessions created before this marker was
-introduced are still available in history but are hidden from the Conversations
-rail by default. A normal runtime stop preserves the open marker and records a
-paused/dormant state. Explicit **End** clears the marker and records a terminal
-state. Local, remote, and clustered operations synchronize this marker with the
-saved store before the rail refreshes.
+introduced are still available in history. A normal runtime stop preserves the
+open marker and records a paused/dormant state. Explicit **End** clears the
+marker and records a terminal state. Local, remote, and clustered operations
+synchronize this marker with the saved store before the rail refreshes.
 
 Resume is singleflight per saved conversation: concurrent browser requests share
 one server operation, while cancellation of one waiter does not cancel the

--- a/docs/zh-CN/guides/sessions.md
+++ b/docs/zh-CN/guides/sessions.md
@@ -116,17 +116,17 @@ graph_id = await engine.adopt_session("runs/other.kohakutr")
 
 ## Web UI 中的开放对话
 
-Conversations Rail 表示用户仍打算继续某段对话，而不是表示其 runtime 当前正在运行。两者是独立的生命周期维度：
+Conversations Rail 只显示当前仍附加 runtime 的对话。持久化对话的生命周期仍是独立维度：
 
-- **在线且开放：** runtime 已附加，对话保留在 Rail 中。
-- **休眠且开放：** 当前没有附加 runtime；关闭标签页、停止 runtime 或退出应用后，已保存对话仍保留在 Rail 中。
-- **已结束：** 用户显式结束对话。它会从 Rail 移除，但保存的历史仍可在 Sessions 中查看。
+- **在线且开放：** runtime 已附加，因此对话显示在 Rail 中。
+- **休眠且开放：** 当前没有附加 runtime。保存的对话仍可从 Sessions 访问，但不会渲染在 Rail 中。
+- **已结束：** 用户显式结束对话。保存的历史仍可在 Sessions 中查看。
 
-关闭 Chat 或 Inspector 标签页只会 detach 该视图，不会停止或结束对话。休眠行只在用户点击时惰性恢复；打开应用不会自动恢复所有已保存 runtime。恢复后，Chat 和 Inspector 会使用新的 runtime ID。现有 Sessions 历史页继续保持只读，并沿用原有的 **View** 与 **Resume** 操作；Rail 不会再添加重复的历史 Continue 按钮。
+关闭 Chat 或 Inspector 标签页只会 detach 该视图，不会停止或结束对话，因此仍在线的 runtime 会保留在 Rail 中。后端将已停止或断线的 Creature 报告为非活跃后，对应行会在下一次刷新时消失。Sessions 历史页继续保持只读，并沿用现有的 **View** 与 **Resume** 操作。
 
-每个新持久化的对话都有稳定的 `conversation_id`。runtime graph ID 在重启或恢复后可以变化，文件也可以移动或重命名，但这些变化不会在 Rail 中产生重复行。`GET /api/sessions/open` 使用该 identity 聚合在线 runtime 与带开放 marker 的已保存 session，并让在线行优先。Session index 与查询按已认证用户的 session directory 隔离，因此一个用户的索引不会返回另一个用户的数据。
+每个新持久化的对话都有稳定的 `conversation_id`。runtime graph ID 在重启或恢复后可以变化，文件也可以移动或重命名，但这些变化不会产生重复记录。`GET /api/sessions/open` 使用该 identity 聚合在线 runtime 与带开放 marker 的已保存 session，并让在线行优先；Rail 只渲染 `is_live: true` 的行。Session index 与查询按已认证用户的 session directory 隔离，因此一个用户的索引不会返回另一个用户的数据。
 
-保存的生命周期 marker 是显式的。引入 marker 之前创建的旧 session 仍可在历史中访问，但默认不显示于 Conversations Rail。普通 runtime Stop 保留开放 marker，并记录 paused/dormant 状态；显式 **End** 清除 marker 并记录 terminal 状态。本地、远程与 cluster 操作都会在 Rail 刷新前同步保存文件中的 marker。
+保存的生命周期 marker 是显式的。引入 marker 之前创建的旧 session 仍可在历史中访问。普通 runtime Stop 保留开放 marker，并记录 paused/dormant 状态；显式 **End** 清除 marker 并记录 terminal 状态。本地、远程与 cluster 操作都会在 Rail 刷新前同步保存文件中的 marker。
 
 Resume 按保存对话执行 singleflight：两个浏览器同时请求时只执行一次服务端恢复；取消一个等待者不会取消共享恢复，失败后仍可重试。Cluster resume 采用 all-or-error 语义：任何成员恢复失败或保存的连接无法重建时，服务端会补偿已恢复成员、清理 partial runtime metadata、保留原始保存生命周期，并返回非成功响应，而不是留下 degraded partial cluster。
 

--- a/docs/zh-TW/guides/sessions.md
+++ b/docs/zh-TW/guides/sessions.md
@@ -99,17 +99,17 @@ graph_id = await engine.adopt_session("runs/other.kohakutr")
 
 ## Web UI 中的開放對話
 
-Conversations Rail 表示使用者仍打算繼續某段對話，而不是表示其 runtime 目前正在執行。兩者是獨立的生命週期維度：
+Conversations Rail 只顯示目前仍附加 runtime 的對話。持久化對話的生命週期仍是獨立維度：
 
-- **在線且開放：** runtime 已附加，對話保留在 Rail 中。
-- **休眠且開放：** 目前沒有附加 runtime；關閉分頁、停止 runtime 或離開應用程式後，已儲存對話仍保留在 Rail 中。
-- **已結束：** 使用者明確結束對話。它會從 Rail 移除，但儲存的歷史仍可在 Sessions 中檢視。
+- **在線且開放：** runtime 已附加，因此對話顯示在 Rail 中。
+- **休眠且開放：** 目前沒有附加 runtime。儲存的對話仍可從 Sessions 存取，但不會渲染在 Rail 中。
+- **已結束：** 使用者明確結束對話。儲存的歷史仍可在 Sessions 中檢視。
 
-關閉 Chat 或 Inspector 分頁只會 detach 該檢視，不會停止或結束對話。休眠列只在使用者點擊時惰性恢復；開啟應用程式不會自動恢復所有已儲存 runtime。恢復後，Chat 與 Inspector 會使用新的 runtime ID。現有 Sessions 歷史頁維持唯讀，並沿用原本的 **View** 與 **Resume** 操作；Rail 不會再加入重複的歷史 Continue 按鈕。
+關閉 Chat 或 Inspector 分頁只會 detach 該檢視，不會停止或結束對話，因此仍在線的 runtime 會保留在 Rail 中。後端將已停止或斷線的 Creature 回報為非活躍後，對應列會在下一次重新整理時消失。Sessions 歷史頁維持唯讀，並沿用既有的 **View** 與 **Resume** 操作。
 
-每個新持久化的對話都有穩定的 `conversation_id`。runtime graph ID 在重新啟動或恢復後可以改變，檔案也可以移動或重新命名，但這些變化不會在 Rail 中產生重複列。`GET /api/sessions/open` 使用此 identity 聚合在線 runtime 與帶開放 marker 的已儲存 session，並讓在線列優先。Session index 與查詢依已驗證使用者的 session directory 隔離，因此一位使用者的索引不會回傳另一位使用者的資料。
+每個新持久化的對話都有穩定的 `conversation_id`。runtime graph ID 在重新啟動或恢復後可以改變，檔案也可以移動或重新命名，但這些變化不會產生重複記錄。`GET /api/sessions/open` 使用此 identity 聚合在線 runtime 與帶開放 marker 的已儲存 session，並讓在線列優先；Rail 只渲染 `is_live: true` 的列。Session index 與查詢依已驗證使用者的 session directory 隔離，因此一位使用者的索引不會回傳另一位使用者的資料。
 
-儲存的生命週期 marker 是明確的。引入 marker 之前建立的舊 session 仍可在歷史中存取，但預設不顯示於 Conversations Rail。一般 runtime Stop 會保留開放 marker，並記錄 paused/dormant 狀態；明確 **End** 會清除 marker 並記錄 terminal 狀態。本機、遠端與 cluster 操作都會在 Rail 重新整理前同步儲存檔中的 marker。
+儲存的生命週期 marker 是明確的。引入 marker 之前建立的舊 session 仍可在歷史中存取。一般 runtime Stop 會保留開放 marker，並記錄 paused/dormant 狀態；明確 **End** 會清除 marker 並記錄 terminal 狀態。本機、遠端與 cluster 操作都會在 Rail 重新整理前同步儲存檔中的 marker。
 
 Resume 依儲存對話執行 singleflight：兩個瀏覽器同時要求時只執行一次伺服器端恢復；取消其中一個等待者不會取消共享恢復，失敗後仍可重試。Cluster resume 採 all-or-error 語意：任何成員恢復失敗或儲存的連線無法重建時，伺服器會補償已恢復成員、清理 partial runtime metadata、保留原始儲存生命週期，並回傳非成功回應，而不是留下 degraded partial cluster。
 

--- a/src/kohakuterrarium-frontend/src/components/shell/MacroShell.test.js
+++ b/src/kohakuterrarium-frontend/src/components/shell/MacroShell.test.js
@@ -259,47 +259,4 @@ describe("MacroShell — surface indicators", () => {
     expect(wrapper.findComponent(RailItem).exists()).toBe(false)
     expect(wrapper.text()).not.toContain("Pvpn")
   })
-
-  it.each([
-    { action: "history", button: "C" },
-    { action: "cancel", button: "I" },
-  ])("does not open a null surface when rail resume chooses $action", async ({ button }) => {
-    const router = makeRouter()
-    const conversations = useConversationsStore()
-    const rows = [
-      {
-        id: "saved-one",
-        runtime_id: null,
-        saved_name: "saved-one",
-        is_live: false,
-        config_name: "Pvpn",
-        type: "terrarium",
-        status: "paused",
-      },
-    ]
-    conversations.rows = rows
-    sessionAPI.listOpen.mockResolvedValue(rows)
-    const tabs = useTabsStore()
-    const createSession = vi.spyOn(tabs, "createSession").mockResolvedValue(null)
-
-    const wrapper = mount(MacroShell, {
-      global: { plugins: [router] },
-    })
-    await router.isReady()
-    await flushPromises()
-
-    const surfaceButton = wrapper
-      .findComponent(RailItem)
-      .findAll("button")
-      .find((candidate) => candidate.text() === button)
-    await surfaceButton.trigger("click")
-    await flushPromises()
-
-    expect(createSession).toHaveBeenCalledTimes(1)
-    expect(tabs.tabs.some((tab) => tab.id === "attach:null" || tab.id === "inspect:null")).toBe(
-      false,
-    )
-    expect(tabs.surfaceTabsForTarget("saved-one").chat).toBeUndefined()
-    expect(tabs.surfaceTabsForTarget("saved-one").inspector).toBeUndefined()
-  })
 })

--- a/src/kohakuterrarium-frontend/src/components/shell/MacroShell.test.js
+++ b/src/kohakuterrarium-frontend/src/components/shell/MacroShell.test.js
@@ -99,7 +99,7 @@ describe("MacroShell — render", () => {
     expect(tabs.tabs.some((t) => t.kind === "dashboard")).toBe(true)
   })
 
-  it("renders one RailItem per open conversation", async () => {
+  it("renders only live conversations in the rail", async () => {
     const router = makeRouter()
     const conversations = useConversationsStore()
     const rows = [
@@ -128,9 +128,9 @@ describe("MacroShell — render", () => {
     })
     await router.isReady()
     const items = wrapper.findAllComponents(RailItem)
-    expect(items).toHaveLength(2)
+    expect(items).toHaveLength(1)
     expect(wrapper.text()).toContain("alice")
-    expect(wrapper.text()).toContain("swe-graph")
+    expect(wrapper.text()).not.toContain("swe-graph")
   })
 })
 
@@ -230,7 +230,7 @@ describe("MacroShell — surface indicators", () => {
     expect(tabs.surfaceTabsForTarget("agent-1").inspector).toBeDefined()
   })
 
-  it("resumes a dormant conversation only after its surface is clicked", async () => {
+  it("does not render dormant conversations in the rail", async () => {
     const router = makeRouter()
     const conversations = useConversationsStore()
     const rows = [
@@ -256,17 +256,8 @@ describe("MacroShell — surface indicators", () => {
     await flushPromises()
 
     expect(createSession).not.toHaveBeenCalled()
-
-    const cBtn = wrapper
-      .findComponent(RailItem)
-      .findAll("button")
-      .find((button) => button.text() === "C")
-    await cBtn.trigger("click")
-    await flushPromises()
-
-    expect(createSession).toHaveBeenCalledTimes(1)
-    expect(tabs.surfaceTabsForTarget("runtime-one").chat).toBeDefined()
-    expect(tabs.surfaceTabsForTarget("saved-one").chat).toBeUndefined()
+    expect(wrapper.findComponent(RailItem).exists()).toBe(false)
+    expect(wrapper.text()).not.toContain("Pvpn")
   })
 
   it.each([

--- a/src/kohakuterrarium-frontend/src/components/shell/RailGroupAttached.vue
+++ b/src/kohakuterrarium-frontend/src/components/shell/RailGroupAttached.vue
@@ -2,11 +2,11 @@
   <div>
     <div class="flex items-center justify-between px-3 py-1">
       <span class="kt-text-caption uppercase tracking-wider text-warm-500 font-medium"> {{ t("shell.rail.conversations") }} </span>
-      <span class="kt-text-caption text-warm-400">{{ conversations.rows.length }}</span>
+      <span class="kt-text-caption text-warm-400">{{ conversations.liveRows.length }}</span>
     </div>
     <div class="flex flex-col gap-0.5">
-      <RailItem v-for="conversation in conversations.rows" :key="conversation.id" :instance="conversation" />
-      <div v-if="conversations.rows.length === 0" class="px-3 py-2 text-[11px] text-warm-400 italic">{{ t("shell.rail.conversationsEmpty") }}</div>
+      <RailItem v-for="conversation in conversations.liveRows" :key="conversation.id" :instance="conversation" />
+      <div v-if="conversations.liveRows.length === 0" class="px-3 py-2 text-[11px] text-warm-400 italic">{{ t("shell.rail.conversationsEmpty") }}</div>
     </div>
   </div>
 </template>

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/ConfirmStopDialog.test.js
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/ConfirmStopDialog.test.js
@@ -2,8 +2,12 @@ import { flushPromises, mount } from "@vue/test-utils"
 import { createPinia, setActivePinia } from "pinia"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+vi.mock("@/stores/runtimeLifecycle", () => ({
+  stopRuntime: vi.fn(),
+}))
+
 import ConfirmStopDialog from "./ConfirmStopDialog.vue"
-import { useInstancesStore } from "@/stores/instances"
+import { stopRuntime } from "@/stores/runtimeLifecycle"
 import { useTabsStore } from "@/stores/tabs"
 
 beforeEach(() => {
@@ -12,9 +16,8 @@ beforeEach(() => {
 
 describe("ConfirmStopDialog", () => {
   it("stops and detaches the selected runtime", async () => {
-    const instances = useInstancesStore()
     const tabs = useTabsStore()
-    const stop = vi.spyOn(instances, "stop").mockResolvedValue()
+    stopRuntime.mockResolvedValue()
     const detach = vi.spyOn(tabs, "detach").mockResolvedValue()
     const wrapper = mount(ConfirmStopDialog, {
       props: {
@@ -29,9 +32,9 @@ describe("ConfirmStopDialog", () => {
     await wrapper.findAll("button").at(-1).trigger("click")
     await flushPromises()
 
-    expect(stop).toHaveBeenCalledWith("runtime-one")
+    expect(stopRuntime).toHaveBeenCalledWith("runtime-one")
     expect(detach).toHaveBeenCalledWith("runtime-one")
-    expect(stop.mock.invocationCallOrder[0]).toBeLessThan(detach.mock.invocationCallOrder[0])
+    expect(stopRuntime.mock.invocationCallOrder[0]).toBeLessThan(detach.mock.invocationCallOrder[0])
     expect(wrapper.emitted("stopped")).toHaveLength(1)
   })
 })

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/ConfirmStopDialog.test.js
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/ConfirmStopDialog.test.js
@@ -1,0 +1,37 @@
+import { flushPromises, mount } from "@vue/test-utils"
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import ConfirmStopDialog from "./ConfirmStopDialog.vue"
+import { useInstancesStore } from "@/stores/instances"
+import { useTabsStore } from "@/stores/tabs"
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe("ConfirmStopDialog", () => {
+  it("stops and detaches the selected runtime", async () => {
+    const instances = useInstancesStore()
+    const tabs = useTabsStore()
+    const stop = vi.spyOn(instances, "stop").mockResolvedValue()
+    const detach = vi.spyOn(tabs, "detach").mockResolvedValue()
+    const wrapper = mount(ConfirmStopDialog, {
+      props: {
+        instance: {
+          id: "runtime-one",
+          config_name: "alice",
+          type: "creature",
+        },
+      },
+    })
+
+    await wrapper.findAll("button").at(-1).trigger("click")
+    await flushPromises()
+
+    expect(stop).toHaveBeenCalledWith("runtime-one")
+    expect(detach).toHaveBeenCalledWith("runtime-one")
+    expect(stop.mock.invocationCallOrder[0]).toBeLessThan(detach.mock.invocationCallOrder[0])
+    expect(wrapper.emitted("stopped")).toHaveLength(1)
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/ConfirmStopDialog.vue
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/ConfirmStopDialog.vue
@@ -21,20 +21,19 @@
 import { ref } from "vue"
 
 import ModalShell from "@/components/common/ModalShell.vue"
-import { useInstancesStore } from "@/stores/instances"
+import { stopRuntime } from "@/stores/runtimeLifecycle"
 import { useTabsStore } from "@/stores/tabs"
 
 const props = defineProps({ instance: { type: Object, required: true } })
 const emit = defineEmits(["close", "stopped"])
 
-const instances = useInstancesStore()
 const tabs = useTabsStore()
 const stopping = ref(false)
 
 async function onStop() {
   stopping.value = true
   try {
-    await instances.stop(props.instance.id)
+    await stopRuntime(props.instance.id)
     // Close any open surface tabs for this target
     await tabs.detach(props.instance.id)
     emit("stopped")

--- a/src/kohakuterrarium-frontend/src/pages/index.vue
+++ b/src/kohakuterrarium-frontend/src/pages/index.vue
@@ -67,6 +67,7 @@ import { ElMessage } from "element-plus"
 import StatusDot from "@/components/common/StatusDot.vue"
 import GraphCounts from "@/components/common/GraphCounts.vue"
 import { useInstancesStore } from "@/stores/instances"
+import { stopRuntime } from "@/stores/runtimeLifecycle"
 import { useI18n } from "@/utils/i18n"
 
 const instances = useInstancesStore()
@@ -115,7 +116,7 @@ async function confirmStop() {
   if (!stopTarget.value) return
   stopping.value = true
   try {
-    await instances.stop(stopTarget.value.id)
+    await stopRuntime(stopTarget.value.id)
     ElMessage({
       message: t("home.stoppedMessage", { name: stopTarget.value.config_name }),
       type: "success",

--- a/src/kohakuterrarium-frontend/src/stores/conversations.js
+++ b/src/kohakuterrarium-frontend/src/stores/conversations.js
@@ -4,11 +4,11 @@ import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
 import { useAuthStore } from "@/stores/auth"
 import { useHostsStore } from "@/stores/hosts"
 import { useInstancesStore } from "@/stores/instances"
+import { getRuntimeScope } from "@/stores/runtimeScope"
 import { useTabsStore } from "@/stores/tabs"
 import { sessionAPI } from "@/utils/api"
 
 const POLL_INTERVAL_MS = 5000
-const SAME_ORIGIN_SCOPE = "_same_origin"
 
 export const useConversationsStore = defineStore("conversations", {
   state: () => ({
@@ -96,7 +96,7 @@ export const useConversationsStore = defineStore("conversations", {
     },
 
     _syncHostScope() {
-      const hostScope = getHostScope()
+      const hostScope = getRuntimeScope()
       if (this._hostScope === null) {
         this._hostScope = hostScope
       } else if (this._hostScope !== hostScope) {
@@ -121,8 +121,10 @@ export const useConversationsStore = defineStore("conversations", {
       if (clearRows) this.rows = []
     },
 
-    markRuntimeStopped(runtimeId) {
-      if (!runtimeId) return
+    markRuntimeStopped(runtimeId, expectedScope = null) {
+      if (!runtimeId) return false
+      const hostScope = this._syncHostScope()
+      if (expectedScope !== null && expectedScope !== hostScope) return false
       // Invalidate any request that started before the successful Stop.
       // Its live snapshot must not resurrect the row after the local
       // liveness transition.
@@ -132,6 +134,7 @@ export const useConversationsStore = defineStore("conversations", {
         if (!matches) return row
         return { ...row, runtime_id: null, is_live: false, status: "paused" }
       })
+      return true
     },
 
     async resume(row) {
@@ -257,21 +260,6 @@ export const useConversationsStore = defineStore("conversations", {
     },
   },
 })
-
-function getHostScope() {
-  const hosts = useHostsStore()
-  const user = hosts.activeUser
-  const auth = useAuthStore()
-  const sameOriginUser = auth.sameOriginUser
-  const userScope =
-    user?.id ||
-    user?.username ||
-    hosts.activeUserToken ||
-    sameOriginUser?.id ||
-    sameOriginUser?.username ||
-    "__anonymous__"
-  return `${hosts.activeHostId || SAME_ORIGIN_SCOPE}:${userScope}`
-}
 
 function mapConversation(data, hostScope) {
   return {

--- a/src/kohakuterrarium-frontend/src/stores/conversations.js
+++ b/src/kohakuterrarium-frontend/src/stores/conversations.js
@@ -19,6 +19,7 @@ export const useConversationsStore = defineStore("conversations", {
     _inflightFetch: null,
     _queuedFetch: null,
     _fetchGeneration: 0,
+    _scopeGeneration: 0,
     _hostScope: null,
     _unsubscribeHosts: null,
     _unsubscribeAuth: null,
@@ -28,6 +29,7 @@ export const useConversationsStore = defineStore("conversations", {
 
   getters: {
     isResuming: (state) => (id) => Boolean(state._resumePromises[`${state._hostScope}:${id}`]),
+    liveRows: (state) => state.rows.filter((row) => row.is_live),
   },
 
   actions: {
@@ -104,14 +106,32 @@ export const useConversationsStore = defineStore("conversations", {
       return hostScope
     },
 
-    _invalidateFetches({ clearRows = false } = {}) {
+    _invalidateListFetches() {
       this._fetchGeneration++
       this._inflightFetch = null
       this._queuedFetch = null
       this.loading = false
+    },
+
+    _invalidateFetches({ clearRows = false } = {}) {
+      this._invalidateListFetches()
+      this._scopeGeneration++
       this._resumePromises = {}
       this._endPromises = {}
       if (clearRows) this.rows = []
+    },
+
+    markRuntimeStopped(runtimeId) {
+      if (!runtimeId) return
+      // Invalidate any request that started before the successful Stop.
+      // Its live snapshot must not resurrect the row after the local
+      // liveness transition.
+      this._invalidateListFetches()
+      this.rows = this.rows.map((row) => {
+        const matches = row.runtime_id === runtimeId || (row.is_live && row.id === runtimeId)
+        if (!matches) return row
+        return { ...row, runtime_id: null, is_live: false, status: "paused" }
+      })
     },
 
     async resume(row) {
@@ -122,7 +142,7 @@ export const useConversationsStore = defineStore("conversations", {
       if (row.is_live && row.runtime_id) return row.runtime_id
       if (!row.saved_name) throw new Error("Conversation has no saved session to resume")
 
-      const generation = this._fetchGeneration
+      const scopeGeneration = this._scopeGeneration
       const key = `${resumeScope}:${row.conversation_id || row.id}`
       if (this._endPromises[key]) throw new Error("Conversation is still ending")
       const existing = this._resumePromises[key]
@@ -138,18 +158,21 @@ export const useConversationsStore = defineStore("conversations", {
           onNode: row.node_id || "_host",
         })
         if (runtimeId === null) return null
+        this._syncHostScope()
+        if (scopeGeneration !== this._scopeGeneration || resumeScope !== this._hostScope) {
+          throw new Error("Conversation host changed while resuming")
+        }
         await Promise.all([instances.fetchAll(), this.fetchAll({ force: true })])
+        this._syncHostScope()
+        if (scopeGeneration !== this._scopeGeneration || resumeScope !== this._hostScope) {
+          throw new Error("Conversation host changed while resuming")
+        }
         return runtimeId
       })()
 
       this._resumePromises[key] = task
       try {
-        const runtimeId = await task
-        this._syncHostScope()
-        if (generation !== this._fetchGeneration || resumeScope !== this._hostScope) {
-          throw new Error("Conversation host changed while resuming")
-        }
-        return runtimeId
+        return await task
       } finally {
         if (this._resumePromises[key] === task) delete this._resumePromises[key]
       }
@@ -160,14 +183,23 @@ export const useConversationsStore = defineStore("conversations", {
       if (row._hostScope && row._hostScope !== endScope) {
         throw new Error("Conversation belongs to a different host")
       }
+      const scopeGeneration = this._scopeGeneration
       const key = `${endScope}:${row.conversation_id || row.id}`
       if (this._resumePromises[key]) throw new Error("Conversation is still resuming")
       if (this._endPromises[key]) return this._endPromises[key]
       let task
       task = (async () => {
         await sessionAPI.endConversation(row.conversation_id || row.id)
+        this._syncHostScope()
+        if (scopeGeneration !== this._scopeGeneration || endScope !== this._hostScope) {
+          throw new Error("Conversation host changed while ending")
+        }
         const instances = useInstancesStore()
         await Promise.all([instances.fetchAll(), this.fetchAll({ force: true })])
+        this._syncHostScope()
+        if (scopeGeneration !== this._scopeGeneration || endScope !== this._hostScope) {
+          throw new Error("Conversation host changed while ending")
+        }
       })().finally(() => {
         if (this._endPromises[key] === task) delete this._endPromises[key]
       })

--- a/src/kohakuterrarium-frontend/src/stores/conversations.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/conversations.test.js
@@ -62,6 +62,84 @@ describe("conversations store", () => {
     expect(createSession).not.toHaveBeenCalled()
   })
 
+  it("removes a stopped or disconnected runtime from the visible rail", async () => {
+    const store = useConversationsStore()
+    sessionAPI.listOpen
+      .mockResolvedValueOnce([
+        {
+          id: "conversation-one",
+          runtime_id: "runtime-one",
+          is_live: true,
+          status: "running",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "conversation-one",
+          runtime_id: null,
+          is_live: false,
+          status: "paused",
+        },
+      ])
+
+    await store.fetchAll()
+    expect(store.liveRows.map((row) => row.id)).toEqual(["conversation-one"])
+
+    await store.fetchAll({ force: true })
+    expect(store.rows.map((row) => row.id)).toEqual(["conversation-one"])
+    expect(store.liveRows).toEqual([])
+  })
+
+  it("keeps a locally stopped runtime hidden from a request started before stop", async () => {
+    const store = useConversationsStore()
+    const deferred = promiseWithResolvers()
+    const live = {
+      id: "conversation-one",
+      runtime_id: "runtime-one",
+      is_live: true,
+      status: "running",
+    }
+    sessionAPI.listOpen.mockReturnValue(deferred.promise)
+    const staleFetch = store.fetchAll()
+
+    store.markRuntimeStopped("runtime-one")
+    expect(store.liveRows).toEqual([])
+
+    deferred.resolve([live])
+    await staleFetch
+    expect(store.liveRows).toEqual([])
+
+    sessionAPI.listOpen.mockResolvedValue([
+      {
+        ...live,
+        runtime_id: null,
+        is_live: false,
+        status: "paused",
+      },
+    ])
+    await store.fetchAll()
+    expect(store.liveRows).toEqual([])
+  })
+
+  it("shows the same runtime id again when a post-stop refresh reports it live", async () => {
+    const store = useConversationsStore()
+    const live = {
+      id: "conversation-one",
+      runtime_id: "runtime-one",
+      is_live: true,
+      status: "running",
+    }
+    sessionAPI.listOpen.mockResolvedValue([live])
+    await store.fetchAll()
+
+    store.markRuntimeStopped("runtime-one")
+    expect(store.liveRows).toEqual([])
+
+    await store.fetchAll()
+
+    expect(store.liveRows).toEqual([expect.objectContaining(live)])
+  })
+
   it("shares one resume while concurrent surface requests target the new runtime id", async () => {
     const store = useConversationsStore()
     const tabs = useTabsStore()
@@ -100,6 +178,73 @@ describe("conversations store", () => {
     expect(tabs.surfaceTabsForTarget("runtime-one").chat).toBeDefined()
     expect(tabs.surfaceTabsForTarget("runtime-one").inspector).toBeDefined()
     expect(tabs.surfaceTabsForTarget("saved-one").chat).toBeUndefined()
+  })
+
+  it("keeps another conversation resume single-flight while a runtime stops", async () => {
+    const store = useConversationsStore()
+    const tabs = useTabsStore()
+    const instances = useInstancesStore()
+    const deferred = promiseWithResolvers()
+    const createSession = vi.spyOn(tabs, "createSession").mockReturnValue(deferred.promise)
+    vi.spyOn(instances, "fetchAll").mockResolvedValue()
+    sessionAPI.listOpen.mockResolvedValue([])
+    const row = {
+      id: "saved-one",
+      runtime_id: null,
+      saved_name: "saved-one",
+      status: "paused",
+      is_live: false,
+      node_id: "_host",
+    }
+    store.rows = [
+      {
+        id: "conversation-two",
+        runtime_id: "runtime-two",
+        status: "running",
+        is_live: true,
+      },
+    ]
+
+    const chat = store.openSurface(row, "chat")
+    store.markRuntimeStopped("runtime-two")
+    const inspector = store.openSurface(row, "inspector")
+
+    expect(createSession).toHaveBeenCalledTimes(1)
+    deferred.resolve("runtime-one")
+    await Promise.all([chat, inspector])
+
+    expect(tabs.surfaceTabsForTarget("runtime-one").chat).toBeDefined()
+    expect(tabs.surfaceTabsForTarget("runtime-one").inspector).toBeDefined()
+  })
+
+  it("keeps another conversation end single-flight while a runtime stops", async () => {
+    const store = useConversationsStore()
+    const instances = useInstancesStore()
+    const deferred = promiseWithResolvers()
+    sessionAPI.endConversation.mockReturnValue(deferred.promise)
+    vi.spyOn(instances, "fetchAll").mockResolvedValue()
+    sessionAPI.listOpen.mockResolvedValue([])
+    const row = {
+      id: "saved-one",
+      conversation_id: "saved-one",
+      _hostScope: "_same_origin:__anonymous__",
+    }
+    store.rows = [
+      {
+        id: "conversation-two",
+        runtime_id: "runtime-two",
+        status: "running",
+        is_live: true,
+      },
+    ]
+
+    const first = store.endConversation(row)
+    store.markRuntimeStopped("runtime-two")
+    const second = store.endConversation(row)
+
+    expect(sessionAPI.endConversation).toHaveBeenCalledTimes(1)
+    deferred.resolve({ status: "ended" })
+    await Promise.all([first, second])
   })
 
   it("opens a live row directly without resuming it", async () => {
@@ -296,7 +441,7 @@ describe("conversations store", () => {
     store.stopPolling()
   })
 
-  it("rejects a completed resume after the host scope changes", async () => {
+  it("rejects every waiter for a shared resume after the host scope changes", async () => {
     const store = useConversationsStore()
     const tabs = useTabsStore()
     const hosts = useHostsStore()
@@ -309,12 +454,41 @@ describe("conversations store", () => {
       is_live: false,
     }
 
-    const opening = store.openSurface(row, "chat")
+    const chat = store.openSurface(row, "chat")
+    const inspector = store.openSurface(row, "inspector")
     hosts.activeHostId = "other-host"
     resume.resolve("runtime-old-host")
 
-    await expect(opening).rejects.toThrow("host changed")
+    const results = await Promise.allSettled([chat, inspector])
+    expect(results.map((result) => result.status)).toEqual(["rejected", "rejected"])
+    expect(results.map((result) => result.reason?.message)).toEqual([
+      expect.stringContaining("host changed"),
+      expect.stringContaining("host changed"),
+    ])
     expect(tabs.surfaceTabsForTarget("runtime-old-host").chat).toBeUndefined()
+    expect(tabs.surfaceTabsForTarget("runtime-old-host").inspector).toBeUndefined()
+  })
+
+  it("rejects a completed end after the host scope changes", async () => {
+    const store = useConversationsStore()
+    const hosts = useHostsStore()
+    const instances = useInstancesStore()
+    const end = promiseWithResolvers()
+    sessionAPI.endConversation.mockReturnValueOnce(end.promise)
+    const fetchInstances = vi.spyOn(instances, "fetchAll").mockResolvedValue()
+    const row = {
+      id: "conversation-one",
+      conversation_id: "conversation-one",
+      saved_name: "saved-one",
+      is_live: false,
+    }
+
+    const ending = store.endConversation(row)
+    hosts.activeHostId = "other-host"
+    end.resolve({ status: "ended" })
+
+    await expect(ending).rejects.toThrow("host changed")
+    expect(fetchInstances).not.toHaveBeenCalled()
   })
 
   it("rejects a row from the previous host before issuing an action", async () => {

--- a/src/kohakuterrarium-frontend/src/stores/instances.js
+++ b/src/kohakuterrarium-frontend/src/stores/instances.js
@@ -1,5 +1,5 @@
-import { agentAPI, sessionAPI, terrariumAPI } from "@/utils/api"
 import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
+import { agentAPI, sessionAPI, terrariumAPI } from "@/utils/api"
 
 /**
  * Instances store — frontend's mirror of the engine's live sessions.
@@ -65,14 +65,18 @@ export const useInstancesStore = defineStore("instances", {
       try {
         const data = await sessionAPI.getActive(id)
         const loaded = _mapSession(data)
-        if (seq === this._fetchSeq) {
-          this.current = loaded
-          const idx = this.list.findIndex((item) => item.id === loaded.id)
-          if (idx >= 0) {
-            this.list.splice(idx, 1, loaded)
-          } else {
-            this.list.unshift(loaded)
-          }
+        if (seq !== this._fetchSeq) {
+          return (
+            this.list.find((item) => item.id === loaded.id) ??
+            (this.current?.id === loaded.id ? this.current : null)
+          )
+        }
+        this.current = loaded
+        const idx = this.list.findIndex((item) => item.id === loaded.id)
+        if (idx >= 0) {
+          this.list.splice(idx, 1, loaded)
+        } else {
+          this.list.unshift(loaded)
         }
         return loaded
       } catch (err) {
@@ -111,22 +115,12 @@ export const useInstancesStore = defineStore("instances", {
       return session_id || agent_id
     },
 
-    async stop(id) {
-      try {
-        await sessionAPI.stopActive(id)
-        ++this._fetchSeq
-        this._inflightFetch = null
-        this.loading = false
-        this.list = this.list.filter((i) => i.id !== id)
-        if (this.current?.id === id) this.current = null
-        const { useConversationsStore } = await import("@/stores/conversations")
-        const conversations = useConversationsStore()
-        conversations.markRuntimeStopped(id)
-        void conversations.fetchAll({ force: true })
-      } catch (err) {
-        console.error("Failed to stop instance:", err)
-        throw err
-      }
+    markRuntimeStopped(id) {
+      ++this._fetchSeq
+      this._inflightFetch = null
+      this.loading = false
+      this.list = this.list.filter((i) => i.id !== id)
+      if (this.current?.id === id) this.current = null
     },
 
     startPolling() {

--- a/src/kohakuterrarium-frontend/src/stores/instances.js
+++ b/src/kohakuterrarium-frontend/src/stores/instances.js
@@ -40,7 +40,8 @@ export const useInstancesStore = defineStore("instances", {
       if (this._inflightFetch) return this._inflightFetch
       this.loading = true
       const seq = ++this._fetchSeq
-      this._inflightFetch = (async () => {
+      let task
+      task = (async () => {
         try {
           const sessions = await sessionAPI.listActive()
           if (seq !== this._fetchSeq) return
@@ -48,32 +49,39 @@ export const useInstancesStore = defineStore("instances", {
         } catch (err) {
           console.error("Failed to fetch instances:", err)
         } finally {
-          this.loading = false
-          this._inflightFetch = null
+          if (this._inflightFetch === task) {
+            this.loading = false
+            this._inflightFetch = null
+          }
         }
       })()
-      return this._inflightFetch
+      this._inflightFetch = task
+      return task
     },
 
     async fetchOne(id) {
       this.loading = true
+      const seq = this._fetchSeq
       try {
         const data = await sessionAPI.getActive(id)
         const loaded = _mapSession(data)
-        this.current = loaded
-        const idx = this.list.findIndex((item) => item.id === loaded.id)
-        if (idx >= 0) {
-          this.list.splice(idx, 1, loaded)
-        } else {
-          this.list.unshift(loaded)
+        if (seq === this._fetchSeq) {
+          this.current = loaded
+          const idx = this.list.findIndex((item) => item.id === loaded.id)
+          if (idx >= 0) {
+            this.list.splice(idx, 1, loaded)
+          } else {
+            this.list.unshift(loaded)
+          }
         }
         return loaded
       } catch (err) {
-        if (err?.response?.status === 404) {
+        if (err?.response?.status === 404 && seq === this._fetchSeq) {
           this.list = this.list.filter((i) => i.id !== id)
           if (this.current?.id === id) this.current = null
           return null
         }
+        if (err?.response?.status === 404) return null
         console.error("Failed to fetch instance:", err)
         throw err
       } finally {
@@ -106,8 +114,15 @@ export const useInstancesStore = defineStore("instances", {
     async stop(id) {
       try {
         await sessionAPI.stopActive(id)
+        ++this._fetchSeq
+        this._inflightFetch = null
+        this.loading = false
         this.list = this.list.filter((i) => i.id !== id)
         if (this.current?.id === id) this.current = null
+        const { useConversationsStore } = await import("@/stores/conversations")
+        const conversations = useConversationsStore()
+        conversations.markRuntimeStopped(id)
+        void conversations.fetchAll({ force: true })
       } catch (err) {
         console.error("Failed to stop instance:", err)
         throw err

--- a/src/kohakuterrarium-frontend/src/stores/instances.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/instances.test.js
@@ -5,6 +5,7 @@ vi.mock("@/utils/api", () => {
   return {
     sessionAPI: {
       listActive: vi.fn(),
+      listOpen: vi.fn(),
       getActive: vi.fn(),
       stopActive: vi.fn(),
     },
@@ -18,11 +19,14 @@ vi.mock("@/utils/api", () => {
 })
 
 import { sessionAPI } from "@/utils/api"
+import { useConversationsStore } from "./conversations"
 import { useInstancesStore } from "./instances"
 
 beforeEach(() => {
   setActivePinia(createPinia())
   vi.clearAllMocks()
+  sessionAPI.listOpen.mockResolvedValue([])
+  sessionAPI.stopActive.mockResolvedValue({ status: "stopped" })
 })
 
 describe("instances.fetchAll — SessionListing payload shape", () => {
@@ -66,6 +70,64 @@ describe("instances.fetchAll — SessionListing payload shape", () => {
 })
 
 describe("instances store", () => {
+  it("invalidates a pre-stop list request and hides the stopped conversation immediately", async () => {
+    const store = useInstancesStore()
+    const conversations = useConversationsStore()
+    const deferred = promiseWithResolvers()
+    sessionAPI.listActive.mockReturnValue(deferred.promise)
+    sessionAPI.listOpen.mockReturnValue(new Promise(() => {}))
+    store.list = [{ id: "graph_dead", status: "running" }]
+    store.current = { id: "graph_dead", status: "running" }
+    conversations.rows = [
+      {
+        id: "conversation-one",
+        runtime_id: "graph_dead",
+        is_live: true,
+        status: "running",
+      },
+    ]
+
+    const staleFetch = store.fetchAll()
+    await store.stop("graph_dead")
+
+    expect(store.list).toEqual([])
+    expect(store.current).toBeNull()
+    expect(conversations.liveRows).toEqual([])
+
+    deferred.resolve([
+      {
+        session_id: "graph_dead",
+        name: "stale",
+        creatures: 1,
+      },
+    ])
+    await staleFetch
+
+    expect(store.list).toEqual([])
+    expect(store.current).toBeNull()
+  })
+
+  it("ignores a pre-stop detail response that resolves after stop", async () => {
+    const store = useInstancesStore()
+    const deferred = promiseWithResolvers()
+    sessionAPI.getActive.mockReturnValue(deferred.promise)
+    store.list = [{ id: "graph_dead", status: "running" }]
+    store.current = { id: "graph_dead", status: "running" }
+
+    const staleFetch = store.fetchOne("graph_dead")
+    await store.stop("graph_dead")
+    deferred.resolve({
+      session_id: "graph_dead",
+      name: "stale",
+      creatures: [],
+      channels: [],
+    })
+    await staleFetch
+
+    expect(store.list).toEqual([])
+    expect(store.current).toBeNull()
+  })
+
   it("clears stale current instance on fetchOne 404", async () => {
     const store = useInstancesStore()
     store.list = [{ id: "graph_dead", type: "creature" }]
@@ -151,3 +213,13 @@ describe("instances store", () => {
     expect(result.creatures[0].name).toBe("alice")
   })
 })
+
+function promiseWithResolvers() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/src/kohakuterrarium-frontend/src/stores/instances.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/instances.test.js
@@ -5,9 +5,7 @@ vi.mock("@/utils/api", () => {
   return {
     sessionAPI: {
       listActive: vi.fn(),
-      listOpen: vi.fn(),
       getActive: vi.fn(),
-      stopActive: vi.fn(),
     },
     agentAPI: {
       create: vi.fn(),
@@ -19,14 +17,11 @@ vi.mock("@/utils/api", () => {
 })
 
 import { sessionAPI } from "@/utils/api"
-import { useConversationsStore } from "./conversations"
 import { useInstancesStore } from "./instances"
 
 beforeEach(() => {
   setActivePinia(createPinia())
   vi.clearAllMocks()
-  sessionAPI.listOpen.mockResolvedValue([])
-  sessionAPI.stopActive.mockResolvedValue({ status: "stopped" })
 })
 
 describe("instances.fetchAll — SessionListing payload shape", () => {
@@ -70,29 +65,18 @@ describe("instances.fetchAll — SessionListing payload shape", () => {
 })
 
 describe("instances store", () => {
-  it("invalidates a pre-stop list request and hides the stopped conversation immediately", async () => {
+  it("invalidates a pre-stop list request and removes the stopped runtime immediately", async () => {
     const store = useInstancesStore()
-    const conversations = useConversationsStore()
     const deferred = promiseWithResolvers()
     sessionAPI.listActive.mockReturnValue(deferred.promise)
-    sessionAPI.listOpen.mockReturnValue(new Promise(() => {}))
     store.list = [{ id: "graph_dead", status: "running" }]
     store.current = { id: "graph_dead", status: "running" }
-    conversations.rows = [
-      {
-        id: "conversation-one",
-        runtime_id: "graph_dead",
-        is_live: true,
-        status: "running",
-      },
-    ]
 
     const staleFetch = store.fetchAll()
-    await store.stop("graph_dead")
+    store.markRuntimeStopped("graph_dead")
 
     expect(store.list).toEqual([])
     expect(store.current).toBeNull()
-    expect(conversations.liveRows).toEqual([])
 
     deferred.resolve([
       {
@@ -107,7 +91,7 @@ describe("instances store", () => {
     expect(store.current).toBeNull()
   })
 
-  it("ignores a pre-stop detail response that resolves after stop", async () => {
+  it("does not return a pre-stop detail response after the runtime is removed", async () => {
     const store = useInstancesStore()
     const deferred = promiseWithResolvers()
     sessionAPI.getActive.mockReturnValue(deferred.promise)
@@ -115,15 +99,16 @@ describe("instances store", () => {
     store.current = { id: "graph_dead", status: "running" }
 
     const staleFetch = store.fetchOne("graph_dead")
-    await store.stop("graph_dead")
+    store.markRuntimeStopped("graph_dead")
     deferred.resolve({
       session_id: "graph_dead",
       name: "stale",
       creatures: [],
       channels: [],
     })
-    await staleFetch
+    const result = await staleFetch
 
+    expect(result).toBeNull()
     expect(store.list).toEqual([])
     expect(store.current).toBeNull()
   })

--- a/src/kohakuterrarium-frontend/src/stores/runtimeGraph.js
+++ b/src/kohakuterrarium-frontend/src/stores/runtimeGraph.js
@@ -2,10 +2,7 @@ import { defineStore } from "pinia"
 import { computed, reactive } from "vue"
 
 import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
-import { runtimeGraphAPI, terrariumAPI, wiringAPI } from "@/utils/api"
-import { getHybridPrefSync, setHybridPref } from "@/utils/uiPrefs"
-import { wsUrl } from "@/utils/wsUrl"
-
+import { useInstancesStore } from "@/stores/instances"
 import {
   FREE_STACK,
   GROUP_PADDING_BOTTOM,
@@ -16,6 +13,10 @@ import {
   Z_BANDS,
   normalizeSnapshot,
 } from "@/stores/runtimeGraphModel"
+import { stopRuntime } from "@/stores/runtimeLifecycle"
+import { runtimeGraphAPI, terrariumAPI, wiringAPI } from "@/utils/api"
+import { getHybridPrefSync, setHybridPref } from "@/utils/uiPrefs"
+import { wsUrl } from "@/utils/wsUrl"
 
 export { FREE_STACK, NODE_HEIGHT, NODE_WIDTH, Z_BANDS }
 
@@ -427,16 +428,8 @@ export const useRuntimeGraphStore = defineStore("runtimeGraph", () => {
     }
   }
 
-  // Lazy-imported to avoid a Pinia init cycle (instances store imports
-  // pieces from `runtimeGraphModel`'s neighborhood at module load).
   function _refreshInstancesSoon() {
-    import("@/stores/instances")
-      .then(({ useInstancesStore }) => {
-        useInstancesStore().fetchAll()
-      })
-      .catch(() => {
-        /* instances store unavailable in tests — fine */
-      })
+    void useInstancesStore().fetchAll()
   }
 
   async function connectNodes(source, target) {
@@ -615,8 +608,7 @@ export const useRuntimeGraphStore = defineStore("runtimeGraph", () => {
       // Stopping the session is the engine-level equivalent of
       // dissolving the molecule — it tears down the graph and removes
       // every creature/channel inside it.
-      const { useInstancesStore } = await import("@/stores/instances")
-      await useInstancesStore().stop(groupId)
+      await stopRuntime(groupId)
       pushLog(`stopped session ${groupId}`)
     } catch (err) {
       pushLog(`stop failed · ${err?.message || err}`)

--- a/src/kohakuterrarium-frontend/src/stores/runtimeGraph.js
+++ b/src/kohakuterrarium-frontend/src/stores/runtimeGraph.js
@@ -615,7 +615,8 @@ export const useRuntimeGraphStore = defineStore("runtimeGraph", () => {
       // Stopping the session is the engine-level equivalent of
       // dissolving the molecule — it tears down the graph and removes
       // every creature/channel inside it.
-      await terrariumAPI.stop(groupId)
+      const { useInstancesStore } = await import("@/stores/instances")
+      await useInstancesStore().stop(groupId)
       pushLog(`stopped session ${groupId}`)
     } catch (err) {
       pushLog(`stop failed · ${err?.message || err}`)

--- a/src/kohakuterrarium-frontend/src/stores/runtimeGraph.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/runtimeGraph.test.js
@@ -22,6 +22,10 @@ vi.mock("@/utils/wsUrl", () => ({
 
 vi.mock("@/utils/api", () => ({
   runtimeGraphAPI: { snapshot: vi.fn() },
+  sessionAPI: {
+    listActive: vi.fn(),
+    stopActive: vi.fn(),
+  },
   terrariumAPI: {
     connect: vi.fn(),
     wireCreature: vi.fn(),
@@ -40,6 +44,7 @@ vi.mock("@/utils/api", () => ({
 }))
 
 import { runtimeGraphAPI, terrariumAPI, wiringAPI } from "@/utils/api"
+import { useInstancesStore } from "./instances"
 import { useRuntimeGraphStore } from "./runtimeGraph"
 
 const snapshot = {
@@ -98,6 +103,17 @@ beforeEach(() => {
 })
 
 describe("runtime graph store", () => {
+  it("routes graph dissolution through the shared instance stop action", async () => {
+    const store = useRuntimeGraphStore()
+    const instances = useInstancesStore()
+    const stop = vi.spyOn(instances, "stop").mockResolvedValue()
+
+    await store.dissolveGroup("graph_1")
+
+    expect(stop).toHaveBeenCalledWith("graph_1")
+    expect(terrariumAPI.stop).not.toHaveBeenCalled()
+  })
+
   it("normalizes runtime snapshot into graph editor data", async () => {
     const store = useRuntimeGraphStore()
 

--- a/src/kohakuterrarium-frontend/src/stores/runtimeGraph.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/runtimeGraph.test.js
@@ -20,11 +20,14 @@ vi.mock("@/utils/wsUrl", () => ({
   wsUrl: vi.fn((path) => `ws://test${path}`),
 }))
 
+vi.mock("@/stores/runtimeLifecycle", () => ({
+  stopRuntime: vi.fn(),
+}))
+
 vi.mock("@/utils/api", () => ({
   runtimeGraphAPI: { snapshot: vi.fn() },
   sessionAPI: {
-    listActive: vi.fn(),
-    stopActive: vi.fn(),
+    listActive: vi.fn(() => Promise.resolve([])),
   },
   terrariumAPI: {
     connect: vi.fn(),
@@ -43,8 +46,8 @@ vi.mock("@/utils/api", () => ({
   },
 }))
 
+import { stopRuntime } from "./runtimeLifecycle"
 import { runtimeGraphAPI, terrariumAPI, wiringAPI } from "@/utils/api"
-import { useInstancesStore } from "./instances"
 import { useRuntimeGraphStore } from "./runtimeGraph"
 
 const snapshot = {
@@ -105,12 +108,11 @@ beforeEach(() => {
 describe("runtime graph store", () => {
   it("routes graph dissolution through the shared instance stop action", async () => {
     const store = useRuntimeGraphStore()
-    const instances = useInstancesStore()
-    const stop = vi.spyOn(instances, "stop").mockResolvedValue()
+    stopRuntime.mockResolvedValue()
 
     await store.dissolveGroup("graph_1")
 
-    expect(stop).toHaveBeenCalledWith("graph_1")
+    expect(stopRuntime).toHaveBeenCalledWith("graph_1")
     expect(terrariumAPI.stop).not.toHaveBeenCalled()
   })
 

--- a/src/kohakuterrarium-frontend/src/stores/runtimeLifecycle.js
+++ b/src/kohakuterrarium-frontend/src/stores/runtimeLifecycle.js
@@ -1,0 +1,19 @@
+import { useConversationsStore } from "@/stores/conversations"
+import { useInstancesStore } from "@/stores/instances"
+import { getRuntimeScope } from "@/stores/runtimeScope"
+import { sessionAPI } from "@/utils/api"
+
+export async function stopRuntime(runtimeId) {
+  const scope = getRuntimeScope()
+  await sessionAPI.stopActive(runtimeId)
+  if (scope !== getRuntimeScope()) {
+    throw new Error("Runtime host changed while stopping")
+  }
+
+  const conversations = useConversationsStore()
+  if (!conversations.markRuntimeStopped(runtimeId, scope)) {
+    throw new Error("Runtime host changed while stopping")
+  }
+  useInstancesStore().markRuntimeStopped(runtimeId)
+  void conversations.fetchAll({ force: true })
+}

--- a/src/kohakuterrarium-frontend/src/stores/runtimeLifecycle.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/runtimeLifecycle.test.js
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createPinia, setActivePinia } from "pinia"
+
+vi.mock("@/utils/api", () => ({
+  sessionAPI: {
+    listOpen: vi.fn(),
+    stopActive: vi.fn(),
+  },
+}))
+
+import { useAuthStore } from "./auth"
+import { useConversationsStore } from "./conversations"
+import { useHostsStore } from "./hosts"
+import { useInstancesStore } from "./instances"
+import { stopRuntime } from "./runtimeLifecycle"
+import { sessionAPI } from "@/utils/api"
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  sessionAPI.listOpen.mockResolvedValue([])
+  sessionAPI.stopActive.mockResolvedValue()
+  useAuthStore().sameOriginUser = null
+})
+
+describe("runtime lifecycle", () => {
+  it("removes a stopped runtime from both live stores in the same scope", async () => {
+    const instances = useInstancesStore()
+    const conversations = useConversationsStore()
+    instances.list = [{ id: "runtime-one", status: "running" }]
+    instances.current = instances.list[0]
+    conversations.rows = [
+      {
+        id: "conversation-one",
+        runtime_id: "runtime-one",
+        is_live: true,
+        status: "running",
+      },
+    ]
+
+    await stopRuntime("runtime-one")
+
+    expect(sessionAPI.stopActive).toHaveBeenCalledWith("runtime-one")
+    expect(instances.list).toEqual([])
+    expect(instances.current).toBeNull()
+    expect(conversations.liveRows).toEqual([])
+    expect(sessionAPI.listOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not mutate the new host when the stop response belongs to the old host", async () => {
+    const hosts = useHostsStore()
+    hosts.hosts = [hostRecord("host-a"), hostRecord("host-b")]
+    hosts.activeHostId = "host-a"
+
+    const instances = useInstancesStore()
+    const conversations = useConversationsStore()
+    conversations._syncHostScope()
+    const stop = promiseWithResolvers()
+    sessionAPI.stopActive.mockReturnValue(stop.promise)
+
+    const stopping = stopRuntime("shared-runtime")
+    hosts.activeHostId = "host-b"
+    conversations._syncHostScope()
+    instances.list = [{ id: "shared-runtime", status: "running", host: "host-b" }]
+    instances.current = instances.list[0]
+    conversations.rows = [
+      {
+        id: "conversation-b",
+        runtime_id: "shared-runtime",
+        is_live: true,
+        status: "running",
+      },
+    ]
+    stop.resolve()
+
+    await expect(stopping).rejects.toThrow("host changed")
+    expect(instances.list).toEqual([{ id: "shared-runtime", status: "running", host: "host-b" }])
+    expect(instances.current).toEqual({
+      id: "shared-runtime",
+      status: "running",
+      host: "host-b",
+    })
+    expect(conversations.liveRows.map((row) => row.id)).toEqual(["conversation-b"])
+    expect(sessionAPI.listOpen).not.toHaveBeenCalled()
+  })
+
+  it("does not mutate the new user when the stop response belongs to the old user", async () => {
+    const auth = useAuthStore()
+    auth.sameOriginUser = { id: "user-a" }
+
+    const instances = useInstancesStore()
+    const conversations = useConversationsStore()
+    conversations._syncHostScope()
+    const stop = promiseWithResolvers()
+    sessionAPI.stopActive.mockReturnValue(stop.promise)
+
+    const stopping = stopRuntime("shared-runtime")
+    auth.sameOriginUser = { id: "user-b" }
+    conversations._syncHostScope()
+    instances.list = [{ id: "shared-runtime", status: "running", user: "user-b" }]
+    instances.current = instances.list[0]
+    conversations.rows = [
+      {
+        id: "conversation-b",
+        runtime_id: "shared-runtime",
+        is_live: true,
+        status: "running",
+      },
+    ]
+    stop.resolve()
+
+    await expect(stopping).rejects.toThrow("host changed")
+    expect(instances.list).toEqual([{ id: "shared-runtime", status: "running", user: "user-b" }])
+    expect(instances.current).toEqual({
+      id: "shared-runtime",
+      status: "running",
+      user: "user-b",
+    })
+    expect(conversations.liveRows.map((row) => row.id)).toEqual(["conversation-b"])
+    expect(sessionAPI.listOpen).not.toHaveBeenCalled()
+  })
+})
+
+function hostRecord(id) {
+  return {
+    id,
+    name: id,
+    url: `https://${id}.example`,
+    token: "",
+    adminToken: "",
+    userToken: "",
+    currentUser: null,
+  }
+}
+
+function promiseWithResolvers() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/src/kohakuterrarium-frontend/src/stores/runtimeScope.js
+++ b/src/kohakuterrarium-frontend/src/stores/runtimeScope.js
@@ -1,0 +1,19 @@
+import { useAuthStore } from "@/stores/auth"
+import { useHostsStore } from "@/stores/hosts"
+
+const SAME_ORIGIN_SCOPE = "_same_origin"
+
+export function getRuntimeScope() {
+  const hosts = useHostsStore()
+  const user = hosts.activeUser
+  const auth = useAuthStore()
+  const sameOriginUser = auth.sameOriginUser
+  const userScope =
+    user?.id ||
+    user?.username ||
+    hosts.activeUserToken ||
+    sameOriginUser?.id ||
+    sameOriginUser?.username ||
+    "__anonymous__"
+  return `${hosts.activeHostId || SAME_ORIGIN_SCOPE}:${userScope}`
+}

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -1143,7 +1143,7 @@ export default {
   "shell.rail.attached": "Attached",
   "shell.rail.attachedEmpty": "No running targets",
   "shell.rail.conversations": "Conversations",
-  "shell.rail.conversationsEmpty": "No open conversations",
+  "shell.rail.conversationsEmpty": "No active conversations",
   "shell.rail.openChat": "Open chat",
   "shell.rail.closeChat": "Close chat",
   "shell.rail.openInspector": "Open inspector",

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
@@ -898,7 +898,7 @@ export default {
   "shell.rail.attached": "已附加",
   "shell.rail.attachedEmpty": "没有正在运行的目标",
   "shell.rail.conversations": "对话",
-  "shell.rail.conversationsEmpty": "没有未结束的对话",
+  "shell.rail.conversationsEmpty": "没有活跃对话",
   "shell.rail.openChat": "打开聊天",
   "shell.rail.closeChat": "关闭聊天",
   "shell.rail.openInspector": "打开检查器",

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-TW.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-TW.js
@@ -894,7 +894,7 @@ export default {
   "shell.rail.attached": "已附加",
   "shell.rail.attachedEmpty": "沒有正在執行的目標",
   "shell.rail.conversations": "對話",
-  "shell.rail.conversationsEmpty": "沒有未結束的對話",
+  "shell.rail.conversationsEmpty": "沒有活躍對話",
   "shell.rail.openChat": "開啟聊天",
   "shell.rail.closeChat": "關閉聊天",
   "shell.rail.openInspector": "開啟檢查器",


### PR DESCRIPTION
## Summary

Keep Dashboard and conversation rails limited to live creatures. Prevent stale detail and stop responses from reopening or mutating a newer host/user scope.

This branch was replayed onto the actual #92 squash result. The three #94 patches and final tree are unchanged; only their ancestry and signed commit identities changed.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

A maintainer reported that creatures which had disconnected or stopped in the backend could remain visible in the frontend because the live views were not refreshed consistently. A late detail or stop response could also affect a newer host/user scope.

## Changes

- Remove stopped creatures from live Dashboard and conversation views.
- Reconcile detail fetches against the authoritative live collection.
- Guard stop completion and detail responses by host/user generation.
- Centralize runtime scope and stop transition helpers.
- Add regressions for stale responses, scope changes, and null resume results.
- Update the session guides in English, Simplified Chinese, and Traditional Chinese.

## Validation

Local validation on exact head `fb49b43dbe4f1ea55194f53b4df9ca2e9bc07de5`:

```bash
git range-diff 6907971d..1625e07c origin/main..fb49b43d
git diff --check origin/main..fb49b43d
ruff check src/ tests/
black --check src/ tests/

cd src/kohakuterrarium-frontend
npm ci
npm test -- --maxWorkers=2 --testTimeout=20000 \
  src/components/shell/MacroShell.test.js \
  src/components/shell/tabs/ConfirmStopDialog.test.js \
  src/stores/conversations.test.js \
  src/stores/instances.test.js \
  src/stores/runtimeGraph.test.js \
  src/stores/runtimeLifecycle.test.js
npm test -- --maxWorkers=2 --testTimeout=20000
npm run lint
npm run format:check
npm run build
```

- The three incremental commits are patch-equivalent to the previously reviewed #94 commits (`range-diff`: 3/3 `=`).
- The candidate Git tree is identical to previous #94 head `1625e07c`.
- The candidate is based directly on current `main` at #92 squash commit `bcb6a836`.
- Focused frontend regressions: 48 passed across 6 files.
- Full frontend: 915 passed across 92 files.
- ESLint, Prettier, production build, Ruff, Black, and `git diff --check` passed.
- All three commits are SSH-signed by `VVittgenstein` and verified by GitHub.
- Exact-head upstream CI: https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/30712587570 (13/13 passed on exact head).

## Checklist

- [x] I read `CONTRIBUTING.md`
- [ ] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Maintainer feedback received on 2026-07-29.

## Notes for Reviewers

- #92 is already squash-merged. This PR now contains only its own three frontend commits and 20-file incremental diff.
- Please focus on stale asynchronous responses and host/user scope transitions.
- No `session_index`, backend, or #95 code is included.

## Screenshots / Logs (if applicable)

The previously reviewed behavior is unchanged and remains pinned by the focused and full frontend test suites. This ancestry-only replay did not repeat the manual browser rehearsal.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- This ancestry-only replay changes no Git tree content relative to previous #94 head `1625e07c`; it only makes #94 descend from the actual #92 squash commit.
- The slice changes only frontend and documentation files, so the full Python unit suite was not repeated locally. The exact-head upstream matrix runs unit and integration tests across Linux, Windows, and macOS.
- Fork `main` currently preserves the earlier full squash rehearsal and is intentionally not force-rewritten solely to rerun an equivalent-tree candidate. The previously reviewed #94 patch passed fork CI; the new exact head must pass the full upstream 13-job matrix before review.
- `npm ci` reported the repository's existing dependency audit warnings (4 moderate and 8 high); dependencies are outside this focused bug-fix scope.