### PR TITLE
fix: enforce pwd guard for JSON tools

### DIFF
--- a/src/kohakuterrarium/builtins/tools/json_read.py
+++ b/src/kohakuterrarium/builtins/tools/json_read.py
@@ -85,6 +85,11 @@ class JsonReadTool(BaseTool):
             return ToolResult(error="Path is required")
 
         file_path = resolve_tool_path(path, context)
+        if context and context.path_guard:
+            msg = context.path_guard.check(str(file_path))
+            if msg:
+                return ToolResult(error=msg)
+
         if not file_path.exists():
             return ToolResult(error=f"File not found: {path}")
 

--- a/src/kohakuterrarium/builtins/tools/json_write.py
+++ b/src/kohakuterrarium/builtins/tools/json_write.py
@@ -97,6 +97,10 @@ class JsonWriteTool(BaseTool):
             value = value_str
 
         file_path = resolve_tool_path(path, context)
+        if context and context.path_guard:
+            msg = context.path_guard.check(str(file_path))
+            if msg:
+                return ToolResult(error=msg)
 
         if file_path.exists():
             try:

--- a/tests/unit/builtins/tools/test_json_read.py
+++ b/tests/unit/builtins/tools/test_json_read.py
@@ -1,0 +1,44 @@
+"""Unit tests for :mod:`kohakuterrarium.builtins.tools.json_read`."""
+
+from kohakuterrarium.builtins.tools.json_read import JsonReadTool
+from kohakuterrarium.modules.tool.base import ToolContext
+from kohakuterrarium.utils.file_guard import PathBoundaryGuard
+
+
+def _context(workspace):
+    return ToolContext(
+        agent_name="agent",
+        session=None,
+        working_dir=workspace,
+        path_guard=PathBoundaryGuard(cwd=workspace, mode="block"),
+    )
+
+
+class TestJsonReadPathGuard:
+    async def test_blocks_file_outside_working_directory(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "outside.json"
+        outside.write_text('{"secret": true}', encoding="utf-8")
+
+        result = await JsonReadTool().execute(
+            {"path": str(outside)}, context=_context(workspace)
+        )
+
+        assert result.success is False
+        assert "Access denied" in result.error
+        assert str(workspace) in result.error
+
+    async def test_reads_file_inside_working_directory(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        inside = workspace / "data.json"
+        inside.write_text('{"allowed": true}', encoding="utf-8")
+
+        result = await JsonReadTool().execute(
+            {"path": "data.json", "query": ".allowed"},
+            context=_context(workspace),
+        )
+
+        assert result.success is True
+        assert result.output == "True"

--- a/tests/unit/builtins/tools/test_json_write.py
+++ b/tests/unit/builtins/tools/test_json_write.py
@@ -1,0 +1,47 @@
+"""Unit tests for :mod:`kohakuterrarium.builtins.tools.json_write`."""
+
+import json
+
+from kohakuterrarium.builtins.tools.json_write import JsonWriteTool
+from kohakuterrarium.modules.tool.base import ToolContext
+from kohakuterrarium.utils.file_guard import PathBoundaryGuard
+
+
+def _context(workspace):
+    return ToolContext(
+        agent_name="agent",
+        session=None,
+        working_dir=workspace,
+        path_guard=PathBoundaryGuard(cwd=workspace, mode="block"),
+    )
+
+
+class TestJsonWritePathGuard:
+    async def test_blocks_new_file_outside_working_directory(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "outside.json"
+
+        result = await JsonWriteTool().execute(
+            {"path": str(outside), "value": '{"secret": true}'},
+            context=_context(workspace),
+        )
+
+        assert result.success is False
+        assert "Access denied" in result.error
+        assert str(workspace) in result.error
+        assert outside.exists() is False
+
+    async def test_updates_file_inside_working_directory(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        inside = workspace / "data.json"
+        inside.write_text('{"allowed": false}', encoding="utf-8")
+
+        result = await JsonWriteTool().execute(
+            {"path": "data.json", "query": ".allowed", "value": "true"},
+            context=_context(workspace),
+        )
+
+        assert result.success is True
+        assert json.loads(inside.read_text(encoding="utf-8")) == {"allowed": True}


### PR DESCRIPTION
## Summary

Make the built-in JSON read and write tools honor the same working-directory path guard as the ordinary filesystem tools. This closes a policy bypass where `pwd_guard: block` rejected `read`/`write` but allowed `json_read`/`json_write` against the same outside path.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

`JsonReadTool` and `JsonWriteTool` resolved paths against the tool context but never called `context.path_guard.check()`. As a result, block and warn policies were silently bypassed for JSON-specific file access.

## Changes

- Apply the configured path guard before JSON files are read or created.
- Return the existing guard message without touching the target file.
- Add negative regression coverage for outside-workspace reads and writes.
- Preserve successful reads and updates inside the working directory.

## Validation

```bash
python -m pytest tests/unit/builtins/tools/test_json_read.py tests/unit/builtins/tools/test_json_write.py tests/unit/builtins/tools/test_read.py tests/unit/utils/test_file_guard.py -q
python -m ruff check src/kohakuterrarium/builtins/tools/json_read.py src/kohakuterrarium/builtins/tools/json_write.py tests/unit/builtins/tools/test_json_read.py tests/unit/builtins/tools/test_json_write.py
python -m ruff format --check src/kohakuterrarium/builtins/tools/json_read.py src/kohakuterrarium/builtins/tools/json_write.py tests/unit/builtins/tools/test_json_read.py tests/unit/builtins/tools/test_json_write.py
git diff --check
```

Result: 39 passed; Ruff lint and format checks passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] No documentation update is needed; this restores the documented path-guard behavior
- [x] I added or updated tests when needed
- [x] Targeted `ruff check` passes
- [ ] Full `black --check src/ tests/` passes
- [ ] Full `pytest tests/unit/` passes locally
- [x] No frontend files changed
- [ ] CI on my fork is green

## Related Issues / Discussions

- Fixes #149

## Notes for Reviewers

The guard call intentionally matches the existing `read`, `write`, `glob`, and `grep` tool behavior, including warn-mode retry semantics.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None. Access already allowed by the configured guard is unchanged.

## Exceptions / Not Run

The focused affected tests were run. Full unit and repository-wide lint suites are deferred to CI. The repository's Black configuration targets Python 3.10 through 3.14, while the available sandbox interpreter is Python 3.12 and Black stalls during its multi-target safety parse; `ruff format --check` passed on every touched file.