### PR TITLE
fix(tui): reconcile dynamic terrarium tabs

### DIFF
--- a/src/kohakuterrarium/builtins/tui/app.py
+++ b/src/kohakuterrarium/builtins/tui/app.py
@@ -242,6 +242,54 @@ class AgentTUI(App):
             logger.warning("Failed to get active tab name", error=str(e), exc_info=True)
         return self._terrarium_tabs[0] if self._terrarium_tabs else ""
 
+    async def reconcile_terrarium_tabs(self, tab_names: list[str]) -> None:
+        """Reconcile mounted chat panes with the current terrarium topology."""
+        desired = list(dict.fromkeys(tab_names))
+        active_name = self.get_active_tab_name()
+        try:
+            tabs = self.query_one("#chat-tabs", TabbedContent)
+        except Exception as e:
+            logger.warning("Failed to find terrarium tabs", error=str(e), exc_info=True)
+            return
+
+        mounted: dict[str, TabPane] = {}
+        for pane in tabs.query(TabPane):
+            if pane.id:
+                mounted[_id_to_name(pane.id.removeprefix("tab-"))] = pane
+
+        for name, pane in list(mounted.items()):
+            if name not in desired and pane.id:
+                await tabs.remove_pane(pane.id)
+                mounted.pop(name)
+
+        for index, name in enumerate(desired):
+            if name in mounted:
+                continue
+            pane = TabPane(
+                name,
+                VerticalScroll(
+                    id=f"chat-{_safe_id(name)}",
+                    classes="chat-tab-scroll",
+                ),
+                id=f"tab-{_safe_id(name)}",
+            )
+            next_name = next(
+                (
+                    candidate
+                    for candidate in desired[index + 1 :]
+                    if candidate in mounted
+                ),
+                None,
+            )
+            before = mounted[next_name].id if next_name else None
+            await tabs.add_pane(pane, before=before)
+            mounted[name] = pane
+
+        self._terrarium_tabs = desired
+        if desired:
+            selected = active_name if active_name in desired else desired[0]
+            tabs.active = f"tab-{_safe_id(selected)}"
+
     def action_interrupt(self) -> None:
         if self.on_interrupt:
             self.on_interrupt()
@@ -366,14 +414,15 @@ class AgentTUI(App):
 
 
 def _safe_id(name: str) -> str:
-    """Convert a tab name to a CSS-safe ID."""
-    if name.startswith("#"):
-        return "ch_" + name[1:].replace("-", "_")
-    return name.replace("-", "_")
+    """Encode a tab name as a reversible CSS-safe ID component."""
+    return f"t_{name.encode('utf-8').hex()}"
 
 
 def _id_to_name(safe: str) -> str:
-    """Convert a CSS-safe tab ID back to its name."""
-    if safe.startswith("ch_"):
-        return "#" + safe[3:]
-    return safe
+    """Decode a CSS-safe tab ID component back to its original name."""
+    if not safe.startswith("t_"):
+        return safe
+    try:
+        return bytes.fromhex(safe[2:]).decode("utf-8")
+    except (UnicodeDecodeError, ValueError):
+        return safe

--- a/src/kohakuterrarium/builtins/tui/session.py
+++ b/src/kohakuterrarium/builtins/tui/session.py
@@ -88,10 +88,19 @@ class TUISession(TabModelRegistryMixin):
         self._pending_safe_calls: list[tuple[Any, tuple[Any, ...]]] = []
 
     def set_terrarium_tabs(self, tabs: list[str]) -> None:
-        """Configure terrarium tabs before startup."""
-        self._terrarium_tabs = tabs
-        if tabs:
-            self._active_target = tabs[0]
+        """Configure terrarium tabs and reconcile a running application."""
+        normalized = list(dict.fromkeys(tabs))
+        active = self.get_active_tab() if self._app else self._active_target
+        self._terrarium_tabs = normalized
+        self._active_target = (
+            active if active in normalized else normalized[0] if normalized else ""
+        )
+        if not self._app:
+            return
+        if not self._app.is_running:
+            self._app._terrarium_tabs = normalized
+            return
+        self._safe_call(self._app.reconcile_terrarium_tabs, normalized)
 
     def set_active_target(self, target: str) -> None:
         """Set the tab that receives new output widgets."""

--- a/tests/unit/builtins/tui/test_app.py
+++ b/tests/unit/builtins/tui/test_app.py
@@ -1,0 +1,74 @@
+"""Tests for the Textual application shell."""
+
+import pytest
+from textual.containers import VerticalScroll
+from textual.widgets import Static, TabbedContent, TabPane
+from textual.widgets._tabbed_content import ContentTab, ContentTabs
+
+from kohakuterrarium.builtins.tui.app import (
+    AgentTUI,
+    _id_to_name,
+    _safe_id,
+)
+
+
+def test_tab_ids_round_trip_without_collisions() -> None:
+    names = [
+        "review-worker",
+        "review_worker",
+        "#task-channel",
+        "#task_channel",
+        "中文-creature",
+    ]
+
+    encoded = [_safe_id(name) for name in names]
+
+    assert len(set(encoded)) == len(names)
+    assert [_id_to_name(value) for value in encoded] == names
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terrarium_tabs_preserves_retained_panes_and_active_tab() -> (
+    None
+):
+    app = AgentTUI(terrarium_tabs=["root", "review-worker"])
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tabs = app.query_one("#chat-tabs", TabbedContent)
+        tabs.active = f"tab-{_safe_id('review-worker')}"
+        retained_chat = app.query_one(
+            f"#chat-{_safe_id('review-worker')}", VerticalScroll
+        )
+        retained_marker = Static("keep me")
+        await retained_chat.mount(retained_marker)
+
+        await app.reconcile_terrarium_tabs(
+            ["root", "new_worker", "review-worker", "#task-channel"]
+        )
+        await pilot.pause()
+
+        expected_ids = [
+            f"tab-{_safe_id('root')}",
+            f"tab-{_safe_id('new_worker')}",
+            f"tab-{_safe_id('review-worker')}",
+            f"tab-{_safe_id('#task-channel')}",
+        ]
+        assert {pane.id for pane in tabs.query(TabPane)} == set(expected_ids)
+        content_tabs = tabs.get_child_by_type(ContentTabs)
+        assert [
+            tab.id.removeprefix(ContentTab._PREFIX)
+            for tab in content_tabs.query(ContentTab)
+            if tab.id
+        ] == expected_ids
+        assert app.get_active_tab_name() == "review-worker"
+        assert retained_marker in retained_chat.children
+
+        await app.reconcile_terrarium_tabs(["root", "new_worker"])
+        await pilot.pause()
+
+        assert {pane.id for pane in tabs.query(TabPane)} == {
+            f"tab-{_safe_id('root')}",
+            f"tab-{_safe_id('new_worker')}",
+        }
+        assert app.get_active_tab_name() == "root"

--- a/tests/unit/builtins/tui/test_session.py
+++ b/tests/unit/builtins/tui/test_session.py
@@ -1,0 +1,42 @@
+"""Tests for shared TUI session state."""
+
+from collections.abc import Callable
+from typing import Any
+
+from kohakuterrarium.builtins.tui.session import TUISession
+
+
+class _RunningApp:
+    is_running = True
+
+    def __init__(self, active: str) -> None:
+        self.active = active
+        self.reconciled: list[list[str]] = []
+
+    def get_active_tab_name(self) -> str:
+        return self.active
+
+    def reconcile_terrarium_tabs(self, tabs: list[str]) -> None:
+        self.reconciled.append(tabs)
+
+    def call_later(self, callback: Callable[..., Any], *args: Any) -> bool:
+        callback(*args)
+        return True
+
+
+def test_set_terrarium_tabs_reconciles_running_app_and_preserves_active() -> None:
+    session = TUISession()
+    session.set_terrarium_tabs(["root", "review-worker"])
+    app = _RunningApp(active="review-worker")
+    session._app = app  # type: ignore[assignment]
+
+    session.set_terrarium_tabs(["root", "new_worker", "review-worker"])
+
+    assert session._active_target == "review-worker"
+    assert app.reconciled == [["root", "new_worker", "review-worker"]]
+
+    app.active = "review-worker"
+    session.set_terrarium_tabs(["root", "new_worker"])
+
+    assert session._active_target == "root"
+    assert app.reconciled[-1] == ["root", "new_worker"]


### PR DESCRIPTION
## Summary

Fix the Textual TUI tab lifecycle so topology changes add and remove mounted chat tabs at runtime, while preserving retained chat panes and the active tab when possible. Replace lossy tab-name sanitization with a reversible collision-free encoding.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Terrarium topology updates only changed `TUISession._terrarium_tabs`; the mounted `TabbedContent` remained frozen at startup. In addition, replacing hyphens with underscores made names such as `review-worker` and `review_worker` collide and caused active-tab routing to return the wrong target.

## Changes

- Reconcile mounted Textual tab panes when the terrarium topology changes.
- Preserve retained chat widgets and the active tab; fall back to the first remaining tab when the active target is removed.
- Encode tab names as reversible UTF-8 hex ID components so creature and channel names round-trip without collisions.
- Add negative regression tests for hyphen/underscore collisions and runtime add/remove behavior.

## Validation

```bash
python -m pytest tests/unit/builtins/tui tests/unit/terrarium/test_engine_cli_active_dispatch.py tests/integration/test_repro_ui_bugs.py -q --basetemp <temp> -p no:cacheprovider
# 45 passed

python -m pytest tests/unit/test_file_sizes.py -q --basetemp <temp> -p no:cacheprovider
# 1678 passed

python scripts/dep_graph.py --lint-imports --fail
# no cycles, import-hygiene violations, or tier violations

ruff check src/kohakuterrarium/builtins/tui/app.py src/kohakuterrarium/builtins/tui/session.py tests/unit/builtins/tui/test_app.py tests/unit/builtins/tui/test_session.py
# all checks passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #124
- Fixes #125

## Notes for Reviewers

The reconciliation keeps existing `TabPane` instances for retained targets, so mounted transcript widgets are not discarded.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The full unit suite reached 1,935 passed and 1 skipped before failing in the pre-existing Windows-specific `tests/unit/cli/test_service.py::TestRenderHostUnit::test_host_unit_carries_required_directives`: `_resolve_kt_executable()` looks for `<venv>/bin/kt` rather than `Scripts/kt.exe`.
- Black formatted the four changed files, but `black --check` did not terminate in this local Python 3.12 environment because the project is configured for Python 3.14. Targeted Ruff and all affected tests pass.
- No frontend files changed.
- Fork CI had not started at PR creation time.
