### PR TITLE
fix(cli): preserve multi-creature output routing

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/app_multi.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app_multi.py
@@ -51,7 +51,9 @@ from kohakuterrarium.builtins.cli_rich.focus import FocusController
 from kohakuterrarium.builtins.cli_rich.live_region import LiveRegion
 from kohakuterrarium.builtins.cli_rich.live_state import LiveRegionState
 from kohakuterrarium.builtins.cli_rich.multiplex import MultiplexedRichOutput
+from kohakuterrarium.builtins.cli_rich.output import RichCLIOutput
 from kohakuterrarium.builtins.cli_rich.roster import RosterWidget
+from kohakuterrarium.modules.output.event import OutputEvent
 from kohakuterrarium.modules.user_command.base import UserCommandContext
 from kohakuterrarium.terrarium.events import EventFilter, EventKind
 from kohakuterrarium.terrarium.service import LocalTerrariumService
@@ -80,6 +82,7 @@ class AppMultiCreatureMixin:
         self.live_region_widgets: dict[str, LiveRegion] = {}
         # Preserve replaced sinks so removal and teardown can restore them.
         self._managed_outputs: dict[str, Any] = {}
+        self._creature_renderers: dict[str, RichCLIOutput] = {}
         self._engine_watch_task: asyncio.Task | None = None
         for c in creatures:
             self._install_creature_slot(c, is_focus=c.creature_id == focus_creature_id)
@@ -121,6 +124,10 @@ class AppMultiCreatureMixin:
         widget = self.live_region_widgets[cid]
         agent = getattr(creature, "agent", None)
         if agent is not None:
+            self._creature_renderers[cid] = RichCLIOutput(
+                self,
+                reply_router=getattr(agent, "output_router", None),
+            )
             try:
                 model = (
                     agent.llm_identifier()
@@ -297,6 +304,9 @@ class AppMultiCreatureMixin:
         state = self.live_regions.get(creature_id)
         if state is None:
             return
+        renderer = self._creature_renderers.get(creature_id)
+        if renderer is None:
+            return
         is_focus = creature_id == self.focus_controller.focus_id
         # Existing output handlers route through self.live_region, so swap it only
         # for this dispatch and let unfocused widgets accumulate silently.
@@ -334,13 +344,17 @@ class AppMultiCreatureMixin:
                     pass
             elif kind == "activity":
                 try:
-                    self.on_activity_with_metadata(
+                    renderer.on_activity_with_metadata(
                         payload.get("activity_type", ""),
                         payload.get("detail", ""),
                         payload.get("metadata", {}),
                     )
                 except Exception:
                     pass
+            elif kind == "emit":
+                event = payload.get("event")
+                if isinstance(event, OutputEvent):
+                    await renderer.emit(event)
         finally:
             self.live_region = prev
             if capture_swapped:
@@ -563,6 +577,7 @@ class AppMultiCreatureMixin:
         old_focus = self.focus_controller.focus_id
         new_focus = self.focus_controller.remove(creature_id)
         self.live_regions.pop(creature_id, None)
+        self._creature_renderers.pop(creature_id, None)
         self.draft_by_creature.pop(creature_id, None)
         try:
             self.committer.clear_capture(creature_id)

--- a/src/kohakuterrarium/builtins/cli_rich/app_multi.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app_multi.py
@@ -602,10 +602,30 @@ class AppMultiCreatureMixin:
                 await task
             except (asyncio.CancelledError, Exception):
                 pass
-        if not self._managed_outputs:
-            return
         for cid in list(self._managed_outputs.keys()):
+            sink = None
+            if self.engine is not None:
+                try:
+                    creature = self.engine.get_creature(cid)
+                    sink = getattr(
+                        getattr(creature.agent, "output_router", None),
+                        "default_output",
+                        None,
+                    )
+                except Exception:
+                    pass
+            if isinstance(sink, MultiplexedRichOutput) and sink.is_running:
+                try:
+                    await sink.stop()
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        "multiplexed sink stop failed",
+                        creature_id=cid,
+                        error=str(e),
+                        exc_info=True,
+                    )
             self.restore_creature_sink(cid)
+        self._creature_renderers.clear()
 
     async def dispatch_topology_command(self, name: str, args: str) -> bool:
         """Run engine-aware commands with focused-creature context."""

--- a/src/kohakuterrarium/builtins/cli_rich/dialogs/bus_overlay.py
+++ b/src/kohakuterrarium/builtins/cli_rich/dialogs/bus_overlay.py
@@ -38,15 +38,16 @@ class BusInteractiveOverlay:
         self._get_textarea_text = get_textarea_text
         self._clear_textarea = clear_textarea
         self.visible: bool = False
-        self._queue: list[OutputEvent] = []
+        self._queue: list[tuple[OutputEvent, Any]] = []
         self._current: OutputEvent | None = None
+        self._current_router: Any = None
 
         self._option_index: int = 0
         self._multi_selected: set[str] = set()
 
-    def open(self, event: OutputEvent) -> None:
+    def open(self, event: OutputEvent, *, router: Any = None) -> None:
         """Queue an event; open if nothing is currently displayed."""
-        self._queue.append(event)
+        self._queue.append((event, router))
         if not self.visible:
             self._activate_next()
 
@@ -55,6 +56,7 @@ class BusInteractiveOverlay:
         if dismiss_current and self._current is not None:
             self._submit("cancel", values={})
         self._current = None
+        self._current_router = None
         self.visible = False
         self._reset_state()
         if self._queue:
@@ -64,7 +66,7 @@ class BusInteractiveOverlay:
         if not self._queue:
             self.visible = False
             return
-        self._current = self._queue.pop(0)
+        self._current, self._current_router = self._queue.pop(0)
         self._reset_state()
         payload = self._current.payload or {}
         default_id = payload.get("default")
@@ -218,7 +220,11 @@ class BusInteractiveOverlay:
     def _submit(self, action_id: str, values: dict[str, Any]) -> None:
         if self._current is None:
             return
-        router = self._get_router()
+        router = (
+            self._current_router
+            if self._current_router is not None
+            else self._get_router()
+        )
         if router is None:
             return
         try:

--- a/src/kohakuterrarium/builtins/cli_rich/multiplex.py
+++ b/src/kohakuterrarium/builtins/cli_rich/multiplex.py
@@ -54,6 +54,9 @@ class MultiplexedRichOutput(BaseOutputModule):
     async def _on_start(self) -> None:
         self._owner_loop = asyncio.get_running_loop()
 
+    async def _on_stop(self) -> None:
+        self._owner_loop = None
+
     async def _dispatch(self, kind: str, payload: dict[str, Any]) -> None:
         self._owner_loop = asyncio.get_running_loop()
         try:

--- a/src/kohakuterrarium/builtins/cli_rich/multiplex.py
+++ b/src/kohakuterrarium/builtins/cli_rich/multiplex.py
@@ -44,8 +44,18 @@ class MultiplexedRichOutput(BaseOutputModule):
         self.handler = handler
         self.creature_id = creature_id
         self.creature_name = creature_name or creature_id
+        try:
+            self._owner_loop: asyncio.AbstractEventLoop | None = (
+                asyncio.get_running_loop()
+            )
+        except RuntimeError:
+            self._owner_loop = None
+
+    async def _on_start(self) -> None:
+        self._owner_loop = asyncio.get_running_loop()
 
     async def _dispatch(self, kind: str, payload: dict[str, Any]) -> None:
+        self._owner_loop = asyncio.get_running_loop()
         try:
             await self.handler(self.creature_id, kind, payload)
         except Exception as e:  # pragma: no cover - defensive
@@ -83,25 +93,29 @@ class MultiplexedRichOutput(BaseOutputModule):
     def on_activity_with_metadata(
         self, activity_type: str, detail: str, metadata: dict[str, Any]
     ) -> None:
-        try:
-            self.handler
-        except AttributeError:
+        # Synchronous callbacks may arrive from worker threads, where Python 3.12
+        # deliberately provides no implicit event loop. Schedule construction of
+        # the coroutine back on the loop which owns this sink.
+        loop = self._owner_loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+                self._owner_loop = loop
+            except RuntimeError:
+                return
+        if loop.is_closed():
             return
-        # Synchronous callbacks may arrive from worker threads.
+        payload = {
+            "activity_type": activity_type,
+            "detail": detail,
+            "metadata": dict(metadata) if metadata else {},
+        }
+
+        def _schedule_dispatch() -> None:
+            asyncio.create_task(self._dispatch("activity", payload))
+
         try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            return
-        coro = self._dispatch(
-            "activity",
-            {
-                "activity_type": activity_type,
-                "detail": detail,
-                "metadata": dict(metadata) if metadata else {},
-            },
-        )
-        try:
-            asyncio.run_coroutine_threadsafe(coro, loop)
+            loop.call_soon_threadsafe(_schedule_dispatch)
         except RuntimeError:
             return
 

--- a/src/kohakuterrarium/builtins/cli_rich/output.py
+++ b/src/kohakuterrarium/builtins/cli_rich/output.py
@@ -27,9 +27,10 @@ def _make_label(job_id: str, name: str) -> str:
 class RichCLIOutput(BaseOutputModule):
     """Output module that routes agent events into RichCLIApp."""
 
-    def __init__(self, app):
+    def __init__(self, app: Any, *, reply_router: Any = None):
         super().__init__()
         self.app = app
+        self.reply_router = reply_router
 
     async def write(self, content: str) -> None:
         if not content or self.app is None:
@@ -155,7 +156,7 @@ class RichCLIOutput(BaseOutputModule):
                     logger.exception("CLI panel fallback failed", error=str(e))
             return
         try:
-            overlay.open(event)
+            overlay.open(event, router=self.reply_router)
             self.app._invalidate()
         except Exception as e:
             logger.exception(
@@ -207,6 +208,23 @@ class RichCLIOutput(BaseOutputModule):
         job_id = metadata.get("job_id", "")
         name_from_label = self._extract_name(detail)
         args_preview = self._extract_args_preview(metadata)
+
+        if activity_type == "command_result":
+            self.app.on_notification_event(
+                {
+                    "title": self._command_name(metadata),
+                    "text": detail,
+                    "level": "info",
+                }
+            )
+            return
+
+        if activity_type == "command_error":
+            self.app.on_processing_error(
+                error_type=self._command_name(metadata),
+                error=detail,
+            )
+            return
 
         # Nested tool events identify their parent sub-agent block by job_id.
         if activity_type == "subagent_tool_start":
@@ -378,6 +396,14 @@ class RichCLIOutput(BaseOutputModule):
                 if isinstance(p, dict) and p.get("type") == "text"
             )
         return ""
+
+    @staticmethod
+    def _command_name(metadata: dict[str, Any]) -> str:
+        """Return a compact slash-command label for command notices."""
+        raw = str(metadata.get("command", "") or "").strip()
+        if not raw:
+            return "command"
+        return raw.lstrip("/").split(None, 1)[0] or "command"
 
     @staticmethod
     def _extract_name(detail: str) -> str:

--- a/tests/unit/builtins/cli_rich/test_app_multi_creature.py
+++ b/tests/unit/builtins/cli_rich/test_app_multi_creature.py
@@ -26,6 +26,7 @@ from kohakuterrarium.builtins.cli_rich.app import RichCLIApp
 from kohakuterrarium.builtins.cli_rich.multiplex import MultiplexedRichOutput
 from kohakuterrarium.builtins.plugins.goal.plugin import GoalCommand
 from kohakuterrarium.builtins.user_commands.drives import DrivesCommand
+from kohakuterrarium.modules.output.event import OutputEvent
 from kohakuterrarium.modules.user_command.base import (
     UserCommandContext,
     UserCommandResult,
@@ -41,6 +42,15 @@ from kohakuterrarium.terrarium.service import LocalTerrariumService
 from kohakuterrarium.testing.terrarium import _FakeAgent as _EngineFakeAgent
 
 
+class _FakeOutputRouter:
+    def __init__(self):
+        self.default_output = None
+        self.submitted_replies = []
+
+    def submit_reply(self, reply) -> None:
+        self.submitted_replies.append(reply)
+
+
 class _FakeAgent:
     """Minimal Agent-shaped namespace for app setup."""
 
@@ -48,7 +58,7 @@ class _FakeAgent:
         self.config = SimpleNamespace(name=name)
         self.llm = SimpleNamespace(model=f"model-for-{name}", _profile_max_context=0)
         self.input = None
-        self.output_router = SimpleNamespace(default_output=None)
+        self.output_router = _FakeOutputRouter()
         self.injected: list[str] = []
         self._processing_task = None
         self._active_handles: dict = {}
@@ -296,6 +306,116 @@ class TestHandleCreatureEventRouting:
         app, _, _ = app_and_engine
         # Should not raise.
         await app._handle_creature_event("nobody", "text", {"text": "x"})
+
+    @pytest.mark.asyncio
+    async def test_structured_notification_commits_to_source_creature(
+        self, app_and_engine
+    ):
+        app, _, _ = app_and_engine
+        event = OutputEvent(
+            type="notification",
+            payload={"title": "Build", "text": "complete", "level": "success"},
+        )
+
+        await app._handle_creature_event("c2", "emit", {"event": event})
+
+        bob_commits = app.committer.captured_for("c2")
+        assert any(
+            "complete" in args[0] for method, args in bob_commits if method == "text"
+        )
+        assert app.committer.captured_for("c1") == []
+
+    @pytest.mark.asyncio
+    async def test_interactive_event_reply_returns_to_source_creature(
+        self, app_and_engine
+    ):
+        app, _, creatures = app_and_engine
+        bob_event = OutputEvent(
+            type="confirm",
+            id="confirm-bob",
+            interactive=True,
+            payload={
+                "prompt": "Deploy Bob?",
+                "options": [{"id": "yes", "label": "Yes", "style": "primary"}],
+            },
+        )
+        carol_event = OutputEvent(
+            type="confirm",
+            id="confirm-carol",
+            interactive=True,
+            payload={
+                "prompt": "Deploy Carol?",
+                "options": [{"id": "yes", "label": "Yes", "style": "primary"}],
+            },
+        )
+
+        await app._handle_creature_event("c2", "emit", {"event": bob_event})
+        await app._handle_creature_event("c3", "emit", {"event": carol_event})
+        assert app.bus_overlay.visible is True
+        assert app.bus_overlay.handle_key("enter") is True
+        assert app.bus_overlay.visible is True
+        assert app.bus_overlay.handle_key("enter") is True
+
+        assert creatures[0].agent.output_router.submitted_replies == []
+        bob_replies = creatures[1].agent.output_router.submitted_replies
+        assert [(reply.event_id, reply.action_id) for reply in bob_replies] == [
+            ("confirm-bob", "yes")
+        ]
+        carol_replies = creatures[2].agent.output_router.submitted_replies
+        assert [(reply.event_id, reply.action_id) for reply in carol_replies] == [
+            ("confirm-carol", "yes")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_tool_activity_updates_source_creature_widget(self, app_and_engine):
+        app, _, _ = app_and_engine
+
+        await app._handle_creature_event(
+            "c2",
+            "activity",
+            {
+                "activity_type": "tool_start",
+                "detail": "[bash] command",
+                "metadata": {"job_id": "job-1", "args": {"cmd": "pwd"}},
+            },
+        )
+
+        assert "job-1" in app.live_region_widgets["c2"].tool_blocks
+        assert "job-1" not in app.live_region_widgets["c1"].tool_blocks
+
+    @pytest.mark.asyncio
+    async def test_command_result_and_error_commit_to_source_creature(
+        self, app_and_engine
+    ):
+        app, _, _ = app_and_engine
+
+        await app._handle_creature_event(
+            "c2",
+            "activity",
+            {
+                "activity_type": "command_result",
+                "detail": "Available commands",
+                "metadata": {"command": "/help", "source": "cli"},
+            },
+        )
+        await app._handle_creature_event(
+            "c2",
+            "activity",
+            {
+                "activity_type": "command_error",
+                "detail": "Unknown command",
+                "metadata": {"command": "/nope", "source": "cli"},
+            },
+        )
+
+        text_commits = [
+            args[0]
+            for method, args in app.committer.captured_for("c2")
+            if method == "text"
+        ]
+        assert any("Available commands" in text for text in text_commits)
+        assert any("Unknown command" in text for text in text_commits)
+        assert app.committer.captured_for("c1") == []
 
 
 class TestFocusSwap:

--- a/tests/unit/builtins/cli_rich/test_app_multi_creature.py
+++ b/tests/unit/builtins/cli_rich/test_app_multi_creature.py
@@ -638,10 +638,18 @@ class TestRuntimeGraphChanges:
     @pytest.mark.asyncio
     async def test_teardown_restores_every_managed_sink(self):
         app, _, c1, c2 = self._build()
+        c1_sink = c1.agent.output_router.default_output
+        await c1_sink.start()
+        assert c1_sink.is_running is True
+
         await app.teardown_multi_creature()
+
+        assert c1_sink.is_running is False
+        assert c1_sink._owner_loop is None
         assert c1.agent.output_router.default_output is None
         assert c2.agent.output_router.default_output is None
         assert app._managed_outputs == {}
+        assert app._creature_renderers == {}
 
     @pytest.mark.asyncio
     async def test_teardown_without_watcher_is_safe(self):

--- a/tests/unit/builtins/cli_rich/test_multiplex.py
+++ b/tests/unit/builtins/cli_rich/test_multiplex.py
@@ -1,5 +1,7 @@
 """Tests for :mod:`builtins.cli_rich.multiplex`."""
 
+import asyncio
+
 import pytest
 
 from kohakuterrarium.builtins.cli_rich.multiplex import MultiplexedRichOutput
@@ -48,6 +50,35 @@ class TestLifecycle:
         await sink.on_processing_start()
         await sink.on_processing_end()
         assert [c[1] for c in rec.calls] == ["processing_start", "processing_end"]
+
+    @pytest.mark.asyncio
+    async def test_worker_thread_activity_returns_to_owner_loop(self):
+        rec = _Recorder()
+        sink = MultiplexedRichOutput(rec, "alice")
+        await sink.start()
+
+        await asyncio.to_thread(
+            sink.on_activity_with_metadata,
+            "tool_start",
+            "[bash] command",
+            {"job_id": "job-1"},
+        )
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if rec.calls:
+                break
+
+        assert rec.calls == [
+            (
+                "alice",
+                "activity",
+                {
+                    "activity_type": "tool_start",
+                    "detail": "[bash] command",
+                    "metadata": {"job_id": "job-1"},
+                },
+            )
+        ]
 
 
 class TestEmit:

--- a/tests/unit/builtins/cli_rich/test_output.py
+++ b/tests/unit/builtins/cli_rich/test_output.py
@@ -1,0 +1,43 @@
+"""Tests for :mod:`kohakuterrarium.builtins.cli_rich.output`."""
+
+from kohakuterrarium.builtins.cli_rich.output import RichCLIOutput
+
+
+class _RecordingApp:
+    def __init__(self):
+        self.notifications = []
+        self.errors = []
+
+    def on_notification_event(self, payload: dict) -> None:
+        self.notifications.append(payload)
+
+    def on_processing_error(self, error_type: str, error: str) -> None:
+        self.errors.append((error_type, error))
+
+
+def test_command_result_is_rendered_as_notification() -> None:
+    app = _RecordingApp()
+    output = RichCLIOutput(app)
+
+    output.on_activity_with_metadata(
+        "command_result",
+        "Available commands",
+        {"command": "/help", "source": "cli"},
+    )
+
+    assert app.notifications == [
+        {"title": "help", "text": "Available commands", "level": "info"}
+    ]
+
+
+def test_command_error_is_rendered_as_processing_error() -> None:
+    app = _RecordingApp()
+    output = RichCLIOutput(app)
+
+    output.on_activity_with_metadata(
+        "command_error",
+        "Unknown command",
+        {"command": "/nope arg", "source": "cli"},
+    )
+
+    assert app.errors == [("nope", "Unknown command")]


### PR DESCRIPTION
## Summary

Preserve Rich CLI output across the multi-creature routing boundary, including structured UI events, targeted slash-command results/errors, normal tool activities, and callbacks originating on worker threads.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The per-creature sink stamped events correctly, but the app-side demultiplexer ignored `emit` events and attempted to send activities through a callback that `RichCLIApp` does not implement. Separately, `RichCLIOutput` did not render injected `command_result` or `command_error` activities. Worker-thread callbacks also asked the worker thread for an event loop and silently returned on Python 3.12.

Together, these gaps made targeted commands such as `@bob /help` invisible, hid structured/interactive output, dropped normal tool activity, and could leave interactive requests blocked.

## Changes

- Reuse the existing `RichCLIOutput` renderer per creature for multiplexed activities and typed output events.
- Render injected command results and errors with compact slash-command labels.
- Bind each queued interactive event to its source creature's output router so replies cannot follow a later focus change.
- Capture the sink's owning event loop and schedule worker-thread activities back onto it without constructing orphaned coroutines.
- Stop active multiplex sinks during app teardown and release their loop/router references before restoring prior outputs.
- Add negative-case coverage for notifications, two-source interactive queues, command results/errors, normal tool activity attribution, worker-thread dispatch, and teardown cleanup.

## Validation

```bash
python -m pytest tests/unit/builtins/cli_rich tests/unit/terrarium/test_engine_rich_cli.py tests/integration/test_repro_ui_bugs.py tests/integration/test_tui_cli_mid_turn_injection.py -q --basetemp .pytest-run-rich-review-final -p no:cacheprovider
python -m pytest tests/unit/test_file_sizes.py -q --basetemp .pytest-run-rich-review-sizes -p no:cacheprovider
black --check --fast --workers 1 --target-version py312 <7 changed Python files>
ruff check <7 changed Python files>
git diff --check
```

Results:

- 235 affected Rich CLI and neighboring integration tests passed.
- 1,678 file-size checks passed.
- Black, Ruff, and whitespace checks passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] This is not a feature PR; the change is limited to a bug fix and regression tests
- [x] I kept this PR focused and did not include unrelated changes
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally
- [ ] If frontend files changed, I ran the frontend checks (not applicable)
- [x] CI is green

## Related Issues / Discussions

Fixes #119

## Notes for Reviewers

The app temporarily swaps both the target live-region widget and scrollback capture target while rendering a creature event. Interactive events additionally retain the source router in the overlay queue, so a reply still returns to the correct creature even if multiple creatures enqueue prompts or focus changes before submission. Teardown now stops any active replacement sink before restoring the original output module.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The full repository lint and unit suites were not run locally; focused checks cover the changed files and neighboring Rich CLI workflows. GitHub CI passed all 13 checks across Windows, macOS, Ubuntu, and Python 3.12-3.14.