### PR TITLE
fix(cli): decode Kitty functional keys

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/composer.py
+++ b/src/kohakuterrarium/builtins/cli_rich/composer.py
@@ -81,6 +81,16 @@ def _register_enhanced_keyboard_keys() -> None:
 
       ``mods`` values: 2 = shift, 5 = ctrl, 6 = ctrl+shift.
 
+    - **Functional keys** under Kitty's legacy CSI form:
+
+      - Press:   ``ESC [ 1 ; <mods> [ABCDEFHPQS]``
+      - Repeat:  ``ESC [ 1 ; <mods> : 2 [ABCDEFHPQS]``
+      - Release: ``ESC [ 1 ; <mods> : 3 [ABCDEFHPQS]`` (ignored)
+
+      Existing prompt_toolkit modifier mappings are mirrored; explicit
+      unmodified (``mods=1``) arrows, Home/End, and supported F-keys use their
+      legacy-key equivalents.
+
     Out of scope (deliberately not registered): Alt+letter, Ctrl+Shift+
     letter, and Cmd/Super+letter. prompt_toolkit has no enum slots for
     most of them, they conflict with classic encodings, and users rarely
@@ -115,6 +125,27 @@ def _register_enhanced_keyboard_keys() -> None:
     ANSI_SEQUENCES["\x1b[13u"] = Keys.ControlM  # Enter
     ANSI_SEQUENCES["\x1b[9u"] = Keys.ControlI  # Tab
     ANSI_SEQUENCES["\x1b[127u"] = Keys.ControlH  # Backspace
+
+    functional_keys = {
+        "A": Keys.Up,
+        "B": Keys.Down,
+        "C": Keys.Right,
+        "D": Keys.Left,
+        "E": Keys.Ignore,
+        "F": Keys.End,
+        "H": Keys.Home,
+        "P": Keys.F1,
+        "Q": Keys.F2,
+        "S": Keys.F4,
+    }
+    for final, plain_key in functional_keys.items():
+        for modifiers in range(1, 9):
+            press = f"\x1b[1;{modifiers}{final}"
+            key = ANSI_SEQUENCES.get(press, plain_key)
+            ANSI_SEQUENCES[press] = key
+            ANSI_SEQUENCES[f"\x1b[1;{modifiers}:1{final}"] = key
+            ANSI_SEQUENCES[f"\x1b[1;{modifiers}:2{final}"] = key
+            ANSI_SEQUENCES[f"\x1b[1;{modifiers}:3{final}"] = Keys.Ignore
 
 
 _register_enhanced_keyboard_keys()

--- a/tests/unit/builtins/cli_rich/test_composer.py
+++ b/tests/unit/builtins/cli_rich/test_composer.py
@@ -1,0 +1,66 @@
+"""Regression coverage for enhanced-keyboard escape decoding."""
+
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.keys import Keys
+
+import kohakuterrarium.builtins.cli_rich.composer as composer
+
+
+def _decode(sequence: str) -> list:
+    keys = []
+    parser = Vt100Parser(keys.append)
+    parser.feed(sequence)
+    parser.flush()
+    return keys
+
+
+def test_existing_enhanced_keyboard_families_remain_registered() -> None:
+    assert ANSI_SEQUENCES["\x1b[27u"] == Keys.Escape
+    assert ANSI_SEQUENCES["\x1b[13u"] == Keys.ControlM
+    assert ANSI_SEQUENCES["\x1b[9u"] == Keys.ControlI
+    assert ANSI_SEQUENCES["\x1b[127u"] == Keys.ControlH
+    assert ANSI_SEQUENCES["\x1b[13;2u"] == composer.SHIFT_ENTER_KEY
+    assert ANSI_SEQUENCES["\x1b[13;5u"] == composer.CTRL_ENTER_KEY
+    assert ANSI_SEQUENCES["\x1b[13;6u"] == composer.CTRL_SHIFT_ENTER_KEY
+
+
+def test_kitty_functional_key_press_repeat_and_release_are_consumed() -> None:
+    plain = {
+        "A": Keys.Up,
+        "B": Keys.Down,
+        "C": Keys.Right,
+        "D": Keys.Left,
+        "E": Keys.Ignore,
+        "F": Keys.End,
+        "H": Keys.Home,
+        "P": Keys.F1,
+        "Q": Keys.F2,
+        "S": Keys.F4,
+    }
+    for final, expected in plain.items():
+        for event in ("", ":1", ":2"):
+            decoded = _decode(f"\x1b[1;1{event}{final}")
+            assert [key.key for key in decoded] == [expected]
+        released = _decode(f"\x1b[1;1:3{final}")
+        assert [key.key for key in released] == [Keys.Ignore]
+
+
+def test_kitty_modified_functional_keys_mirror_prompt_toolkit_mappings() -> None:
+    finals = "ABCDEFHPQS"
+    for final in finals:
+        for modifiers in range(2, 9):
+            press = f"\x1b[1;{modifiers}{final}"
+            expected = [key.key for key in _decode(press)]
+            for event in (":1", ":2"):
+                decoded = _decode(f"\x1b[1;{modifiers}{event}{final}")
+                assert [key.key for key in decoded] == expected
+            released = _decode(f"\x1b[1;{modifiers}:3{final}")
+            assert [key.key for key in released] == [Keys.Ignore]
+
+
+def test_enhanced_keyboard_registration_is_idempotent() -> None:
+    before = dict(ANSI_SEQUENCES)
+    composer._register_enhanced_keyboard_keys()
+    composer._register_enhanced_keyboard_keys()
+    assert ANSI_SEQUENCES == before


### PR DESCRIPTION
## Summary

Decode Kitty keyboard protocol functional-key sequences in the Rich CLI so arrows, Home/End, and modified variants no longer leak raw escape bytes into the composer. Press/repeat events reuse prompt_toolkit's existing key mappings, while release events are consumed without firing the action twice.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The Rich CLI enables Kitty keyboard reporting but only registered CSI-u control-key forms. Terminals that emit explicit functional-key modifiers such as `ESC [ 1 ; 1 D` therefore sent unknown bytes through prompt_toolkit into the editable buffer instead of moving the cursor.

## Changes

- Register Kitty's `CSI 1;<mods><final>` functional-key family for `ABCDEFHPQS`.
- Map explicit press and repeat event variants to the same prompt_toolkit key.
- Map release variants to `Keys.Ignore` to prevent duplicate actions.
- Restore source-aligned regression coverage for existing enhanced-key mappings, all supported functional modifiers/events, parser behavior, and idempotent registration.

## Validation

```bash
python -m pytest tests/unit/builtins/cli_rich -q --basetemp .pytest-run-84-audit -p no:cacheprovider
# 205 passed

ruff check src/kohakuterrarium/builtins/cli_rich/composer.py tests/unit/builtins/cli_rich/test_composer.py
# All checks passed

python -m pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q --basetemp .pytest-run-84-guards2 -p no:cacheprovider
# 1682 passed

git diff --check
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran the frontend checks
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #84

## Notes for Reviewers

This PR deliberately leaves the issue's secondary terminal-state restoration and prompt_toolkit Ctrl+Shift+Up/Down findings out of scope.

## Exceptions / Not Run

- The full unit suite was not run; the complete Rich CLI unit directory and repository structure guards passed.
- Full-tree Ruff was not run; Ruff passed for both changed Python files.
- Black could not complete in this Windows environment: the available Python 3.12 runtime cannot parse project code formatted for Python 3.14, and scoped normal/`--fast` invocations timed out. CI should provide the authoritative formatting result.
- Fork CI is pending.
