### PR TITLE
fix(cli): resolve virtualenv service scripts

### DIFF
--- a/src/kohakuterrarium/cli/service.py
+++ b/src/kohakuterrarium/cli/service.py
@@ -71,21 +71,32 @@ def _read_template(name: str) -> str:
     )
 
 
-def _resolve_kt_executable() -> str:
-    """Absolute path to the ``kt`` console script.
-
-    Prefer ``shutil.which("kt")`` — that's what the user already has
-    on PATH and what the unit will use after a reboot. Fall back to
-    the running interpreter's ``Scripts/bin`` dir.
-    """
-    found = shutil.which("kt")
+def _find_console_script(name: str) -> str | None:
+    """Find a console script on PATH or beside the running interpreter."""
+    found = shutil.which(name)
     if found:
         return found
-    candidate = Path(sys.exec_prefix) / "bin" / "kt"
-    if candidate.is_file():
-        return str(candidate)
+
+    bin_script = Path(sys.exec_prefix) / "bin" / name
+    windows_script = Path(sys.exec_prefix) / "Scripts" / f"{name}.exe"
+    candidates = (
+        (windows_script, bin_script)
+        if os.name == "nt"
+        else (bin_script, windows_script)
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def _resolve_kt_executable() -> str:
+    """Absolute path to the ``kt`` console script."""
+    found = _find_console_script("kt")
+    if found:
+        return found
     raise FileNotFoundError(
-        "Could not locate `kt` on PATH or in this interpreter's bin dir. "
+        "Could not locate `kt` on PATH or in this interpreter's Scripts/bin dir. "
         "Install KohakuTerrarium globally (or in a venv on PATH) before "
         "running `kt service install`."
     )
@@ -93,15 +104,13 @@ def _resolve_kt_executable() -> str:
 
 def _resolve_kt_aio_executable() -> str:
     """Absolute path to the ``kt-aio`` console script."""
-    found = shutil.which("kt-aio")
+    found = _find_console_script("kt-aio")
     if found:
         return found
-    candidate = Path(sys.exec_prefix) / "bin" / "kt-aio"
-    if candidate.is_file():
-        return str(candidate)
     raise FileNotFoundError(
-        "Could not locate `kt-aio` on PATH. The `kt-aio` console script "
-        "is shipped by KohakuTerrarium 1.5+; reinstall the package."
+        "Could not locate `kt-aio` on PATH or in this interpreter's "
+        "Scripts/bin dir. The `kt-aio` console script is shipped by "
+        "KohakuTerrarium 1.5+; reinstall the package."
     )
 
 

--- a/tests/unit/cli/test_service.py
+++ b/tests/unit/cli/test_service.py
@@ -24,9 +24,7 @@ class TestResolveConsoleScripts:
         expected = windows_script if service.os.name == "nt" else bin_script
         assert service._resolve_kt_executable() == str(expected)
 
-    def test_kt_falls_back_to_windows_virtualenv_scripts(
-        self, tmp_path, monkeypatch
-    ):
+    def test_kt_falls_back_to_windows_virtualenv_scripts(self, tmp_path, monkeypatch):
         monkeypatch.setattr(service.shutil, "which", lambda _name: None)
         monkeypatch.setattr(service.sys, "exec_prefix", str(tmp_path))
         executable = tmp_path / "Scripts" / "kt.exe"

--- a/tests/unit/cli/test_service.py
+++ b/tests/unit/cli/test_service.py
@@ -10,6 +10,43 @@ deploys.
 from kohakuterrarium.cli import service
 
 
+class TestResolveConsoleScripts:
+    def test_interpreter_native_layout_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(service.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(service.sys, "exec_prefix", str(tmp_path))
+        bin_script = tmp_path / "bin" / "kt"
+        windows_script = tmp_path / "Scripts" / "kt.exe"
+        bin_script.parent.mkdir()
+        windows_script.parent.mkdir()
+        bin_script.touch()
+        windows_script.touch()
+
+        expected = windows_script if service.os.name == "nt" else bin_script
+        assert service._resolve_kt_executable() == str(expected)
+
+    def test_kt_falls_back_to_windows_virtualenv_scripts(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(service.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(service.sys, "exec_prefix", str(tmp_path))
+        executable = tmp_path / "Scripts" / "kt.exe"
+        executable.parent.mkdir()
+        executable.touch()
+
+        assert service._resolve_kt_executable() == str(executable)
+
+    def test_kt_aio_falls_back_to_windows_virtualenv_scripts(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(service.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(service.sys, "exec_prefix", str(tmp_path))
+        executable = tmp_path / "Scripts" / "kt-aio.exe"
+        executable.parent.mkdir()
+        executable.touch()
+
+        assert service._resolve_kt_aio_executable() == str(executable)
+
+
 class TestRenderHostUnit:
     def test_host_unit_carries_required_directives(self):
         unit = service._render_host_unit(


### PR DESCRIPTION
## Summary

Resolve `kt` and `kt-aio` console scripts from either POSIX `bin/` or Windows virtualenv `Scripts/` layouts while preserving PATH and platform-native precedence.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The resolver documentation promised a `Scripts/bin` fallback, but the implementation only checked `bin/<name>`. In a Windows virtualenv with a sanitized PATH, all render-only service tests that need `kt` failed even though `Scripts/kt.exe` existed.

## Changes

- Share console-script discovery between `kt` and `kt-aio`.
- Preserve PATH precedence.
- Prefer the running platform's native interpreter layout, with the other layout as a compatibility fallback.
- Add regression coverage for both Windows launchers and native-layout precedence.

## Validation

```bash
python -m pytest tests/unit/cli/test_service.py -q
# 9 passed

python -m pytest tests/unit/cli -q
# 173 passed, 3 skipped

python -m pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
# 1680 passed

python -m ruff check src/kohakuterrarium/cli/service.py tests/unit/cli/test_service.py
# All checks passed!

git diff --check
# passed
```

Before the fix, five existing render tests and both new direct resolver regressions failed in the managed Windows virtualenv.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #135

## Notes for Reviewers

`kt service` remains Linux-only for installation and systemd interaction. This fix covers its platform-independent rendering helpers and keeps the Linux `bin/` path first on Linux.

## Exceptions / Not Run

- The full repository unit suite was not run; the entire CLI unit folder and both project guard suites passed.
- Project-configured Black targets Python 3.14 syntax, but the available Python 3.12 Black process could not validate that target. Ruff and `git diff --check` passed.
- A formatting follow-up was pushed; the new GitHub lint, format guard, dependency guard, package, and frontend jobs are green. The remaining test matrix is still in progress.