### PR TITLE
fix(bash): keep bash tool independent from user login shell

### DIFF
--- a/docs/en/reference/builtins.md
+++ b/docs/en/reference/builtins.md
@@ -27,9 +27,7 @@ config under `tools:` by bare name.
 
 **`bash`**: Run a shell command. Uses `bash` by default on every platform
 (Git Bash on Windows). Pass `type="..."` to select another supported shell:
-`bash`, `zsh`, `sh`, `fish`, `pwsh`, or `powershell`. A per-shell
-`KT_<SHELL>_PATH` override takes precedence over `KT_SHELL_PATH`; the
-process `$SHELL` does not change the default executable. Captures stdout and
+`bash`, `zsh`, `sh`, `fish`, `pwsh`, or `powershell`. Captures stdout and
 stderr, truncated to a cap. Direct execution.
 
 - Args: `command` (str), `working_dir` (str, optional),

--- a/docs/en/reference/builtins.md
+++ b/docs/en/reference/builtins.md
@@ -25,9 +25,12 @@ config under `tools:` by bare name.
 
 ### Shell and scripting
 
-**`bash`**: Run a shell command. Picks the first available of `bash`,
-`zsh`, `sh`, `fish`, `pwsh`. Respects `KT_SHELL_PATH`. Captures stdout
-and stderr, truncated to a cap. Direct execution.
+**`bash`**: Run a shell command. Uses `bash` by default on every platform
+(Git Bash on Windows). Pass `type="..."` to select another supported shell:
+`bash`, `zsh`, `sh`, `fish`, `pwsh`, or `powershell`. A per-shell
+`KT_<SHELL>_PATH` override takes precedence over `KT_SHELL_PATH`; the
+process `$SHELL` does not change the default executable. Captures stdout and
+stderr, truncated to a cap. Direct execution.
 
 - Args: `command` (str), `working_dir` (str, optional),
   `timeout` (float, optional).

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -633,7 +633,8 @@ auto-attached but can be referenced by name.
 | `EDITOR`, `VISUAL` | Editor for `kt edit` / `kt config edit`. |
 | `VIRTUAL_ENV` | Reported by `kt --version --verbose`. |
 | `<PROVIDER>_API_KEY` | Whatever `api_key_env` each provider references. |
-| `KT_SHELL_PATH` | Override shell used by the `bash` tool. |
+| `KT_<SHELL>_PATH` | Override a specific shell executable (for example, `KT_BASH_PATH`); takes precedence over `KT_SHELL_PATH`. |
+| `KT_SHELL_PATH` | Generic shell executable override used by the `bash` tool when no per-shell override is set. |
 | `KT_SESSION_DIR` | Override session directory for the web API (default `~/.kohakuterrarium/sessions`). |
 
 ## Exit codes

--- a/docs/zh-CN/reference/builtins.md
+++ b/docs/zh-CN/reference/builtins.md
@@ -21,7 +21,7 @@ KohakuTerrarium 随附的所有内置工具、子代理、输入、输出、用�
 
 ### Shell 与脚本
 
- **`bash`**：执行 shell 命令。所有平台默认使用 `bash`（Windows 上使用 Git Bash）。可通过 `type="..."` 选择其他 shell：`bash`、`zsh`、`sh`、`fish`、`pwsh` 或 `powershell`。按 shell 指定的 `KT_<SHELL>_PATH` 优先于通用的 `KT_SHELL_PATH`；进程的 `$SHELL` 不会改变默认 executable。会捕获 stdout 与 stderr，并在达到上限时截断。直接执行。
+ **`bash`**：执行 shell 命令。所有平台默认使用 `bash`（Windows 上使用 Git Bash）。可通过 `type="..."` 选择其他 shell：`bash`、`zsh`、`sh`、`fish`、`pwsh` 或 `powershell`。会捕获 stdout 与 stderr，并在达到上限时截断。直接执行。
 
 - 参数：`command`（str）、`working_dir`（str，可选）、
   `timeout`（float，可选）。

--- a/docs/zh-CN/reference/builtins.md
+++ b/docs/zh-CN/reference/builtins.md
@@ -21,8 +21,7 @@ KohakuTerrarium 随附的所有内置工具、子代理、输入、输出、用�
 
 ### Shell 与脚本
 
- **`bash`**：执行 shell 命令。会在 `bash`、`zsh`、`sh`、`fish`、`pwsh`
-中选择第一个可用项。遵守 `KT_SHELL_PATH`。会捕获 stdout 与 stderr，并在达到上限时截断。直接执行。
+ **`bash`**：执行 shell 命令。所有平台默认使用 `bash`（Windows 上使用 Git Bash）。可通过 `type="..."` 选择其他 shell：`bash`、`zsh`、`sh`、`fish`、`pwsh` 或 `powershell`。按 shell 指定的 `KT_<SHELL>_PATH` 优先于通用的 `KT_SHELL_PATH`；进程的 `$SHELL` 不会改变默认 executable。会捕获 stdout 与 stderr，并在达到上限时截断。直接执行。
 
 - 参数：`command`（str）、`working_dir`（str，可选）、
   `timeout`（float，可选）。

--- a/docs/zh-CN/reference/cli.md
+++ b/docs/zh-CN/reference/cli.md
@@ -580,7 +580,8 @@ MCP server 也可以放在 `~/.kohakuterrarium/mcp_servers.yaml` 全域目录，
 | `EDITOR`、`VISUAL` | `kt edit` / `kt config edit` 用的编辑器。 |
 | `VIRTUAL_ENV` | `kt --version --verbose` 会印出。 |
 | `<PROVIDER>_API_KEY` | 每个 provider 的 `api_key_env` 指到的变数。 |
-| `KT_SHELL_PATH` | 覆盖 `bash` 工具用的 shell。 |
+| `KT_<SHELL>_PATH` | 覆盖指定 shell 的 executable（例如 `KT_BASH_PATH`）；优先于 `KT_SHELL_PATH`。 |
+| `KT_SHELL_PATH` | 在没有指定 shell 专用覆盖时，覆盖 `bash` 工具使用的 shell executable。 |
 | `KT_SESSION_DIR` | 覆盖 web API 的会话目录 (默认 `~/.kohakuterrarium/sessions`)。 |
 
 ## Exit code

--- a/docs/zh-TW/reference/builtins.md
+++ b/docs/zh-TW/reference/builtins.md
@@ -24,8 +24,7 @@ KohakuTerrarium 隨附的所有內建工具、子代理、輸入、輸出、使�
 
 ### Shell 與腳本
 
-**`bash`**：執行 shell 命令。會在 `bash`、`zsh`、`sh`、`fish`、`pwsh`
-之中選擇第一個可用者。遵守 `KT_SHELL_PATH`。會擷取 stdout 與 stderr，並在達到上限時截斷。直接執行。
+**`bash`**：執行 shell 命令。所有平台預設使用 `bash`（Windows 上使用 Git Bash）。可透過 `type="..."` 選擇其他 shell：`bash`、`zsh`、`sh`、`fish`、`pwsh` 或 `powershell`。按 shell 指定的 `KT_<SHELL>_PATH` 優先於通用的 `KT_SHELL_PATH`；程序的 `$SHELL` 不會改變預設 executable。會擷取 stdout 與 stderr，並在達到上限時截斷。直接執行。
 
 - 參數：`command`（str）、`working_dir`（str，可選）、
   `timeout`（float，可選）。

--- a/docs/zh-TW/reference/builtins.md
+++ b/docs/zh-TW/reference/builtins.md
@@ -24,7 +24,7 @@ KohakuTerrarium 隨附的所有內建工具、子代理、輸入、輸出、使�
 
 ### Shell 與腳本
 
-**`bash`**：執行 shell 命令。所有平台預設使用 `bash`（Windows 上使用 Git Bash）。可透過 `type="..."` 選擇其他 shell：`bash`、`zsh`、`sh`、`fish`、`pwsh` 或 `powershell`。按 shell 指定的 `KT_<SHELL>_PATH` 優先於通用的 `KT_SHELL_PATH`；程序的 `$SHELL` 不會改變預設 executable。會擷取 stdout 與 stderr，並在達到上限時截斷。直接執行。
+**`bash`**：執行 shell 命令。所有平台預設使用 `bash`（Windows 上使用 Git Bash）。可透過 `type="..."` 選擇其他 shell：`bash`、`zsh`、`sh`、`fish`、`pwsh` 或 `powershell`。會擷取 stdout 與 stderr，並在達到上限時截斷。直接執行。
 
 - 參數：`command`（str）、`working_dir`（str，可選）、
   `timeout`（float，可選）。

--- a/docs/zh-TW/reference/cli.md
+++ b/docs/zh-TW/reference/cli.md
@@ -580,7 +580,8 @@ MCP server 也可以放在 `~/.kohakuterrarium/mcp_servers.yaml` 的全域目錄
 | `EDITOR`、`VISUAL` | `kt edit` / `kt config edit` 用的編輯器。 |
 | `VIRTUAL_ENV` | `kt --version --verbose` 會印出。 |
 | `<PROVIDER>_API_KEY` | 每個 provider 的 `api_key_env` 指到的變數。 |
-| `KT_SHELL_PATH` | 覆寫 `bash` 工具用的 shell。 |
+| `KT_<SHELL>_PATH` | 覆寫指定 shell 的 executable（例如 `KT_BASH_PATH`）；優先於 `KT_SHELL_PATH`。 |
+| `KT_SHELL_PATH` | 在沒有指定 shell 專用覆寫時，覆寫 `bash` 工具使用的 shell executable。 |
 | `KT_SESSION_DIR` | 覆寫 web API 的工作階段目錄 (預設 `~/.kohakuterrarium/sessions`)。 |
 
 ## Exit code

--- a/src/kohakuterrarium/builtin_skills/tools/bash.md
+++ b/src/kohakuterrarium/builtin_skills/tools/bash.md
@@ -33,9 +33,16 @@ Using dedicated tools gives structured output and enables safety guards.
 ## Shell Type
 
 By default, all commands run in **bash** on every platform (including
-Windows, via git bash). If bash is not available, the tool will report
-which shells are installed so you can choose an alternative with
-`type="..."`.
+Windows, via Git Bash). The process `$SHELL` does not replace this default.
+Use `type="..."` to select another shell explicitly. Supported values are
+`bash`, `zsh`, `sh`, `fish`, `pwsh`, and `powershell`. If the requested shell
+is not available, the tool reports which shells are installed.
+
+Shell executable overrides are checked in this order:
+
+1. `KT_<SHELL>_PATH`, such as `KT_BASH_PATH`
+2. `KT_SHELL_PATH`
+3. Platform shell discovery
 
 ## Git Safety
 
@@ -53,8 +60,8 @@ which shells are installed so you can choose an alternative with
 
 ## Behavior
 
-- Commands run in bash on all platforms (git bash on Windows).
-- Use `type` parameter to switch shell if bash is unavailable.
+- Commands run in bash on all platforms (Git Bash on Windows) unless `type` selects another shell.
+- Use the `type` parameter to switch shells explicitly.
 - stdout and stderr are combined in the output.
 - Commands have a configurable timeout; pass `timeout` per call to override the tool default.
 - `timeout: 0` disables the execution timeout for long-running commands.

--- a/src/kohakuterrarium/builtins/tools/bash.py
+++ b/src/kohakuterrarium/builtins/tools/bash.py
@@ -47,19 +47,30 @@ _SHELL_SPECS: dict[str, tuple[str, list[str]]] = {
 _AVAILABLE_SHELLS: list[str] | None = None
 
 
+def _shell_override_name(shell_type: str) -> str | None:
+    """Return the environment variable providing the active shell override."""
+    specific_name = f"KT_{shell_type.upper()}_PATH"
+    if os.environ.get(specific_name):
+        return specific_name
+    if os.environ.get("KT_SHELL_PATH"):
+        return "KT_SHELL_PATH"
+    return None
+
+
 def _shell_override_env(shell_type: str) -> str | None:
-    specific = os.environ.get(f"KT_{shell_type.upper()}_PATH")
-    if specific:
-        return specific
-    generic = os.environ.get("KT_SHELL_PATH")
-    if generic:
-        return generic
-    if shell_type in {"bash", "zsh", "sh"}:
-        env_shell = os.environ.get("SHELL")
-        if env_shell and any(
-            name in env_shell.lower() for name in ("bash", "zsh", "sh")
-        ):
-            return env_shell
+    override_name = _shell_override_name(shell_type)
+    return os.environ.get(override_name) if override_name else None
+
+
+def _resolve_override_executable(override: str | None) -> str | None:
+    """Resolve an explicit shell override without selecting a fallback."""
+    if not override:
+        return None
+    resolved = shutil.which(override)
+    if resolved:
+        return resolved
+    if Path(override).exists():
+        return override
     return None
 
 
@@ -75,10 +86,8 @@ def _resolve_shell_executable(shell_type: str) -> str | None:
         if bundled is not None:
             return str(bundled)
 
-    override = _shell_override_env(shell_type)
-    if override and shutil.which(override):
-        return shutil.which(override)
-    if override and Path(override).exists():
+    override = _resolve_override_executable(_shell_override_env(shell_type))
+    if override:
         return override
 
     exe = _SHELL_SPECS[shell_type][0]


### PR DESCRIPTION
Fixes #128

## English

The built-in `bash` tool no longer uses the process `$SHELL` variable as an implicit executable override. This keeps the default bash tool on Bash when a Linux user has configured fish, zsh, or another shell as their login shell, while preserving explicit `KT_*_PATH` overrides.

### Problem

When `$SHELL=/usr/bin/fish`, the previous resolver could accept fish as the executable for a request whose shell type was `bash`. This happened because shell names were checked with substring matching: `fish` contains the substring `sh`.

As a result, the tool could effectively run:

```text
/usr/bin/fish -c "..."
```

even though the requested tool type was `bash`.

### Changes

- Removed `$SHELL` from the bash tool's implicit executable resolution path.
- Kept the default shell behavior fixed to Bash unless another shell is explicitly requested.
- Preserved per-shell overrides such as `KT_BASH_PATH` and `KT_SH_PATH`.
- Preserved the generic `KT_SHELL_PATH` override.
- Kept per-shell overrides ahead of the generic override.
- Avoided duplicate `shutil.which()` calls while resolving explicit overrides.
- Updated the English, Simplified Chinese, and Traditional Chinese shell documentation.
- Did not change PTY or Web Terminal shell resolution.
- Did not add the deferred first-use override notification.

### Expected behavior

With:

```text
SHELL=/usr/bin/fish
```

the default bash tool now resolves to Bash. Users who need another shell can select it explicitly with `type="fish"`, `type="zsh"`, or another supported shell type.

### Validation

Local checks passed:

- `ruff check src/ tests/`
- `black --check src/ tests/`
- Unit tests: `11835 passed, 1 skipped`
- File-size guards: `1678 passed`
- Dependency-graph guard: `2 passed`
- Integration tests: `172 passed`
- Frontend `npm run format:check`
- Frontend `npm run build`
- Wheel build with `python -m build --wheel`
- Manual regression check with `SHELL=/usr/bin/fish`, confirming `/usr/bin/bash` is selected

The fork CI passed on Linux and macOS, as well as the lint, frontend, package, format-guard, and dependency-graph jobs. One unrelated Windows Python 3.12 unit test failed in `tests/unit/studio/persistence/session_index/test_hooks.py::TestSessionIndexHook::test_event_flush_debounced_by_time`; the same test suite passed on Windows Python 3.13 and on all Linux/macOS matrix jobs.

## 中文

内置的 `bash` 工具不再把进程环境变量 `$SHELL` 当作隐式 executable 覆盖项。这样即使 Linux 用户将 fish、zsh 或其他 shell 设置为登录 shell，默认的 bash 工具仍会使用 Bash，同时继续保留显式的 `KT_*_PATH` 覆盖配置。

### 问题

当环境变量为：

```text
SHELL=/usr/bin/fish
```

旧的解析逻辑可能会把 fish 当成 `bash` 类型请求的 executable。原因是旧逻辑使用字符串子串匹配，`fish` 中包含 `sh` 子串。

因此，即使工具请求的类型是 `bash`，实际命令也可能被执行为：

```text
/usr/bin/fish -c "..."
```

### 修改内容

- 从 bash tool 的隐式 executable 解析路径中移除 `$SHELL`。
- 除非用户显式选择其他 shell，否则默认 shell 类型固定使用 Bash。
- 保留 `KT_BASH_PATH`、`KT_SH_PATH` 等 shell 专用覆盖项。
- 保留通用的 `KT_SHELL_PATH` 覆盖项。
- 保持 shell 专用覆盖项优先于通用覆盖项。
- 解析显式覆盖项时避免重复调用 `shutil.which()`。
- 更新英文、简体中文和繁体中文 shell 文档。
- 未修改 PTY 或 Web Terminal 的 shell 解析逻辑。
- 未加入延后的首次使用覆盖提醒功能。

### 预期行为

在：

```text
SHELL=/usr/bin/fish
```

的环境下，默认的 bash tool 现在会解析到 Bash。用户如果需要其他 shell，可以通过 `type="fish"`、`type="zsh"` 或其他受支持的 shell 类型显式选择。

### 验证结果

本地检查已通过：

- `ruff check src/ tests/`
- `black --check src/ tests/`
- 单元测试：`11835 passed, 1 skipped`
- 文件大小检查：`1678 passed`
- 依赖图检查：`2 passed`
- 集成测试：`172 passed`
- 前端 `npm run format:check`
- 前端 `npm run build`
- 使用 `python -m build --wheel` 构建 wheel
- 手动回归验证 `SHELL=/usr/bin/fish` 时会选择 `/usr/bin/bash`

Fork CI 中 Linux 和 macOS 测试、lint、前端、package、格式检查和依赖图检查均已通过。Windows Python 3.12 有一个与本次修改无关的单元测试失败：`tests/unit/studio/persistence/session_index/test_hooks.py::TestSessionIndexHook::test_event_flush_debounced_by_time`；同一测试套件在 Windows Python 3.13 以及全部 Linux/macOS 矩阵中均已通过。

## Scope

This change is intentionally limited to the command-execution bash tool and its documentation. No new test files were added, and PTY/Web Terminal behavior was left unchanged.

本次修改仅限于命令执行 bash tool 及其文档。没有新增测试文件，也没有修改 PTY/Web Terminal 行为。
