### PR TITLE
fix(studio): self-heal stale closed session stores after graph merge

### DIFF
--- a/src/kohakuterrarium/studio/sessions/store_attach.py
+++ b/src/kohakuterrarium/studio/sessions/store_attach.py
@@ -45,6 +45,19 @@ def attach_session_store_for_creature(
         existing = session_stores.get(sid) or getattr(
             engine, "_session_stores", {}
         ).get(sid)
+        # A stale closed handle can survive in the studio registry after a
+        # graph merge/split replaces the store (session_coord closes
+        # superseded stores but never refreshes stores_for). Prefer the
+        # engine's live store; rebuild when even that is closed.
+        if existing is not None and getattr(existing, "_closed", False):
+            logger.warning(
+                "stale closed session store; refreshing",
+                sid=sid,
+            )
+            session_stores.pop(sid, None)
+            existing = getattr(engine, "_session_stores", {}).get(sid)
+            if existing is not None and getattr(existing, "_closed", False):
+                existing = None
         if existing is not None:
             creature.agent.attach_session_store(existing)
             session_stores[sid] = existing

--- a/src/kohakuterrarium/terrarium/autosession.py
+++ b/src/kohakuterrarium/terrarium/autosession.py
@@ -173,10 +173,19 @@ async def attach_for_new_creature(
 
     if session is None and existing is not None:
         # Joining a graph that already persists — fold this creature in.
-        register_agents_in_meta(existing, [creature.name])
-        if hasattr(creature.agent, "attach_session_store"):
-            creature.agent.attach_session_store(existing)
-        return existing
+        if getattr(existing, "_closed", False):
+            # Defensive: never attach a closed store (e.g. after a merge
+            # replaced the graph store); treat it as absent and rebuild.
+            logger.warning(
+                "engine session store is closed; rebuilding",
+                graph_id=gid,
+            )
+            existing = None
+        else:
+            register_agents_in_meta(existing, [creature.name])
+            if hasattr(creature.agent, "attach_session_store"):
+                creature.agent.attach_session_store(existing)
+            return existing
 
     path: "str | Path | None"
     if isinstance(session, (str, Path)):

--- a/src/kohakuterrarium/terrarium/group_hooks.py
+++ b/src/kohakuterrarium/terrarium/group_hooks.py
@@ -20,6 +20,10 @@ the studio layer present.
 
 from typing import Any, Callable
 
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
 # (engine, creature, *, config_path: str = "", config_type: str = "agent") -> None
 StoreAttachHook = Callable[..., None]
 # (creature, name) -> None
@@ -70,7 +74,14 @@ def attach_session_store(
             engine, creature, config_path=config_path, config_type=config_type
         )
     except Exception:
-        pass
+        # Never break the spawn, but surface the failure: a creature that
+        # fails store attach silently loses its entire session history.
+        logger.warning(
+            "session store attach failed",
+            creature=getattr(creature, "name", "?"),
+            config_path=config_path,
+            exc_info=True,
+        )
 
 
 def apply_creature_name(creature: Any, name: str) -> None:

--- a/tests/unit/studio/test_store_attach.py
+++ b/tests/unit/studio/test_store_attach.py
@@ -79,3 +79,92 @@ class TestReuseBranchIndexHook:
 
         store_attach.attach_session_store_for_creature(engine, creature)
         assert calls == [("graph_1", existing)]
+
+
+class TestStaleClosedStoreSelfHeal:
+    """A stale closed handle in the studio registry (left behind by a graph
+    merge/split that replaced the store without refreshing stores_for) must
+    be discarded in favor of the engine's live store — otherwise the newly
+    added creature attaches a closed KVault and loses its whole session."""
+
+    def test_registry_closed_engine_open_prefers_engine(self, monkeypatch, tmp_path):
+        registry = {}
+        closed = SimpleNamespace(_closed=True)
+        live = SimpleNamespace(_closed=False)
+        attached = []
+        agent = SimpleNamespace(
+            config=SimpleNamespace(name="alice"),
+            attach_session_store=lambda store: attached.append(store),
+        )
+        creature = SimpleNamespace(
+            graph_id="graph_1", creature_id="alice_1", agent=agent
+        )
+        engine = SimpleNamespace(
+            _session_stores={"graph_1": live},
+            _environments={},
+            _topology=SimpleNamespace(graphs={"graph_1": object()}),
+        )
+        monkeypatch.setattr(store_attach, "as_engine", lambda svc: engine)
+        monkeypatch.setattr(store_attach, "stores_for", lambda svc: registry)
+        monkeypatch.setattr(
+            store_attach._autosession,
+            "register_agents_in_meta",
+            lambda store, names: None,
+        )
+        monkeypatch.setattr(
+            store_attach._index_hooks,
+            "attach",
+            lambda sid, store, sess_dir: None,
+        )
+        monkeypatch.setattr(
+            store_attach._manifest,
+            "checkpoint_graph",
+            lambda engine, sid: None,
+        )
+
+        registry["graph_1"] = closed  # stale handle
+        store_attach.attach_session_store_for_creature(engine, creature)
+
+        assert attached == [live], "must attach the engine's live store"
+        assert registry["graph_1"] is live, "registry must be refreshed"
+
+    def test_registry_closed_engine_closed_mints_new(self, monkeypatch, tmp_path):
+        registry = {}
+        closed = SimpleNamespace(_closed=True)
+        minted = SimpleNamespace(_closed=False)
+        attached = []
+        agent = SimpleNamespace(
+            config=SimpleNamespace(name="alice"),
+            attach_session_store=lambda store: attached.append(store),
+        )
+        creature = SimpleNamespace(
+            graph_id="graph_1", creature_id="alice_1", agent=agent
+        )
+        engine = SimpleNamespace(
+            _session_stores={"graph_1": closed},
+            _environments={},
+            _topology=SimpleNamespace(graphs={"graph_1": object()}),
+        )
+        monkeypatch.setattr(store_attach, "as_engine", lambda svc: engine)
+        monkeypatch.setattr(store_attach, "stores_for", lambda svc: registry)
+        monkeypatch.setattr(
+            store_attach._autosession,
+            "mint_store",
+            lambda engine, sid, **kwargs: minted,
+        )
+        monkeypatch.setattr(
+            store_attach._index_hooks,
+            "attach",
+            lambda sid, store, sess_dir: None,
+        )
+        monkeypatch.setattr(
+            store_attach._manifest,
+            "checkpoint_graph",
+            lambda engine, sid: None,
+        )
+
+        registry["graph_1"] = closed
+        store_attach.attach_session_store_for_creature(engine, creature)
+
+        assert attached == [minted], "must mint a fresh store"
+        assert registry["graph_1"] is minted

--- a/tests/unit/terrarium/test_autosession.py
+++ b/tests/unit/terrarium/test_autosession.py
@@ -193,6 +193,26 @@ class TestSessionArg:
         finally:
             await t.shutdown()
 
+    async def test_joining_graph_with_closed_store_rebuilds(self, tmp_path):
+        # Defensive: a closed store in engine._session_stores (e.g. after a
+        # merge replaced it) must not be attached; a fresh store is minted.
+        t = Terrarium(session_dir=str(tmp_path / "runs"))
+        try:
+            first = await t.add_creature(_prebuilt("alice"), start=False)
+            stale = t._session_stores[first.graph_id]
+            stale.close(update_status=False)
+            # New creature on the same graph — previously would attach the
+            # closed store and lose its session.
+            await t.add_creature(_prebuilt("bob"), graph=first.graph_id, start=False)
+            new_store = t._session_stores[first.graph_id]
+            assert not getattr(new_store, "_closed", False)
+            # The fresh store serves the joining creature; alice's history
+            # lived in the closed store and is unrecoverable by design.
+            meta = new_store.load_meta()
+            assert "bob" in set(meta["agents"])
+        finally:
+            await t.shutdown()
+
 
 class TestAttachSessionMintMode:
     async def test_path_attach_mints_with_meta(self, tmp_path):


### PR DESCRIPTION
## Summary

Stops dynamically added creatures from being attached to a closed session store after a graph merge/split: `attach_session_store_for_creature` now detects a stale closed handle, discards it, and prefers the engine's live store (rebuilding when that is closed too). Attach failures are also surfaced at warning level instead of being swallowed.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactoring / performance
- [ ] Feature

## Motivation / Context

Fixes #107. After a graph merge/split, `session_coord` replaces the session store and closes the superseded handle, but the studio `stores_for` registry is not refreshed (the terrarium layer cannot import studio). A creature added afterwards resolves the closed handle from the registry, `Agent.attach_session_store` overwrites its `session_store` with it, and every event/conversation write fails with "Cannot operate on closed KVault" — silently, because `group_hooks.attach_session_store` swallowed the exception.

## Changes

- `studio/sessions/store_attach.py`: in `attach_session_store_for_creature`, when the resolved store is closed, drop the stale registry entry and prefer `engine._session_stores`; if that is closed too, treat as absent and mint a fresh store. Registry is refreshed with whatever ends up attached.
- `terrarium/group_hooks.py`: `attach_session_store` logs the failure at warning level (creature name + config path) instead of `except: pass` — a creature that fails attach loses its whole history, so the failure must be visible.
- `terrarium/autosession.py`: defensive — when joining a graph whose `engine._session_stores` entry is closed, never attach it; rebuild instead.
- Tests: registry-closed/engine-open prefers the live store; both closed mints fresh; engine-closed on graph join rebuilds.

## Validation

```bash
pytest tests/unit/studio/test_store_attach.py tests/unit/terrarium/test_autosession.py tests/unit/terrarium/test_group_hooks.py -q  # 35 passed
pytest tests/unit/studio tests/unit/terrarium -q                # 4050 passed; 2 pre-existing env failures (Windows fsync EINVAL), verified unrelated
pytest tests/unit/test_dep_graph_lint.py test_file_sizes.py -q  # passed
ruff check && black --check src/ tests/                         # clean
```

## Checklist

- [x] I read CONTRIBUTING.md
- [x] I linked the relevant issue(s) below
- [x] The change is limited to a bug fix
- [ ] CI on my fork is green — fork Actions status TBD (see Exceptions)

## Related Issues / Discussions

- Fixes #107

## Notes for Reviewers

The self-heal lives in the studio layer (which can see both the registry and the engine's store map), so it also covers any other future cause of a stale closed handle. The `group_hooks` change is observability only — spawn still never fails on store attach.

## Exceptions / Not Run

- Full CI matrix not run locally; fork CI pending.
- e2e tier not run (change touches store attach / session persistence paths; unit tests cover the stale-handle cases).