### PR TITLE
fix(tui): make exit commands close the session

### DIFF
--- a/src/kohakuterrarium/builtins/tui/session.py
+++ b/src/kohakuterrarium/builtins/tui/session.py
@@ -789,8 +789,18 @@ class TUISession(TabModelRegistryMixin):
         finally:
             self.running = False
             self._stop_event.set()
-            # Empty input wakes a pending reader and signals shutdown.
-            self._app._input_queue.put_nowait("")
+            self._signal_input_shutdown()
+
+    def _signal_input_shutdown(self) -> None:
+        """Discard pending submissions and wake the runner with shutdown."""
+        if not self._app:
+            return
+        while True:
+            try:
+                self._app._input_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        self._app._input_queue.put_nowait("")
 
     async def get_input(self, prompt: str = "You: ") -> str:
         if not self._app:
@@ -879,8 +889,7 @@ class TUISession(TabModelRegistryMixin):
         self.running = False
         self._stop_event.set()
         if self._app:
-            # Empty input wakes a pending reader and signals shutdown.
-            self._app._input_queue.put_nowait("")
+            self._signal_input_shutdown()
             if self._app.is_running:
                 self._app.exit()
 

--- a/src/kohakuterrarium/terrarium/engine_cli.py
+++ b/src/kohakuterrarium/terrarium/engine_cli.py
@@ -68,6 +68,15 @@ async def _handle_tui_slash(text: str, tui: "TUISession", focus: Any) -> bool:
     resolver = getattr(tui, "agent_for_tab", None)
     target_agent = (resolver() if callable(resolver) else None) or focus
 
+    # The engine runner owns Textual's input loop. Its creatures use
+    # ``NoneInput``, so forwarding ExitCommand would only set that module's
+    # private flag -- a flag this loop never reads. Stop the TUISession here;
+    # ``stop()`` wakes ``get_input()`` with an empty value so the runner can
+    # leave the loop and perform its normal cleanup.
+    if name in ("exit", "quit", "q"):
+        tui.stop()
+        return True
+
     if name == "model" and not stripped_args:
         await tui.show_model_picker_modal(target_agent)
         return True

--- a/tests/integration/test_repro_ui_bugs.py
+++ b/tests/integration/test_repro_ui_bugs.py
@@ -879,11 +879,27 @@ class TestTuiStdinStealFix:
                 raise AssertionError("should not be called for /help")
 
         # Bare /model is the modal path; with args it falls through.
-        for variant in ("/help", "/clear", "/exit", "/status"):
+        for variant in ("/help", "/clear", "/status"):
             handled = _asyncio.run(_handle_tui_slash(variant, _NoModalTUI(), object()))
             assert (
                 handled is False
             ), f"{variant!r} should fall through to agent slash dispatch"
+
+        # Engine-managed TUI sessions replace stdin inputs with NoneInput.
+        # Dispatching /exit through that input only toggles a flag which this
+        # runner never observes, so the runner must stop its own TUISession.
+        class _RecordingTUI:
+            def __init__(self):
+                self.stop_calls = 0
+
+            def stop(self) -> None:
+                self.stop_calls += 1
+
+        for variant in ("/exit", "/quit", "/q"):
+            tui = _RecordingTUI()
+            handled = _asyncio.run(_handle_tui_slash(variant, tui, object()))
+            assert handled is True
+            assert tui.stop_calls == 1
 
     def test_handle_tui_slash_targets_active_tab_agent(self):
         # Multi-creature: ``/model`` (no args) must open the picker for

--- a/tests/integration/test_repro_ui_bugs.py
+++ b/tests/integration/test_repro_ui_bugs.py
@@ -957,6 +957,14 @@ class TestTuiStdinStealFix:
         solo.host_agent = host
         assert solo.agent_for_tab() is host
 
+        # Explicit stop must discard already-queued input before adding the
+        # empty shutdown sentinel. Otherwise /exit can process a later queued
+        # message before the runner observes shutdown.
+        asyncio.run(solo.start())
+        solo._app._input_queue.put_nowait("queued before exit")
+        solo.stop()
+        assert asyncio.run(solo.get_input()) == ""
+
     def test_tui_session_per_target_model_registry(self):
         # A sibling creature's model switch must NOT stomp the visible
         # tab's ``Model:`` line; switching tabs re-renders the line


### PR DESCRIPTION
## Summary

Make `/exit`, `/quit`, and `/q` close engine-managed Textual TUI sessions immediately and preserve the runner's normal cleanup path.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The engine TUI replaces stdin-consuming inputs with `NoneInput`. Forwarding an exit command to that input only sets its private `_exit_requested` flag, while the engine TUI loop waits on `TUISession.get_input()` and never reads the flag. The UI therefore remained open after a valid exit command.

Final review also found that an empty shutdown sentinel was appended behind any already-queued submissions. In that race, a message could still be processed after `/exit`.

## Changes

- Intercept the three built-in exit command names at the engine TUI ownership boundary.
- Stop the `TUISession`, which wakes the input loop and preserves the existing cleanup path.
- Discard queued submissions before publishing the shutdown sentinel, both for explicit stop and Textual app exit.
- Add regression coverage for all three aliases and the queued-input shutdown race.

## Validation

```bash
python -m pytest tests/unit/builtins/tui tests/integration/test_repro_ui_bugs.py tests/unit/terrarium/test_engine_cli_drive_intercept.py tests/integration/test_tui_cli_mid_turn_injection.py -q --basetemp .pytest-run-exit-review-final -p no:cacheprovider
python -m pytest tests/unit/test_file_sizes.py -q --basetemp .pytest-run-exit-review-sizes -p no:cacheprovider
black --check --fast --workers 1 --target-version py312 src/kohakuterrarium/terrarium/engine_cli.py src/kohakuterrarium/builtins/tui/session.py tests/integration/test_repro_ui_bugs.py
ruff check src/kohakuterrarium/terrarium/engine_cli.py src/kohakuterrarium/builtins/tui/session.py tests/integration/test_repro_ui_bugs.py
git diff --check
```

Results:

- 47 affected TUI tests passed.
- 1,678 file-size checks passed.
- Black, Ruff, and whitespace checks passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] This is not a feature PR; the change is limited to a bug fix and its regression tests
- [x] I kept this PR focused and did not include unrelated changes
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally
- [ ] If frontend files changed, I ran the frontend checks (not applicable)
- [x] CI is green

## Related Issues / Discussions

Fixes #118

## Notes for Reviewers

The intercept lives in the engine TUI runner because it owns both the Textual application and the input loop. `TUISession.stop()` now clears pending submissions before queuing an empty input, so the next read exits deterministically and cleanup continues through the existing `finally` block.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The full repository lint and unit suites were not run locally; focused checks cover the changed files and neighboring TUI workflows. GitHub CI passed all 13 checks across Windows, macOS, Ubuntu, and Python 3.12-3.14.