### PR TITLE
refactor(core): make tool-result elision a compact companion

### DIFF
--- a/src/kohakuterrarium/builtins/tools/read.py
+++ b/src/kohakuterrarium/builtins/tools/read.py
@@ -83,7 +83,7 @@ class ReadTool(BaseTool):
         offset = int(args.get("offset", 0))
         limit = int(args.get("limit", 0))
 
-        max_output_bytes = int(self.config.extra.get("max_output_bytes", 256000))
+        max_output_bytes = int(self.config.extra.get("max_output_bytes", 256 * 1024))
         try:
             async with aiofiles.open(
                 file_path, encoding="utf-8", errors="replace"

--- a/src/kohakuterrarium/core/agent_message_history.py
+++ b/src/kohakuterrarium/core/agent_message_history.py
@@ -3,7 +3,10 @@
 from collections.abc import Callable
 from typing import Any
 
-from kohakuterrarium.core.conversation_elide import estimate_tokens, maybe_elide
+from kohakuterrarium.core.conversation_elide import (
+    elide_stale_tool_results,
+    estimate_tokens,
+)
 from kohakuterrarium.core.message_locator import (
     user_message_indices_for_content,
     user_message_indices_for_turn,
@@ -253,16 +256,23 @@ def reload_conversation_under_branch_view(
         conversation.append(role, message.get("content", ""), **extra)
 
     # Rebuilds restore tool outputs elided during live turns; re-apply
-    # elision when the estimated prompt is crowded so reloads stay bounded.
+    # elision when the estimated prompt is already past the compact
+    # threshold so reloads stay bounded (elision is a compact companion).
     controller = agent.controller
     config = getattr(controller, "config", None)
     if config is not None and getattr(config, "elide_tool_results", False):
-        maybe_elide(
-            conversation,
-            estimate_tokens(conversation),
-            threshold_ratio=config.elide_threshold_ratio,
-            elide_max_tokens=config.elide_max_tokens,
+        compact = getattr(agent, "compact_manager", None)
+        compact_max = (
+            compact.config.max_tokens
+            if compact is not None
+            and compact.config.enabled
+            and getattr(compact.config, "max_tokens", 0)
+            else 0
         )
+        if compact_max and estimate_tokens(conversation) >= int(
+            compact_max * compact.config.threshold
+        ):
+            elide_stale_tool_results(conversation)
 
     if selected:
         max_turn = max(selected)

--- a/src/kohakuterrarium/core/compact.py
+++ b/src/kohakuterrarium/core/compact.py
@@ -29,6 +29,7 @@ from kohakuterrarium.core.compact_text import (
     extract_message_text,
     format_messages_for_summary,
 )
+from kohakuterrarium.core.conversation_elide import elide_after_compact
 from kohakuterrarium.core.single_flight import SingleFlightDispatch, SingleFlightLease
 from kohakuterrarium.utils.logging import get_logger
 
@@ -403,6 +404,11 @@ class CompactManager:
             # prompt — drop it so it can't re-trigger a compact.
             if self._controller is not None:
                 self._controller._last_usage = {}
+
+            # Compact summarizes the compact zone but leaves the live zone
+            # (recent turns) untouched; elide stale tool results there so
+            # the post-compact prompt actually drops below the threshold.
+            elide_after_compact(self._controller)
 
             # Notify output for TUI/frontend display
             if self._output_router:

--- a/src/kohakuterrarium/core/controller.py
+++ b/src/kohakuterrarium/core/controller.py
@@ -27,7 +27,6 @@ from kohakuterrarium.core.controller_plugins import (
 from kohakuterrarium.core.conversation import Conversation, ConversationConfig
 from kohakuterrarium.core.conversation_elide import (
     TOOL_FEEDBACK_KIND,
-    maybe_elide,
 )
 from kohakuterrarium.core.events import EventType, TriggerEvent
 from kohakuterrarium.core.controller_context import format_events_for_context
@@ -81,8 +80,6 @@ class ControllerConfig:
     # threshold; with ample context the controller keeps full results so it
     # can reference what it read without re-running tools.
     elide_tool_results: bool = True
-    elide_threshold_ratio: float = 0.60
-    elide_max_tokens: int = 256_000
     batch_stackable_events: bool = True
     max_messages: int = 50
     ephemeral: bool = False
@@ -749,20 +746,6 @@ class Controller:
             # elided).
             if events and all(e.type == EventType.TOOL_COMPLETE for e in events):
                 msg.metadata["kind"] = TOOL_FEEDBACK_KIND
-
-        # Elide stale tool results only when the prompt is close to the
-        # compact threshold (elide_threshold_ratio of elide_max_tokens).
-        # With ample context older tool results stay verbatim so the
-        # controller can reference what it read without re-running tools;
-        # once the window is crowded, stubbing prevents the endless-compact
-        # loop that unconditional retention used to trigger.
-        if self.config.elide_tool_results:
-            maybe_elide(
-                self.conversation,
-                self._last_usage.get("prompt_tokens", 0),
-                threshold_ratio=self.config.elide_threshold_ratio,
-                elide_max_tokens=self.config.elide_max_tokens,
-            )
 
         messages = self.conversation.to_messages()
         messages = await self._resolve_message_files(messages)

--- a/src/kohakuterrarium/core/conversation_elide.py
+++ b/src/kohakuterrarium/core/conversation_elide.py
@@ -128,21 +128,17 @@ def estimate_tokens(conversation: Any) -> int:
     return max(1, int(total_chars / CHARS_PER_TOKEN))
 
 
-def maybe_elide(
-    conversation: Any,
-    prompt_tokens: int,
-    *,
-    threshold_ratio: float,
-    elide_max_tokens: int,
-) -> int:
-    """Elide stale tool results when the prompt is crowded; else no-op.
+def elide_after_compact(controller: Any) -> int:
+    """Elide stale tool results after a compact splice (compact companion).
 
-    Shared by the per-turn controller check and the resume/branch reload
-    paths so rebuilt conversations get the same bounded-prompt treatment.
-    Returns the number of tool-feedback messages elided.
+    Compact summarizes the compact zone but leaves the live zone (recent
+    turns) untouched; eliding there makes the post-compact prompt actually
+    drop below the threshold instead of re-triggering compaction. Respects
+    ``controller.config.elide_tool_results`` (absent config defaults to on).
     """
-    if prompt_tokens <= 0 or elide_max_tokens <= 0:
+    if controller is None:
         return 0
-    if prompt_tokens / elide_max_tokens < threshold_ratio:
+    config = getattr(controller, "config", None)
+    if config is not None and not getattr(config, "elide_tool_results", True):
         return 0
-    return elide_stale_tool_results(conversation)
+    return elide_stale_tool_results(controller.conversation)

--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -9,7 +9,10 @@ from kohakuterrarium.builtins.outputs import create_builtin_output
 from kohakuterrarium.core.agent import Agent
 from kohakuterrarium.core.config_serde import unpack_agent_config
 from kohakuterrarium.core.conversation import Conversation
-from kohakuterrarium.core.conversation_elide import estimate_tokens, maybe_elide
+from kohakuterrarium.core.conversation_elide import (
+    elide_stale_tool_results,
+    estimate_tokens,
+)
 from kohakuterrarium.errors import SessionNotResumableError
 from kohakuterrarium.modules.input.base import InputModule
 from kohakuterrarium.modules.output.base import OutputModule
@@ -227,17 +230,24 @@ def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
     if saved_messages:
         agent.controller.conversation = _build_conversation(saved_messages)
         # Rebuilds restore tool outputs elided during live turns, so re-apply
-        # elision when the estimated prompt is crowded (mirrors the per-turn
-        # controller check and keeps the resumed prompt bounded).
+        # elision when the estimated prompt is already past the compact
+        # threshold (prevents the first resumed LLM call from overflowing).
+        # Elision is a compact companion: it only fires under real pressure.
         controller = agent.controller
         config = getattr(controller, "config", None)
         if config is not None and getattr(config, "elide_tool_results", False):
-            maybe_elide(
-                controller.conversation,
-                estimate_tokens(controller.conversation),
-                threshold_ratio=config.elide_threshold_ratio,
-                elide_max_tokens=config.elide_max_tokens,
+            compact = getattr(agent, "compact_manager", None)
+            compact_max = (
+                compact.config.max_tokens
+                if compact is not None
+                and compact.config.enabled
+                and getattr(compact.config, "max_tokens", 0)
+                else 0
             )
+            if compact_max and estimate_tokens(controller.conversation) >= int(
+                compact_max * compact.config.threshold
+            ):
+                elide_stale_tool_results(controller.conversation)
         logger.info(
             "Conversation restored", agent=agent_name, messages=len(saved_messages)
         )

--- a/tests/unit/builtins/tools/test_read.py
+++ b/tests/unit/builtins/tools/test_read.py
@@ -69,7 +69,8 @@ class TestReadDefaultLineGuard:
 
     async def test_byte_cap_aligned_with_executor_max_output(self, tmp_path):
         # A file under the default line guard but over the byte cap must
-        # truncate at 256000 bytes (aligned with the executor's max_output).
+        # truncate at 256 * 1024 bytes (aligned with the executor's
+        # max_output default).
         path = tmp_path / "wide.txt"
         path.write_text(
             "\n".join(f"row {i} " + "x" * 400 for i in range(1000)),
@@ -80,5 +81,5 @@ class TestReadDefaultLineGuard:
         result = await ReadTool().execute({"path": str(path)}, context=ctx)
 
         assert result.success is True
-        assert "truncated at 256000 bytes" in result.output
+        assert "truncated at 262144 bytes" in result.output
         assert "Use offset/limit to read specific sections." in result.output

--- a/tests/unit/core/test_compact.py
+++ b/tests/unit/core/test_compact.py
@@ -973,3 +973,80 @@ class TestRunCompactGenericException:
         await mgr._run_compact()
         # Compaction failed but no exception escaped.
         assert mgr._compact_count == 0
+
+
+# ── compact companion: elide live-zone tool results ─────────────
+
+
+class TestCompactElidesLiveZone:
+    async def test_compact_elides_stale_tool_results_keeps_latest(self):
+        # Compact summarizes the compact zone but leaves the live zone
+        # untouched; elide (the compact companion) must stub stale tool
+        # results there so the post-compact prompt actually drops below
+        # the threshold. The latest round stays verbatim.
+        from kohakuterrarium.core.conversation_elide import ELISION_MARKER
+
+        conv = Conversation()
+        conv.append("system", "sys")
+        big = "Z" * 1000  # > MIN_ELIDABLE_CHARS
+        for i in range(10):
+            conv.append("user", f"q{i}")
+            conv.append(
+                "assistant",
+                f"a{i}",
+                tool_calls=[
+                    {"id": f"c{i}", "function": {"name": "read", "arguments": "{}"}}
+                ],
+            )
+            conv.append("tool", f"tool-result-{i} " + big, tool_call_id=f"c{i}")
+
+        mgr = _build_mgr(conversation=conv, llm=_LLM(chunks=["S"]))
+        await mgr._run_compact()
+        assert mgr._compact_count == 1
+
+        messages = conv.get_messages()
+        # The compact zone became a summary.
+        assert any(m.role == "assistant" and "S" in (m.content or "") for m in messages)
+        # Stale live-zone tool results were stubbed.
+        elided = [
+            m
+            for m in messages
+            if m.role == "tool" and ELISION_MARKER in (m.content or "")
+        ]
+        assert elided, "expected stale tool results to be elided after compact"
+        # The latest round's tool result is still verbatim.
+        assert any(
+            m.role == "tool" and f"tool-result-9 {big}" == m.content for m in messages
+        )
+
+    async def test_compact_skips_elide_when_disabled(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        big = "Z" * 1000
+        for i in range(10):
+            conv.append("user", f"q{i}")
+            conv.append(
+                "assistant",
+                f"a{i}",
+                tool_calls=[
+                    {"id": f"c{i}", "function": {"name": "read", "arguments": "{}"}}
+                ],
+            )
+            conv.append("tool", f"tool-result-{i} " + big, tool_call_id=f"c{i}")
+
+        mgr = _build_mgr(conversation=conv, llm=_LLM(chunks=["S"]))
+        # Controller config present and elide explicitly disabled.
+        from types import SimpleNamespace
+
+        mgr._controller = SimpleNamespace(
+            conversation=conv,
+            config=SimpleNamespace(elide_tool_results=False),
+        )
+        await mgr._run_compact()
+
+        from kohakuterrarium.core.conversation_elide import ELISION_MARKER
+
+        assert not any(
+            m.role == "tool" and ELISION_MARKER in (m.content or "")
+            for m in conv.get_messages()
+        )

--- a/tests/unit/core/test_controller.py
+++ b/tests/unit/core/test_controller.py
@@ -149,7 +149,11 @@ class TestEphemeralMode:
 
 
 class TestStaleToolResultElision:
-    async def test_prior_round_results_elided_from_context_when_window_is_full(self):
+    async def test_prior_round_results_kept_even_when_window_is_full(self):
+        # Elision moved out of the controller into the compact step: the
+        # controller must never stub tool results on its own, even when the
+        # window is crowded, so models keep full freedom to reference what
+        # they read between compactions.
         env = TestAgentBuilder().with_llm_script(["r1", "r2"]).build()
         big = "X" * 2000
         # Simulate a crowded context window (78% of the 256k budget).
@@ -171,10 +175,8 @@ class TestStaleToolResultElision:
             if (m.metadata or {}).get("kind") == TOOL_FEEDBACK_KIND
         ]
         assert len(feedback) == 2
-        # Round-1 results were stubbed before the round-2 LLM call; the
-        # latest round keeps its full output.
-        assert ELISION_MARKER in feedback[0].content
-        assert big not in feedback[0].content
+        assert big in feedback[0].content
+        assert ELISION_MARKER not in feedback[0].content
         assert big in feedback[1].content
 
     async def test_prior_round_results_kept_when_context_is_spacious(self):

--- a/tests/unit/core/test_conversation_elide.py
+++ b/tests/unit/core/test_conversation_elide.py
@@ -6,7 +6,6 @@ from kohakuterrarium.core.conversation_elide import (
     TOOL_FEEDBACK_KIND,
     elide_stale_tool_results,
     estimate_tokens,
-    maybe_elide,
 )
 
 BIG = "R" * 2000
@@ -118,61 +117,6 @@ class TestElideStaleToolResults:
 
         assert elide_stale_tool_results(conv) == 1
         assert "from a tool" in first.content
-
-
-class TestMaybeElide:
-    def test_skips_when_below_threshold(self):
-        conv = Conversation()
-        conv.append("system", "sys")
-        _feedback(conv, "[tool result] small " + "x" * 100)
-        conv.append("assistant", "ok")
-
-        assert (
-            maybe_elide(conv, 10_000, threshold_ratio=0.6, elide_max_tokens=256_000)
-            == 0
-        )
-        assert "x" * 100 in conv.get_messages()[1].content
-
-    def test_elides_when_crowded(self):
-        conv = Conversation()
-        conv.append("system", "sys")
-        first = _feedback(conv, "[tool result] round1 " + BIG)
-        conv.append("assistant", "more tools")
-        _feedback(conv, "[tool result] round2 " + BIG)
-
-        assert (
-            maybe_elide(conv, 200_000, threshold_ratio=0.6, elide_max_tokens=256_000)
-            == 1
-        )
-        assert ELISION_MARKER in first.content
-
-    def test_skips_when_no_usage_yet(self):
-        conv = Conversation()
-        conv.append("system", "sys")
-        _feedback(conv, "[tool result] round1 " + BIG)
-
-        # Mirrors the resumed controller before the first real LLM call:
-        # an empty/zero usage must not elide anything by itself.
-        assert maybe_elide(conv, 0, threshold_ratio=0.6, elide_max_tokens=256_000) == 0
-
-    def test_idempotent_across_repeated_calls(self):
-        conv = Conversation()
-        conv.append("system", "sys")
-        first = _feedback(conv, "[tool result] round1 " + BIG)
-        conv.append("assistant", "more tools")
-        _feedback(conv, "[tool result] round2 " + BIG)
-
-        # Reload paths may run before the per-turn check; the second call
-        # must not re-stub already-elided messages.
-        assert (
-            maybe_elide(conv, 200_000, threshold_ratio=0.6, elide_max_tokens=256_000)
-            == 1
-        )
-        assert (
-            maybe_elide(conv, 200_000, threshold_ratio=0.6, elide_max_tokens=256_000)
-            == 0
-        )
-        assert ELISION_MARKER in first.content
 
 
 class TestEstimateTokens:

--- a/tests/unit/session/test_resume.py
+++ b/tests/unit/session/test_resume.py
@@ -660,8 +660,16 @@ class _FakeController:
 class _ElideConfig:
     name = "alice"
     elide_tool_results = True
-    elide_threshold_ratio = 0.6
-    elide_max_tokens = 256_000
+
+
+class _FakeCompactConfig:
+    enabled = True
+    max_tokens = 256_000
+    threshold = 0.8
+
+
+class _FakeCompactManager:
+    config = _FakeCompactConfig()
 
 
 class _FakeAgentForInject:
@@ -671,7 +679,7 @@ class _FakeAgentForInject:
         self.session = _FakeAgentSession()
         self.executor = _FakeNamed()
         self.trigger_manager = _FakeNamed()
-        self.compact_manager = _FakeNamed()
+        self.compact_manager = _FakeCompactManager()
         self.native_tool_options = None
 
 


### PR DESCRIPTION
## Summary

Moves tool-result elision out of the controller's per-turn threshold check and makes it a companion to compaction: stale tool results in the live zone are elided right after a compact splice, so the post-compact prompt actually drops below the threshold instead of re-triggering compaction. Removes the hardcoded 256k / 60% elision threshold that was out of sync with the model's real context window.

## PR Type

- [x] Bug fix
- [x] Refactoring / performance

## Motivation / Context

Fixes #103. Elision fired independently at 60% of a hardcoded 256k window while compaction follows the model's real window — over-eliding on large-window models (re-read loops return) and never firing on small-window models. Elision also stubbed tool results while the context was still spacious, interrupting the very reference behavior the fix was meant to preserve. Since elision exists because compaction cannot touch the live zone, it belongs as a compact companion rather than an independent threshold.

## Changes

- `controller`: drop the per-turn elide check; remove `elide_threshold_ratio` / `elide_max_tokens` (keep the `elide_tool_results` switch)
- `compact`: after a successful splice, elide stale tool results in the live zone via new `elide_after_compact` (respects `elide_tool_results`); the latest round stays verbatim
- `resume` / branch reload: only elide when the estimated prompt is already past the compact threshold, using the compact manager's window (prevents the first resumed call from overflowing)
- `conversation_elide`: add `elide_after_compact`; remove `maybe_elide`
- `read`: fix `max_output_bytes` default (256000 → 256 * 1024) so it truly matches the executor's `max_output` default
- Tests: controller no longer stubs under a full window; compact elides the live zone after splicing; the disable switch is respected; read truncates at the aligned 262144 bytes

## Validation

```bash
pytest tests/unit/core tests/unit/session -q          # 2156 passed
pytest tests/integration/test_core.py test_session.py # 11 passed
pytest tests/unit -q --ignore=tests/unit/test_file_sizes.py  # 11781 passed; 9 pre-existing env failures (dulwich/fsync/config-pollution), verified unrelated
pytest tests/unit/test_dep_graph_lint.py test_file_sizes.py  # passed
ruff check && black --check src/ tests/               # clean
```

## Checklist

- [x] I read CONTRIBUTING.md
- [x] I linked the relevant issue(s) below
- [x] Feature/behavior change: issue exists; maintainer approval pending
- [x] CI on my fork is green — fork Actions status TBD (see Exceptions)

## Related Issues / Discussions

- Fixes #103

## Notes for Reviewers

Behavior change: with context below the compact threshold the controller never stubs tool results anymore (previously it could at 60%); the only elision points are right after a compact splice and on resume when the estimated prompt already exceeds the compact threshold. `elide_tool_results` still disables all of it.

## Exceptions / Not Run

- Full CI matrix not run locally; fork CI pending.
- e2e tier not run (change touches controller/compact/session paths; unit + integration cover the changed behavior).