### PR TITLE
fix: address runtime logging and input regressions

### DIFF
--- a/src/kohakuterrarium/builtins/inputs/cli.py
+++ b/src/kohakuterrarium/builtins/inputs/cli.py
@@ -1,8 +1,11 @@
 """Terminal input modules for blocking and polled agent interaction."""
 
 import asyncio
+import queue
 import select
 import sys
+import threading
+from typing import TextIO
 
 from kohakuterrarium.core.events import TriggerEvent, create_user_input_event
 from kohakuterrarium.modules.input.base import BaseInputModule
@@ -80,6 +83,7 @@ class CLIInput(BaseInputModule):
             self._exit_requested = True
             return None
         except Exception as e:
+            self._exit_requested = True
             logger.error("Error reading input", error=str(e))
             return None
 
@@ -89,7 +93,10 @@ class CLIInput(BaseInputModule):
             sys.stdout.write(self.prompt)
             sys.stdout.flush()
 
-            line = sys.stdin.readline()
+            stdin = sys.stdin
+            if stdin is None:
+                return None
+            line = stdin.readline()
             if not line:
                 return None
             return line
@@ -159,44 +166,104 @@ class NonBlockingCLIInput(BaseInputModule):
         self.timeout = timeout
         self._buffer = ""
         self._prompt_shown = False
+        self._exit_requested = False
+        self._read_results: queue.Queue[tuple[bool, str | BaseException | None]] = (
+            queue.Queue(maxsize=1)
+        )
+        self._reader_thread: threading.Thread | None = None
+
+    async def _on_stop(self) -> None:
+        """Leave any Windows blocking read to finish in its daemon thread."""
+
+    @property
+    def exit_requested(self) -> bool:
+        """Return whether terminal input is permanently closed."""
+        return self._exit_requested
 
     async def get_input(self) -> TriggerEvent | None:
         """Return a complete input line when one is available."""
-        if not self._running:
+        if not self._running or self._exit_requested:
             return None
 
-        if not self._prompt_shown:
-            sys.stdout.write(self.prompt)
-            sys.stdout.flush()
-            self._prompt_shown = True
+        if sys.stdin is None:
+            self._exit_requested = True
+            return None
 
-        loop = asyncio.get_event_loop()
         try:
-            line = await asyncio.wait_for(
-                loop.run_in_executor(None, self._try_read),
-                timeout=self.timeout,
-            )
+            if not self._prompt_shown:
+                sys.stdout.write(self.prompt)
+                sys.stdout.flush()
+                self._prompt_shown = True
+
+            if sys.platform == "win32":
+                line = await self._poll_windows_read()
+            else:
+                line = await asyncio.to_thread(self._try_read)
             if line is not None:
                 self._prompt_shown = False
                 return create_user_input_event(line.strip())
-        except asyncio.TimeoutError:
-            pass
+        except (KeyboardInterrupt, EOFError):
+            self._exit_requested = True
         except Exception as e:
+            self._exit_requested = True
             logger.error("Error in non-blocking read", error=str(e))
 
         return None
 
-    def _try_read(self) -> str | None:
-        """Read one line if the platform reports stdin readiness."""
-        # Windows lacks the same ``select`` support for console handles.
-        if sys.platform != "win32":
-            ready, _, _ = select.select([sys.stdin], [], [], self.timeout)
-            if not ready:
-                return None
+    async def _poll_windows_read(self) -> str | None:
+        """Poll one daemon-backed Windows stdin read without queueing duplicates."""
+        if self._reader_thread is None:
+            stdin = sys.stdin
+            if stdin is None:
+                raise EOFError
+            self._reader_thread = threading.Thread(
+                target=self._read_windows_line,
+                args=(stdin,),
+                daemon=True,
+                name="non-blocking-cli-input",
+            )
+            self._reader_thread.start()
 
         try:
-            line = sys.stdin.readline()
-            return line if line else None
-        except Exception as e:
-            logger.warning("stdin readline failed", error=str(e), exc_info=True)
+            succeeded, result = self._read_results.get_nowait()
+        except queue.Empty:
+            await asyncio.sleep(self.timeout)
+            if not self._running:
+                return None
+            try:
+                succeeded, result = self._read_results.get_nowait()
+            except queue.Empty:
+                return None
+
+        self._reader_thread = None
+        if succeeded:
+            return result if isinstance(result, str) else None
+        if isinstance(result, BaseException):
+            raise result
+        raise EOFError
+
+    def _read_windows_line(self, stdin: TextIO) -> None:
+        """Perform one blocking Windows read and publish exactly one result."""
+        try:
+            line = stdin.readline()
+            if not line:
+                raise EOFError
+        except BaseException as error:
+            self._read_results.put((False, error))
+        else:
+            self._read_results.put((True, line))
+
+    def _try_read(self) -> str | None:
+        """Read one POSIX line if select reports stdin readiness."""
+        stdin = sys.stdin
+        if stdin is None:
+            raise EOFError
+
+        ready, _, _ = select.select([stdin], [], [], self.timeout)
+        if not ready:
             return None
+
+        line = stdin.readline()
+        if not line:
+            raise EOFError
+        return line

--- a/src/kohakuterrarium/core/agent.py
+++ b/src/kohakuterrarium/core/agent.py
@@ -724,6 +724,7 @@ class Agent(
                     ):
                         logger.info("Exit requested")
                         break
+                    await asyncio.sleep(0.01)
                     continue
 
                 idle_logged = False

--- a/src/kohakuterrarium/serving/web.py
+++ b/src/kohakuterrarium/serving/web.py
@@ -21,6 +21,7 @@ from kohakuterrarium.packages.locations import get_package_root, packages_dir
 from kohakuterrarium.packages.walk import list_packages
 from kohakuterrarium.utils.logging import (
     configure_utf8_stdio,
+    enable_file_logging,
     enable_stderr_logging,
     get_logger,
     set_level,
@@ -318,6 +319,7 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
 def _run_desktop_app_blocking(port: int = 8001, log_level: str = "INFO") -> None:
     """Run uvicorn and the native desktop window until the UI closes."""
     configure_utf8_stdio(log=True)
+    enable_file_logging()
 
     # A stable application ID lets Windows associate the packaged taskbar icon.
     if sys.platform == "win32":

--- a/src/kohakuterrarium/studio/attach/log.py
+++ b/src/kohakuterrarium/studio/attach/log.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from fastapi import WebSocket, WebSocketDisconnect
 
-from kohakuterrarium.utils.logging import DEFAULT_LOG_DIR, get_logger
+from kohakuterrarium.utils.logging import _default_log_dir, get_logger
 
 logger = get_logger(__name__)
 
@@ -24,11 +24,12 @@ _LINE_RE = re.compile(
 
 def _find_current_process_log() -> Path | None:
     """Locate the newest log file whose filename identifies this process."""
-    if not DEFAULT_LOG_DIR.exists():
+    log_dir = _default_log_dir()
+    if not log_dir.exists():
         return None
     pid = os.getpid()
     marker = f"pid{pid}_"
-    candidates = [p for p in DEFAULT_LOG_DIR.glob("*.log") if marker in p.name]
+    candidates = [p for p in log_dir.glob("*.log") if marker in p.name]
     if not candidates:
         return None
     # PID reuse can leave older matches, so modification time breaks the tie.

--- a/src/kohakuterrarium/studio/persistence/session_index/reconcile.py
+++ b/src/kohakuterrarium/studio/persistence/session_index/reconcile.py
@@ -240,12 +240,13 @@ def reconcile(
         total=len(on_disk_paths),
         elapsed_ms=elapsed,
     )
-    logger.info(
-        "session index reconciled",
-        read=report.read,
-        deleted=report.deleted,
-        total=report.total,
-        elapsed_ms=round(report.elapsed_ms, 1),
-        full=full,
-    )
+    if report.read or report.deleted:
+        logger.info(
+            "session index reconciled",
+            read=report.read,
+            deleted=report.deleted,
+            total=report.total,
+            elapsed_ms=round(report.elapsed_ms, 1),
+            full=full,
+        )
     return report

--- a/src/kohakuterrarium/utils/logging.py
+++ b/src/kohakuterrarium/utils/logging.py
@@ -336,6 +336,31 @@ def _create_file_handler() -> logging.Handler:
     return handler
 
 
+def enable_file_logging() -> None:
+    """Ensure this process logs to its per-PID file in the active config dir.
+
+    This also repairs a handler inherited from an earlier process or created
+    before ``KT_CONFIG_DIR`` was finalized.
+    """
+    global _handler
+
+    expected_dir = _default_log_dir().resolve()
+    current_path = getattr(_handler, "baseFilename", None)
+    if current_path is not None:
+        path = Path(current_path)
+        if path.parent.resolve() == expected_dir and f"pid{os.getpid()}_" in path.name:
+            return
+
+    root_logger = logging.getLogger("kohakuterrarium")
+    if _handler is not None:
+        root_logger.removeHandler(_handler)
+        _handler.close()
+
+    _handler = _create_file_handler()
+    _handler.addFilter(_TokenMaskingFilter())
+    root_logger.addHandler(_handler)
+
+
 def get_logger(name: str, level: int | str = logging.INFO) -> logging.Logger:
     """
     Get a configured logger for a module.
@@ -364,9 +389,7 @@ def get_logger(name: str, level: int | str = logging.INFO) -> logging.Logger:
         root_logger = logging.getLogger("kohakuterrarium")
 
         # Default: file handler only
-        _handler = _create_file_handler()
-        _handler.addFilter(_TokenMaskingFilter())
-        root_logger.addHandler(_handler)
+        enable_file_logging()
 
         # Optional: stderr handler if KT_LOG_STDERR=1
         if os.environ.get("KT_LOG_STDERR"):

--- a/tests/unit/api/routes/persistence/test_open_sessions.py
+++ b/tests/unit/api/routes/persistence/test_open_sessions.py
@@ -227,6 +227,29 @@ class TestOpenSessions:
         finally:
             close_session_index()
 
+    def test_repeated_reads_reconcile_external_session_changes(self, tmp_path):
+        service = LocalTerrariumService(Terrarium())
+        app = FastAPI()
+        app.dependency_overrides[get_service] = lambda: service
+        app.dependency_overrides[resolve_request_session_dir] = lambda: tmp_path
+        app.include_router(open_sessions.router, prefix="/sessions")
+
+        try:
+            client = TestClient(app)
+            assert client.get("/sessions/open").json() == []
+
+            _saved_store(
+                tmp_path / "external.kohakutr",
+                session_id="external",
+                conversation_open=True,
+            )
+
+            response = client.get("/sessions/open")
+            assert response.status_code == 200
+            assert [row["saved_name"] for row in response.json()] == ["external"]
+        finally:
+            close_session_index()
+
     def test_end_route_closes_dormant_marker_without_resuming(self, tmp_path):
         path = tmp_path / "dormant.kohakutr"
         _saved_store(

--- a/tests/unit/builtins/test_cli_input.py
+++ b/tests/unit/builtins/test_cli_input.py
@@ -1,0 +1,219 @@
+"""Regression tests for terminal closure handling in CLI input."""
+
+import asyncio
+import io
+import threading
+
+from kohakuterrarium.builtins.inputs import cli
+from kohakuterrarium.builtins.inputs.cli import CLIInput, NonBlockingCLIInput
+
+
+class _UnreadableStdin:
+    def readline(self):
+        raise OSError("stdin unavailable")
+
+
+async def test_nonblocking_input_read_does_not_block_event_loop(monkeypatch):
+    release = threading.Event()
+    input_module = NonBlockingCLIInput()
+    input_module._running = True
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+
+    def blocking_read():
+        release.wait(timeout=1.0)
+        return None
+
+    monkeypatch.setattr(input_module, "_try_read", blocking_read)
+
+    task = asyncio.create_task(input_module.get_input())
+    await asyncio.sleep(0.02)
+    assert not task.done()
+
+    release.set()
+    assert await task is None
+
+
+async def test_missing_stdin_is_terminal_eof_without_logging(monkeypatch):
+    input_module = CLIInput()
+    output = io.StringIO()
+    errors = []
+    monkeypatch.setattr(cli.sys, "stdin", None)
+    monkeypatch.setattr(cli.sys, "stdout", output)
+    monkeypatch.setattr(
+        cli.logger,
+        "error",
+        lambda *args, **kwargs: errors.append((args, kwargs)),
+    )
+
+    await input_module.start()
+    assert await input_module.get_input() is None
+    assert input_module.exit_requested is True
+
+    assert await input_module.get_input() is None
+    assert output.getvalue() == "> "
+    assert errors == []
+
+
+async def test_stdin_eof_closes_without_logging(monkeypatch):
+    input_module = CLIInput()
+    output = io.StringIO()
+    errors = []
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr(cli.sys, "stdout", output)
+    monkeypatch.setattr(
+        cli.logger,
+        "error",
+        lambda *args, **kwargs: errors.append((args, kwargs)),
+    )
+
+    await input_module.start()
+    assert await input_module.get_input() is None
+    assert input_module.exit_requested is True
+
+    assert await input_module.get_input() is None
+    assert output.getvalue() == "> "
+    assert errors == []
+
+
+async def test_unexpected_readline_error_is_logged_only_once(monkeypatch):
+    input_module = CLIInput()
+    output = io.StringIO()
+    errors = []
+    monkeypatch.setattr(cli.sys, "stdin", _UnreadableStdin())
+    monkeypatch.setattr(cli.sys, "stdout", output)
+    monkeypatch.setattr(
+        cli.logger,
+        "error",
+        lambda *args, **kwargs: errors.append((args, kwargs)),
+    )
+
+    await input_module.start()
+    assert await input_module.get_input() is None
+    assert input_module.exit_requested is True
+    assert await input_module.get_input() is None
+
+    assert output.getvalue() == "> "
+    assert len(errors) == 1
+    assert errors[0][1]["error"] == "stdin unavailable"
+
+
+async def test_unexpected_executor_read_error_is_logged_only_once(monkeypatch):
+    input_module = CLIInput()
+    errors = []
+
+    def fail_read():
+        raise RuntimeError("broken input")
+
+    monkeypatch.setattr(input_module, "_read_line", fail_read)
+    monkeypatch.setattr(
+        cli.logger,
+        "error",
+        lambda *args, **kwargs: errors.append((args, kwargs)),
+    )
+
+    await input_module.start()
+    assert await input_module.get_input() is None
+    assert input_module.exit_requested is True
+    assert await input_module.get_input() is None
+    assert len(errors) == 1
+    assert errors[0][1]["error"] == "broken input"
+
+
+async def test_non_blocking_missing_stdin_closes_without_repolling(monkeypatch):
+    input_module = NonBlockingCLIInput(timeout=1)
+    output = io.StringIO()
+    errors = []
+    monkeypatch.setattr(cli.sys, "stdin", None)
+    monkeypatch.setattr(cli.sys, "stdout", output)
+    monkeypatch.setattr(
+        cli.logger,
+        "error",
+        lambda *args, **kwargs: errors.append((args, kwargs)),
+    )
+
+    await input_module.start()
+    assert await input_module.get_input() is None
+    assert input_module.exit_requested is True
+    assert await input_module.get_input() is None
+    assert output.getvalue() == ""
+    assert errors == []
+
+
+async def test_non_blocking_readline_failure_is_logged_only_once(monkeypatch):
+    input_module = NonBlockingCLIInput(timeout=1)
+    output = io.StringIO()
+    errors = []
+    monkeypatch.setattr(cli.sys, "stdin", _UnreadableStdin())
+    monkeypatch.setattr(cli.sys, "stdout", output)
+    monkeypatch.setattr(cli.sys, "platform", "win32")
+    monkeypatch.setattr(
+        cli.logger,
+        "error",
+        lambda *args, **kwargs: errors.append((args, kwargs)),
+    )
+
+    await input_module.start()
+    assert await input_module.get_input() is None
+    assert input_module.exit_requested is True
+    assert await input_module.get_input() is None
+    assert output.getvalue() == "> "
+    assert len(errors) == 1
+    assert errors[0][1]["error"] == "stdin unavailable"
+
+
+async def test_non_blocking_timeouts_start_only_one_daemon_reader(monkeypatch):
+    input_module = NonBlockingCLIInput(timeout=0)
+    output = io.StringIO()
+    readers = []
+
+    class FakeThread:
+        def __init__(self, *, target, args, daemon, name):
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+            self.name = name
+            readers.append(self)
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO())
+    monkeypatch.setattr(cli.sys, "stdout", output)
+    monkeypatch.setattr(cli.sys, "platform", "win32")
+    monkeypatch.setattr(cli.threading, "Thread", FakeThread)
+
+    await input_module.start()
+    for _ in range(3):
+        assert await input_module.get_input() is None
+
+    assert len(readers) == 1
+    assert readers[0].daemon is True
+
+
+async def test_non_blocking_stop_does_not_start_or_restart_reader(monkeypatch):
+    input_module = NonBlockingCLIInput(timeout=0)
+    readers = []
+
+    class FakeThread:
+        def __init__(self, **kwargs):
+            readers.append(self)
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO())
+    monkeypatch.setattr(cli.sys, "platform", "win32")
+    monkeypatch.setattr(cli.threading, "Thread", FakeThread)
+
+    await input_module.start()
+    assert await input_module.get_input() is None
+    assert len(readers) == 1
+
+    await input_module.stop()
+    assert await input_module.get_input() is None
+    assert len(readers) == 1
+
+    stopped_input = NonBlockingCLIInput(timeout=0)
+    await stopped_input.stop()
+    assert await stopped_input.get_input() is None
+    assert len(readers) == 1

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -17,6 +17,7 @@ and using a `OutputRecorder` as the default output module.
 """
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -1816,6 +1817,28 @@ class TestDriveInput:
             assert agent.controller.conversation.get_last_assistant_message()
         finally:
             await agent.stop()
+
+    async def test_drive_input_waits_when_generic_input_returns_none(self, monkeypatch):
+        agent = Agent.__new__(Agent)
+        agent._pending_resume_events = None
+        agent._pending_resume_triggers = None
+        agent._startup_settled = asyncio.Event()
+        agent._fire_startup_trigger = AsyncMock()
+        agent._running = True
+        agent.input = type(
+            "GenericInput", (), {"get_input": AsyncMock(return_value=None)}
+        )()
+
+        async def stop_after_wait(delay):
+            agent._running = False
+
+        sleep = AsyncMock(side_effect=stop_after_wait)
+        monkeypatch.setattr("kohakuterrarium.core.agent.asyncio.sleep", sleep)
+
+        await agent._drive_input()
+
+        agent.input.get_input.assert_awaited_once()
+        sleep.assert_awaited_once_with(0.01)
 
 
 # ── update_system_prompt edge cases ──────────────────────────────

--- a/tests/unit/serving/test_web.py
+++ b/tests/unit/serving/test_web.py
@@ -8,14 +8,34 @@ end-user-facing UI / platform-dependent — they fall under the
 
 import json
 import socket
+import sys
 
 import pytest
 
+import kohakuterrarium.serving.web as web_mod
 from kohakuterrarium.serving.web import (
     _publish_actual_port,
     _resolve_config_dirs,
+    _run_desktop_app_blocking,
     find_free_port,
 )
+
+# ── desktop logging ─────────────────────────────────────────────
+
+
+def test_desktop_blocking_ensures_file_logging(monkeypatch):
+    calls = []
+    monkeypatch.setattr(web_mod, "configure_utf8_stdio", lambda **kwargs: None)
+    monkeypatch.setattr(web_mod, "enable_file_logging", lambda: calls.append("file"))
+    monkeypatch.setattr(web_mod, "set_level", lambda level: None)
+    monkeypatch.setattr(web_mod, "enable_stderr_logging", lambda level: None)
+    monkeypatch.setitem(sys.modules, "webview", None)
+
+    with pytest.raises(SystemExit):
+        _run_desktop_app_blocking()
+
+    assert calls == ["file"]
+
 
 # ── find_free_port ──────────────────────────────────────────────
 

--- a/tests/unit/studio/persistence/session_index/test_reconcile.py
+++ b/tests/unit/studio/persistence/session_index/test_reconcile.py
@@ -10,6 +10,7 @@ from kohakuterrarium.studio.persistence.session_index.reconcile import (
     _extract_text_preview,
     _first_user_input_preview,
     _has_vector_index,
+    logger as reconcile_logger,
     read_entry_from_disk,
     reconcile,
 )
@@ -323,6 +324,27 @@ class TestReadEntryFromDisk:
 
 
 class TestReconcile:
+    def test_noop_incremental_reconcile_does_not_log_info(
+        self, idx, session_dir, monkeypatch
+    ):
+        _make_session(session_dir, "quiet")
+        calls = []
+        monkeypatch.setattr(
+            reconcile_logger,
+            "info",
+            lambda *args, **kwargs: calls.append((args, kwargs)),
+        )
+
+        first = reconcile(idx, session_dir, full=False)
+        assert first.read == 1
+        assert len(calls) == 1
+
+        calls.clear()
+        second = reconcile(idx, session_dir, full=False)
+        assert second.read == 0
+        assert second.deleted == 0
+        assert calls == []
+
     def test_empty_session_dir_returns_zero_report(self, idx, tmp_path):
         missing = tmp_path / "no-such-dir"
         report = reconcile(idx, missing, full=True)

--- a/tests/unit/studio/test_attach_log_more.py
+++ b/tests/unit/studio/test_attach_log_more.py
@@ -1,6 +1,7 @@
 """Push studio.attach.log._tail_file backfill + poll loop coverage."""
 
 import asyncio
+import os
 
 
 from kohakuterrarium.studio.attach import log as log_mod
@@ -12,6 +13,16 @@ class _FakeWebSocket:
 
     async def send_json(self, data):
         self.sent.append(data)
+
+
+def test_find_current_process_log_honors_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("KT_CONFIG_DIR", str(tmp_path))
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    expected = logs / f"2025-01-01_000000_pid{os.getpid()}_desktop.log"
+    expected.write_text("desktop log\n", encoding="utf-8")
+
+    assert log_mod._find_current_process_log() == expected
 
 
 class TestRunLogAttachErrorPath:

--- a/tests/unit/studio/test_attach_modules.py
+++ b/tests/unit/studio/test_attach_modules.py
@@ -153,17 +153,17 @@ class TestLogHelpers:
         assert out["text"] == "not a log line"
 
     def test_find_current_process_log_no_dir(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(log_mod, "DEFAULT_LOG_DIR", tmp_path / "ghost")
+        monkeypatch.setattr(log_mod, "_default_log_dir", lambda: tmp_path / "ghost")
         assert log_mod._find_current_process_log() is None
 
     def test_find_current_process_log_no_matches(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(log_mod, "DEFAULT_LOG_DIR", tmp_path)
+        monkeypatch.setattr(log_mod, "_default_log_dir", lambda: tmp_path)
         # Create a log file with a different pid pattern.
         (tmp_path / "20260101_000000_pid99999_x.log").write_text("x")
         assert log_mod._find_current_process_log() is None
 
     def test_find_current_process_log_picks_newest(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(log_mod, "DEFAULT_LOG_DIR", tmp_path)
+        monkeypatch.setattr(log_mod, "_default_log_dir", lambda: tmp_path)
         pid = os.getpid()
         old = tmp_path / f"20260101_000000_pid{pid}_x.log"
         old.write_text("old")

--- a/tests/unit/studio/test_identity_modules.py
+++ b/tests/unit/studio/test_identity_modules.py
@@ -321,7 +321,7 @@ class TestSettings:
         assert rc == 1
 
     def test_edit_config_with_editor(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("EDITOR", "true")
+        monkeypatch.setenv("EDITOR", "echo")
         # Override the config path to a temp location.
         target = tmp_path / "x.yaml"
         monkeypatch.setattr(
@@ -330,7 +330,7 @@ class TestSettings:
             lambda: {"llm_profiles": target},
         )
         rc = settings_mod.edit_config("llm_profiles")
-        # ``EDITOR=true`` exits 0 → edit_config returns that exit code,
+        # The editor exits 0, so edit_config returns that exit code,
         # and the config file is created if it was missing.
         assert rc == 0
         assert target.exists()

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -10,6 +10,7 @@ import io
 import logging
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -358,6 +359,22 @@ class TestGetLogger:
         get_logger("kohakuterrarium.gl_no_env")
         root = logging.getLogger("kohakuterrarium")
         assert not any(isinstance(h, FlushingStreamHandler) for h in root.handlers)
+
+    def test_enable_file_logging_moves_handler_to_active_config_dir(
+        self, tmp_path, monkeypatch
+    ):
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        monkeypatch.setenv("KT_CONFIG_DIR", str(first))
+        get_logger("kohakuterrarium.gl_first")
+
+        monkeypatch.setenv("KT_CONFIG_DIR", str(second))
+        ktlog.enable_file_logging()
+
+        assert ktlog._handler is not None
+        path = Path(ktlog._handler.baseFilename)
+        assert path.parent == second / "logs"
+        assert f"pid{os.getpid()}_" in path.name
 
 
 # ── set_level ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix stdin retry loops and async blocking, restore desktop debug logs, silence no-op session reconciliation logs, and make the Studio editor test cross-platform.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Repeated session reconciliation logs filled the disk on a remote machine and interrupted remote access. The other issues were found while investigating and testing the runtime on Windows.

## Changes

- Stop retrying permanently unavailable stdin without blocking the asyncio event loop.
- Expose the current desktop process log in the debug panel.
- Keep session reconciliation, but log only when sessions actually change.
- Replace the Unix-only `EDITOR=true` test command with `EDITOR=echo`.
- Add regression tests.

## Validation

```bash
uv run python -m ruff check src/ tests/
uv run python -m black --check src/ tests/
uv run python -m pytest tests/unit/ tests/integration/
```

- Ruff and Black passed.
- Unit and integration: 13,647 passed, 9 skipped. The config-pollution guard conflicted with active review agents and passed when rerun in isolation.
- Related Studio/API e2e: 3 passed.
- Frontend format check and build passed.
- Fork CI: 13/13 passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [ ] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [ ] I kept this PR focused and did not include unrelated changes
- [ ] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

None. These are bug fixes and a test portability fix.

## Notes for Reviewers

Session reconciliation is still performed so external session changes remain visible; only no-op info logs are suppressed.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

None.
