### PR TITLE
fix(tui): route history and clean up inputs

### DIFF
--- a/src/kohakuterrarium/builtins/tui/session.py
+++ b/src/kohakuterrarium/builtins/tui/session.py
@@ -150,6 +150,7 @@ class TUISession(TabModelRegistryMixin):
         if not self._app or not self._app.is_running:
             return
         scroll_id = self._get_chat_scroll_id(target)
+        target_key = target or self._active_target or "_default"
 
         def _do():
             try:
@@ -157,13 +158,13 @@ class TUISession(TabModelRegistryMixin):
                 chat.mount(widget)
                 if scroll:
                     chat.scroll_end(animate=False)
-                self._cull_chat_widgets(chat)
+                self._cull_chat_widgets(chat, target_key)
             except Exception as e:
                 logger.warning("TUI safe_mount failed", error=str(e), exc_info=True)
 
         self._safe_call(_do)
 
-    def _cull_chat_widgets(self, chat: VerticalScroll) -> None:
+    def _cull_chat_widgets(self, chat: VerticalScroll, target: str) -> None:
         """Cull old widgets while retaining the configured recent window."""
         children = list(chat.children)
         if len(children) <= self._max_chat_widgets:
@@ -172,7 +173,6 @@ class TUISession(TabModelRegistryMixin):
         remove_count = len(children) - self._cull_keep
         to_remove = children[:remove_count]
 
-        target = self._active_target or "_default"
         self._culled_count[target] = self._culled_count.get(target, 0) + remove_count
 
         for w in to_remove:
@@ -559,6 +559,7 @@ class TUISession(TabModelRegistryMixin):
         if not widget:
             return
         scroll_id = self._get_chat_scroll_id(target)
+        target_key = target or self._active_target or "_default"
 
         def _do():
             try:
@@ -574,7 +575,7 @@ class TUISession(TabModelRegistryMixin):
                 widget.remove()
                 if at_bottom:
                     chat.scroll_end(animate=False)
-                self._cull_chat_widgets(chat)
+                self._cull_chat_widgets(chat, target_key)
             except Exception as e:
                 logger.warning("TUI end_streaming failed", error=str(e), exc_info=True)
 

--- a/src/kohakuterrarium/terrarium/engine_cli.py
+++ b/src/kohakuterrarium/terrarium/engine_cli.py
@@ -44,6 +44,7 @@ from kohakuterrarium.terrarium.engine_cli_commands import (
 )
 from kohakuterrarium.terrarium.events import EventFilter, EventKind
 from kohakuterrarium.terrarium.service import LocalTerrariumService
+from kohakuterrarium.utils.async_utils import cancel_tasks
 from kohakuterrarium.utils.logging import get_logger, restore_logging, suppress_logging
 
 logger = get_logger(__name__)
@@ -324,13 +325,21 @@ async def run_engine_with_tui(
     # first turn holds the lock. Firing as a task hands the second
     # call into the agent immediately; ``_process_event`` detects the
     # lock is held and buffers it for the current turn's drain.
-    inflight_inputs: list[asyncio.Task] = []
+    inflight_inputs: set[asyncio.Task[Any]] = set()
 
     def _spawn_inject(coro) -> None:
         task = asyncio.create_task(coro)
-        inflight_inputs.append(task)
-        # Reap finished tasks so the list doesn't grow forever.
-        inflight_inputs[:] = [t for t in inflight_inputs if not t.done()]
+        inflight_inputs.add(task)
+
+        def _reap(completed: asyncio.Task[Any]) -> None:
+            inflight_inputs.discard(completed)
+            if completed.cancelled():
+                return
+            error = completed.exception()
+            if error is not None:
+                logger.error("TUI input injection failed", error=str(error))
+
+        task.add_done_callback(_reap)
 
     try:
         while True:
@@ -387,6 +396,7 @@ async def run_engine_with_tui(
     except (KeyboardInterrupt, asyncio.CancelledError):
         pass
     finally:
+        await cancel_tasks(inflight_inputs)
         restore_logging()
         refresh_task.cancel()
         try:

--- a/src/kohakuterrarium/utils/async_utils.py
+++ b/src/kohakuterrarium/utils/async_utils.py
@@ -63,6 +63,17 @@ async def gather_with_concurrency(
     )
 
 
+async def cancel_tasks(tasks: set[asyncio.Task[Any]]) -> None:
+    """Cancel and join a mutable set of owned tasks, then clear it."""
+    pending = tuple(tasks)
+    for task in pending:
+        if not task.done():
+            task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+    tasks.clear()
+
+
 async def retry_async(
     func: Callable[..., Awaitable[T]],
     *args: Any,

--- a/tests/integration/test_repro_ui_bugs.py
+++ b/tests/integration/test_repro_ui_bugs.py
@@ -924,9 +924,7 @@ class TestTuiStdinStealFix:
             "mid-turn injection."
         )
 
-        cleanup_idx = text.index(
-            "await cancel_tasks(inflight_inputs)", try_idx
-        )
+        cleanup_idx = text.index("await cancel_tasks(inflight_inputs)", try_idx)
         finally_idx = text.index("    finally:", try_idx)
         assert cleanup_idx > finally_idx
 

--- a/tests/integration/test_repro_ui_bugs.py
+++ b/tests/integration/test_repro_ui_bugs.py
@@ -19,6 +19,7 @@ from kohakuterrarium.core.config_types import (
 )
 from kohakuterrarium.testing.llm import ScriptedLLM
 from kohakuterrarium.testing.output import OutputRecorder
+from kohakuterrarium.utils.async_utils import cancel_tasks
 
 
 async def _make_agent(tmp_path, llm_holder):
@@ -879,7 +880,7 @@ class TestTuiStdinStealFix:
             "F2 / F3 modal action handlers can reach the live agent."
         )
 
-    def test_tui_main_loop_uses_fire_and_forget_inject(self):
+    async def test_tui_main_loop_uses_fire_and_forget_inject(self):
         # Regression: the engine's input loop MUST NOT ``await
         # focus.inject_input(text)`` inline. Awaiting blocks the loop
         # for the entire turn — a second user message that arrives
@@ -922,6 +923,29 @@ class TestTuiStdinStealFix:
             "focus.inject_input(text, ...)`` inline — this defeats "
             "mid-turn injection."
         )
+
+        cleanup_idx = text.index(
+            "await cancel_tasks(inflight_inputs)", try_idx
+        )
+        finally_idx = text.index("    finally:", try_idx)
+        assert cleanup_idx > finally_idx
+
+        cancelled = asyncio.Event()
+
+        async def _pending_input() -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        task = asyncio.create_task(_pending_input())
+        await asyncio.sleep(0)
+        inflight = {task}
+        await cancel_tasks(inflight)
+
+        assert task.cancelled()
+        assert cancelled.is_set()
+        assert inflight == set()
 
     def test_handle_tui_slash_falls_through_for_other_commands(self):
         # Other slash commands (e.g. ``/help``, ``/clear``) MUST fall

--- a/tests/unit/builtins/tui/test_session.py
+++ b/tests/unit/builtins/tui/test_session.py
@@ -3,6 +3,9 @@
 from collections.abc import Callable
 from typing import Any
 
+from textual.containers import VerticalScroll
+
+from kohakuterrarium.builtins.tui.app import _safe_id
 from kohakuterrarium.builtins.tui.session import TUISession
 
 
@@ -40,3 +43,22 @@ def test_set_terrarium_tabs_reconciles_running_app_and_preserves_active() -> Non
 
     assert session._active_target == "root"
     assert app.reconciled[-1] == ["root", "new_worker"]
+
+
+async def test_background_tab_culling_keeps_target_history_count() -> None:
+    session = TUISession(max_chat_widgets=2, cull_keep=1)
+    session.set_terrarium_tabs(["alice", "bob"])
+    await session.start()
+    assert session._app is not None
+
+    async with session._app.run_test(size=(100, 40)) as pilot:
+        session.set_active_target("alice")
+        for index in range(3):
+            session.add_system_notice(f"background-{index}", target="bob")
+            await pilot.pause()
+
+        bob_chat = session._app.query_one(
+            f"#chat-{_safe_id('bob')}", VerticalScroll
+        )
+        assert len(bob_chat.children) == 2
+        assert session._culled_count == {"bob": 2}

--- a/tests/unit/builtins/tui/test_session.py
+++ b/tests/unit/builtins/tui/test_session.py
@@ -57,8 +57,6 @@ async def test_background_tab_culling_keeps_target_history_count() -> None:
             session.add_system_notice(f"background-{index}", target="bob")
             await pilot.pause()
 
-        bob_chat = session._app.query_one(
-            f"#chat-{_safe_id('bob')}", VerticalScroll
-        )
+        bob_chat = session._app.query_one(f"#chat-{_safe_id('bob')}", VerticalScroll)
         assert len(bob_chat.children) == 2
         assert session._culled_count == {"bob": 2}

--- a/tests/unit/utils/test_async_utils.py
+++ b/tests/unit/utils/test_async_utils.py
@@ -6,6 +6,7 @@ import pytest
 
 from kohakuterrarium.utils.async_utils import (
     AsyncQueue,
+    cancel_tasks,
     collect_async_iterator,
     first_result,
     gather_with_concurrency,
@@ -91,6 +92,27 @@ class TestGatherWithConcurrency:
         assert out[0] == 1
         assert isinstance(out[1], RuntimeError)
         assert out[2] == 1
+
+
+class TestCancelTasks:
+    async def test_cancels_joins_and_clears_owned_tasks(self):
+        cancelled = asyncio.Event()
+
+        async def pending():
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        task = asyncio.create_task(pending())
+        await asyncio.sleep(0)
+        tasks = {task}
+
+        await cancel_tasks(tasks)
+
+        assert task.cancelled()
+        assert cancelled.is_set()
+        assert tasks == set()
 
 
 # ── retry_async ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix deferred TUI routing and owned-task cleanup so background-tab history remains attributed correctly and input injections do not outlive the UI loop.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Deferred widget callbacks read the active tab at execution time, which could charge a background tab's culled history to whichever tab was active later. The engine TUI also created input-injection tasks without joining them during shutdown.

## Changes

- Capture the target tab before scheduling deferred mount and streaming-finalization callbacks.
- Pass the captured target into history culling.
- Track fire-and-forget input injections as owned tasks and cancel/join them when the TUI exits.
- Add unit and integration regression coverage for both paths.

## Validation

```bash
python -m pytest tests/unit/builtins/tui tests/unit/utils/test_async_utils.py tests/integration/test_repro_ui_bugs.py -q
# 73 passed

python -m pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
# 1680 passed

python -m ruff check src/kohakuterrarium/builtins/tui/session.py src/kohakuterrarium/terrarium/engine_cli.py src/kohakuterrarium/utils/async_utils.py tests/unit/builtins/tui/test_session.py tests/unit/utils/test_async_utils.py tests/integration/test_repro_ui_bugs.py
# All checks passed!

git diff --check
# passed
```

The background-tab regression was first run against the unfixed implementation and attributed both culled widgets to `alice` instead of `bob`.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #134

## Notes for Reviewers

The helper cancels only the mutable set of tasks owned by this TUI loop. It preserves the fire-and-forget injection behavior required for mid-turn input buffering.

## Exceptions / Not Run

- The full repository unit suite was not run; the affected TUI/unit/integration workflows and both project guard suites passed.
- Project-configured Black targets Python 3.14 syntax, but the available Python 3.12 Black process could not validate that target. Ruff and `git diff --check` passed.
- A formatting follow-up was pushed; the new GitHub lint job is green. The remaining test matrix is still in progress.