### PR TITLE
fix(subagent): attribute same-name tool results to their own calls

### DIFF
--- a/src/kohakuterrarium/modules/subagent/base.py
+++ b/src/kohakuterrarium/modules/subagent/base.py
@@ -515,7 +515,7 @@ class SubAgent:
             for tc, result in zip(tool_calls, tool_results):
                 prefix = f"[{tc.name}]"
                 if result.startswith(prefix):
-                    if "Error:" in result:
+                    if result.startswith(f"{prefix} Error:"):
                         error_msg = result.split("Error:", 1)[-1].strip()[:100]
                         self.on_tool_activity("tool_error", tc.name, error_msg)
                     else:

--- a/src/kohakuterrarium/modules/subagent/base.py
+++ b/src/kohakuterrarium/modules/subagent/base.py
@@ -487,7 +487,9 @@ class SubAgent:
             preview=preview + ("..." if len(assistant_content) > 200 else ""),
         )
 
-    async def _execute_and_report_tools(self, tool_calls: list[ToolCallEvent]) -> str:
+    async def _execute_and_report_tools(
+        self, tool_calls: list[ToolCallEvent]
+    ) -> list[str]:
         """Execute tools, notifying parent of start/done via callback."""
         logger.info(
             "Sub-agent executing tools",
@@ -508,36 +510,31 @@ class SubAgent:
         tool_results = await self._execute_tools(tool_calls)
 
         if self.on_tool_activity:
-            for tc in tool_calls:
+            # Results are positional: attribute each preview to its own call so
+            # several calls to the same tool don't all report the first block.
+            for tc, result in zip(tool_calls, tool_results):
                 prefix = f"[{tc.name}]"
-                for block in tool_results.split("\n\n"):
-                    if block.startswith(prefix):
-                        if "Error:" in block:
-                            error_msg = block.split("Error:", 1)[-1].strip()[:100]
-                            self.on_tool_activity("tool_error", tc.name, error_msg)
-                        else:
-                            preview = block[len(prefix) :].strip()[:100]
-                            self.on_tool_activity("tool_done", tc.name, preview)
-                        break
+                if result.startswith(prefix):
+                    if "Error:" in result:
+                        error_msg = result.split("Error:", 1)[-1].strip()[:100]
+                        self.on_tool_activity("tool_error", tc.name, error_msg)
+                    else:
+                        preview = result[len(prefix) :].strip()[:100]
+                        self.on_tool_activity("tool_done", tc.name, preview)
                 else:
                     self.on_tool_activity("tool_done", tc.name, "")
 
         return tool_results
 
     def _append_tool_results(
-        self, tool_calls: list[ToolCallEvent], tool_results: str
+        self, tool_calls: list[ToolCallEvent], tool_results: list[str]
     ) -> None:
         """Add tool results to conversation in the appropriate format."""
         if self._is_native:
-            for tc in tool_calls:
+            for tc, result_text in zip(tool_calls, tool_results):
                 tool_call_id = tc.args.get("_tool_call_id", "")
-                result_text = ""
-                for r in tool_results.split("\n\n") if tool_results else []:
-                    if r.startswith(f"[{tc.name}]"):
-                        result_text = r
-                        break
                 if not result_text:
-                    result_text = tool_results or "(no output)"
+                    result_text = "(no output)"
                 if tool_call_id:
                     self.conversation.append(
                         "tool",
@@ -547,7 +544,7 @@ class SubAgent:
                     )
         else:
             if tool_results:
-                self.conversation.append("user", tool_results)
+                self.conversation.append("user", "\n\n".join(tool_results))
 
     def _build_result(
         self, output_parts: list[str], tools_used: list[str]
@@ -595,8 +592,8 @@ class SubAgent:
             metadata={"tools_used": tools_used},
         )
 
-    async def _execute_tools(self, tool_calls: list[ToolCallEvent]) -> str:
-        """Execute tool calls and return formatted results."""
+    async def _execute_tools(self, tool_calls: list[ToolCallEvent]) -> list[str]:
+        """Execute tool calls and return one formatted result per call."""
         results: list[str] = []
 
         for tool_call in tool_calls:
@@ -674,7 +671,7 @@ class SubAgent:
                     error=str(e),
                 )
 
-        return "\n\n".join(results)
+        return results
 
     def _calculate_duration(self) -> float:
         """Calculate elapsed time."""

--- a/src/kohakuterrarium/modules/subagent/interactive.py
+++ b/src/kohakuterrarium/modules/subagent/interactive.py
@@ -259,7 +259,7 @@ class InteractiveSubAgent(SubAgent):
 
                     tool_results = await self._execute_tools(tool_calls)
                     if tool_results:
-                        self.conversation.append("user", tool_results)
+                        self.conversation.append("user", "\n\n".join(tool_results))
 
                 final_output = "".join(output_parts).strip()
                 complete_output = InteractiveOutput(

--- a/tests/unit/modules/subagent/test_base.py
+++ b/tests/unit/modules/subagent/test_base.py
@@ -302,6 +302,58 @@ class TestNativeMode:
         assert result.total_tokens == 30  # 15 per turn × 2 turns
         assert result.cached_tokens == 6
 
+    async def test_native_same_name_tool_calls_keep_own_results(self):
+        # Regression: several calls to the SAME tool in one turn must each
+        # receive their own result and preview; the old first-prefix-match
+        # logic replayed the first block for every call.
+        class _ReadStub(BaseTool):
+            @property
+            def tool_name(self):
+                return "read"
+
+            @property
+            def description(self):
+                return "stub read"
+
+            async def execute(self, args, context=None):
+                return ToolResult(output=f"content of {args['path']}")
+
+        activities: list[tuple] = []
+
+        class _TwoReadLLM(_NativeLLM):
+            async def chat(self, messages, *, stream=True, tools=None, **kwargs):
+                self._turn += 1
+                if self._turn == 1:
+                    self.last_tool_calls = [
+                        _NativeToolCall("call-a", "read", '{"path": "a.go"}'),
+                        _NativeToolCall("call-b", "read", '{"path": "b.go"}'),
+                    ]
+                    yield ""
+                else:
+                    self.last_tool_calls = []
+                    yield "native run complete"
+
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["read"], max_turns=5),
+            _registry(_ReadStub()),
+            _TwoReadLLM(),
+            tool_format="native",
+        )
+        sa.on_tool_activity = lambda *args: activities.append(args)
+        result = await sa.run("read both")
+        assert result.success is True
+
+        tool_msgs = [
+            m for m in sa.conversation.to_messages() if m.get("role") == "tool"
+        ]
+        by_id = {m.get("tool_call_id"): m.get("content") for m in tool_msgs}
+        # Each native call id receives its own file's content, not the first.
+        assert by_id["call-a"] == "[read]\ncontent of a.go"
+        assert by_id["call-b"] == "[read]\ncontent of b.go"
+
+        dones = [a for a in activities if a[0] == "tool_done"]
+        assert [a[2] for a in dones] == ["content of a.go", "content of b.go"]
+
 
 class _UsageLLM:
     """Text-mode LLM that reports token usage."""
@@ -491,7 +543,7 @@ class TestToolExecutionEdgeCases:
         results = await sa._execute_tools(
             [ToolCallEvent(name="not_registered", args={})]
         )
-        assert "Error: Tool not available" in results
+        assert "Error: Tool not available" in results[0]
 
     async def test_str_returning_tool_is_wrapped(self):
         # A tool whose execute() yields a bare str (not ToolResult) is
@@ -520,7 +572,7 @@ class TestToolExecutionEdgeCases:
         from kohakuterrarium.parsing import ToolCallEvent
 
         results = await sa._execute_tools([ToolCallEvent(name="stringy", args={})])
-        assert "raw string" in results
+        assert "raw string" in results[0]
 
     async def test_tool_raising_exception_is_caught(self):
         class _RaiseTool(BaseTool):
@@ -548,7 +600,7 @@ class TestToolExecutionEdgeCases:
 
         results = await sa._execute_tools([ToolCallEvent(name="raiser", args={})])
         # The exception is caught and surfaced as an error block.
-        assert "Error: tool internal error" in results
+        assert "Error: tool internal error" in results[0]
 
 
 class TestParserFormatResolution:


### PR DESCRIPTION
## Summary

Fix subagent result attribution in native mode: when a subagent issues multiple calls to the same tool in one turn, each `tool_call_id` now receives its own call's result instead of the first same-name result block.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [x] Tests only (regression test added)
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

In a real session a critic subagent read 4 different files in one turn; all 4 tool results contained the first file's content, producing a false verdict about the files' content. Root cause is result attribution: `_execute_tools` returned a joined string, and `_append_tool_results`/`_execute_and_report_tools` re-parsed it by first-prefix-match on `[name]`, so same-name calls all matched the first block. Details in the linked issue.

## Changes

- `modules/subagent/base.py`: `_execute_tools` now returns one formatted result per call (`list[str]`); `_append_tool_results` (native branch) and `_execute_and_report_tools` pair results positionally with the originating `ToolCallEvent` instead of first-prefix matching; non-native path keeps the same joined wire format.
- `modules/subagent/interactive.py`: adapts to the list return (`"\n\n".join(...)` preserves the previous format).
- `tests/unit/modules/subagent/test_base.py`: new regression test for native multi-same-name calls (asserts both conversation attribution and activity preview attribution); updated 3 assertions that called `_execute_tools` directly.

## Validation

```bash
python -m pytest tests/unit/modules/subagent/ -q        # 152 passed
python -m pytest tests/unit/modules/ -q                 # 561 passed
python -m pytest tests/integration/test_modules.py -q   # 9 passed
python -m pytest tests/unit/ -q                         # 5788 passed, 1 failed (see Exceptions)
ruff check src/kohakuterrarium/modules/subagent/base.py src/kohakuterrarium/modules/subagent/interactive.py tests/unit/modules/subagent/test_base.py
black --check src/kohakuterrarium/modules/subagent/base.py src/kohakuterrarium/modules/subagent/interactive.py tests/unit/modules/subagent/test_base.py
```

The regression test was verified to fail on the unfixed code (`call-b` received `content of a.go`) and passes after the fix.

## Checklist

- [x] I read `CONTRIBUTING.md` (English-only rule applied; repo conventions: max 600 lines/file, no memo comments, black/ruff)
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] This is not a feature PR — change is limited to a bug fix + tests
- [x] I kept this PR focused and did not include unrelated changes (pre-existing dirty `package-lock.json` and untracked notes were not staged)
- [x] No doc update needed (internal behavior fix; no user-visible config/API change)
- [x] I added or updated tests when needed
- [x] `ruff check` and `black --check` pass
- [x] `pytest tests/unit/` ran locally (1 unrelated failure, see Exceptions)
- [ ] No frontend files changed
- [ ] CI explanation in Exceptions

## Related Issues / Discussions

- Fixes #130

## Notes for Reviewers

- `_execute_tools` return type changes from `str` to `list[str]`; it is a private method and all call sites (base.py, interactive.py, tests) were updated.
- Checked for other "first-prefix-match" patterns of the same class — none remain.
- Both session-log previews and the actual content sent to the model are now attributed per call.

## Screenshots / Logs (if applicable)

Sanitized reproduction script and log shape are included in the linked issue (no local paths, file names, or content).

## Breaking Changes (if applicable)

None. Private method signature change only; public API untouched.

## Exceptions / Not Run

- Full `pytest tests/unit/`: 1 failure, `tests/unit/packages/test_git_backend_dulwich_integration.py::TestDulwichRealRefCheckout::test_clone_at_tag_checks_out_tagged_commit` — `KeyError: b'refs/heads/master'` while cloning a remote repo (remote default branch/network environment issue). No overlap with this PR's diff (only `modules/subagent/` touched); judged a pre-existing environment failure.
- e2e tier is not run in CI per repo convention; not run locally (change does not touch multi-node / Studio / serving stack).
- No frontend changes, so `npm run format:check` / `build` not run.
