### PR TITLE
fix(core): make tool-output truncation/elision recoverable and context-aware

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/output.py
+++ b/src/kohakuterrarium/builtins/cli_rich/output.py
@@ -278,7 +278,12 @@ class RichCLIOutput(BaseOutputModule):
             return
 
         if activity_type == "tool_done":
-            output = metadata.get("output") or metadata.get("result") or ""
+            output = (
+                metadata.get("output_preview")
+                or metadata.get("output")
+                or metadata.get("result")
+                or ""
+            )
             self.app.on_tool_done(job_id=job_id, output=str(output))
             return
 

--- a/src/kohakuterrarium/builtins/tools/read.py
+++ b/src/kohakuterrarium/builtins/tools/read.py
@@ -23,6 +23,8 @@ from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+MAX_DEFAULT_LINES = 2000
+
 
 @register_builtin("read")
 class ReadTool(BaseTool):
@@ -82,7 +84,6 @@ class ReadTool(BaseTool):
         limit = int(args.get("limit", 0))
 
         max_output_bytes = int(self.config.extra.get("max_output_bytes", 200000))
-
         try:
             async with aiofiles.open(
                 file_path, encoding="utf-8", errors="replace"
@@ -97,6 +98,11 @@ class ReadTool(BaseTool):
                 lines = lines[offset:]
             if limit > 0:
                 lines = lines[:limit]
+            elif total_lines > MAX_DEFAULT_LINES:
+                # guard against unbounded full reads: cap the default read
+                # so huge files don't flood the context; the notice below
+                # tells the model how to navigate with offset/limit
+                lines = lines[:MAX_DEFAULT_LINES]
 
             # Format with line numbers
             output_lines = []
@@ -119,6 +125,11 @@ class ReadTool(BaseTool):
             # Add truncation notice if applicable
             if limit > 0 and offset + limit < total_lines:
                 output += f"\n\n... (showing lines {offset + 1}-{offset + len(lines)} of {total_lines})"
+            elif limit == 0 and offset + len(lines) < total_lines:
+                output += (
+                    f"\n\n... (showing lines {offset + 1}-{offset + len(lines)} "
+                    f"of {total_lines}. Use offset/limit to read more.)"
+                )
 
             # Truncate total output if it exceeds max bytes
             if max_output_bytes > 0 and len(output.encode("utf-8")) > max_output_bytes:

--- a/src/kohakuterrarium/builtins/tools/read.py
+++ b/src/kohakuterrarium/builtins/tools/read.py
@@ -83,7 +83,7 @@ class ReadTool(BaseTool):
         offset = int(args.get("offset", 0))
         limit = int(args.get("limit", 0))
 
-        max_output_bytes = int(self.config.extra.get("max_output_bytes", 200000))
+        max_output_bytes = int(self.config.extra.get("max_output_bytes", 256000))
         try:
             async with aiofiles.open(
                 file_path, encoding="utf-8", errors="replace"

--- a/src/kohakuterrarium/builtins/tools/search_memory.py
+++ b/src/kohakuterrarium/builtins/tools/search_memory.py
@@ -15,6 +15,10 @@ from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Display cap per search result: large enough to surface the meaningful body
+# of a recovered tool output while bounding the tool-result context.
+SEARCH_RESULT_DISPLAY_CHARS = 2000
+
 
 @register_builtin("search_memory")
 class SearchMemoryTool(BaseTool):
@@ -79,8 +83,11 @@ class SearchMemoryTool(BaseTool):
             lines.append(header)
             # Bound each result so one event cannot consume the tool-result context.
             content = r.content
-            if len(content) > 500:
-                content = content[:500] + f"... ({len(r.content)} chars total)"
+            if len(content) > SEARCH_RESULT_DISPLAY_CHARS:
+                content = (
+                    content[:SEARCH_RESULT_DISPLAY_CHARS]
+                    + f"... ({len(r.content)} chars total)"
+                )
             lines.append(content)
             lines.append("")
 

--- a/src/kohakuterrarium/builtins/tui/output.py
+++ b/src/kohakuterrarium/builtins/tui/output.py
@@ -409,7 +409,7 @@ class TUIOutput(BaseOutputModule):
     def _handle_tool_done(
         self, name: str, rest: str, job_id: str, t: str, metadata: dict
     ) -> None:
-        output = metadata.get("output", rest)
+        output = metadata.get("output_preview") or metadata.get("output", rest)
         self._tui.update_tool_block(name, output=output, tool_id=job_id, target=t)
         self._tui.update_running(job_id or name, name, remove=True)
 

--- a/src/kohakuterrarium/core/agent_message_history.py
+++ b/src/kohakuterrarium/core/agent_message_history.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from typing import Any
 
+from kohakuterrarium.core.conversation_elide import estimate_tokens, maybe_elide
 from kohakuterrarium.core.message_locator import (
     user_message_indices_for_content,
     user_message_indices_for_turn,
@@ -250,6 +251,18 @@ def reload_conversation_under_branch_view(
             if message.get(key):
                 extra[key] = message[key]
         conversation.append(role, message.get("content", ""), **extra)
+
+    # Rebuilds restore tool outputs elided during live turns; re-apply
+    # elision when the estimated prompt is crowded so reloads stay bounded.
+    controller = agent.controller
+    config = getattr(controller, "config", None)
+    if config is not None and getattr(config, "elide_tool_results", False):
+        maybe_elide(
+            conversation,
+            estimate_tokens(conversation),
+            threshold_ratio=config.elide_threshold_ratio,
+            elide_max_tokens=config.elide_max_tokens,
+        )
 
     if selected:
         max_turn = max(selected)

--- a/src/kohakuterrarium/core/agent_tools.py
+++ b/src/kohakuterrarium/core/agent_tools.py
@@ -506,7 +506,13 @@ class AgentToolsMixin(AgentRuntimeToolsMixin):
             if hasattr(result, "get_text_output")
             else str(output)[:5000]
         )
-        metadata = {"job_id": job_id, "output": preview}
+        metadata = {
+            "job_id": job_id,
+            # Full output for the session event log (recoverable via search_memory);
+            # preview stays for UI rendering.
+            "output": output,
+            "output_preview": preview,
+        }
         if is_subagent:
             metadata["result"] = preview
             metadata["turns"] = getattr(result, "turns", 0)

--- a/src/kohakuterrarium/core/controller.py
+++ b/src/kohakuterrarium/core/controller.py
@@ -77,6 +77,12 @@ class ControllerConfig:
     system_prompt: str = "You are a helpful assistant."
     include_job_status: bool = True
     include_tools_list: bool = True
+    # Elide stale tool results only when the prompt is near the compact
+    # threshold; with ample context the controller keeps full results so it
+    # can reference what it read without re-running tools.
+    elide_tool_results: bool = True
+    elide_threshold_ratio: float = 0.60
+    elide_max_tokens: int = 256_000
     batch_stackable_events: bool = True
     max_messages: int = 50
     ephemeral: bool = False
@@ -708,6 +714,14 @@ class Controller:
             resolved_messages.append(resolved_msg)
         return resolved_messages
 
+    def _should_elide_tool_results(self) -> bool:
+        """True when the last model call already filled most of the window."""
+        prompt_tokens = self._last_usage.get("prompt_tokens", 0)
+        if prompt_tokens <= 0:
+            return False
+        ratio = prompt_tokens / self.config.elide_max_tokens
+        return ratio >= self.config.elide_threshold_ratio
+
     async def run_once(self) -> AsyncIterator[ParseEvent]:
         """
         Run one controller turn.
@@ -744,9 +758,14 @@ class Controller:
             if events and all(e.type == EventType.TOOL_COMPLETE for e in events):
                 msg.metadata["kind"] = TOOL_FEEDBACK_KIND
 
-        # Only the latest round keeps full tool output; older rounds are
-        # stubbed in place so tool results never accumulate in context.
-        elide_stale_tool_results(self.conversation)
+        # Elide stale tool results only when the prompt is close to the
+        # compact threshold (elide_threshold_ratio of elide_max_tokens).
+        # With ample context older tool results stay verbatim so the
+        # controller can reference what it read without re-running tools;
+        # once the window is crowded, stubbing prevents the endless-compact
+        # loop that unconditional retention used to trigger.
+        if self.config.elide_tool_results and self._should_elide_tool_results():
+            elide_stale_tool_results(self.conversation)
 
         messages = self.conversation.to_messages()
         messages = await self._resolve_message_files(messages)

--- a/src/kohakuterrarium/core/controller.py
+++ b/src/kohakuterrarium/core/controller.py
@@ -27,7 +27,7 @@ from kohakuterrarium.core.controller_plugins import (
 from kohakuterrarium.core.conversation import Conversation, ConversationConfig
 from kohakuterrarium.core.conversation_elide import (
     TOOL_FEEDBACK_KIND,
-    elide_stale_tool_results,
+    maybe_elide,
 )
 from kohakuterrarium.core.events import EventType, TriggerEvent
 from kohakuterrarium.core.controller_context import format_events_for_context
@@ -714,14 +714,6 @@ class Controller:
             resolved_messages.append(resolved_msg)
         return resolved_messages
 
-    def _should_elide_tool_results(self) -> bool:
-        """True when the last model call already filled most of the window."""
-        prompt_tokens = self._last_usage.get("prompt_tokens", 0)
-        if prompt_tokens <= 0:
-            return False
-        ratio = prompt_tokens / self.config.elide_max_tokens
-        return ratio >= self.config.elide_threshold_ratio
-
     async def run_once(self) -> AsyncIterator[ParseEvent]:
         """
         Run one controller turn.
@@ -764,8 +756,13 @@ class Controller:
         # controller can reference what it read without re-running tools;
         # once the window is crowded, stubbing prevents the endless-compact
         # loop that unconditional retention used to trigger.
-        if self.config.elide_tool_results and self._should_elide_tool_results():
-            elide_stale_tool_results(self.conversation)
+        if self.config.elide_tool_results:
+            maybe_elide(
+                self.conversation,
+                self._last_usage.get("prompt_tokens", 0),
+                threshold_ratio=self.config.elide_threshold_ratio,
+                elide_max_tokens=self.config.elide_max_tokens,
+            )
 
         messages = self.conversation.to_messages()
         messages = await self._resolve_message_files(messages)

--- a/src/kohakuterrarium/core/conversation_elide.py
+++ b/src/kohakuterrarium/core/conversation_elide.py
@@ -121,7 +121,10 @@ def estimate_tokens(conversation: Any) -> int:
         total_chars += len(text)
         for call in getattr(msg, "tool_calls", None) or []:
             fn = call.get("function") or {}
-            total_chars += len(fn.get("arguments") or "")
+            args = fn.get("arguments") or ""
+            if not isinstance(args, str):
+                args = str(args)
+            total_chars += len(args)
     return max(1, int(total_chars / CHARS_PER_TOKEN))
 
 

--- a/src/kohakuterrarium/core/conversation_elide.py
+++ b/src/kohakuterrarium/core/conversation_elide.py
@@ -105,3 +105,41 @@ def elide_stale_tool_results(conversation: Any) -> int:
         conversation._metadata.total_chars = conversation.get_context_length()
         logger.debug("Stale tool results elided", count=elided)
     return elided
+
+
+# Conservative chars-per-token for prompt-size estimation: slightly low for
+# English/code, which over-estimates tokens and errs toward eliding when a
+# rebuilt conversation is close to the threshold.
+CHARS_PER_TOKEN = 3.5
+
+
+def estimate_tokens(conversation: Any) -> int:
+    """Conservative prompt-token estimate for a rebuilt conversation."""
+    total_chars = 0
+    for msg in conversation.get_messages():
+        text = extract_message_text(msg) or ""
+        total_chars += len(text)
+        for call in getattr(msg, "tool_calls", None) or []:
+            fn = call.get("function") or {}
+            total_chars += len(fn.get("arguments") or "")
+    return max(1, int(total_chars / CHARS_PER_TOKEN))
+
+
+def maybe_elide(
+    conversation: Any,
+    prompt_tokens: int,
+    *,
+    threshold_ratio: float,
+    elide_max_tokens: int,
+) -> int:
+    """Elide stale tool results when the prompt is crowded; else no-op.
+
+    Shared by the per-turn controller check and the resume/branch reload
+    paths so rebuilt conversations get the same bounded-prompt treatment.
+    Returns the number of tool-feedback messages elided.
+    """
+    if prompt_tokens <= 0 or elide_max_tokens <= 0:
+        return 0
+    if prompt_tokens / elide_max_tokens < threshold_ratio:
+        return 0
+    return elide_stale_tool_results(conversation)

--- a/src/kohakuterrarium/core/conversation_elide.py
+++ b/src/kohakuterrarium/core/conversation_elide.py
@@ -2,10 +2,11 @@
 
 Tool results are kept verbatim only for the LATEST feedback round —
 the trailing run of tool-feedback messages. Every earlier round is
-reduced in place to a short head plus a recovery notice, so the
-controller still sees WHAT it called without paying the full context
-cost every turn. Full outputs stay in the session event log, so the
-agent can re-run the tool or use ``search_memory`` to get them back.
+reduced in place to a short head plus a recovery notice that names the
+originating tool call (name + arguments), so the controller sees WHAT
+it called and can re-run exactly that call instead of guessing. Full
+outputs stay in the session event log, so the agent can re-run the tool
+or use ``search_memory`` to get them back.
 """
 
 from typing import Any
@@ -26,6 +27,30 @@ TOOL_FEEDBACK_KIND = "tool_results"
 HEAD_CHARS = 200
 # Below this size a stub saves nothing — leave the message alone.
 MIN_ELIDABLE_CHARS = 320
+MAX_DESC_CHARS = 80
+
+
+def _describe_tool_call(conversation, tool_call_id):
+    """Recover 'name(args…)' for a tool message from the matching assistant call."""
+    if not tool_call_id:
+        return "a tool"
+    for msg in reversed(conversation.get_messages()):
+        calls = getattr(msg, "tool_calls", None)
+        if not calls:
+            continue
+        for call in calls:
+            if call.get("id") != tool_call_id:
+                continue
+            fn = call.get("function") or {}
+            name = fn.get("name") or "tool"
+            args = fn.get("arguments") or ""
+            if isinstance(args, dict):
+                args = str(args)
+            args = " ".join(str(args).split())
+            if len(args) > MAX_DESC_CHARS:
+                args = args[:MAX_DESC_CHARS] + "…"
+            return f"{name}({args})"
+    return "a tool"
 
 
 def _is_tool_feedback(msg: Any) -> bool:
@@ -35,11 +60,11 @@ def _is_tool_feedback(msg: Any) -> bool:
     return isinstance(meta, dict) and meta.get("kind") == TOOL_FEEDBACK_KIND
 
 
-def _stub(text: str) -> str:
+def _stub(text: str, desc: str = "a tool") -> str:
     dropped = len(text) - HEAD_CHARS
     return (
-        f"{text[:HEAD_CHARS]}\n… {ELISION_MARKER} — {dropped} chars dropped. "
-        "Re-run the tool or use search_memory if the full output is needed again]"
+        f"{text[:HEAD_CHARS]}\n… {ELISION_MARKER} — {dropped} chars dropped "
+        f"from {desc}. Re-run the tool or use search_memory if the full output is needed again]"
     )
 
 
@@ -68,7 +93,10 @@ def elide_stale_tool_results(conversation: Any) -> int:
         text = extract_message_text(msg) or ""
         if len(text) < MIN_ELIDABLE_CHARS or ELISION_MARKER in text[: HEAD_CHARS + 80]:
             continue
-        msg.content = _stub(text)
+        msg.content = _stub(
+            text,
+            _describe_tool_call(conversation, getattr(msg, "tool_call_id", None)),
+        )
         if isinstance(meta, dict):
             meta["tool_results_elided"] = True
         elided += 1

--- a/src/kohakuterrarium/core/executor.py
+++ b/src/kohakuterrarium/core/executor.py
@@ -267,7 +267,9 @@ class Executor:
                 job_id=job_id,
                 tool_name=tool.tool_name,
                 artifact_store=artifact_store,
-                saved_to=result_metadata.get("output_path"),
+                # Bash materializes the full output to a temp file and exposes
+                # its path via this metadata key (see builtins.tools.bash).
+                saved_to=result_metadata.get("raw_output_path"),
             )
             metadata = dict(result.metadata or {})
             metadata.update(normalized.metadata)

--- a/src/kohakuterrarium/core/executor.py
+++ b/src/kohakuterrarium/core/executor.py
@@ -271,7 +271,7 @@ class Executor:
                 # its path via this metadata key (see builtins.tools.bash).
                 saved_to=result_metadata.get("raw_output_path"),
             )
-            metadata = dict(result.metadata or {})
+            metadata = dict(result_metadata)
             metadata.update(normalized.metadata)
 
             job_result = JobResult(

--- a/src/kohakuterrarium/core/executor.py
+++ b/src/kohakuterrarium/core/executor.py
@@ -258,12 +258,16 @@ class Executor:
 
             max_output = tool.config.max_output if isinstance(tool, BaseTool) else 0
             artifact_store = getattr(self._agent, "session_store", None)
+            result_metadata = (
+                result.metadata if isinstance(result.metadata, dict) else {}
+            )
             normalized = normalize_tool_output(
                 result.output,
                 max_output=max_output,
                 job_id=job_id,
                 tool_name=tool.tool_name,
                 artifact_store=artifact_store,
+                saved_to=result_metadata.get("output_path"),
             )
             metadata = dict(result.metadata or {})
             metadata.update(normalized.metadata)

--- a/src/kohakuterrarium/core/tool_output.py
+++ b/src/kohakuterrarium/core/tool_output.py
@@ -67,7 +67,8 @@ def truncate_text_utf8(text: str, max_bytes: int) -> tuple[str, dict[str, Any]]:
     omitted = max(0, original_bytes - kept_bytes)
     note = (
         f"\n... [tool output truncated to {max_bytes} bytes; "
-        f"{omitted} bytes omitted]"
+        f"{omitted} bytes omitted. Re-run the tool with a smaller scope "
+        f"(e.g. offset/limit) to read the omitted sections]"
     )
     return (
         prefix + note,

--- a/src/kohakuterrarium/core/tool_output.py
+++ b/src/kohakuterrarium/core/tool_output.py
@@ -51,7 +51,13 @@ class NormalizedToolOutput:
         return self.stats.text
 
 
-def truncate_text_utf8(text: str, max_bytes: int) -> tuple[str, dict[str, Any]]:
+def truncate_text_utf8(
+    text: str,
+    max_bytes: int,
+    *,
+    tool_name: str = "",
+    saved_to: str | None = None,
+) -> tuple[str, dict[str, Any]]:
     """Truncate tool text at a valid UTF-8 boundary.
 
     The byte limit applies to retained source text; the explanatory truncation note
@@ -65,11 +71,7 @@ def truncate_text_utf8(text: str, max_bytes: int) -> tuple[str, dict[str, Any]]:
     prefix = raw[:max_bytes].decode("utf-8", errors="ignore")
     kept_bytes = len(prefix.encode("utf-8"))
     omitted = max(0, original_bytes - kept_bytes)
-    note = (
-        f"\n... [tool output truncated to {max_bytes} bytes; "
-        f"{omitted} bytes omitted. Re-run the tool with a smaller scope "
-        f"(e.g. offset/limit) to read the omitted sections]"
-    )
+    note = _truncation_note(max_bytes, omitted, tool_name=tool_name, saved_to=saved_to)
     return (
         prefix + note,
         {
@@ -78,6 +80,32 @@ def truncate_text_utf8(text: str, max_bytes: int) -> tuple[str, dict[str, Any]]:
             "max_output_bytes": max_bytes,
             "omitted_text_bytes": omitted,
         },
+    )
+
+
+def _truncation_note(
+    max_bytes: int,
+    omitted: int,
+    *,
+    tool_name: str = "",
+    saved_to: str | None = None,
+) -> str:
+    """Build the truncation hint appropriate to the tool and its fallback path."""
+    if saved_to:
+        return (
+            f"\n... [tool output truncated to {max_bytes} bytes; "
+            f"{omitted} bytes omitted. Full output saved to {saved_to}; "
+            f"use read to view it]"
+        )
+    if tool_name == "read":
+        return (
+            f"\n... [tool output truncated to {max_bytes} bytes; "
+            f"{omitted} bytes omitted. Re-run the tool with a smaller scope "
+            f"(e.g. offset/limit) to read the omitted sections]"
+        )
+    return (
+        f"\n... [tool output truncated to {max_bytes} bytes; "
+        f"{omitted} bytes omitted. Re-run the tool with a smaller scope]"
     )
 
 
@@ -124,6 +152,7 @@ def normalize_tool_output(
     tool_name: str = "",
     artifact_store: Any = None,
     preview_chars: int = TOOL_OUTPUT_PREVIEW_CHARS,
+    saved_to: str | None = None,
 ) -> NormalizedToolOutput:
     """Normalize and byte-limit a tool result before storage or injection.
 
@@ -136,7 +165,9 @@ def normalize_tool_output(
         normalized = ""
 
     if isinstance(normalized, str):
-        truncated, trunc_meta = truncate_text_utf8(normalized, max_output)
+        truncated, trunc_meta = truncate_text_utf8(
+            normalized, max_output, tool_name=tool_name, saved_to=saved_to
+        )
         metadata.update(trunc_meta)
         stats = output_stats(truncated, preview_chars=preview_chars)
         return NormalizedToolOutput(output=truncated, stats=stats, metadata=metadata)
@@ -163,7 +194,9 @@ def normalize_tool_output(
         else:
             parts.append(part)
 
-    parts, trunc_meta = _truncate_text_parts(parts, max_output)
+    parts, trunc_meta = _truncate_text_parts(
+        parts, max_output, tool_name=tool_name, saved_to=saved_to
+    )
     metadata.update(trunc_meta)
     if materialized:
         metadata["data_urls_materialized"] = materialized
@@ -238,7 +271,11 @@ def materialize_image_part(
 
 
 def _truncate_text_parts(
-    parts: list[ContentPart], max_output: int
+    parts: list[ContentPart],
+    max_output: int,
+    *,
+    tool_name: str = "",
+    saved_to: str | None = None,
 ) -> tuple[list[ContentPart], dict[str, Any]]:
     text_bytes = sum(
         len(part.text.encode("utf-8")) for part in parts if isinstance(part, TextPart)
@@ -271,9 +308,8 @@ def _truncate_text_parts(
     if not note_added:
         out.append(
             TextPart(
-                text=(
-                    f"... [tool output truncated to {max_output} bytes; "
-                    f"{omitted} bytes omitted]"
+                text=_truncation_note(
+                    max_output, omitted, tool_name=tool_name, saved_to=saved_to
                 )
             )
         )

--- a/src/kohakuterrarium/modules/tool/base.py
+++ b/src/kohakuterrarium/modules/tool/base.py
@@ -29,7 +29,7 @@ class ToolConfig:
     """Configure execution limits, environment, and background notification."""
 
     timeout: float = 60.0
-    max_output: int = 64 * 1024
+    max_output: int = 256 * 1024
     working_dir: str | None = None
     env: dict[str, str] = field(default_factory=dict)
     notify_controller_on_background_complete: bool = True

--- a/src/kohakuterrarium/session/memory.py
+++ b/src/kohakuterrarium/session/memory.py
@@ -16,6 +16,10 @@ from kohakuterrarium.session.history import (
 )
 from kohakuterrarium.utils.logging import get_logger
 
+# Tool results are indexed up to this many chars so elided-but-≤256KB outputs
+# stay recoverable via search_memory without bloating the FTS index.
+TOOL_RESULT_INDEX_CHARS = 50_000
+
 logger = get_logger(__name__)
 
 
@@ -515,7 +519,7 @@ def _extract_blocks(
                         block_num=block_num,
                         agent=agent,
                         block_type="tool",
-                        content=content[:2000],
+                        content=content[:TOOL_RESULT_INDEX_CHARS],
                         ts=ts,
                         tool_name=name,
                     )

--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -9,6 +9,7 @@ from kohakuterrarium.builtins.outputs import create_builtin_output
 from kohakuterrarium.core.agent import Agent
 from kohakuterrarium.core.config_serde import unpack_agent_config
 from kohakuterrarium.core.conversation import Conversation
+from kohakuterrarium.core.conversation_elide import estimate_tokens, maybe_elide
 from kohakuterrarium.modules.input.base import InputModule
 from kohakuterrarium.modules.output.base import OutputModule
 from kohakuterrarium.packages.resolve import resolve_any_path
@@ -220,6 +221,18 @@ def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
     saved_messages = _load_conversation_with_replay_fallback(store, agent_name)
     if saved_messages:
         agent.controller.conversation = _build_conversation(saved_messages)
+        # Rebuilds restore tool outputs elided during live turns, so re-apply
+        # elision when the estimated prompt is crowded (mirrors the per-turn
+        # controller check and keeps the resumed prompt bounded).
+        controller = agent.controller
+        config = getattr(controller, "config", None)
+        if config is not None and getattr(config, "elide_tool_results", False):
+            maybe_elide(
+                controller.conversation,
+                estimate_tokens(controller.conversation),
+                threshold_ratio=config.elide_threshold_ratio,
+                elide_max_tokens=config.elide_max_tokens,
+            )
         logger.info(
             "Conversation restored", agent=agent_name, messages=len(saved_messages)
         )

--- a/src/kohakuterrarium/studio/attach/_event_stream.py
+++ b/src/kohakuterrarium/studio/attach/_event_stream.py
@@ -33,6 +33,19 @@ def _parse_detail(detail: str) -> tuple[str, str]:
     return "unknown", detail
 
 
+def _stream_metadata(metadata: dict) -> dict:
+    """Whitelist activity metadata for streaming; prefer the bounded preview."""
+    out = {}
+    for k in _STREAM_METADATA_KEYS:
+        if k in metadata:
+            out[k] = metadata[k]
+    # Full tool output lives in the session event log; stream frames only
+    # carry the bounded preview so WS payloads stay small.
+    if "output_preview" in metadata and "output" in out:
+        out["output"] = metadata["output_preview"]
+    return out
+
+
 class StreamOutput(OutputModule):
     """Queue source-tagged websocket frames as a secondary agent output.
 
@@ -150,9 +163,7 @@ class StreamOutput(OutputModule):
             "id": frame_id,
         }
         if metadata:
-            for k in _STREAM_METADATA_KEYS:
-                if k in metadata:
-                    msg[k] = metadata[k]
+            msg.update(_stream_metadata(metadata))
         self._put(msg)
         self._emit_typed_mirror(activity_type, name, info, frame_id, metadata)
         self._n += 1
@@ -184,9 +195,7 @@ class StreamOutput(OutputModule):
             "id": frame_id,
         }
         if metadata:
-            for k in _STREAM_METADATA_KEYS:
-                if k in metadata:
-                    mirror[k] = metadata[k]
+            mirror.update(_stream_metadata(metadata))
         self._put(mirror)
 
     async def emit(self, event: OutputEvent) -> None:

--- a/tests/unit/builtins/tools/test_read.py
+++ b/tests/unit/builtins/tools/test_read.py
@@ -1,0 +1,68 @@
+"""Unit tests for :mod:`kohakuterrarium.builtins.tools.read`."""
+
+from kohakuterrarium.builtins.tools.read import MAX_DEFAULT_LINES, ReadTool
+from kohakuterrarium.modules.tool.base import ToolContext
+
+
+def _ctx(tmp_path):
+    return ToolContext(agent_name="agent", session=None, working_dir=tmp_path)
+
+
+class TestReadDefaultLineGuard:
+    async def test_huge_file_capped_at_default_lines_with_navigation(self, tmp_path):
+        path = tmp_path / "big.txt"
+        path.write_text(
+            "\n".join(f"line {i}" for i in range(MAX_DEFAULT_LINES + 500)),
+            encoding="utf-8",
+        )
+        ctx = _ctx(tmp_path)
+
+        result = await ReadTool().execute({"path": str(path)}, context=ctx)
+
+        assert result.success is True
+        lines = result.output.splitlines()
+        assert len(lines) == MAX_DEFAULT_LINES + 2  # body + 2-line notice
+        assert (
+            f"showing lines 1-{MAX_DEFAULT_LINES} of {MAX_DEFAULT_LINES + 500}"
+            in result.output
+        )
+        assert "Use offset/limit to read more." in result.output
+
+    async def test_small_file_full_read_has_no_notice(self, tmp_path):
+        path = tmp_path / "small.txt"
+        path.write_text("\n".join(f"line {i}" for i in range(100)), encoding="utf-8")
+        ctx = _ctx(tmp_path)
+
+        result = await ReadTool().execute({"path": str(path)}, context=ctx)
+
+        assert result.success is True
+        assert "showing lines" not in result.output
+        assert len(result.output.splitlines()) == 100
+
+    async def test_explicit_limit_keeps_existing_notice_format(self, tmp_path):
+        path = tmp_path / "big.txt"
+        path.write_text("\n".join(f"line {i}" for i in range(3000)), encoding="utf-8")
+        ctx = _ctx(tmp_path)
+
+        result = await ReadTool().execute(
+            {"path": str(path), "limit": 500}, context=ctx
+        )
+
+        assert result.success is True
+        assert "showing lines 1-500 of 3000" in result.output
+        assert "Use offset/limit to read more." not in result.output
+
+    async def test_explicit_offset_plus_limit_navigates_beyond_default(self, tmp_path):
+        path = tmp_path / "big.txt"
+        path.write_text("\n".join(f"line {i}" for i in range(3000)), encoding="utf-8")
+        ctx = _ctx(tmp_path)
+
+        result = await ReadTool().execute(
+            {"path": str(path), "offset": MAX_DEFAULT_LINES, "limit": 100}, context=ctx
+        )
+
+        assert result.success is True
+        assert (
+            f"showing lines {MAX_DEFAULT_LINES + 1}-{MAX_DEFAULT_LINES + 100} of 3000"
+            in result.output
+        )

--- a/tests/unit/builtins/tools/test_read.py
+++ b/tests/unit/builtins/tools/test_read.py
@@ -66,3 +66,19 @@ class TestReadDefaultLineGuard:
             f"showing lines {MAX_DEFAULT_LINES + 1}-{MAX_DEFAULT_LINES + 100} of 3000"
             in result.output
         )
+
+    async def test_byte_cap_aligned_with_executor_max_output(self, tmp_path):
+        # A file under the default line guard but over the byte cap must
+        # truncate at 256000 bytes (aligned with the executor's max_output).
+        path = tmp_path / "wide.txt"
+        path.write_text(
+            "\n".join(f"row {i} " + "x" * 400 for i in range(1000)),
+            encoding="utf-8",
+        )
+        ctx = _ctx(tmp_path)
+
+        result = await ReadTool().execute({"path": str(path)}, context=ctx)
+
+        assert result.success is True
+        assert "truncated at 256000 bytes" in result.output
+        assert "Use offset/limit to read specific sections." in result.output

--- a/tests/unit/builtins/tools/test_search_memory.py
+++ b/tests/unit/builtins/tools/test_search_memory.py
@@ -1,0 +1,75 @@
+"""Unit tests for :mod:`kohakuterrarium.builtins.tools.search_memory`."""
+
+from kohakuterrarium.builtins.tools.search_memory import (
+    SEARCH_RESULT_DISPLAY_CHARS,
+    SearchMemoryTool,
+)
+from kohakuterrarium.modules.tool.base import ToolContext
+from kohakuterrarium.session.memory import SearchResult
+
+
+class _FakeMemory:
+    def __init__(self, results):
+        self._results = results
+
+    def search(self, query, mode="auto", k=5, agent=None):
+        return self._results
+
+
+class _FakeSession:
+    def __init__(self, results):
+        self._memory = _FakeMemory(results)
+
+
+def _ctx(session):
+    return ToolContext(agent_name="agent", session=session, working_dir=None)
+
+
+async def _run(query, results):
+    tool = SearchMemoryTool()
+    ctx = _ctx(_FakeSession(results))
+    return await tool.execute({"query": query}, context=ctx)
+
+
+class TestSearchMemoryDisplay:
+    async def test_no_results(self):
+        result = await _run("q", [])
+        assert "No results found" in result.output
+
+    async def test_long_result_display_capped_at_constant(self):
+        long_content = "y" * 5000
+        result = await _run(
+            "q",
+            [
+                SearchResult(
+                    content=long_content,
+                    round_num=1,
+                    block_num=1,
+                    agent="a",
+                    block_type="tool",
+                    score=1.0,
+                    tool_name="bash",
+                )
+            ],
+        )
+        assert "bash" in result.output
+        assert f"({len(long_content)} chars total)" in result.output
+        assert "y" * SEARCH_RESULT_DISPLAY_CHARS in result.output
+        assert long_content not in result.output
+
+    async def test_short_result_not_capped(self):
+        result = await _run(
+            "q",
+            [
+                SearchResult(
+                    content="needle",
+                    round_num=1,
+                    block_num=1,
+                    agent="a",
+                    block_type="tool",
+                    score=1.0,
+                )
+            ],
+        )
+        assert "needle" in result.output
+        assert "chars total" not in result.output

--- a/tests/unit/core/test_agent_tools.py
+++ b/tests/unit/core/test_agent_tools.py
@@ -164,6 +164,20 @@ class TestEmitDirectCompletion:
         kinds = [c[0] for c in agent.output_router.activity_calls]
         assert "tool_done" in kinds
 
+    def test_tool_done_carries_full_output_and_preview(self, agent):
+        # The event log must keep the full tool output (recoverable via
+        # search_memory) while UI rendering keeps using the bounded preview.
+        agent._register_direct_job("bash_x", kind="tool", name="bash")
+        big = "x" * 12000
+        result = JobResult(job_id="bash_x", output=big, exit_code=0)
+        agent._emit_direct_completion_activity("bash_x", result)
+        meta = next(
+            c[2] for c in agent.output_router.activity_calls if c[0] == "tool_done"
+        )
+        assert meta["output"] == big
+        assert meta["output_preview"] == big[:5000]
+        assert len(meta["output_preview"]) == 5000
+
     def test_tool_error(self, agent):
         agent._register_direct_job("bash_x", kind="tool", name="bash")
         result = JobResult(job_id="bash_x", error="boom", output="")

--- a/tests/unit/core/test_controller.py
+++ b/tests/unit/core/test_controller.py
@@ -149,9 +149,11 @@ class TestEphemeralMode:
 
 
 class TestStaleToolResultElision:
-    async def test_prior_round_results_elided_from_context(self):
+    async def test_prior_round_results_elided_from_context_when_window_is_full(self):
         env = TestAgentBuilder().with_llm_script(["r1", "r2"]).build()
         big = "X" * 2000
+        # Simulate a crowded context window (78% of the 256k budget).
+        env.controller._last_usage = {"prompt_tokens": 200_000}
         await env.controller.push_event(
             create_tool_complete_event("job1", "round1 output " + big)
         )
@@ -174,6 +176,57 @@ class TestStaleToolResultElision:
         assert ELISION_MARKER in feedback[0].content
         assert big not in feedback[0].content
         assert big in feedback[1].content
+
+    async def test_prior_round_results_kept_when_context_is_spacious(self):
+        env = TestAgentBuilder().with_llm_script(["r1", "r2"]).build()
+        big = "X" * 2000
+        # No usage recorded: the window is not crowded, so stale rounds
+        # stay verbatim and the controller can reference what it read
+        # without re-running tools.
+        await env.controller.push_event(
+            create_tool_complete_event("job1", "round1 output " + big)
+        )
+        async for _ in env.controller.run_once():
+            pass
+        await env.controller.push_event(
+            create_tool_complete_event("job2", "round2 output " + big)
+        )
+        async for _ in env.controller.run_once():
+            pass
+
+        feedback = [
+            m
+            for m in env.controller.conversation.get_messages()
+            if (m.metadata or {}).get("kind") == TOOL_FEEDBACK_KIND
+        ]
+        assert len(feedback) == 2
+        assert big in feedback[0].content
+        assert ELISION_MARKER not in feedback[0].content
+        assert big in feedback[1].content
+
+    async def test_elide_disabled_by_config(self):
+        env = TestAgentBuilder().with_llm_script(["r1", "r2"]).build()
+        env.controller.config.elide_tool_results = False
+        env.controller._last_usage = {"prompt_tokens": 200_000}
+        big = "X" * 2000
+        await env.controller.push_event(
+            create_tool_complete_event("job1", "round1 output " + big)
+        )
+        async for _ in env.controller.run_once():
+            pass
+        await env.controller.push_event(
+            create_tool_complete_event("job2", "round2 output " + big)
+        )
+        async for _ in env.controller.run_once():
+            pass
+
+        feedback = [
+            m
+            for m in env.controller.conversation.get_messages()
+            if (m.metadata or {}).get("kind") == TOOL_FEEDBACK_KIND
+        ]
+        assert big in feedback[0].content
+        assert ELISION_MARKER not in feedback[0].content
 
     async def test_real_user_input_is_never_tagged_or_elided(self):
         env = TestAgentBuilder().with_llm_script(["r1", "r2"]).build()

--- a/tests/unit/core/test_conversation_elide.py
+++ b/tests/unit/core/test_conversation_elide.py
@@ -5,6 +5,8 @@ from kohakuterrarium.core.conversation_elide import (
     ELISION_MARKER,
     TOOL_FEEDBACK_KIND,
     elide_stale_tool_results,
+    estimate_tokens,
+    maybe_elide,
 )
 
 BIG = "R" * 2000
@@ -116,3 +118,90 @@ class TestElideStaleToolResults:
 
         assert elide_stale_tool_results(conv) == 1
         assert "from a tool" in first.content
+
+
+class TestMaybeElide:
+    def test_skips_when_below_threshold(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        _feedback(conv, "[tool result] small " + "x" * 100)
+        conv.append("assistant", "ok")
+
+        assert (
+            maybe_elide(conv, 10_000, threshold_ratio=0.6, elide_max_tokens=256_000)
+            == 0
+        )
+        assert "x" * 100 in conv.get_messages()[1].content
+
+    def test_elides_when_crowded(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        first = _feedback(conv, "[tool result] round1 " + BIG)
+        conv.append("assistant", "more tools")
+        _feedback(conv, "[tool result] round2 " + BIG)
+
+        assert (
+            maybe_elide(conv, 200_000, threshold_ratio=0.6, elide_max_tokens=256_000)
+            == 1
+        )
+        assert ELISION_MARKER in first.content
+
+    def test_skips_when_no_usage_yet(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        _feedback(conv, "[tool result] round1 " + BIG)
+
+        # Mirrors the resumed controller before the first real LLM call:
+        # an empty/zero usage must not elide anything by itself.
+        assert maybe_elide(conv, 0, threshold_ratio=0.6, elide_max_tokens=256_000) == 0
+
+    def test_idempotent_across_repeated_calls(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        first = _feedback(conv, "[tool result] round1 " + BIG)
+        conv.append("assistant", "more tools")
+        _feedback(conv, "[tool result] round2 " + BIG)
+
+        # Reload paths may run before the per-turn check; the second call
+        # must not re-stub already-elided messages.
+        assert (
+            maybe_elide(conv, 200_000, threshold_ratio=0.6, elide_max_tokens=256_000)
+            == 1
+        )
+        assert (
+            maybe_elide(conv, 200_000, threshold_ratio=0.6, elide_max_tokens=256_000)
+            == 0
+        )
+        assert ELISION_MARKER in first.content
+
+
+class TestEstimateTokens:
+    def test_scales_with_content_length(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        conv.append("user", "x" * 1000)
+        small = estimate_tokens(conv)
+        conv.append("user", "x" * 100_000)
+        large = estimate_tokens(conv)
+        assert small > 0
+        assert large > small
+        # Conservative: ~3.5 chars/token → 100KB content is at least ~20K tokens.
+        assert large >= 20_000
+
+    def test_counts_tool_call_arguments(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        conv.append(
+            "assistant",
+            "",
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "function": {
+                        "name": "read",
+                        "arguments": '{"path": "' + "y" * 500 + '"}',
+                    },
+                }
+            ],
+        )
+        assert estimate_tokens(conv) >= 100

--- a/tests/unit/core/test_conversation_elide.py
+++ b/tests/unit/core/test_conversation_elide.py
@@ -86,3 +86,33 @@ class TestElideStaleToolResults:
         # Second pass finds nothing new and rewrites nothing.
         assert elide_stale_tool_results(conv) == 0
         assert big.content == stubbed
+
+    def test_stub_names_the_originating_tool_call(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read", "arguments": '{"path": "big.py"}'},
+            }
+        ]
+        conv.append("assistant", "dispatch", tool_calls=calls)
+        old = conv.append("tool", "file content " + BIG, tool_call_id="call_1")
+        conv.append("assistant", "again", tool_calls=[{**calls[0], "id": "call_2"}])
+        latest = conv.append("tool", "new content " + BIG, tool_call_id="call_2")
+
+        assert elide_stale_tool_results(conv) == 1
+        assert 'read({"path": "big.py"})' in old.content
+        assert "from read" in old.content
+        assert latest.content.endswith(BIG)
+
+    def test_stub_without_call_id_falls_back_to_generic(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        first = _feedback(conv, "[tool result] round1 " + BIG)
+        conv.append("assistant", "more tools")
+        _feedback(conv, "[tool result] round2 " + BIG)
+
+        assert elide_stale_tool_results(conv) == 1
+        assert "from a tool" in first.content

--- a/tests/unit/core/test_executor.py
+++ b/tests/unit/core/test_executor.py
@@ -449,6 +449,27 @@ class TestOutputNormalisation:
         assert "truncated" in result.output
         assert result.metadata.get("truncated") is True
 
+    async def test_truncation_note_points_at_bash_output_file(self):
+        # Bash materializes full output to a temp file and exposes the path
+        # as metadata["raw_output_path"]; the truncation hint must surface it.
+        class _BashLikeTool(_EchoTool):
+            @property
+            def tool_name(self):
+                return "bash"
+
+            async def _execute(self, args, **kwargs):
+                return ToolResult(
+                    output=str(args.get("msg", "")),
+                    metadata={"raw_output_path": "/tmp/kohakuterrarium-bash/bash_1.log"},
+                )
+
+        ex = Executor()
+        ex.register_tool(_BashLikeTool(max_output=10))
+        jid = await ex.submit("bash", {"msg": "x" * 1000})
+        result = await ex.wait_for(jid)
+        assert "Full output saved to /tmp/kohakuterrarium-bash/bash_1.log" in result.output
+        assert "use read to view it" in result.output
+
 
 # ── pending / running / task accessors ───────────────────────────
 

--- a/tests/unit/core/test_executor.py
+++ b/tests/unit/core/test_executor.py
@@ -460,14 +460,18 @@ class TestOutputNormalisation:
             async def _execute(self, args, **kwargs):
                 return ToolResult(
                     output=str(args.get("msg", "")),
-                    metadata={"raw_output_path": "/tmp/kohakuterrarium-bash/bash_1.log"},
+                    metadata={
+                        "raw_output_path": "/tmp/kohakuterrarium-bash/bash_1.log"
+                    },
                 )
 
         ex = Executor()
         ex.register_tool(_BashLikeTool(max_output=10))
         jid = await ex.submit("bash", {"msg": "x" * 1000})
         result = await ex.wait_for(jid)
-        assert "Full output saved to /tmp/kohakuterrarium-bash/bash_1.log" in result.output
+        assert (
+            "Full output saved to /tmp/kohakuterrarium-bash/bash_1.log" in result.output
+        )
         assert "use read to view it" in result.output
 
 

--- a/tests/unit/core/test_tool_output.py
+++ b/tests/unit/core/test_tool_output.py
@@ -67,6 +67,12 @@ class TestTruncateUtf8:
         assert meta["omitted_text_bytes"] >= 990
         assert meta["max_output_bytes"] == 10
 
+    def test_truncation_note_suggests_narrower_scope(self):
+        text = "x" * 1000
+        out, _ = truncate_text_utf8(text, 10)
+        assert "offset/limit" in out
+        assert "omitted sections" in out
+
     def test_multibyte_safe_decode(self):
         # 3-byte chars — split position cannot fall mid-character.
         text = "日本語" * 10

--- a/tests/unit/core/test_tool_output.py
+++ b/tests/unit/core/test_tool_output.py
@@ -67,11 +67,26 @@ class TestTruncateUtf8:
         assert meta["omitted_text_bytes"] >= 990
         assert meta["max_output_bytes"] == 10
 
-    def test_truncation_note_suggests_narrower_scope(self):
+    def test_truncation_note_suggests_narrower_scope_for_read(self):
         text = "x" * 1000
-        out, _ = truncate_text_utf8(text, 10)
+        out, _ = truncate_text_utf8(text, 10, tool_name="read")
         assert "offset/limit" in out
         assert "omitted sections" in out
+
+    def test_generic_truncation_note_has_no_read_specific_hint(self):
+        text = "x" * 1000
+        out, _ = truncate_text_utf8(text, 10)
+        assert "truncated" in out
+        assert "offset/limit" not in out
+
+    def test_truncation_note_points_at_saved_output_file(self):
+        text = "x" * 1000
+        out, _ = truncate_text_utf8(
+            text, 10, tool_name="bash", saved_to="/tmp/kohakuterrarium-bash/bash_1.log"
+        )
+        assert "Full output saved to /tmp/kohakuterrarium-bash/bash_1.log" in out
+        assert "use read to view it" in out
+        assert "offset/limit" not in out
 
     def test_multibyte_safe_decode(self):
         # 3-byte chars — split position cannot fall mid-character.

--- a/tests/unit/session/test_memory.py
+++ b/tests/unit/session/test_memory.py
@@ -261,6 +261,30 @@ class TestExtractBlocks:
         tool_blocks = [b for b in blocks if b.block_type == "tool"]
         assert tool_blocks == []
 
+    def test_large_tool_result_indexed_beyond_old_2000_cap(self):
+        # Elided tool results (≤256KB) must stay recoverable: the index cap
+        # covers far more than the historical 2000-char truncation.
+        from kohakuterrarium.session.memory import TOOL_RESULT_INDEX_CHARS
+
+        big = (
+            "needle-at-tail "
+            + "z" * (TOOL_RESULT_INDEX_CHARS - 50)
+            + " unique-tail-marker"
+        )
+        events = [
+            {"type": "user_input", "content": "q", "event_id": 1},
+            {
+                "type": "tool_result",
+                "name": "bash",
+                "output": big,
+                "event_id": 2,
+            },
+        ]
+        blocks = _extract_blocks("alice", events)
+        tool_blocks = [b for b in blocks if b.block_type == "tool"]
+        assert len(tool_blocks) == 1
+        assert "unique-tail-marker" in tool_blocks[0].content
+
     def test_processing_end_ends_round(self):
         events = [
             {"type": "user_input", "content": "q", "event_id": 1},

--- a/tests/unit/session/test_resume.py
+++ b/tests/unit/session/test_resume.py
@@ -656,6 +656,13 @@ class _FakeController:
         self.conversation = Conversation()
 
 
+class _ElideConfig:
+    name = "alice"
+    elide_tool_results = True
+    elide_threshold_ratio = 0.6
+    elide_max_tokens = 256_000
+
+
 class _FakeAgentForInject:
     def __init__(self):
         self.config = _FakeConfig()
@@ -1004,6 +1011,97 @@ class TestResumeAgent:
         agent, store = resume_agent(path, io_mode="plain")
         try:
             assert agent.config.name == "resumee"
+        finally:
+            store.close()
+
+    def test_crowded_resume_elides_stale_tool_results(self, tmp_path):
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            big = "y" * 1_000_000
+            store.save_conversation(
+                "alice",
+                [
+                    {"role": "user", "content": "q1"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "c1",
+                                "function": {
+                                    "name": "read",
+                                    "arguments": '{"path": "big.py"}',
+                                },
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "c1", "content": big},
+                    {"role": "assistant", "content": "reading done"},
+                    {"role": "user", "content": "q2"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "c2",
+                                "function": {
+                                    "name": "grep",
+                                    "arguments": '{"pattern": "x"}',
+                                },
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "c2", "content": "small"},
+                    {"role": "assistant", "content": "latest"},
+                ],
+            )
+            agent = _FakeAgentForInject()
+            agent.config = _ElideConfig()
+            agent.controller.config = _ElideConfig()
+            inject_saved_state(agent, store, "alice")
+            from kohakuterrarium.core.conversation_elide import ELISION_MARKER
+
+            contents = [
+                m.get("content", "")
+                for m in agent.controller.conversation.to_messages()
+            ]
+            # The 1MB tool result from the earlier round is stubbed out.
+            assert any(isinstance(c, str) and ELISION_MARKER in c for c in contents)
+            # The latest feedback round stays verbatim.
+            assert "small" in contents
+        finally:
+            store.close()
+
+    def test_spacious_resume_keeps_tool_results_verbatim(self, tmp_path):
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.save_conversation(
+                "alice",
+                [
+                    {"role": "user", "content": "q1"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "c1",
+                                "function": {"name": "read", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "c1", "content": "small"},
+                    {"role": "assistant", "content": "done"},
+                ],
+            )
+            agent = _FakeAgentForInject()
+            agent.config = _ElideConfig()
+            agent.controller.config = _ElideConfig()
+            inject_saved_state(agent, store, "alice")
+            contents = [
+                m.get("content", "")
+                for m in agent.controller.conversation.to_messages()
+            ]
+            assert "small" in contents
         finally:
             store.close()
 

--- a/tests/unit/studio/test_event_stream.py
+++ b/tests/unit/studio/test_event_stream.py
@@ -112,6 +112,28 @@ class TestStreamOutputSync:
         # Unknown keys are filtered.
         assert "unknown_key" not in msg
 
+    def test_tool_done_streams_preview_not_full_output(self, _stream):
+        so, q, _log = _stream
+        full = "x" * 200_000
+        so.on_activity_with_metadata(
+            "tool_done",
+            "[bash] big",
+            metadata={
+                "job_id": "j1",
+                "output": full,
+                "output_preview": full[:5000],
+            },
+        )
+        msg = q.get_nowait()
+        assert msg["type"] == "activity"
+        assert msg["output"] == full[:5000]
+        assert len(msg["output"]) == 5000
+        mirror = q.get_nowait()
+        assert mirror["type"] == "tool_done"
+        assert mirror["output"] == full[:5000]
+        # The raw full output never leaves the process over the stream.
+        assert full not in (msg["output"], mirror["output"])
+
     def test_on_assistant_image(self, _stream):
         so, q, _log = _stream
         so.on_assistant_image(


### PR DESCRIPTION
## Summary

Fixes the tool-output truncation/elision stack that makes agents re-read files in a loop: make elision context-aware, keep full tool output recoverable via search_memory, bound rebuilt conversations on resume, and give truncation hints that actually point somewhere useful.

## PR Type

- [x] Bug fix
- [x] Feature / behavior change

## Motivation / Context

Fixes the loop described in issue #98. Elision was introduced to stop an endless compact loop on tool-heavy sessions, but its boundary is too coarse: it runs before every LLM call and keeps tool results verbatim only for the most recent round — every earlier round's results are elided as soon as the next tool call is issued. Cross-round references fail structurally, so models that work through long uninterrupted tool-call chains (e.g. the gpt-5.6 family, which several community users have reported exhibiting this loop) re-read the same files in a loop. Additional related defects:
- truncated bytes were dropped before the event log, so search_memory could never recover them (the elide placeholder's own hint was a dead end)
- resumed sessions rebuilt full tool outputs with an empty `_last_usage`, so the first resumed LLM call could exceed the model window
- bash truncation hinted "offset/limit" (meaningless for bash) while the full output was already materialized to a temp file the model never saw

## Changes

- `conversation_elide`: elide only when the prompt is crowded (threshold ratio, default 60% of 256k); placeholders now name the tool call (e.g. `read({"path": "big.py"})`) so the model can re-run precisely; add `estimate_tokens` + `maybe_elide` shared by per-turn and reload paths
- `tool_output`/`executor`: truncation notes are tool-aware — bash output points at its saved temp file ("use read to view it"); `offset/limit` advice only for read; generic tools get a neutral hint
- `agent_tools`/`session/output`/`memory`: tool_done events keep the full output plus `output_preview` for UI; memory index cap 2KB → 50KB; search_memory display cap 500 → 2000 — elided (≤256KB) results are now actually recoverable
- `read`: default byte cap aligned to 256KB with the executor default; default read guard of 2000 lines with a `showing lines 1-2000 of N` hint so the model can plan `offset/limit` reads
- `attach/_event_stream`: WS stream frames carry `output_preview` instead of the full output
- `resume`/`agent_message_history`: rebuilt conversations re-apply elision when estimated tokens are crowded (keeps the latest round verbatim)
- `ControllerConfig`: `elide_tool_results` / `elide_threshold_ratio` / `elide_max_tokens` knobs

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py   # 11668 passed; 9 pre-existing env failures (dulwich git backend, Windows fsync, config-pollution), verified unrelated
pytest tests/integration/ -q                                  # passed
```

Plus an end-to-end check: a 20KB tool result was indexed and recovered via search_memory.

## Checklist

- [x] I read CONTRIBUTING.md
- [x] I linked the relevant issue(s) below
- [x] Feature/behavior change: issue exists; maintainer approval pending
- [ ] CI on my fork is green — pushed to self fork; Actions status TBD (see Exceptions)

## Related Issues / Discussions

- Fixes #98

## Notes for Reviewers

The 5 commits form one coherent fix (elide → recovery → resume).

## Exceptions / Not Run

- Full CI matrix not run locally; fork CI pending.
- e2e tier not run (change touches core/session/attach, not multi-node/ Studio journeys; unit + integration cover the changed paths).
