### PR TITLE
fix(utils): root-directory workspaces no longer block every path

### DIFF
--- a/src/kohakuterrarium/utils/file_guard.py
+++ b/src/kohakuterrarium/utils/file_guard.py
@@ -148,10 +148,19 @@ class PathBoundaryGuard:
         if self.mode == "off":
             return None
 
-        resolved = str(Path(path).resolve())
+        resolved = Path(path).resolve()
+        cwd = Path(self.cwd)
 
-        # Check if path is under cwd
-        if resolved.startswith(self.cwd + os.sep) or resolved == self.cwd:
+        # Check if path is under cwd. Use relative_to rather than
+        # ``str.startswith(self.cwd + os.sep)``: at a filesystem root
+        # ("E:\\" or "/") the naive prefix becomes "E:\\\\" / "//" and
+        # every child path is misjudged as outside the workspace.
+        # relative_to is also case-insensitive on Windows.
+        try:
+            resolved.relative_to(cwd)
+        except ValueError:
+            pass  # outside cwd
+        else:
             return None  # inside cwd, always OK
 
         if self.mode == "block":
@@ -161,10 +170,10 @@ class PathBoundaryGuard:
             )
 
         # "warn" mode: first attempt is blocked, retry is allowed
-        if resolved in self._warned_paths:
+        if str(resolved) in self._warned_paths:
             return None  # already warned, allow this time
 
-        self._warned_paths.add(resolved)
+        self._warned_paths.add(str(resolved))
         return (
             f"Warning: '{path}' is outside the working directory ({self.cwd}). "
             "If this is intentional, retry the same operation to proceed."

--- a/tests/unit/utils/test_file_guard.py
+++ b/tests/unit/utils/test_file_guard.py
@@ -209,8 +209,12 @@ class TestPathBoundaryGuard:
     def test_sibling_prefix_not_treated_as_child(self, tmp_path):
         # A sibling whose name shares a prefix ("ws2") must not be judged
         # inside "ws" — path containment is component-wise, not textual.
-        guard = PathBoundaryGuard(tmp_path / "ws", mode="warn")
-        sibling = tmp_path / "ws2" / "file.txt"
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        guard = PathBoundaryGuard(ws, mode="warn")
+        sibling_dir = tmp_path / "ws2"
+        sibling_dir.mkdir()
+        sibling = sibling_dir / "file.txt"
         err = guard.check(str(sibling))
         assert err is not None
         assert "Warning" in err

--- a/tests/unit/utils/test_file_guard.py
+++ b/tests/unit/utils/test_file_guard.py
@@ -197,6 +197,24 @@ class TestPathBoundaryGuard:
         # Retry of A allowed, B still warned/allowed independently.
         assert guard.check(str(out_a)) is None
 
+    def test_filesystem_root_cwd_allows_children(self):
+        # Regression: cwd at a filesystem root ("E:\\" or "/") previously
+        # produced a double-separator prefix ("E:\\\\" / "//") so every
+        # child path was misjudged as outside the working directory.
+        root = Path(Path.cwd().anchor)
+        guard = PathBoundaryGuard(root, mode="warn")
+        child = root / "kt-path-guard-regression-child"
+        assert guard.check(str(child)) is None
+
+    def test_sibling_prefix_not_treated_as_child(self, tmp_path):
+        # A sibling whose name shares a prefix ("ws2") must not be judged
+        # inside "ws" — path containment is component-wise, not textual.
+        guard = PathBoundaryGuard(tmp_path / "ws", mode="warn")
+        sibling = tmp_path / "ws2" / "file.txt"
+        err = guard.check(str(sibling))
+        assert err is not None
+        assert "Warning" in err
+
 
 # ── is_binary_file ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes `PathBoundaryGuard.check` so a filesystem-root workspace (`E:\` or `/`) no longer misjudges every child path as outside the working directory.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactoring / performance
- [ ] Feature

## Motivation / Context

`str.startswith(self.cwd + os.sep)` produces a double separator at a filesystem root (`E:\\` or `//`), so no child path matches and every file tool access triggers a spurious warn-and-retry (or a hard block in `block` mode). Reported in #96.

## Changes

- `PathBoundaryGuard.check`: use `Path.relative_to` for containment instead of the string-prefix test. This is root-safe, case-insensitive on Windows, and component-wise (`ws2` is not inside `ws`).
- Tests: regressions for a drive-root cwd and for prefix-sibling paths.

## Validation

- `pytest tests/unit/utils/test_file_guard.py -q` — 30 passed (2 new regression tests)
- `ruff check` / `black --check` clean on changed files
- Live check: `PathBoundaryGuard("E:\")` allows children (`E:\repo\file.py`) and still blocks genuinely outside paths (`D:\outside`)

## Checklist

- [x] I read CONTRIBUTING.md
- [x] I linked the relevant issue(s) below
- [x] The change is limited to a bug fix (no unrelated churn)
- [x] CI on my fork is green — branch pushed to self fork; fork Actions status TBD (see Exceptions)

## Related Issues / Discussions

- Fixes #96

## Notes for Reviewers

No behavior change outside the root-directory case and the fix of the prefix-sibling false positive; warn/block/off modes are untouched.

## Exceptions / Not Run

- Full CI matrix not run locally; fork CI pending.

