### PR TITLE
fix(drive): guide goal creation and assignee transitions in tool docs

### DIFF
--- a/src/kohakuterrarium/builtins/plugins/goal/plugin.py
+++ b/src/kohakuterrarium/builtins/plugins/goal/plugin.py
@@ -40,8 +40,9 @@ _PLUGIN_PROMPT = (
     "material progress with evidence, and propose completion with evidence "
     "rather than asserting it. Completion is authoritative only through the "
     "goal's completion policy — a user_confirm goal completes only when the "
-    "human confirms via /goal complete. If a budget is exhausted, propose "
-    "pausing; a budget never means success. When a Goal event starts a turn, its "
+    "human confirms via /goal complete. If a budget is exhausted, stop pursuit "
+    "and report the state — a budget never means success, and only the owner "
+    "can raise it and wake the goal. When a Goal event starts a turn, its "
     "objective and ID are already in that event: act directly instead of calling "
     "drive_status or group_drive just to rediscover the assigned Goal."
 )

--- a/src/kohakuterrarium/terrarium/drive/goal.py
+++ b/src/kohakuterrarium/terrarium/drive/goal.py
@@ -145,8 +145,9 @@ _PROMPT = (
     "continuing commitment — never invent a new objective. On a recovery event, "
     "inspect the current world before repeating any side effect. Report material "
     "progress (or blocking) with evidence, and propose completion with evidence "
-    "rather than asserting it. Obey the goal's budgets and wait/pause policy; if a "
-    "budget is exhausted, propose pausing, never completing."
+    "rather than asserting it. Obey the goal's budgets; exhausting a budget stops "
+    "continuation without completing or resuming the goal — stop and report the "
+    "state so the owner can raise the budget and wake it."
 )
 
 # Per-field limits keep goal projections bounded before aggregate size checks.

--- a/src/kohakuterrarium/terrarium/drive/prompt.py
+++ b/src/kohakuterrarium/terrarium/drive/prompt.py
@@ -18,8 +18,10 @@ _GENERIC_CONTRACT = (
     "an ordinary event. You interpret it, act with your normal tools, and report "
     "outcomes — the runtime owns identity, delivery, and recovery.\n"
     "- Ownership: you may create and manage your own drives; a drive owned by "
-    "someone else that is merely assigned to you is report/propose-only — do not "
-    "cancel, reassign, or retire it.\n"
+    "someone else that is merely assigned to you is report/propose-only — you "
+    "may set it to 'waiting' or 'blocked' to suspend pursuit (use 'blocked' when "
+    "you need user intervention), but do not cancel, reassign, retire, or pause "
+    "it.\n"
     "- Recovery: a redelivered drive may follow an attempt that already ran side "
     "effects. Inspect current state and reconcile before repeating actions.\n"
     "- Delivery: the active Drive's projected objective and identity arrive in "
@@ -28,8 +30,9 @@ _GENERIC_CONTRACT = (
     "- Progress: report material progress with evidence rather than narrating.\n"
     "- Completion: propose completion or failure with evidence for verification; "
     "do not assert a terminal outcome yourself.\n"
-    "- Budgets: obey wait/pause policy and any declared budgets; exhausting a "
-    "budget pauses or blocks a drive, it never means success."
+    "- Budgets: obey declared budgets; exhausting a budget stops continuation "
+    "without changing the drive's status — it never completes and never resumes "
+    "on its own. Recovery is an explicit owner act (raise the budget and wake)."
 )
 
 

--- a/src/kohakuterrarium/terrarium/drive/tools.py
+++ b/src/kohakuterrarium/terrarium/drive/tools.py
@@ -7,33 +7,25 @@ model while structured payloads remain available in :class:`ToolResult` metadata
 
 from typing import Any
 
-from kohakuterrarium.modules.tool.base import (
-    BaseTool,
-    ExecutionMode,
-    ToolContext,
-    ToolResult,
-)
-from kohakuterrarium.terrarium.channels import DRIVE_SERVICE_KEY
+from kohakuterrarium.modules.tool.base import BaseTool, ToolContext, ToolResult
 from kohakuterrarium.terrarium.drive.errors import (
-    DriveConflictError,
     DriveError,
-    DriveIdempotencyConflictError,
-    DriveNotFoundError,
     DrivePermissionError,
-    DriveRegistrationDisabledError,
-    DriveRegistrationIncompatibleError,
-    DriveRegistrationNotFoundError,
     DriveValidationError,
 )
-from kohakuterrarium.terrarium.drive.models import ActorRef, DriveRecord, DriveStatus
+from kohakuterrarium.terrarium.drive.models import DriveRecord, DriveStatus
 from kohakuterrarium.terrarium.drive.requests import (
     CreateDriveRequest,
     DrivePatch,
     DriveQuery,
 )
-from kohakuterrarium.terrarium.group_tool_context import (
-    GroupToolError,
-    resolve_group_context,
+from kohakuterrarium.terrarium.drive.tools_common import (
+    _BaseDriveTool,
+    _DriveCall,
+    _drive_error_result,
+    _err,
+    _ok,
+    _summary_with_actions,
 )
 
 # Terminal states require proposal verification; administrative retirement is
@@ -51,179 +43,6 @@ _TRANSITION_TARGETS = frozenset(
 )
 
 
-class _DriveCall:
-    """Hold the trusted runtime context for one Drive tool invocation."""
-
-    __slots__ = (
-        "manager",
-        "runtime",
-        "engine",
-        "caller",
-        "actor",
-        "graph_id",
-        "is_privileged",
-    )
-
-    def __init__(self, manager, runtime, engine, caller) -> None:
-        self.manager = manager
-        self.runtime = runtime
-        self.engine = engine
-        self.caller = caller
-        self.actor = ActorRef("creature", caller.creature_id)
-        self.graph_id = caller.graph_id
-        self.is_privileged = bool(getattr(caller, "is_privileged", False))
-
-
-def _resolve_call(ctx: ToolContext | None) -> _DriveCall:
-    """Resolve the caller, engine, and graph-scoped Drive manager."""
-    gctx = resolve_group_context(ctx, require_privileged=False)
-    runtime = ctx.environment.get(DRIVE_SERVICE_KEY) if ctx.environment else None
-    if runtime is None:
-        raise GroupToolError("the Drive runtime is not enabled on this terrarium")
-    manager = runtime.manager_for(gctx.caller.graph_id)
-    if manager is None:
-        raise GroupToolError("no Drive manager is available for this graph")
-    return _DriveCall(manager, runtime, gctx.engine, gctx.caller)
-
-
-def _err(message: str) -> ToolResult:
-    return ToolResult(error=message)
-
-
-def _format_value(value: Any) -> str:
-    if value is None:
-        return "none"
-    if isinstance(value, bool):
-        return "yes" if value else "no"
-    if isinstance(value, (list, tuple)):
-        return ", ".join(str(item) for item in value) or "none"
-    return str(value)
-
-
-def _format_drive(summary: dict[str, Any]) -> str:
-    lines = [
-        f"Drive {summary['drive_id']}: {summary['title']}",
-        f"Status: {summary['status']} | Kind: {summary['kind']} | Revision: {summary['revision']}",
-        f"Owner: {summary['owner']} | Assignee: {_format_value(summary.get('assignee'))}",
-        f"Scope: {summary['scope_type']}:{summary['scope_id']} | Priority: {summary['priority']}",
-    ]
-    if summary.get("availability") is not None:
-        lines.append(f"Availability: {summary['availability']}")
-    if summary.get("durability") is not None:
-        lines.append(f"Durability: {summary['durability']}")
-    if summary.get("proposal") is not None:
-        lines.append(f"Proposal: {summary['proposal']}")
-    actions = summary.get("allowed_actions") or []
-    if actions:
-        lines.append(f"Allowed actions: {_format_value(actions)}")
-    return "\n".join(lines)
-
-
-def _format_payload(payload: dict[str, Any]) -> str:
-    drives = payload.get("drives")
-    if isinstance(drives, list):
-        if not drives:
-            return "No matching drives."
-        return "\n\n".join(_format_drive(item) for item in drives)
-    if {"drive_id", "title", "status", "kind"}.issubset(payload):
-        return _format_drive(payload)
-    if "progress_id" in payload:
-        return (
-            f"Progress recorded for drive {payload['drive_id']}.\n"
-            f"Progress ID: {payload['progress_id']}"
-        )
-    if "proposal_id" in payload:
-        return (
-            f"Transition proposed for drive {payload['drive_id']}: "
-            f"{payload['target_status']} ({payload.get('proposal', 'pending')}).\n"
-            f"Proposal ID: {payload['proposal_id']}"
-        )
-    if "delivery_id" in payload:
-        return (
-            f"Delivery {payload['delivery_id']} replayed for drive "
-            f"{payload['drive_id']}."
-        )
-    return "\n".join(f"{key}: {_format_value(value)}" for key, value in payload.items())
-
-
-def _ok(payload: dict[str, Any]) -> ToolResult:
-    return ToolResult(
-        output=_format_payload(payload),
-        exit_code=0,
-        metadata={"drive": payload},
-    )
-
-
-def _drive_error_result(exc: DriveError) -> ToolResult:
-    """Map a typed Drive error to a distinct, model-shaped tool error."""
-    if isinstance(exc, (DriveConflictError, DriveIdempotencyConflictError)):
-        return _err(f"conflict: {exc}")
-    if isinstance(exc, DrivePermissionError):
-        return _err(f"permission denied: {exc}")
-    if isinstance(
-        exc,
-        (
-            DriveRegistrationDisabledError,
-            DriveRegistrationIncompatibleError,
-            DriveRegistrationNotFoundError,
-        ),
-    ):
-        return _err(f"registration unavailable: {exc}")
-    if isinstance(exc, DriveNotFoundError):
-        return _err(f"not found: {exc}")
-    return _err(f"invalid: {exc}")
-
-
-def _record_summary(call: _DriveCall, record: DriveRecord) -> dict[str, Any]:
-    """Build a bounded authorized summary without exposing the raw Drive spec."""
-    return {
-        "drive_id": record.drive_id,
-        "kind": record.kind,
-        "title": record.title,
-        "status": record.status.value,
-        "revision": record.revision,
-        "scope_type": record.scope_type,
-        "scope_id": record.scope_id,
-        "owner": record.owner.format(),
-        "priority": record.priority,
-        # Durability must describe the record's graph rather than a possibly
-        # mixed aggregate across the engine.
-        "durability": call.runtime.durability_for(call.graph_id),
-    }
-
-
-async def _summary_with_actions(
-    call: _DriveCall, record: DriveRecord
-) -> dict[str, Any]:
-    assignment = await call.manager.get_assignment(record.drive_id)
-    summary = _record_summary(call, record)
-    summary["assignee"] = (
-        assignment.assignee_creature_id if assignment is not None else None
-    )
-    summary["allowed_actions"] = list(
-        call.manager.allowed_actions(
-            call.actor, record, assignment, is_privileged=call.is_privileged
-        )
-    )
-    return summary
-
-
-class _BaseDriveTool(BaseTool):
-    needs_context = True
-
-    @property
-    def execution_mode(self) -> ExecutionMode:
-        return ExecutionMode.DIRECT
-
-    async def _resolve_or_error(
-        self, ctx: ToolContext | None
-    ) -> tuple[_DriveCall | None, ToolResult | None]:
-        try:
-            return _resolve_call(ctx), None
-        except GroupToolError as exc:
-            return None, _err(str(exc))
-
-
 class DriveCreateTool(_BaseDriveTool):
     """Create a caller-owned, caller-scoped Drive of an enabled kind."""
 
@@ -237,10 +56,11 @@ class DriveCreateTool(_BaseDriveTool):
             "Create a durable drive you own (kind, title, spec). Use kind='goal': "
             "it is the only kind with a user-facing /goal command surface, so "
             "prefer it for anything a human should track. For 'goal', spec must "
-            "include a non-empty 'objective' and set "
-            "spec.autonomy='continue_when_ready' so the goal keeps driving you "
-            "automatically. Other kinds (e.g. 'generic') have no dedicated "
-            "command surface and are managed via the drive tools."
+            "include a non-empty 'objective'; set "
+            "spec.autonomy='continue_when_ready' (the default is 'manual') so "
+            "the goal keeps driving you automatically. Other kinds (e.g. "
+            "'generic') have no dedicated command surface and are managed via "
+            "the drive tools."
         )
 
     def get_parameters_schema(self) -> dict:
@@ -276,7 +96,8 @@ class DriveCreateTool(_BaseDriveTool):
                             "type": "string",
                             "enum": ["manual", "continue_when_ready"],
                             "description": (
-                                "Set 'continue_when_ready' so the goal keeps "
+                                "Optional; defaults to 'manual'. Set "
+                                "'continue_when_ready' so the goal keeps "
                                 "driving you automatically."
                             ),
                         },
@@ -549,6 +370,7 @@ class DriveTransitionTool(_BaseDriveTool):
                 "status": {
                     "type": "string",
                     "enum": [
+                        "draft",
                         "active",
                         "waiting",
                         "blocked",
@@ -594,8 +416,8 @@ class DriveTransitionTool(_BaseDriveTool):
             target = DriveStatus(status_raw)
         except ValueError:
             return _err(
-                f"unknown status {status_raw!r}; use one of active, waiting, "
-                "blocked, paused, cancelled, completed, failed"
+                f"unknown status {status_raw!r}; use one of draft, active, "
+                "waiting, blocked, paused, cancelled, completed, failed"
             )
         expected_revision = args.get("expected_revision")
         if expected_revision is not None and (

--- a/src/kohakuterrarium/terrarium/drive/tools.py
+++ b/src/kohakuterrarium/terrarium/drive/tools.py
@@ -235,10 +235,12 @@ class DriveCreateTool(_BaseDriveTool):
     def description(self) -> str:
         return (
             "Create a durable drive you own (kind, title, spec). Use kind='goal': "
-            "it is the only kind users can see and manage (via /goal), so prefer "
-            "it for anything a human should track. For 'goal', spec must include "
-            "a non-empty 'objective' and set spec.autonomy='continue_when_ready' "
-            "so the goal keeps driving you automatically."
+            "it is the only kind with a user-facing /goal command surface, so "
+            "prefer it for anything a human should track. For 'goal', spec must "
+            "include a non-empty 'objective' and set "
+            "spec.autonomy='continue_when_ready' so the goal keeps driving you "
+            "automatically. Other kinds (e.g. 'generic') have no dedicated "
+            "command surface and are managed via the drive tools."
         )
 
     def get_parameters_schema(self) -> dict:
@@ -248,10 +250,11 @@ class DriveCreateTool(_BaseDriveTool):
                 "kind": {
                     "type": "string",
                     "description": (
-                        "Drive kind; use 'goal' — the only kind with a "
-                        "user-facing surface (users see and manage it via /goal). "
-                        "Other kinds (e.g. 'generic') have no user command and are "
-                        "invisible to users. For 'goal', see the spec description."
+                        "Drive kind; prefer 'goal' — the only kind with a "
+                        "user-facing /goal command surface. Other kinds "
+                        "(e.g. 'generic') have no dedicated command surface and "
+                        "are managed via the drive tools. For 'goal', see the "
+                        "spec description."
                     ),
                 },
                 "title": {"type": "string"},

--- a/src/kohakuterrarium/terrarium/drive/tools.py
+++ b/src/kohakuterrarium/terrarium/drive/tools.py
@@ -23,6 +23,7 @@ from kohakuterrarium.terrarium.drive.errors import (
     DriveRegistrationDisabledError,
     DriveRegistrationIncompatibleError,
     DriveRegistrationNotFoundError,
+    DriveValidationError,
 )
 from kohakuterrarium.terrarium.drive.models import ActorRef, DriveRecord, DriveStatus
 from kohakuterrarium.terrarium.drive.requests import (
@@ -232,15 +233,81 @@ class DriveCreateTool(_BaseDriveTool):
 
     @property
     def description(self) -> str:
-        return "Create a durable drive you own (kind, title, spec)"
+        return (
+            "Create a durable drive you own (kind, title, spec). Use kind='goal': "
+            "it is the only kind users can see and manage (via /goal), so prefer "
+            "it for anything a human should track. For 'goal', spec must include "
+            "a non-empty 'objective' and set spec.autonomy='continue_when_ready' "
+            "so the goal keeps driving you automatically."
+        )
 
     def get_parameters_schema(self) -> dict:
         return {
             "type": "object",
             "properties": {
-                "kind": {"type": "string"},
+                "kind": {
+                    "type": "string",
+                    "description": (
+                        "Drive kind; use 'goal' — the only kind with a "
+                        "user-facing surface (users see and manage it via /goal). "
+                        "Other kinds (e.g. 'generic') have no user command and are "
+                        "invisible to users. For 'goal', see the spec description."
+                    ),
+                },
                 "title": {"type": "string"},
-                "spec": {"type": "object"},
+                "spec": {
+                    "type": "object",
+                    "description": (
+                        "Kind-specific spec. For kind='goal', use the properties "
+                        "below ('objective' is required); other kinds treat spec "
+                        "as opaque."
+                    ),
+                    "properties": {
+                        "objective": {
+                            "type": "string",
+                            "description": (
+                                "Required for 'goal': the durable objective to pursue."
+                            ),
+                        },
+                        "autonomy": {
+                            "type": "string",
+                            "enum": ["manual", "continue_when_ready"],
+                            "description": (
+                                "Set 'continue_when_ready' so the goal keeps "
+                                "driving you automatically."
+                            ),
+                        },
+                        "success_criteria": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional criteria that would demonstrate completion."
+                            ),
+                        },
+                        "constraints": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional constraints the goal must respect.",
+                        },
+                        "completion_policy": {
+                            "type": "string",
+                            "enum": ["self_propose", "user_confirm", "verifier"],
+                            "description": "Optional; default 'self_propose'.",
+                        },
+                        "budgets": {
+                            "type": "object",
+                            "description": (
+                                "Optional pursuit limits; continuation stops when "
+                                "exhausted."
+                            ),
+                            "properties": {
+                                "max_turns": {"type": "integer"},
+                                "max_tool_calls": {"type": "integer"},
+                                "max_walltime_s": {"type": "integer"},
+                            },
+                        },
+                    },
+                },
                 "priority": {"type": "integer"},
                 "idempotency_key": {"type": "string"},
             },
@@ -285,6 +352,14 @@ class DriveCreateTool(_BaseDriveTool):
                 graph_id=call.graph_id,
                 is_privileged=call.is_privileged,
             )
+        except DriveValidationError as exc:
+            if kind == "goal":
+                return _err(
+                    f"invalid goal spec: {exc}; kind='goal' requires a spec with "
+                    "a non-empty 'objective' — e.g. spec={'objective': '...', "
+                    "'autonomy': 'continue_when_ready'}"
+                )
+            return _drive_error_result(exc)
         except DriveError as exc:
             return _drive_error_result(exc)
         return _ok(await _summary_with_actions(call, record))
@@ -455,17 +530,49 @@ class DriveTransitionTool(_BaseDriveTool):
 
     @property
     def description(self) -> str:
-        return "Transition a drive (pause/resume/…) or propose completed/failed"
+        return (
+            "Transition a drive you own, or as the assignee of a foreign-owned "
+            "drive set it to 'waiting'/'blocked' (use 'blocked' when you need "
+            "user intervention; 'paused'/'cancelled' are owner-only). Control "
+            "transitions require 'expected_revision' (see drive_status); "
+            "completed/failed go through proposal with evidence."
+        )
 
     def get_parameters_schema(self) -> dict:
         return {
             "type": "object",
             "properties": {
                 "drive_id": {"type": "string"},
-                "status": {"type": "string"},
-                "expected_revision": {"type": "integer"},
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "waiting",
+                        "blocked",
+                        "paused",
+                        "cancelled",
+                        "completed",
+                        "failed",
+                    ],
+                    "description": (
+                        "Target status. As an assignee you may only set "
+                        "'waiting' or 'blocked'; 'paused'/'cancelled' require "
+                        "the owner; completed/failed go through proposal with "
+                        "evidence."
+                    ),
+                },
+                "expected_revision": {
+                    "type": "integer",
+                    "description": (
+                        "Current revision from drive_status; required for control "
+                        "transitions, optional for completed/failed proposals."
+                    ),
+                },
                 "reason": {"type": "string"},
-                "evidence": {"type": "object"},
+                "evidence": {
+                    "type": "object",
+                    "description": "Evidence for completed/failed proposals.",
+                },
             },
             "required": ["drive_id", "status"],
         }
@@ -509,6 +616,13 @@ class DriveTransitionTool(_BaseDriveTool):
                 actor=call.actor,
                 status_reason=(args.get("reason") or None),
                 is_privileged=call.is_privileged,
+            )
+        except DrivePermissionError as exc:
+            return _err(
+                f"permission denied: {exc}; as an assignee you may only "
+                "transition to 'waiting' or 'blocked' (use 'blocked' when you "
+                "need user intervention); 'paused' and 'cancelled' require the "
+                "owner"
             )
         except DriveError as exc:
             return _drive_error_result(exc)

--- a/src/kohakuterrarium/terrarium/drive/tools_common.py
+++ b/src/kohakuterrarium/terrarium/drive/tools_common.py
@@ -1,0 +1,199 @@
+"""Shared helpers and base tool for the self-service Drive tools."""
+
+from typing import Any
+
+from kohakuterrarium.modules.tool.base import (
+    BaseTool,
+    ExecutionMode,
+    ToolContext,
+    ToolResult,
+)
+from kohakuterrarium.terrarium.channels import DRIVE_SERVICE_KEY
+from kohakuterrarium.terrarium.drive.errors import (
+    DriveConflictError,
+    DriveError,
+    DriveIdempotencyConflictError,
+    DriveNotFoundError,
+    DrivePermissionError,
+    DriveRegistrationDisabledError,
+    DriveRegistrationIncompatibleError,
+    DriveRegistrationNotFoundError,
+)
+from kohakuterrarium.terrarium.drive.models import ActorRef, DriveRecord
+from kohakuterrarium.terrarium.group_tool_context import (
+    GroupToolError,
+    resolve_group_context,
+)
+
+
+class _DriveCall:
+    """Hold the trusted runtime context for one Drive tool invocation."""
+
+    __slots__ = (
+        "manager",
+        "runtime",
+        "engine",
+        "caller",
+        "actor",
+        "graph_id",
+        "is_privileged",
+    )
+
+    def __init__(self, manager, runtime, engine, caller) -> None:
+        self.manager = manager
+        self.runtime = runtime
+        self.engine = engine
+        self.caller = caller
+        self.actor = ActorRef("creature", caller.creature_id)
+        self.graph_id = caller.graph_id
+        self.is_privileged = bool(getattr(caller, "is_privileged", False))
+
+
+def _resolve_call(ctx: ToolContext | None) -> _DriveCall:
+    """Resolve the caller, engine, and graph-scoped Drive manager."""
+    gctx = resolve_group_context(ctx, require_privileged=False)
+    runtime = ctx.environment.get(DRIVE_SERVICE_KEY) if ctx.environment else None
+    if runtime is None:
+        raise GroupToolError("the Drive runtime is not enabled on this terrarium")
+    manager = runtime.manager_for(gctx.caller.graph_id)
+    if manager is None:
+        raise GroupToolError("no Drive manager is available for this graph")
+    return _DriveCall(manager, runtime, gctx.engine, gctx.caller)
+
+
+def _err(message: str) -> ToolResult:
+    return ToolResult(error=message)
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (list, tuple)):
+        return ", ".join(str(item) for item in value) or "none"
+    return str(value)
+
+
+def _format_drive(summary: dict[str, Any]) -> str:
+    lines = [
+        f"Drive {summary['drive_id']}: {summary['title']}",
+        f"Status: {summary['status']} | Kind: {summary['kind']} | Revision: {summary['revision']}",
+        f"Owner: {summary['owner']} | Assignee: {_format_value(summary.get('assignee'))}",
+        f"Scope: {summary['scope_type']}:{summary['scope_id']} | Priority: {summary['priority']}",
+    ]
+    if summary.get("availability") is not None:
+        lines.append(f"Availability: {summary['availability']}")
+    if summary.get("durability") is not None:
+        lines.append(f"Durability: {summary['durability']}")
+    if summary.get("proposal") is not None:
+        lines.append(f"Proposal: {summary['proposal']}")
+    actions = summary.get("allowed_actions") or []
+    if actions:
+        lines.append(f"Allowed actions: {_format_value(actions)}")
+    return "\n".join(lines)
+
+
+def _format_payload(payload: dict[str, Any]) -> str:
+    drives = payload.get("drives")
+    if isinstance(drives, list):
+        if not drives:
+            return "No matching drives."
+        return "\n\n".join(_format_drive(item) for item in drives)
+    if {"drive_id", "title", "status", "kind"}.issubset(payload):
+        return _format_drive(payload)
+    if "progress_id" in payload:
+        return (
+            f"Progress recorded for drive {payload['drive_id']}.\n"
+            f"Progress ID: {payload['progress_id']}"
+        )
+    if "proposal_id" in payload:
+        return (
+            f"Transition proposed for drive {payload['drive_id']}: "
+            f"{payload['target_status']} ({payload.get('proposal', 'pending')}).\n"
+            f"Proposal ID: {payload['proposal_id']}"
+        )
+    if "delivery_id" in payload:
+        return (
+            f"Delivery {payload['delivery_id']} replayed for drive "
+            f"{payload['drive_id']}."
+        )
+    return "\n".join(f"{key}: {_format_value(value)}" for key, value in payload.items())
+
+
+def _ok(payload: dict[str, Any]) -> ToolResult:
+    return ToolResult(
+        output=_format_payload(payload),
+        exit_code=0,
+        metadata={"drive": payload},
+    )
+
+
+def _drive_error_result(exc: DriveError) -> ToolResult:
+    """Map a typed Drive error to a distinct, model-shaped tool error."""
+    if isinstance(exc, (DriveConflictError, DriveIdempotencyConflictError)):
+        return _err(f"conflict: {exc}")
+    if isinstance(exc, DrivePermissionError):
+        return _err(f"permission denied: {exc}")
+    if isinstance(
+        exc,
+        (
+            DriveRegistrationDisabledError,
+            DriveRegistrationIncompatibleError,
+            DriveRegistrationNotFoundError,
+        ),
+    ):
+        return _err(f"registration unavailable: {exc}")
+    if isinstance(exc, DriveNotFoundError):
+        return _err(f"not found: {exc}")
+    return _err(f"invalid: {exc}")
+
+
+def _record_summary(call: _DriveCall, record: DriveRecord) -> dict[str, Any]:
+    """Build a bounded authorized summary without exposing the raw Drive spec."""
+    return {
+        "drive_id": record.drive_id,
+        "kind": record.kind,
+        "title": record.title,
+        "status": record.status.value,
+        "revision": record.revision,
+        "scope_type": record.scope_type,
+        "scope_id": record.scope_id,
+        "owner": record.owner.format(),
+        "priority": record.priority,
+        # Durability must describe the record's graph rather than a possibly
+        # mixed aggregate across the engine.
+        "durability": call.runtime.durability_for(call.graph_id),
+    }
+
+
+async def _summary_with_actions(
+    call: _DriveCall, record: DriveRecord
+) -> dict[str, Any]:
+    assignment = await call.manager.get_assignment(record.drive_id)
+    summary = _record_summary(call, record)
+    summary["assignee"] = (
+        assignment.assignee_creature_id if assignment is not None else None
+    )
+    summary["allowed_actions"] = list(
+        call.manager.allowed_actions(
+            call.actor, record, assignment, is_privileged=call.is_privileged
+        )
+    )
+    return summary
+
+
+class _BaseDriveTool(BaseTool):
+    needs_context = True
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _resolve_or_error(
+        self, ctx: ToolContext | None
+    ) -> tuple[_DriveCall | None, ToolResult | None]:
+        try:
+            return _resolve_call(ctx), None
+        except GroupToolError as exc:
+            return None, _err(str(exc))

--- a/tests/unit/terrarium/drive/test_drive_prompt.py
+++ b/tests/unit/terrarium/drive/test_drive_prompt.py
@@ -48,6 +48,9 @@ def test_generic_contract_always_present():
     assert text is not None
     assert "Drive runtime" in text
     assert "do not begin by listing or inspecting Drives" in text
+    # Assignee lifecycle + budget semantics are spelled out, not implied.
+    assert "'blocked' when you need user intervention" in text
+    assert "raise the budget and wake" in text
     # An empty snapshot contributes NO kind prose.
     assert "Drive kind:" not in text
 

--- a/tests/unit/terrarium/drive/test_drive_tools.py
+++ b/tests/unit/terrarium/drive/test_drive_tools.py
@@ -80,6 +80,27 @@ class TestDriveCreate:
         finally:
             await engine.shutdown()
 
+    def test_goal_spec_schema_is_expanded(self):
+        # The goal spec schema exposes concrete fields so the model can build a
+        # valid spec instead of guessing from prose.
+        schema = DriveCreateTool().get_parameters_schema()
+        spec = schema["properties"]["spec"]
+        assert spec["type"] == "object"
+        props = spec["properties"]
+        assert "objective" in props
+        assert "required" in props["objective"]["description"].lower()
+        assert props["autonomy"]["enum"] == ["manual", "continue_when_ready"]
+        assert props["completion_policy"]["enum"] == [
+            "self_propose",
+            "user_confirm",
+            "verifier",
+        ]
+        assert set(props["budgets"]["properties"]) == {
+            "max_turns",
+            "max_tool_calls",
+            "max_walltime_s",
+        }
+
     async def test_actor_is_never_taken_from_args(self):
         # Passing owner/actor/scope in args must be ignored — ownership is
         # forced to the trusted caller identity (design §9.3, rule §4.15).
@@ -115,6 +136,8 @@ class TestDriveCreate:
             )
             assert res.error is not None
             assert "objective" in res.error
+            # The error points the model at the working spec shape.
+            assert "continue_when_ready" in res.error
         finally:
             await engine.shutdown()
 
@@ -313,6 +336,19 @@ class TestForeignOwnedAcl:
             )
             assert cancel.error is not None
             assert "permission denied" in cancel.error
+            # Pausing a foreign-owned drive is also owner-only; the error hints
+            # at the assignee's actual transition targets.
+            paused = await DriveTransitionTool()._execute(
+                {
+                    "drive_id": record.drive_id,
+                    "status": "paused",
+                    "expected_revision": record.revision,
+                },
+                context=ctx,
+            )
+            assert paused.error is not None
+            assert "permission denied" in paused.error
+            assert "'waiting' or 'blocked'" in paused.error
             # Updating a foreign-owned drive is denied too.
             upd = await DriveUpdateTool()._execute(
                 {

--- a/tests/unit/terrarium/drive/test_drive_tools.py
+++ b/tests/unit/terrarium/drive/test_drive_tools.py
@@ -236,6 +236,24 @@ class TestDriveUpdateStatusReport:
 
 
 class TestDriveTransition:
+    def test_transition_status_enum_covers_self_service_targets(self):
+        # Regression: the provider-visible enum must include every self-service
+        # transition target — draft was missing and would have been rejected
+        # before reaching the tool.
+        enum = DriveTransitionTool().get_parameters_schema()["properties"]["status"][
+            "enum"
+        ]
+        assert set(enum) == {
+            "draft",
+            "active",
+            "waiting",
+            "blocked",
+            "paused",
+            "cancelled",
+            "completed",
+            "failed",
+        }
+
     async def test_pause_then_propose_completion(self):
         engine, worker = await _engine_with_worker()
         try:


### PR DESCRIPTION
## Summary

Improve the drive tool docs and drive prompt contracts so models and users are guided correctly on two by-design behaviors: goal creation (kind='goal' spec shape, autonomy) and assignee transition permissions (waiting/blocked only). Also fixes the kind wording so it does not promise a /drives user command where it does not exist.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The drive tools' docs and errors misled models on several by-design behaviors:

- `drive_create kind='goal'` was presented as one option among equals, but goal is the only kind with a dedicated user-facing /goal command surface; the spec schema is now expanded into concrete fields (objective required, autonomy=continue_when_ready for autonomous pursuit, budgets, completion_policy).
- `drive_transition` implied pause was available to assignees, but assignees may only set waiting/blocked (paused/cancelled are owner-only per policy `_ASSIGNEE_TRANSITIONS`); the description, schema enum, and runtime permission error now say so.
- Drive prompt contracts claimed budget exhaustion pauses/blocks a drive; it only stops continuation without changing status. Recovery is an explicit owner act (raise the budget and wake).
- The kind wording previously claimed generic drives have "no user command and are invisible to users". That is wrong in both directions: in the kt app chat UI only /goal is routed as a command (/drives is sent as plain text), while in engine-mode CLIs /drives does exist. The docs now state the cross-surface truth: goal is the only kind with a user-facing /goal command surface; other kinds are managed via the drive tools.

## Changes

- `src/kohakuterrarium/builtins/plugins/goal/plugin.py`: goal plugin prompt — budget exhaustion stops pursuit and is an owner act, not a self-pause suggestion.
- `src/kohakuterrarium/terrarium/drive/goal.py`: goal registration prompt — budget semantics corrected (stops continuation, does not complete/resume).
- `src/kohakuterrarium/terrarium/drive/prompt.py`: generic drive contract — assignee may set waiting/blocked; budget exhaustion stops continuation without status change.
- `src/kohakuterrarium/terrarium/drive/tools.py`:
  - `drive_create`: expanded goal spec schema (objective/autonomy/success_criteria/constraints/completion_policy/budgets), kind wording now accurate about /goal vs other kinds, friendlier validation error with a working spec example.
  - `drive_transition`: status enum + description + runtime permission error now state assignee may only set waiting/blocked.
- `tests/unit/terrarium/drive/test_drive_prompt.py`, `test_drive_tools.py`: new assertions pin the expanded schema, the error hints, and the assignee permission error.

## Validation

```bash
python -m pytest tests/unit/terrarium/drive/ -q        # 872 passed
python -m pytest tests/unit/terrarium/drive/test_drive_tools.py -q  # 13 passed
ruff check src/kohakuterrarium/builtins/plugins/goal/plugin.py src/kohakuterrarium/terrarium/drive/goal.py src/kohakuterrarium/terrarium/drive/prompt.py src/kohakuterrarium/terrarium/drive/tools.py tests/unit/terrarium/drive/test_drive_prompt.py tests/unit/terrarium/drive/test_drive_tools.py
black --check src/kohakuterrarium/builtins/plugins/goal/plugin.py src/kohakuterrarium/terrarium/drive/goal.py src/kohakuterrarium/terrarium/drive/prompt.py src/kohakuterrarium/terrarium/drive/tools.py tests/unit/terrarium/drive/test_drive_prompt.py tests/unit/terrarium/drive/test_drive_tools.py
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] This is not a feature PR — change is limited to bug fix + docs + tests
- [x] I kept this PR focused and did not include unrelated changes
- [x] No doc update needed beyond the changed strings themselves (internal prompt/error wording; no user-visible config/API change)
- [x] I added or updated tests when needed
- [x] `ruff check` and `black --check` pass
- [x] `pytest tests/unit/terrarium/drive/` passes locally
- [ ] No frontend files changed
- [ ] CI explanation in Exceptions

## Related Issues / Discussions

None — docs/tests-only improvement, no prior feature approval required per CONTRIBUTING.

## Notes for Reviewers

- The kind wording change in `drive_create` intentionally avoids promising a /drives user command: the kt app chat UI only routes /goal (frontend `chat.js` special-cases it), while engine-mode CLIs do intercept /drives. "No dedicated command surface" holds in both.
- All changed strings are prompt/error text consumed by the model; the runtime behavior is unchanged.

## Screenshots / Logs (if applicable)

N/A

## Breaking Changes (if applicable)

None. Runtime behavior unchanged; only tool descriptions, schemas, error text, and prompt contracts.

## Exceptions / Not Run

- Full `pytest tests/unit/` not rerun for this PR (drive-folder tests + lint pass; change is confined to `terrarium/drive/` and the goal plugin prompt).
- e2e tier not run per repo convention (no multi-node / Studio / serving stack changes).
- No frontend changes, so `npm run format:check` / `build` not run.
