### PR TITLE
fix(tui): refresh live slash command hints

### DIFF
--- a/src/kohakuterrarium/builtins/tui/app.py
+++ b/src/kohakuterrarium/builtins/tui/app.py
@@ -369,6 +369,9 @@ class AgentTUI(App):
         refresh = getattr(self.tui_session, "refresh_model_for_tab", None)
         if callable(refresh):
             refresh(self.get_active_tab_name())
+        refresh_hints = getattr(self.tui_session, "refresh_command_hints_for_tab", None)
+        if callable(refresh_hints):
+            refresh_hints(self.get_active_tab_name())
 
     def start_thinking_animation(self) -> None:
         self._thinking_active = True

--- a/src/kohakuterrarium/builtins/tui/model_info.py
+++ b/src/kohakuterrarium/builtins/tui/model_info.py
@@ -4,9 +4,10 @@ Tabbed sessions retain model and context limits per creature, resolve modal
 actions against that creature, and ignore sibling updates until their tab is active.
 """
 
+import weakref
 from typing import Any
 
-from kohakuterrarium.builtins.tui.widgets import SessionInfoPanel
+from kohakuterrarium.builtins.tui.widgets import ChatInput, SessionInfoPanel
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -21,6 +22,8 @@ class TabModelRegistryMixin:
     _terrarium_tabs: list[str] | None
     _model_by_target: dict[str, str]
     _context_by_target: dict[str, tuple[int, int]]
+    _command_hint_watches: set[tuple[str, int]]
+    command_hint_fallback: dict[str, Any]
 
     def agent_for_tab(self, tab: str | None = None) -> Any:
         """Resolve creature tabs to live agents; channels and failures use the host."""
@@ -33,6 +36,48 @@ class TabModelRegistryMixin:
             if agent is not None:
                 return agent
         return self.host_agent
+
+    def set_command_hints(self, commands: dict, *, target: str = "") -> None:
+        """Render one tab's live command registry when that tab is active."""
+        if target and target != self.get_active_tab():
+            return
+        registry = commands or self.command_hint_fallback
+        names = list(registry)
+        for command in registry.values():
+            names.extend(getattr(command, "aliases", None) or [])
+        names = sorted(set(names))
+
+        def _apply() -> None:
+            inp = self._app.query_one("#input-box", ChatInput)
+            inp.command_names = names
+            inp.on_text_area_changed()
+
+        self._safe_call(_apply)
+
+    def refresh_command_hints_for_tab(self, tab: str = "") -> None:
+        """Read command hints from the currently selected tab's live agent."""
+        target = tab or self.get_active_tab()
+        agent = self.agent_for_tab(target)
+        lister = getattr(agent, "list_user_commands", None)
+        commands = lister() if callable(lister) else {}
+        self.set_command_hints(commands, target=target)
+
+    def watch_command_agent(self, target: str, agent: Any) -> None:
+        """Subscribe a creature tab to runtime command-registry changes."""
+        key = (target, id(agent))
+        if key in self._command_hint_watches:
+            return
+        self._command_hint_watches.add(key)
+        add_listener = getattr(agent, "add_user_command_listener", None)
+        if callable(add_listener):
+            session_ref = weakref.ref(self)
+
+            def _on_commands_changed(commands: dict) -> None:
+                session = session_ref()
+                if session is not None:
+                    session.set_command_hints(commands, target=target)
+
+            add_listener(_on_commands_changed)
 
     def update_target_model(
         self,

--- a/src/kohakuterrarium/builtins/tui/session.py
+++ b/src/kohakuterrarium/builtins/tui/session.py
@@ -84,6 +84,8 @@ class TUISession(TabModelRegistryMixin):
         # active tab's model and context details.
         self._model_by_target: dict[str, str] = {}
         self._context_by_target: dict[str, tuple[int, int]] = {}
+        self._command_hint_watches: set[tuple[str, int]] = set()
+        self.command_hint_fallback: dict[str, Any] = {}
         # Buffer mutations until Textual mounts so startup events are not lost.
         self._pending_safe_calls: list[tuple[Any, tuple[Any, ...]]] = []
 

--- a/src/kohakuterrarium/terrarium/engine_cli.py
+++ b/src/kohakuterrarium/terrarium/engine_cli.py
@@ -26,7 +26,6 @@ from kohakuterrarium.builtins.inputs.none import NoneInput
 from kohakuterrarium.builtins.tui.input import TUIInput
 from kohakuterrarium.builtins.tui.output import TUIOutput
 from kohakuterrarium.builtins.tui.session import TUISession
-from kohakuterrarium.builtins.tui.widgets import ChatInput
 from kohakuterrarium.core.session import get_session
 from kohakuterrarium.builtins.user_commands import (
     get_builtin_user_command,
@@ -313,7 +312,10 @@ async def run_engine_with_tui(
     commands = {n: get_builtin_user_command(n) for n in list_builtin_user_commands()}
     aliases = _build_command_aliases(commands)
     cmd_context = _engine_command_context(focus, engine, focus_creature_id, commands)
-    _set_command_hints(tui, commands)
+    tui.command_hint_fallback = commands
+    for creature in graph_creatures:
+        tui.watch_command_agent(creature.creature_id, creature.agent)
+    tui.refresh_command_hints_for_tab(focus_creature_id)
 
     # Track in-flight inject_input tasks so we can drain them on exit
     # but DON'T await them inline. Awaiting inline blocks the input
@@ -486,18 +488,6 @@ def _update_terrarium_panel(
     tui.update_terrarium(creature_info, env.shared_channels.get_channel_info())
 
 
-def _set_command_hints(tui: TUISession, commands: dict) -> None:
-    if not tui._app:
-        return
-    try:
-        inp = tui._app.query_one("#input-box", ChatInput)
-        inp.command_names = list(commands.keys())
-    except Exception as e:
-        logger.warning(
-            "Failed to set command hints on TUI input", error=str(e), exc_info=True
-        )
-
-
 def _wire_new_channels(env, tui: "TUISession", wired: set[str]) -> None:
     """Install on_send callbacks on every channel not already wired.
 
@@ -575,6 +565,7 @@ async def _refresh_tui_on_topology_change(
                 creature_out._default_target = creature.creature_id
                 creature.agent.output_router.default_output = creature_out
                 routed_creatures.add(creature.creature_id)
+                tui.watch_command_agent(creature.creature_id, creature.agent)
                 # New tab → seed its model line so the panel is right
                 # the first time the user switches to it.
                 _seed_tab_models(tui, [creature])

--- a/tests/unit/builtins/tui/test_session.py
+++ b/tests/unit/builtins/tui/test_session.py
@@ -15,6 +15,7 @@ class _RunningApp:
     def __init__(self, active: str) -> None:
         self.active = active
         self.reconciled: list[list[str]] = []
+        self.command_input = _CommandInput()
 
     def get_active_tab_name(self) -> str:
         return self.active
@@ -25,6 +26,41 @@ class _RunningApp:
     def call_later(self, callback: Callable[..., Any], *args: Any) -> bool:
         callback(*args)
         return True
+
+    def query_one(self, selector: str, _widget_type: type) -> Any:
+        assert selector == "#input-box"
+        return self.command_input
+
+
+class _CommandInput:
+    def __init__(self) -> None:
+        self.command_names: list[str] = []
+        self.refreshes = 0
+
+    def on_text_area_changed(self) -> None:
+        self.refreshes += 1
+
+
+class _Command:
+    def __init__(self, *aliases: str) -> None:
+        self.aliases = list(aliases)
+
+
+class _CommandAgent:
+    def __init__(self, commands: dict[str, _Command]) -> None:
+        self.commands = commands
+        self.listeners: list[Callable[[dict], None]] = []
+
+    def list_user_commands(self) -> dict[str, _Command]:
+        return dict(self.commands)
+
+    def add_user_command_listener(self, listener: Callable[[dict], None]) -> None:
+        self.listeners.append(listener)
+
+    def replace_commands(self, commands: dict[str, _Command]) -> None:
+        self.commands = commands
+        for listener in self.listeners:
+            listener(commands)
 
 
 def test_set_terrarium_tabs_reconciles_running_app_and_preserves_active() -> None:
@@ -43,6 +79,36 @@ def test_set_terrarium_tabs_reconciles_running_app_and_preserves_active() -> Non
 
     assert session._active_target == "root"
     assert app.reconciled[-1] == ["root", "new_worker"]
+
+
+def test_command_hints_follow_active_tab_and_runtime_plugin_changes() -> None:
+    root = _CommandAgent({"help": _Command("h"), "goal": _Command()})
+    worker = _CommandAgent({"help": _Command("h"), "review": _Command("rv")})
+    agents = {"root": root, "worker": worker}
+    session = TUISession()
+    session.host_agent = root
+    session.resolve_tab_agent = agents.get
+    app = _RunningApp(active="root")
+    session._app = app  # type: ignore[assignment]
+
+    session.watch_command_agent("root", root)
+    session.watch_command_agent("worker", worker)
+    session.watch_command_agent("root", root)
+    session.refresh_command_hints_for_tab("root")
+    assert app.command_input.command_names == ["goal", "h", "help"]
+    assert len(root.listeners) == 1
+
+    root.replace_commands({"help": _Command("h")})
+    assert app.command_input.command_names == ["h", "help"]
+
+    app.active = "worker"
+    session.refresh_command_hints_for_tab("worker")
+    assert app.command_input.command_names == ["h", "help", "review", "rv"]
+
+    root.replace_commands({"goal": _Command()})
+    assert app.command_input.command_names == ["h", "help", "review", "rv"]
+    worker.replace_commands({"deploy": _Command("d")})
+    assert app.command_input.command_names == ["d", "deploy"]
 
 
 async def test_background_tab_culling_keeps_target_history_count() -> None:


### PR DESCRIPTION
## Summary

Keep Textual TUI slash-command hints synchronized with the active creature tab's live aggregated command registry. Plugin/custom commands and aliases now appear and disappear immediately when runtime availability changes.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The Terrarium TUI swaps stdin-owning agent inputs for `NoneInput` and seeded completion hints from a startup-only builtin snapshot. Command execution already used the selected agent's live registry, so hints could omit valid plugin commands such as `/goal` and could remain stale after plugin toggles.

## Changes

- Subscribe each creature tab to its agent's user-command registry listener.
- Refresh command hints from the selected tab's live agent on tab activation.
- Include command aliases and update an already-open slash hint immediately.
- Wire newly added creatures into the same command-hint subscription.
- Add regression coverage for tab switching, aliases, plugin removal/addition, and duplicate listener prevention.

## Validation

```bash
python -m pytest tests/unit/builtins/tui tests/unit/terrarium/test_engine_cli_active_dispatch.py tests/unit/terrarium/test_engine_cli_drive_intercept.py tests/integration/test_repro_ui_bugs.py -q --basetemp .pytest-run-120-audit -p no:cacheprovider
# 55 passed

ruff check src/kohakuterrarium/builtins/tui/model_info.py src/kohakuterrarium/builtins/tui/session.py src/kohakuterrarium/builtins/tui/app.py src/kohakuterrarium/terrarium/engine_cli.py tests/unit/builtins/tui/test_session.py
# All checks passed

python -m pytest tests/unit/test_file_sizes.py -q --basetemp .pytest-run-120-size -p no:cacheprovider
# 1680 passed

git diff --check
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran the frontend checks
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #120

## Notes for Reviewers

Standalone TUI behavior remains compatible. The new subscription path matters specifically for Terrarium tabs whose input module is replaced while Textual owns stdin.

## Exceptions / Not Run

- The full unit suite was not run; focused TUI, active-dispatch, and UI regression suites passed.
- Full-tree Ruff was not run; Ruff passed for every changed Python file.
- Black could not complete in this Windows environment because the available Python 3.12 runtime cannot parse project code formatted for Python 3.14 and scoped invocations timed out. CI should provide the authoritative formatting result.
- Fork CI is pending.
