### PR TITLE
fix(compact): enforce a target live-zone budget

### DIFF
--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -331,6 +331,7 @@ setup tool via a `tools` entry with `type: trigger, name: add_schedule`
 | `enabled` | bool | `true` | Turn compaction on. |
 | `max_tokens` | int | profile-default | Target token ceiling. |
 | `threshold` | float | `0.8` | Fraction of `max_tokens` at which compaction starts. |
+| `target` | float | `0.5` | Target fraction after compaction; recent turns remain verbatim when they fit. |
 | `keep_recent_turns` | int | `8` | Turns preserved verbatim. |
 | `compact_model` | str | controller's model | Override LLM used for summarisation. |
 

--- a/docs/zh-CN/reference/configuration.md
+++ b/docs/zh-CN/reference/configuration.md
@@ -263,6 +263,7 @@ subagents:
 | `enabled` | bool | `true` | 开启压缩。 |
 | `max_tokens` | int | profile 默认 | 目标 token 上限。 |
 | `threshold` | float | `0.8` | 达到 `max_tokens` 多少比例时启动压缩。 |
+| `target` | float | `0.5` | 压缩后的目标比例；预算允许时近期回合仍原样保留。 |
 | `keep_recent_turns` | int | `8` | 原样保留的回合数。 |
 | `compact_model` | str | 控制器的 model | 摘要用的 LLM 覆盖。 |
 

--- a/docs/zh-TW/reference/configuration.md
+++ b/docs/zh-TW/reference/configuration.md
@@ -263,6 +263,7 @@ subagents:
 | `enabled` | bool | `true` | 開啟壓縮。 |
 | `max_tokens` | int | profile 預設 | 目標 token 上限。 |
 | `threshold` | float | `0.8` | 達到 `max_tokens` 多少比例時啟動壓縮。 |
+| `target` | float | `0.5` | 壓縮後的目標比例；預算允許時近期回合仍原樣保留。 |
 | `keep_recent_turns` | int | `8` | 原樣保留的回合數。 |
 | `compact_model` | str | 控制器的 model | 摘要用的 LLM 覆寫。 |
 

--- a/src/kohakuterrarium/core/agent.py
+++ b/src/kohakuterrarium/core/agent.py
@@ -395,6 +395,7 @@ class Agent(
         compact_cfg = CompactConfig(
             max_tokens=compact_data.get("max_tokens", default_compact_max),
             threshold=compact_data.get("threshold", CompactConfig.threshold),
+            target=compact_data.get("target", CompactConfig.target),
             keep_recent_turns=compact_data.get(
                 "keep_recent_turns", CompactConfig.keep_recent_turns
             ),

--- a/src/kohakuterrarium/core/compact.py
+++ b/src/kohakuterrarium/core/compact.py
@@ -1,18 +1,4 @@
-"""
-Non-blocking auto-compact system.
-
-Automatically summarizes old conversation context in the background
-when approaching token limits. The agent keeps working during compaction.
-
-Design:
-  - Two-zone model: compact zone (old, will be summarized) + live zone (recent, untouched)
-  - Background task: LLM summarizes the compact zone asynchronously
-  - Atomic splice: when summary is ready, replaces compact zone
-  - Incremental: each round's summary includes the previous summary
-  - Failure preserves context unchanged — no emergency truncation, no
-    silent data loss; the agent keeps the full context if the LLM call
-    fails so the user can retry / switch model / etc.
-"""
+"""Non-blocking context compaction with atomic summary splicing."""
 
 import asyncio
 import time
@@ -22,6 +8,7 @@ from typing import Any
 from kohakuterrarium.core.compact_splice import (
     count_keep_messages,
     prefix_fingerprint,
+    select_compact_boundary,
     splice_conversation,
 )
 from kohakuterrarium.core.compact_text import (
@@ -42,6 +29,7 @@ logger = get_logger(__name__)
 # of max_tokens. If context somehow exceeds max_tokens, emergency truncation.
 DEFAULT_MAX_TOKENS = 256_000
 DEFAULT_THRESHOLD = 0.80  # compact when prompt_tokens >= 80% of max_tokens
+DEFAULT_TARGET = 0.50  # aim for 50% of max_tokens after compact
 DEFAULT_KEEP_RECENT = 8  # keep last 8 turns raw (not summarized)
 
 # Usage from an LLM round that STARTED before a splice can land long
@@ -56,6 +44,7 @@ class CompactConfig:
 
     max_tokens: int = DEFAULT_MAX_TOKENS
     threshold: float = DEFAULT_THRESHOLD
+    target: float = DEFAULT_TARGET
     keep_recent_turns: int = DEFAULT_KEEP_RECENT
     enabled: bool = True
     cooldown_seconds: float = 30.0
@@ -160,8 +149,7 @@ class CompactManager:
         # clean ``compact_skipped`` without flipping the compacting flag
         # or misleadingly showing a "compacting..." banner.
         messages = self._controller.conversation.get_messages()
-        keep_count = self._count_keep_messages(messages)
-        boundary = len(messages) - keep_count
+        boundary = self._compact_boundary(messages)
         if boundary <= 1:
             if self._output_router:
                 self._output_router.notify_activity(
@@ -275,16 +263,10 @@ class CompactManager:
             conversation = self._controller.conversation
             messages = conversation.get_messages()
 
-            # Find boundary: keep system prompt + last N turns
-            # A "turn" is roughly: user message + assistant response + tool calls
-            keep_count = self._count_keep_messages(messages)
-            boundary = len(messages) - keep_count
-            # Tool-safe boundary BEFORE summarization — adjusting at
-            # splice time would keep already-summarized content raw
-            # (duplicated in summary AND live zone).
-            while boundary > 1 and getattr(messages[boundary], "role", None) == "tool":
-                boundary -= 1
-
+            boundary = self._compact_boundary(messages)
+            preferred_boundary = select_compact_boundary(
+                messages, self.config.keep_recent_turns
+            )
             if boundary <= 1:
                 logger.debug("Not enough messages to compact")
                 self._emit_compact_skipped("nothing_to_compact", "Nothing to compact")
@@ -383,6 +365,7 @@ class CompactManager:
                 summary,
                 expected_last=compact_messages[-1],
                 expected_fingerprint=expected_fingerprint,
+                retain_latest_user=boundary > preferred_boundary,
             )
             if not applied:
                 logger.warning(
@@ -511,6 +494,17 @@ class CompactManager:
     def _count_keep_messages(self, messages: list) -> int:
         return count_keep_messages(messages, self.config.keep_recent_turns)
 
+    def _compact_boundary(self, messages: list) -> int:
+        usage = getattr(self._controller, "_last_usage", {}) or {}
+        prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+        return select_compact_boundary(
+            messages,
+            self.config.keep_recent_turns,
+            target_tokens=int(self.config.max_tokens * self.config.target),
+            prompt_tokens=prompt_tokens,
+            summary_tokens=self._summary_max_tokens(),
+        )
+
     def _format_messages_for_summary(self, messages: list) -> str:
         return format_messages_for_summary(messages)
 
@@ -567,6 +561,7 @@ class CompactManager:
         summary: str,
         expected_last: Any = None,
         expected_fingerprint: tuple | None = None,
+        retain_latest_user: bool = False,
     ) -> bool:
         """Atomic splice — see :func:`compact_splice.splice_conversation`."""
         return splice_conversation(
@@ -576,6 +571,7 @@ class CompactManager:
             self._compact_count + 1,
             expected_last=expected_last,
             expected_fingerprint=expected_fingerprint,
+            retain_latest_user=retain_latest_user,
         )
 
     async def wait_for_current(self) -> None:

--- a/src/kohakuterrarium/core/compact_splice.py
+++ b/src/kohakuterrarium/core/compact_splice.py
@@ -7,6 +7,10 @@ guard.
 from datetime import datetime
 from typing import Any
 
+from kohakuterrarium.core.conversation_elide import (
+    estimate_message_tokens,
+    estimate_messages_tokens,
+)
 from kohakuterrarium.llm.message import create_message
 
 
@@ -43,6 +47,7 @@ def splice_conversation(
     compact_round: int,
     expected_last: Any = None,
     expected_fingerprint: tuple | None = None,
+    retain_latest_user: bool = False,
 ) -> bool:
     """Atomic splice: replace compact zone with summary message.
 
@@ -53,7 +58,7 @@ def splice_conversation(
     """
     messages = conversation.get_messages()
 
-    if boundary >= len(messages) or boundary <= 1:
+    if boundary > len(messages) or boundary <= 1:
         return False
     if expected_last is not None and messages[boundary - 1] is not expected_last:
         return False
@@ -66,11 +71,21 @@ def splice_conversation(
     # summarizer ran — moving it here would keep already-summarized
     # content raw, duplicating it). A tool-result head means the
     # conversation changed shape: reject.
-    if getattr(messages[boundary], "role", None) == "tool":
+    if boundary < len(messages) and getattr(messages[boundary], "role", None) == "tool":
         return False
 
     system_msg = messages[0]  # The system prompt survives every compaction round.
     live_zone = messages[boundary:]  # Messages after the boundary remain verbatim.
+    retained_user = None
+    if retain_latest_user:
+        retained_user = next(
+            (
+                msg
+                for msg in reversed(messages[1:boundary])
+                if is_real_user_message(msg)
+            ),
+            None,
+        )
 
     conversation._messages.clear()
     conversation._messages.append(system_msg)
@@ -81,6 +96,8 @@ def splice_conversation(
         f"[Previous context summary (compact round {compact_round})]\n\n{summary}",
     )
     conversation._messages.append(summary_msg)
+    if retained_user is not None:
+        conversation._messages.append(retained_user)
 
     # Restore live zone
     conversation._messages.extend(live_zone)
@@ -97,6 +114,78 @@ def splice_conversation(
     conversation._metadata.total_chars = conversation.get_context_length()
     conversation._metadata.updated_at = datetime.now()
     return True
+
+
+def is_real_user_message(msg: Any) -> bool:
+    """Return whether a message represents explicit user input."""
+    if getattr(msg, "role", None) != "user":
+        return False
+    metadata = getattr(msg, "metadata", None)
+    return not isinstance(metadata, dict) or metadata.get("kind") != "tool_results"
+
+
+def select_compact_boundary(
+    messages: list,
+    keep_recent_turns: int,
+    *,
+    target_tokens: int | None = None,
+    prompt_tokens: int = 0,
+    summary_tokens: int = 0,
+) -> int:
+    """Select the old turn boundary, tightening it only when over budget."""
+    n = len(messages)
+    boundary = n - count_keep_messages(messages, keep_recent_turns)
+    while boundary > 1 and boundary < n and messages[boundary].role == "tool":
+        boundary -= 1
+
+    if target_tokens is None or prompt_tokens <= 0:
+        return boundary
+
+    estimated_history = estimate_messages_tokens(messages)
+    fixed_tokens = max(0, prompt_tokens - estimated_history)
+    if fixed_tokens + summary_tokens >= target_tokens:
+        return boundary
+    live_budget = max(1, target_tokens - fixed_tokens - summary_tokens)
+    live_tokens = estimate_message_tokens(messages[0]) + sum(
+        estimate_message_tokens(msg) for msg in messages[boundary:]
+    )
+    if live_tokens <= live_budget:
+        return boundary
+
+    suffix_tokens = estimate_message_tokens(messages[0])
+    token_boundary = n
+    for index in range(n - 1, 0, -1):
+        message_tokens = estimate_message_tokens(messages[index])
+        if suffix_tokens + message_tokens > live_budget:
+            break
+        suffix_tokens += message_tokens
+        token_boundary = index
+
+    while token_boundary < n and messages[token_boundary].role == "tool":
+        token_boundary += 1
+
+    pending_start = _pending_tool_round_start(messages)
+    if pending_start is not None:
+        token_boundary = min(token_boundary, pending_start)
+    return max(boundary, token_boundary)
+
+
+def _pending_tool_round_start(messages: list) -> int | None:
+    result_ids: set[str] = set()
+    for index in range(len(messages) - 1, 0, -1):
+        msg = messages[index]
+        if getattr(msg, "role", None) == "tool":
+            tool_call_id = getattr(msg, "tool_call_id", None)
+            if tool_call_id:
+                result_ids.add(tool_call_id)
+            continue
+        calls = getattr(msg, "tool_calls", None)
+        if getattr(msg, "role", None) == "assistant" and calls:
+            call_ids = {call.get("id") for call in calls if call.get("id")}
+            if len(call_ids) != len(calls) or not call_ids.issubset(result_ids):
+                return index
+        return None
+    return None
 
 
 def count_keep_messages(messages: list, keep_recent_turns: int) -> int:
@@ -128,7 +217,7 @@ def count_keep_messages(messages: list, keep_recent_turns: int) -> int:
     found_target = False
     for msg in reversed(messages):
         by_turn_count += 1
-        if msg.role == "user":
+        if is_real_user_message(msg):
             turns += 1
             if turns >= keep_recent_turns:
                 found_target = True

--- a/src/kohakuterrarium/core/conversation_elide.py
+++ b/src/kohakuterrarium/core/conversation_elide.py
@@ -113,19 +113,28 @@ def elide_stale_tool_results(conversation: Any) -> int:
 CHARS_PER_TOKEN = 3.5
 
 
+def estimate_message_tokens(msg: Any) -> int:
+    """Conservatively estimate one message's model-visible tokens."""
+    total_chars = 0
+    text = extract_message_text(msg) or ""
+    total_chars += len(text)
+    for call in getattr(msg, "tool_calls", None) or []:
+        fn = call.get("function") or {}
+        args = fn.get("arguments") or ""
+        if not isinstance(args, str):
+            args = str(args)
+        total_chars += len(args)
+    return max(1, int(total_chars / CHARS_PER_TOKEN))
+
+
+def estimate_messages_tokens(messages: list[Any]) -> int:
+    """Conservatively estimate a sequence of model-visible messages."""
+    return sum(estimate_message_tokens(msg) for msg in messages)
+
+
 def estimate_tokens(conversation: Any) -> int:
     """Conservative prompt-token estimate for a rebuilt conversation."""
-    total_chars = 0
-    for msg in conversation.get_messages():
-        text = extract_message_text(msg) or ""
-        total_chars += len(text)
-        for call in getattr(msg, "tool_calls", None) or []:
-            fn = call.get("function") or {}
-            args = fn.get("arguments") or ""
-            if not isinstance(args, str):
-                args = str(args)
-            total_chars += len(args)
-    return max(1, int(total_chars / CHARS_PER_TOKEN))
+    return estimate_messages_tokens(conversation.get_messages())
 
 
 def elide_after_compact(controller: Any) -> int:

--- a/src/kohakuterrarium/modules/subagent/runtime_builders.py
+++ b/src/kohakuterrarium/modules/subagent/runtime_builders.py
@@ -62,6 +62,7 @@ def build_compact_manager(
         CompactConfig(
             max_tokens=int(data.get("max_tokens") or default_max),
             threshold=float(data.get("threshold", 0.75)),
+            target=float(data.get("target", CompactConfig.target)),
             keep_recent_turns=int(data.get("keep_recent_turns", 4)),
             cooldown_seconds=float(
                 data.get("cooldown", data.get("cooldown_seconds", 20.0))

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -1022,6 +1022,7 @@ class TestCoreIntegration:
             # Compact manager + termination checker were built by start().
             assert agent.compact_manager.config.max_tokens == 100
             assert agent.compact_manager.config.threshold == 0.5
+            assert agent.compact_manager.config.target == 0.2
             assert agent._termination_checker.is_active is True
 
             # Run several turns to build a conversation long enough for

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -926,8 +926,6 @@ class TestCompactManagerInit:
         agent.config.compact = {
             "max_tokens": 10_000,
             "threshold": 0.5,
-            # Legacy key from configs written before ``target`` was
-            # removed — must be ignored, never crash agent init.
             "target": 0.3,
             "keep_recent_turns": 4,
             "cooldown_seconds": 5.0,
@@ -938,7 +936,7 @@ class TestCompactManagerInit:
             cfg = agent.compact_manager.config
             assert cfg.max_tokens == 10_000
             assert cfg.threshold == 0.5
-            assert not hasattr(cfg, "target")
+            assert cfg.target == 0.3
             assert cfg.keep_recent_turns == 4
             assert cfg.cooldown_seconds == 5.0
         finally:

--- a/tests/unit/core/test_compact.py
+++ b/tests/unit/core/test_compact.py
@@ -9,10 +9,12 @@ from kohakuterrarium.core.compact import (
     COMPACT_PROMPT,
     DEFAULT_KEEP_RECENT,
     DEFAULT_MAX_TOKENS,
+    DEFAULT_TARGET,
     DEFAULT_THRESHOLD,
     CompactConfig,
     CompactManager,
 )
+from kohakuterrarium.core.compact_splice import select_compact_boundary
 from kohakuterrarium.core.conversation import Conversation
 from kohakuterrarium.llm.message import create_message
 
@@ -108,6 +110,7 @@ class TestCompactConfig:
         c = CompactConfig()
         assert c.max_tokens == DEFAULT_MAX_TOKENS
         assert c.threshold == DEFAULT_THRESHOLD
+        assert c.target == DEFAULT_TARGET
         assert c.keep_recent_turns == DEFAULT_KEEP_RECENT
         assert c.enabled is True
         assert c.cooldown_seconds == 30.0
@@ -248,6 +251,105 @@ class TestCountKeepMessages:
         keep = mgr._count_keep_messages(msgs)
         # Returns by_turn_count or n-1 — whichever is smaller.
         assert keep == 2  # n-1
+
+    def test_tool_feedback_does_not_count_as_user_turn(self):
+        mgr = CompactManager(CompactConfig(keep_recent_turns=2))
+        msgs = [types.SimpleNamespace(role="user", metadata={})]
+        for _ in range(12):
+            msgs.append(
+                types.SimpleNamespace(role="user", metadata={"kind": "tool_results"})
+            )
+        assert mgr._count_keep_messages(msgs) == len(msgs) // 2
+
+    def test_target_tightens_only_an_oversized_live_zone(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        for index in range(8):
+            conv.append("user", f"goal-{index}")
+            conv.append("assistant", "done")
+        for _ in range(2_984):
+            conv.append("assistant", "x" * 350)
+
+        mgr = CompactManager(
+            CompactConfig(
+                max_tokens=400_000,
+                threshold=0.8,
+                target=0.5,
+                keep_recent_turns=8,
+            )
+        )
+        mgr._controller = types.SimpleNamespace(
+            conversation=conv,
+            _last_usage={"prompt_tokens": 370_000},
+        )
+        boundary = mgr._compact_boundary(conv.get_messages())
+        assert boundary > len(conv.get_messages()) // 2
+
+    def test_target_keeps_the_existing_boundary_when_it_already_fits(self):
+        conv = _build_conversation(n_user=5)
+        mgr = CompactManager(CompactConfig(max_tokens=10_000, target=0.5))
+        mgr._controller = types.SimpleNamespace(
+            conversation=conv,
+            _last_usage={"prompt_tokens": 8_500},
+        )
+        messages = conv.get_messages()
+        assert mgr._compact_boundary(messages) == (
+            len(messages) - mgr._count_keep_messages(messages)
+        )
+
+    def test_target_can_summarize_a_completed_500_call_tool_round(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        conv.append("user", "run the batch")
+        calls = [
+            {
+                "id": f"tc_{index}",
+                "type": "function",
+                "function": {"name": "work", "arguments": "{}"},
+            }
+            for index in range(500)
+        ]
+        conv.append("assistant", "", tool_calls=calls)
+        for index in range(500):
+            conv.append("tool", "x" * 350, tool_call_id=f"tc_{index}")
+
+        messages = conv.get_messages()
+        completed_boundary = select_compact_boundary(
+            messages,
+            8,
+            target_tokens=10_000,
+            prompt_tokens=50_000,
+            summary_tokens=1_000,
+        )
+        assert completed_boundary == len(messages)
+
+        conv._messages.pop()
+        pending_boundary = select_compact_boundary(
+            conv.get_messages(),
+            8,
+            target_tokens=10_000,
+            prompt_tokens=50_000,
+            summary_tokens=1_000,
+        )
+        assert pending_boundary == 2
+
+    async def test_target_compaction_retains_latest_real_user_message(self):
+        conv = Conversation()
+        conv.append("system", "sys")
+        for index in range(8):
+            conv.append("user", f"goal-{index}")
+            conv.append("assistant", "done")
+        for _ in range(100):
+            conv.append("assistant", "x" * 350)
+
+        mgr = _build_mgr(conversation=conv, llm=_LLM(chunks=["S"]))
+        mgr.config = CompactConfig(max_tokens=10_000, target=0.5)
+        mgr._controller._last_usage = {"prompt_tokens": 9_000}
+        await mgr._run_compact()
+
+        assert mgr._compact_count == 1
+        user_text = [msg.content for msg in conv.get_messages() if msg.role == "user"]
+        assert "goal-7" in user_text
 
 
 # ── _format_messages_for_summary ─────────────────────────────────

--- a/tests/unit/modules/subagent/test_runtime_builders.py
+++ b/tests/unit/modules/subagent/test_runtime_builders.py
@@ -162,7 +162,6 @@ class TestBuildCompactManager:
     def test_compact_config_builds_and_wires_manager(self):
         cfg = SubAgentConfig(
             name="x",
-            # "target" is a removed legacy key — tolerated, ignored.
             compact={"threshold": 0.8, "target": 0.3, "keep_recent_turns": 6},
         )
         llm = _FakeLLM()
@@ -170,7 +169,7 @@ class TestBuildCompactManager:
         assert cm is not None
         # The configured values landed on the CompactConfig.
         assert cm.config.threshold == 0.8
-        assert not hasattr(cm.config, "target")
+        assert cm.config.target == 0.3
         assert cm.config.keep_recent_turns == 6
         # The manager is wired to this llm and the sub-agent's name.
         assert cm._llm is llm


### PR DESCRIPTION
## Summary

Make automatic compaction target a meaningful post-compaction live-zone budget when a turn-based boundary would retain an oversized tool-heavy history. Normal conversations keep the existing recent-turn boundary, so ordinary user-visible behavior remains unchanged.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

A single turn can contain hundreds of tool calls. The existing recent-turn policy can therefore retain almost the entire conversation and compact only one message, immediately overflowing again.

## Changes

- Restore and wire the documented `compact.target` setting with a default of `0.5`.
- Tighten the compact boundary by estimated prompt budget only when the normal recent-turn live zone exceeds the target.
- Preserve the latest explicit user goal and any incomplete native tool-call round.
- Allow completed large tool-call rounds, including a 500-call regression shape, to be summarized safely.
- Document the target setting in all three configuration references and add unit/integration coverage.

## Validation

```bash
python -m pytest tests/unit/core/test_compact.py tests/unit/core/test_agent_real.py tests/unit/core/test_conversation_elide.py tests/unit/modules/subagent/test_runtime_builders.py tests/integration/test_core.py::TestCoreIntegration::test_compaction_and_termination -q --basetemp .pytest-run-115-audit -p no:cacheprovider
# 308 passed

ruff check src/kohakuterrarium/core/compact.py src/kohakuterrarium/core/compact_splice.py src/kohakuterrarium/core/conversation_elide.py src/kohakuterrarium/core/agent.py src/kohakuterrarium/modules/subagent/runtime_builders.py tests/unit/core/test_compact.py tests/unit/core/test_agent_real.py tests/unit/modules/subagent/test_runtime_builders.py tests/integration/test_core.py
# All checks passed

python -m pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q -p no:cacheprovider
# 1682 passed

git diff --check
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran the frontend checks
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #115

## Notes for Reviewers

The token target is a fallback, not a replacement for the recent-turn policy. It activates only when the preferred live zone is estimated to exceed the target. If fixed prompt overhead plus the summary reserve cannot fit the target, compaction keeps the prior boundary rather than forcing an impossible cut.

## Exceptions / Not Run

- The full unit suite was not run; focused affected suites and repository structure guards passed.
- Full-tree Ruff was not run; Ruff passed for every changed Python file.
- Black could not complete in this Windows environment: the available Python 3.12 runtime cannot parse project code formatted for Python 3.14, and both normal and `--fast` scoped invocations timed out. CI should provide the authoritative formatting result.
- Fork CI is pending.
