### PR TITLE
fix(terrarium): creature removal survives a closed drive repository

### DIFF
--- a/src/kohakuterrarium/terrarium/drive/runtime.py
+++ b/src/kohakuterrarium/terrarium/drive/runtime.py
@@ -405,8 +405,15 @@ class DriveRuntime:
 
     async def on_creature_stopped(self, creature_id: str) -> None:
         manager = self._manager_for_creature(creature_id)
-        if manager is not None:
+        if manager is None:
+            return
+        try:
             await manager.on_creature_stopped(creature_id)
+        except DriveRepositoryClosedError:
+            # Repository closure is a quiescence signal, not an error: the
+            # graph's drive repo may already be closed (Windows closes a
+            # session-backed repo's sqlite connection with its store).
+            return
 
     async def on_creature_removed(
         self,
@@ -422,9 +429,13 @@ class DriveRuntime:
         )
         if manager is None:
             return ()
-        return await manager.on_creature_removed(
-            creature_id, graph_member_ids=graph_member_ids
-        )
+        try:
+            return await manager.on_creature_removed(
+                creature_id, graph_member_ids=graph_member_ids
+            )
+        except DriveRepositoryClosedError:
+            # Repository closure is a quiescence signal, not an error.
+            return ()
 
     def _manager_for_creature(self, creature_id: str) -> DriveManager | None:
         creature = self._engine._creatures.get(creature_id)

--- a/src/kohakuterrarium/terrarium/engine.py
+++ b/src/kohakuterrarium/terrarium/engine.py
@@ -28,6 +28,9 @@ import kohakuterrarium.terrarium.root as _root
 import kohakuterrarium.terrarium.topology as _topo
 import kohakuterrarium.terrarium.wiring as _wiring
 import kohakuterrarium.terrarium.drive.runtime as _drive_runtime
+from kohakuterrarium.terrarium.drive.store import (
+    DriveRepositoryClosedError,
+)
 from kohakuterrarium.core.environment import Environment
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.terrarium.creature_host import (
@@ -309,6 +312,11 @@ class Terrarium:
         # A creature-scoped Drive orphans-and-blocks on removal,
         # a graph-scoped one unassigns / auto-assigns among the remaining
         # graph members — never a silent semantic reassignment.
+        # Drive cleanup must never block the creature removal itself: the
+        # repository may already be closed (Windows closes a session-backed
+        # repo's sqlite connection when its store closes; a stale registry
+        # entry can survive a merge/split). Treat that as quiescence and
+        # continue the topology removal below.
         if self._drive_runtime is not None:
             old_graph = self._topology.graphs.get(old_gid)
             members = (
@@ -316,9 +324,17 @@ class Terrarium:
                 if old_graph is not None
                 else frozenset()
             )
-            await self._drive_runtime.on_creature_removed(
-                cid, graph_id=old_gid, graph_member_ids=members
-            )
+            try:
+                await self._drive_runtime.on_creature_removed(
+                    cid, graph_id=old_gid, graph_member_ids=members
+                )
+            except DriveRepositoryClosedError as exc:
+                _logger.warning(
+                    "Drive cleanup skipped during creature removal "
+                    "(repository closed)",
+                    creature_id=cid,
+                    error=str(exc),
+                )
         delta = _topo.remove_creature(self._topology, cid)
         self._creatures.pop(cid, None)
         _wiring.install_output_wiring_resolver(self)

--- a/tests/unit/terrarium/drive/test_drive_runtime.py
+++ b/tests/unit/terrarium/drive/test_drive_runtime.py
@@ -522,8 +522,59 @@ class TestLifecycle:
         assignment = await manager.get_assignment(record.drive_id)
         assert assignment.assignment_state == "orphaned"
 
+    # ── per-graph partitioning (Phase F, design §3.1) ─────────────
 
-# ── per-graph partitioning (Phase F, design §3.1) ─────────────
+    async def test_on_creature_removed_tolerates_closed_repo(self):
+        # A stale registry entry can point at an already-closed repository
+        # (Windows closes a session-backed repo's sqlite connection with its
+        # store after a merge/split). Removal must treat that as quiescence
+        # instead of propagating DriveRepositoryClosedError.
+        from kohakuterrarium.terrarium.drive.store import (
+            DriveRepositoryClosedError,
+        )
+
+        clock = _Clock()
+        rt = _runtime(clock=clock)
+
+        async def _boom(*_a, **_k):
+            raise DriveRepositoryClosedError(
+                "Drive repository is closed; its executor has been shut down"
+            )
+
+        mgr = rt.manager_for("g1")
+        mgr.on_creature_removed = _boom
+        # Must not raise.
+        affected = await rt.on_creature_removed(
+            "worker", graph_id="g1", graph_member_ids=frozenset()
+        )
+        assert affected == ()
+
+    async def test_on_creature_stopped_tolerates_closed_repo(self):
+        from kohakuterrarium.terrarium.drive.store import (
+            DriveRepositoryClosedError,
+        )
+
+        clock = _Clock()
+        rt = _runtime(clock=clock)
+
+        async def _boom(*_a, **_k):
+            raise DriveRepositoryClosedError(
+                "Drive repository is closed; its executor has been shut down"
+            )
+
+        # Register a creature so _manager_for_creature resolves via graph_id.
+        engine = rt._engine
+        engine._creatures["worker"] = type("C", (), {"graph_id": "g1"})()
+        mgr = rt.manager_for("g1")
+        mgr.on_creature_stopped = _boom
+        # Must not raise.
+        await rt.on_creature_stopped("worker")
+
+    async def test_on_creature_stopped_skips_when_no_manager(self):
+        clock = _Clock()
+        rt = _runtime(clock=clock)
+        # No creature registered -> _manager_for_creature returns None.
+        await rt.on_creature_stopped("ghost")
 
 
 class TestPerGraph:

--- a/tests/unit/terrarium/drive/test_drive_runtime.py
+++ b/tests/unit/terrarium/drive/test_drive_runtime.py
@@ -19,6 +19,7 @@ from kohakuterrarium.terrarium.drive.config import (
 )
 from kohakuterrarium.terrarium.drive.errors import DriveValidationError
 from kohakuterrarium.terrarium.drive.memory import MemoryDriveRepository
+from kohakuterrarium.terrarium.drive.store import DriveRepositoryClosedError
 from kohakuterrarium.terrarium.drive.models import ActorRef, DriveStatus
 from kohakuterrarium.terrarium.drive.registration import (
     DriveRegistrationDescriptor,
@@ -529,10 +530,6 @@ class TestLifecycle:
         # (Windows closes a session-backed repo's sqlite connection with its
         # store after a merge/split). Removal must treat that as quiescence
         # instead of propagating DriveRepositoryClosedError.
-        from kohakuterrarium.terrarium.drive.store import (
-            DriveRepositoryClosedError,
-        )
-
         clock = _Clock()
         rt = _runtime(clock=clock)
 
@@ -550,10 +547,6 @@ class TestLifecycle:
         assert affected == ()
 
     async def test_on_creature_stopped_tolerates_closed_repo(self):
-        from kohakuterrarium.terrarium.drive.store import (
-            DriveRepositoryClosedError,
-        )
-
         clock = _Clock()
         rt = _runtime(clock=clock)
 

--- a/tests/unit/terrarium/test_engine.py
+++ b/tests/unit/terrarium/test_engine.py
@@ -13,6 +13,9 @@ import pytest
 from kohakuterrarium.errors import SessionNotResumableError
 from kohakuterrarium.terrarium.creature_host import Creature
 from kohakuterrarium.terrarium.engine import Terrarium
+from kohakuterrarium.terrarium.drive.store import (
+    DriveRepositoryClosedError,
+)
 from kohakuterrarium.terrarium.events import EventFilter, EventKind
 from kohakuterrarium.testing.terrarium import _FakeAgent, TestTerrariumBuilder
 
@@ -159,6 +162,28 @@ class TestAddRemoveCreature:
         t = Terrarium()
         with pytest.raises(KeyError):
             await t.remove_creature("ghost")
+
+    async def test_remove_survives_closed_drive_repo(self):
+        # A stale drive registry entry can point at an already-closed
+        # repository (Windows closes a session-backed repo's sqlite connection
+        # with its store after a merge/split). Creature removal must treat
+        # that as quiescence and STILL remove the creature from the topology —
+        # otherwise a dead node lingers and later splits into its own session.
+        t = await TestTerrariumBuilder().with_creature("alice").build()
+        try:
+            assert "alice" in t
+
+            async def _boom(*_a, **_k):
+                raise DriveRepositoryClosedError(
+                    "Drive repository is closed; its executor has been shut down"
+                )
+
+            t._drive_runtime.on_creature_removed = _boom
+            await t.remove_creature("alice")
+            assert "alice" not in t
+            assert t.list_graphs() == []
+        finally:
+            await t.shutdown()
 
     async def test_get_creature(self):
         t = await TestTerrariumBuilder().with_creature("alice").build()


### PR DESCRIPTION
## Summary

`group_remove_node` / `group_remove_node` failed with "Drive repository is
closed; its executor has been shut down", leaving the node stuck in the
topology (it later splits into its own session when channels are removed).
This PR makes creature removal and stop resilient to an already-closed drive
repository: the drive cleanup is treated as quiescence and the topology removal
always completes.

## PR Type

- [x] Bug fix

## Motivation / Context

On Windows, a session-backed drive repository's sqlite connection is closed
when its store closes, and a stale drive-registry entry can survive a graph
merge/split. When `remove_creature` then called
`drive_runtime.on_creature_removed`, the closed repository raised
`DriveRepositoryClosedError` **inside the call, before the topology removal**.
`remove_creature` has no error handling there, so the whole removal aborted:
the creature stayed in `_topology` and in `_creatures`, and the graph-drop /
split bookkeeping never ran. Removing the channel afterwards split the leftover
node into its own session that had to be closed by hand.

Root cause chain:
1. `remove_creature` calls `drive_runtime.on_creature_removed` before
   `_topo.remove_creature` / `_creatures.pop`.
2. `on_creature_removed` reads `repo.list_drives(...)` with no guard.
3. On a stale/closed repository this raises `DriveRepositoryClosedError`.
4. No `try/except` → removal aborts → creature lingers.

The repository-closure path is a known lifecycle event elsewhere in the drive
code: `delivery.py` and `runtime.py` already treat
`DriveRepositoryClosedError` as a quiescence signal ("Repository closure is a
quiescence signal, not a failed round"). The two creature-lifecycle entry
points were missing that guard.

## Changes

- `terrarium/engine.py` — `remove_creature`: wrap the drive cleanup in
  `try/except DriveRepositoryClosedError` and **always continue** the topology
  removal (creature + graph are still cleaned up). A closed drive repo is
  logged as a warning, never allowed to abort removal.
- `terrarium/drive/runtime.py` — `on_creature_stopped` and
  `on_creature_removed` tolerate `DriveRepositoryClosedError` (return
  immediately / empty tuple), consistent with the existing quiescence handling
  in `delivery.py`.
- Tests:
  - `tests/unit/terrarium/test_engine.py` — `test_remove_survives_closed_drive_repo`
    (drive cleanup raises closed-repo, creature is still removed and the graph
    drops).
  - `tests/unit/terrarium/drive/test_drive_runtime.py` —
    `test_on_creature_removed_tolerates_closed_repo`,
    `test_on_creature_stopped_tolerates_closed_repo`,
    `test_on_creature_stopped_skips_when_no_manager`.

## Validation

```bash
pytest tests/unit/terrarium/ -q            # 2167 passed
pytest tests/unit/studio/ -q               # 4050 passed (2 pre-existing fsync EINVAL failures on Windows, unrelated)
ruff check src/ tests/                     # all checks passed
black --check src/ tests/                  # 1481 files unchanged
python scripts/dep_graph.py --lint-imports # no tier violations
pytest tests/unit/test_file_sizes.py -q    # 1678 passed
```

Live check: with `on_creature_removed` stubbed to raise the closed-repo error,
`remove_creature` still removes the creature and drops the graph.

## Checklist

- [x] I read the CONTRIBUTING guide.
- [x] I linked the relevant issue(s) below.
- [x] The change is limited to a bug fix.
- [ ] CI on my fork is green — pushed to self fork; Actions status pending.

## Related Issues / Discussions

- Fixes #113

## Notes for Reviewers

This is a guard/robustness fix: it prevents drive cleanup from aborting
creature removal. The deeper issue — a stale drive-registry entry surviving a
merge/split (the reason the repository is already closed) — is related to the
same class of stale-reference bugs and can be addressed separately; this PR
makes the observable failure (node stuck / split into its own session)
impossible.

## Exceptions / Not Run

- e2e tier not run locally (change is covered by unit tests on the exact
  failure path).
- Full CI matrix not run locally; fork CI pending.