### PR TITLE
fix(cli): track foreground turns per creature

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/app.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app.py
@@ -109,6 +109,8 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
         self._command_registry: dict = {}
         self._command_registry_agents: list[weakref.ReferenceType] = []
         self._pending_task: asyncio.Task | None = None
+        self._pending_task_target: str | None = None
+        self._turn_tasks: dict[str, asyncio.Task] = {}
         self._ctrl_c_armed = False
         self._ctrl_c_reset_task: asyncio.Task | None = None
         self._render_ticker_task: asyncio.Task | None = None
@@ -209,12 +211,15 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
                     await self._ctrl_c_reset_task
                 except (asyncio.CancelledError, Exception):
                     pass
-            if self._pending_task and not self._pending_task.done():
-                self._pending_task.cancel()
-                try:
-                    await self._pending_task
-                except (asyncio.CancelledError, Exception):
-                    pass
+            pending = set(self._turn_tasks.values())
+            if self._pending_task:
+                pending.add(self._pending_task)
+            for task in pending:
+                if not task.done():
+                    task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+            self._turn_tasks.clear()
             self.app = None
             print()  # Leave the shell cursor on a clean line.
 
@@ -444,16 +449,19 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
         # Mid-turn input remains pending until the agent confirms its injection.
         is_slash = text.startswith("/")
         is_at_name = self.multi_creature_enabled and text.startswith("@")
-        if self._processing and not is_slash and not is_at_name:
+        if self._focused_is_processing() and not is_slash and not is_at_name:
+            target_agent = self.agent
             self.live_region.add_queued_input(text)
             self._invalidate()
-            spawn(self._mid_turn_inject(text))
+            spawn(self._mid_turn_inject(text, target_agent))
             return
 
-        if self._pending_task and not self._pending_task.done():
-            self._pending_task.cancel()
+        pending = self._focused_pending_task()
+        focused_processing = self._focused_is_processing()
+        if pending and not pending.done():
+            pending.cancel()
             # The engine owns the active turn, so cancelling this wrapper is insufficient.
-            if self._processing:
+            if focused_processing:
                 self.agent.interrupt()
 
         # Resolve @name before slash commands so targeted commands reach that creature.
@@ -463,6 +471,7 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
                 if redirect.is_broadcast:
                     self.commit_user_message_broadcast(text)
                     self._pending_task = spawn(self.broadcast_to_all(redirect.payload))
+                    self._pending_task_target = self._focused_target_id()
                 else:
                     target = self.resolve_creature_by_name(redirect.name)
                     if target is None:
@@ -472,38 +481,100 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
                         self._invalidate()
                         return
                     self.commit_user_message_for(target.creature_id, text)
-                    self._pending_task = spawn(
-                        self.inject_to_creature(target.creature_id, redirect.payload)
+                    self._spawn_agent_turn(
+                        redirect.payload,
+                        target_id=target.creature_id,
+                        target_agent=target.agent,
+                        target_region=self.live_region_widgets[target.creature_id],
                     )
                 return
 
         self._commit_user_message(text)
 
         if text.startswith("/"):
-            self._pending_task = spawn(self._handle_slash(text))
+            self._spawn_slash(text)
             return
 
-        self._processing = True
-        self.live_region.set_processing(True)
+        self._spawn_agent_turn(
+            text,
+            target_id=self._focused_target_id(),
+            target_agent=self.agent,
+            target_region=self.live_region,
+        )
+
+    def _focused_target_id(self) -> str:
+        if self.multi_creature_enabled:
+            return self.focus_controller.focus_id
+        return ""
+
+    def _focused_pending_task(self) -> asyncio.Task | None:
+        if not self.multi_creature_enabled:
+            return self._pending_task
+        target_id = self._focused_target_id()
+        turn_task = self._turn_tasks.get(target_id)
+        if turn_task and not turn_task.done():
+            return turn_task
+        if self._pending_task_target == target_id:
+            return self._pending_task
+        return None
+
+    def _focused_is_processing(self) -> bool:
+        if not self.multi_creature_enabled and self._processing:
+            return True
+        target_id = self._focused_target_id()
+        turn_task = self._turn_tasks.get(target_id)
+        if turn_task and not turn_task.done():
+            return True
+        processing_task = getattr(self.agent, "_processing_task", None)
+        return bool(processing_task and not processing_task.done())
+
+    def _spawn_agent_turn(
+        self,
+        text: str,
+        *,
+        target_id: str,
+        target_agent: Any,
+        target_region: LiveRegion,
+    ) -> asyncio.Task:
+        """Start and track one foreground turn for a captured creature."""
+        key = target_id if self.multi_creature_enabled else ""
+        target_region.set_processing(True)
+        if not self.multi_creature_enabled:
+            self._processing = True
         self._invalidate()
 
-        async def _send():
+        async def _send() -> None:
             try:
-                await self.agent.inject_input(text, source="cli")
+                await target_agent.inject_input(text, source="cli")
             except Exception as e:
                 logger.exception("Error processing input", error=str(e))
             finally:
-                self._processing = False
-                self.live_region.set_processing(False)
-                # Close a deferred rule even when the turn ends without more output.
-                self.committer.flush_block_close()
-                self._invalidate()
+                current = asyncio.current_task()
+                if self._turn_tasks.get(key) is current:
+                    self._turn_tasks.pop(key, None)
+                    target_region.set_processing(False)
+                    if not self.multi_creature_enabled:
+                        self._processing = False
+                    self.committer.flush_block_close()
+                    self._invalidate()
 
-        self._pending_task = spawn(_send())
+        task = spawn(_send())
+        self._turn_tasks[key] = task
+        self._pending_task = task
+        self._pending_task_target = key
+        return task
 
-    async def _mid_turn_inject(self, text: str) -> None:
+    def _spawn_slash(self, text: str) -> asyncio.Task:
+        """Run a slash command and associate it with the focused creature."""
+        target_id = self._focused_target_id()
+        task = spawn(self._handle_slash(text))
+        self._pending_task = task
+        self._pending_task_target = target_id
+        return task
+
+    async def _mid_turn_inject(self, text: str, target_agent: Any = None) -> None:
         try:
-            await self.agent.inject_input(text, source="cli")
+            await (target_agent or self.agent).inject_input(text, source="cli")
         except asyncio.CancelledError:
             raise
         except Exception as e:
@@ -566,6 +637,9 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
         self._invalidate()
 
     async def _handle_slash(self, text: str) -> None:
+        target_id = self._focused_target_id()
+        target_agent = self.agent
+        target_region = self.live_region
         name, args = parse_slash_command(text)
 
         # Bare /model is interactive; selectors use the command implementation.
@@ -605,7 +679,7 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
             return
 
         try:
-            result = await self.agent._try_slash_command_text(text)
+            result = await target_agent._try_slash_command_text(text)
         except Exception as e:
             self._commit_text(f"[red]Command error:[/red] {e}")
             return
@@ -619,22 +693,12 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
         elif result.output and result.consumed:
             self._commit_text(result.output)
         elif result.output:
-            self._processing = True
-            self.live_region.set_processing(True)
-            self._invalidate()
-
-            async def _send_skill_turn():
-                try:
-                    await self.agent.inject_input(result.output, source="cli")
-                except Exception as e:
-                    logger.exception("Error processing skill slash input", error=str(e))
-                finally:
-                    self._processing = False
-                    self.live_region.set_processing(False)
-                    self.committer.flush_block_close()
-                    self._invalidate()
-
-            self._pending_task = spawn(_send_skill_turn())
+            self._spawn_agent_turn(
+                result.output,
+                target_id=target_id,
+                target_agent=target_agent,
+                target_region=target_region,
+            )
 
         if name in ("exit", "quit"):
             self._exit_requested = True
@@ -707,14 +771,14 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
         if self._ctrl_c_reset_task and not self._ctrl_c_reset_task.done():
             self._ctrl_c_reset_task.cancel()
             self._ctrl_c_reset_task = None
-        if self._processing and self.agent:
+        if self._focused_is_processing() and self.agent:
             try:
                 self.agent.interrupt()
             except Exception as e:
                 logger.exception("Interrupt failed", error=str(e))
 
     def _on_ctrl_c(self) -> None:
-        if self._processing:
+        if self._focused_is_processing():
             self._on_interrupt()
             return
         if self._ctrl_c_armed:
@@ -793,7 +857,7 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
         """Apply a picker selection through the standard /model command path."""
         if not selector:
             return
-        self._pending_task = spawn(self._handle_slash(f"/model {selector}"))
+        self._spawn_slash(f"/model {selector}")
 
     def _get_composer_text(self) -> str:
         """Return composer text for interactive overlay prompts."""

--- a/tests/unit/builtins/cli_rich/test_app_layout_integration.py
+++ b/tests/unit/builtins/cli_rich/test_app_layout_integration.py
@@ -15,6 +15,7 @@ a real terminal). They DO exercise:
   so the Tab / Shift+Tab / Ctrl+A keys reach the right handlers
 """
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -29,6 +30,7 @@ class _FakeAgent:
         self.input = None
         self.output_router = SimpleNamespace(default_output=None)
         self.injected: list[str] = []
+        self.interrupt_calls = 0
         self._processing_task = None
         self._active_handles: dict = {}
         self._last_activity_ts = None
@@ -39,6 +41,9 @@ class _FakeAgent:
 
     async def inject_input(self, text, source="cli"):
         self.injected.append(text)
+
+    def interrupt(self):
+        self.interrupt_calls += 1
 
 
 class _FakeCreature:
@@ -163,6 +168,129 @@ class TestComposerCallbacks:
         assert app.agent_overlay.visible is False
         app.composer._on_open_overlay()
         assert app.agent_overlay.visible is True
+
+
+class TestPerCreatureTurnLifecycle:
+    @pytest.mark.asyncio
+    async def test_targeted_turn_interrupts_target_after_focus_change(self, multi_app):
+        app, engine = multi_app
+        bob = engine.get_creature("c2").agent
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def wait_for_release(text, source="cli"):
+            bob.injected.append(text)
+            started.set()
+            await release.wait()
+
+        bob.inject_input = wait_for_release
+        app._handle_submit("@bob long task")
+        task = app._pending_task
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        assert app.live_region_widgets["c2"]._turn_active is True
+        app.set_focus("c2")
+        app._on_ctrl_c()
+
+        assert bob.interrupt_calls == 1
+        assert app._ctrl_c_armed is False
+        release.set()
+        await task
+
+    @pytest.mark.asyncio
+    async def test_turn_completion_clears_its_original_live_region(self, multi_app):
+        app, engine = multi_app
+        alice = engine.get_creature("c1").agent
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def wait_for_release(text, source="cli"):
+            alice.injected.append(text)
+            started.set()
+            await release.wait()
+
+        alice.inject_input = wait_for_release
+        app._handle_submit("alice task")
+        task = app._pending_task
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert app.live_region_widgets["c1"]._turn_active is True
+
+        app.set_focus("c2")
+        release.set()
+        await task
+
+        assert app.live_region_widgets["c1"]._turn_active is False
+        assert app.live_region_widgets["c2"]._turn_active is False
+
+    @pytest.mark.asyncio
+    async def test_idle_focus_can_start_turn_while_another_creature_runs(
+        self, multi_app
+    ):
+        app, engine = multi_app
+        alice = engine.get_creature("c1").agent
+        bob = engine.get_creature("c2").agent
+        alice_started = asyncio.Event()
+        bob_started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def wait_alice(text, source="cli"):
+            alice.injected.append(text)
+            alice_started.set()
+            await release.wait()
+
+        async def wait_bob(text, source="cli"):
+            bob.injected.append(text)
+            bob_started.set()
+            await release.wait()
+
+        alice.inject_input = wait_alice
+        bob.inject_input = wait_bob
+        app._handle_submit("alice task")
+        alice_task = app._pending_task
+        await asyncio.wait_for(alice_started.wait(), timeout=1)
+
+        app.set_focus("c2")
+        app._handle_submit("bob task")
+        bob_task = app._pending_task
+        await asyncio.wait_for(bob_started.wait(), timeout=1)
+
+        assert bob_task is not alice_task
+        assert app.live_region_widgets["c1"]._turn_active is True
+        assert app.live_region_widgets["c2"]._turn_active is True
+
+        release.set()
+        await asyncio.gather(alice_task, bob_task)
+
+    @pytest.mark.asyncio
+    async def test_mid_turn_injection_keeps_submit_time_agent(self, multi_app):
+        app, engine = multi_app
+        alice = engine.get_creature("c1").agent
+        bob = engine.get_creature("c2").agent
+        first_started = asyncio.Event()
+        follow_up_seen = asyncio.Event()
+        release = asyncio.Event()
+
+        async def inject_alice(text, source="cli"):
+            alice.injected.append(text)
+            if text == "first task":
+                first_started.set()
+                await release.wait()
+            else:
+                follow_up_seen.set()
+
+        alice.inject_input = inject_alice
+        app._handle_submit("first task")
+        first_task = app._pending_task
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+
+        app._handle_submit("follow up")
+        app.set_focus("c2")
+        await asyncio.wait_for(follow_up_seen.wait(), timeout=1)
+
+        assert alice.injected == ["first task", "follow up"]
+        assert bob.injected == []
+        release.set()
+        await first_task
 
 
 class TestPickerIntegration:


### PR DESCRIPTION
## Summary

Track foreground Rich CLI turns per creature instead of through one mutable global processing flag and task. Capture the target agent and LiveRegion for each submission so focus changes cannot redirect cleanup, mid-turn injection, or interruption to another creature.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

In multi-creature mode, `_processing`, `_pending_task`, `self.agent`, and `self.live_region` were shared mutable state. A targeted `@name` turn was not marked as processing, Ctrl+C could miss it, completion after a focus change could clear the wrong widget, and an idle focused creature could not start its own turn while a sibling was running.

## Changes

- Track active foreground turn tasks by creature ID while retaining the single-creature compatibility state.
- Resolve busy, cancellation, and Ctrl+C behavior against the currently focused creature.
- Capture the submit-time agent and LiveRegion for primary and mid-turn injections.
- Mark targeted `@name` turns as processing and clean up their original region on completion.
- Cancel every tracked foreground wrapper when the Rich CLI exits.
- Route skill-command turns through the same lifecycle helper.
- Add negative regression tests for targeted interruption, focus-switch cleanup, concurrent turns on independent creatures, and submit-time mid-turn routing.

## Validation

```bash
python -m pytest tests/unit/builtins/cli_rich tests/integration/test_repro_ui_bugs.py -q --basetemp <temp> -p no:cacheprovider
# 225 passed

python -m pytest tests/integration/test_tui_cli_mid_turn_injection.py -q --basetemp <temp> -p no:cacheprovider
# 7 passed

python -m pytest tests/unit/test_file_sizes.py -q --basetemp <temp> -p no:cacheprovider
# 1678 passed

python scripts/dep_graph.py --lint-imports --fail
# no cycles, import-hygiene violations, or tier violations

ruff check src/kohakuterrarium/builtins/cli_rich/app.py tests/unit/builtins/cli_rich/test_app_layout_integration.py
# all checks passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #123

## Notes for Reviewers

The change deliberately does not alter `@all` fan-out strategy. It only scopes foreground lifecycle ownership and interruption to the relevant creature.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The full unit suite reached 1,935 passed and 1 skipped before failing in the pre-existing Windows-specific `tests/unit/cli/test_service.py::TestRenderHostUnit::test_host_unit_carries_required_directives`: `_resolve_kt_executable()` looks for `<venv>/bin/kt` rather than `Scripts/kt.exe`.
- Local Black 26.3.1 did not terminate under Python 3.12 while the project targets Python 3.14. Targeted Ruff, affected tests, file-size checks, and dependency checks pass.
- No frontend files changed.
- Fork CI had not started at PR creation time.
