### PR TITLE
fix(goal): let operator users manage creature-owned goals

### DIFF
--- a/src/kohakuterrarium/builtins/plugins/goal/plugin.py
+++ b/src/kohakuterrarium/builtins/plugins/goal/plugin.py
@@ -218,13 +218,15 @@ class GoalCommand(BaseUserCommand):
         view = await _select_eligible(ctx, drive_id, sub)
         if view is None:
             return _no_eligible_goal(sub)
-        # The authenticated owner can manage lifecycle without operator elevation.
+        # The authenticated owner can manage lifecycle without operator elevation;
+        # an operator user also manages goals created by their creatures.
+        elevated = ctx.is_operator and view.record.owner != ctx.principal
         updated = await ctx.service.transition_drive(
             view.record.drive_id,
             _TRANSITION_TARGETS[sub],
             expected_revision=view.record.revision,
             actor=ctx.principal,
-            is_privileged=False,
+            is_privileged=elevated,
         )
         return _panel(_TRANSITION_TITLES[sub], updated)
 
@@ -233,7 +235,9 @@ class GoalCommand(BaseUserCommand):
         if view is None:
             return _no_eligible_goal("complete")
         # Completion is proposed with owner evidence; the registration applies
-        # the drive's configured completion policy.
+        # the drive's configured completion policy. An operator user may also
+        # complete goals created by their creatures.
+        elevated = ctx.is_operator and view.record.owner != ctx.principal
         try:
             result = await ctx.service.propose_drive_transition(
                 view.record.drive_id,
@@ -241,7 +245,7 @@ class GoalCommand(BaseUserCommand):
                 actor=ctx.principal,
                 evidence={"confirmed_by": ctx.principal.format()},
                 expected_revision=view.record.revision,
-                is_privileged=False,
+                is_privileged=elevated,
             )
         except DriveTransitionError as exc:
             return UserCommandResult(error=f"completion rejected: {exc}")

--- a/tests/unit/builtins/plugins/test_goal.py
+++ b/tests/unit/builtins/plugins/test_goal.py
@@ -50,6 +50,7 @@ def _fake_view(
     kind="goal",
     title="obj",
     created_at=0,
+    owner=ActorRef("user", "alice"),
 ):
     return SimpleNamespace(
         record=SimpleNamespace(
@@ -59,7 +60,7 @@ def _fake_view(
             kind=kind,
             spec=spec or {"objective": title, "autonomy": "manual"},
             title=title,
-            owner=ActorRef("user", "alice"),
+            owner=owner,
             created_at=created_at,
         ),
         assignee_creature_id="worker",
@@ -276,6 +277,63 @@ class TestGoalCommand:
         assert res.success, res.error
         assert svc.transition_call.target == DriveStatus.PAUSED
         assert svc.transition_call.is_privileged is False
+
+    async def test_pause_elevates_operator_for_creature_owned_goal(self):
+        # A goal created by a creature (owner=creature) is not the user's own;
+        # an operator user still manages it via explicit operator privilege.
+        svc = _FakeService(
+            views=[_fake_view(drive_id="d1", owner=ActorRef("creature", "worker"))]
+        )
+        cmd = GoalCommand()
+        res = await cmd._execute(
+            "pause d1",
+            _ctx(
+                service=svc,
+                creature_id="worker",
+                principal="user:alice",
+                is_operator=True,
+            ),
+        )
+        assert res.success, res.error
+        assert svc.transition_call.target == DriveStatus.PAUSED
+        assert svc.transition_call.is_privileged is True
+
+    async def test_pause_non_operator_user_does_not_elevate(self):
+        # A non-operator user is never elevated, even for creature-owned goals.
+        svc = _FakeService(
+            views=[_fake_view(drive_id="d1", owner=ActorRef("creature", "worker"))]
+        )
+        cmd = GoalCommand()
+        res = await cmd._execute(
+            "pause d1",
+            _ctx(
+                service=svc,
+                creature_id="worker",
+                principal="user:alice",
+                is_operator=False,
+            ),
+        )
+        assert res.success, res.error
+        assert svc.transition_call.is_privileged is False
+
+    async def test_complete_elevates_operator_for_creature_owned_goal(self):
+        # Completion of a creature-owned goal also rides the operator grant.
+        svc = _FakeService(
+            views=[_fake_view(drive_id="d1", owner=ActorRef("creature", "worker"))]
+        )
+        cmd = GoalCommand()
+        res = await cmd._execute(
+            "complete d1",
+            _ctx(
+                service=svc,
+                creature_id="worker",
+                principal="user:alice",
+                is_operator=True,
+            ),
+        )
+        assert res.success, res.error
+        assert svc.propose_call.target == DriveStatus.COMPLETED
+        assert svc.propose_call.is_privileged is True
 
     async def test_list_shows_only_live_goals_with_explicit_status(self):
         svc = _FakeService(


### PR DESCRIPTION
## Summary

Fix `/goal` so an operator user can manage goals created by their creatures (`drive_create` sets `owner=creature`), while keeping the least-privilege owner path intact for the user's own goals.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [x] Tests only (regression tests added)
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

`/goal`'s `_transition` (pause/resume/cancel) and `_complete` hard-coded `is_privileged=False`, assuming the authenticated user owns the goal. That holds for goals created via `/goal set` (`owner=user`), but goals created by an agent via `drive_create` have `owner=creature` and `assignee=creature`. The user then gets `permission denied: actor 'user:local' may not transition this Drive` — even though the local user is an operator (`_command_authority` returns `is_operator=True` in single-user mode). The operator privilege was simply never forwarded to the drive service.

## Changes

- `src/kohakuterrarium/builtins/plugins/goal/plugin.py`:
  - `_transition`: `is_privileged=False` → `is_privileged=elevated`, where `elevated = ctx.is_operator and view.record.owner != ctx.principal`.
  - `_complete` (propose step): same conditional elevation.
- `tests/unit/builtins/plugins/test_goal.py`:
  - `_fake_view` gains an `owner` parameter (default `user:alice`, compatible with existing tests).
  - New tests: creature-owned goal pause/complete with an operator user forwards `is_privileged=True`; a non-operator user is never elevated.

## Validation

```bash
python -m pytest tests/unit/builtins/plugins/test_goal.py -q        # 35 passed
python -m pytest tests/unit/builtins/plugins/ tests/unit/builtins/user_commands/ tests/unit/terrarium/drive/ tests/unit/test_file_sizes.py -q  # 2613 passed
ruff check src/kohakuterrarium/builtins/plugins/goal/plugin.py tests/unit/builtins/plugins/test_goal.py
black --check src/kohakuterrarium/builtins/plugins/goal/plugin.py tests/unit/builtins/plugins/test_goal.py
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] This is not a feature PR — change is limited to a bug fix + tests
- [x] I kept this PR focused and did not include unrelated changes (branch created from `origin/main`; no PR #140 drive-doc changes included)
- [x] No doc update needed (internal permission fix; no user-visible config/API change)
- [x] I added or updated tests when needed
- [x] `ruff check` and `black --check` pass
- [x] `pytest tests/unit/...` ran locally for the touched areas
- [ ] No frontend files changed
- [ ] CI explanation in Exceptions

## Related Issues / Discussions

None — small bug fix, no prior feature approval required per CONTRIBUTING.

## Notes for Reviewers

- Design intent preserved: a user managing their **own** goal still goes through the owner capability with no operator elevation (`test_pause_uses_owner_capability_not_operator`, `test_complete_proposes_as_user_owner_without_privilege` still assert `is_privileged is False`). Elevation only kicks in when the goal is **not** owned by the caller and the caller is an operator.
- The runtime ACL already grants operators `TRANSITION` / `PROPOSE_TERMINAL` on any drive (`effective_capabilities`); this PR only stops `/goal` from discarding that grant.

## Screenshots / Logs (if applicable)

N/A

## Breaking Changes (if applicable)

None. Behavior for owners is unchanged; non-operator users are never elevated.

## Exceptions / Not Run

- Full `pytest tests/unit/` not rerun for this PR (touched areas + file-size guard + lint pass).
- e2e tier not run per repo convention (no multi-node / Studio / serving stack changes).
- No frontend changes, so `npm run format:check` / `build` not run.
