### PR TITLE
fix: roll back failed creature startup

### DIFF
--- a/src/kohakuterrarium/terrarium/creature_host.py
+++ b/src/kohakuterrarium/terrarium/creature_host.py
@@ -150,7 +150,21 @@ class Creature:
                 return
             self._ensure_chat_pipe()
             self._restoration_state = RESTORATION_RESTORING
-            await self.agent.start()
+            try:
+                await self.agent.start()
+            except BaseException:
+                self._restoration_state = RESTORATION_ADDED
+                try:
+                    await self.agent.stop()
+                except Exception as cleanup_error:
+                    logger.error(
+                        "Creature startup rollback failed",
+                        creature_id=self.creature_id,
+                        creature_name=self.name,
+                        error=str(cleanup_error),
+                        exc_info=True,
+                    )
+                raise
             self._running = True
             self._ever_started = True
             self._input_loop_error = None

--- a/tests/unit/terrarium/test_creature_host.py
+++ b/tests/unit/terrarium/test_creature_host.py
@@ -7,6 +7,7 @@ import pytest
 from kohakuterrarium.builtins.inputs.none import NoneInput
 from kohakuterrarium.builtins.outputs.none import NoneOutput
 from kohakuterrarium.builtins.outputs.stdout import StdoutOutput
+from kohakuterrarium.modules.trigger.base import BaseTrigger
 from kohakuterrarium.terrarium.creature_host import Creature, build_creature
 from kohakuterrarium.testing.llm import ScriptedLLM
 from kohakuterrarium.testing.terrarium import _FakeAgent
@@ -250,6 +251,45 @@ class TestStartStop:
         c = _creature()
         await c.start()
         assert c._input_task is None
+
+    async def test_failed_agent_start_rolls_back_partial_resources(self, tmp_path):
+        class FailingTrigger(BaseTrigger):
+            def __init__(self):
+                super().__init__()
+                self.stop_calls = 0
+
+            async def _on_start(self):
+                raise RuntimeError("startup failed")
+
+            async def _on_stop(self):
+                self.stop_calls += 1
+
+            async def wait_for_trigger(self):
+                await asyncio.Event().wait()
+
+        (tmp_path / "config.yaml").write_text(
+            "name: failing\ninput:\n  type: none\noutput:\n  type: none\n",
+            encoding="utf-8",
+        )
+        creature = build_creature(
+            str(tmp_path), llm=ScriptedLLM(["unused"]), io="headless"
+        )
+        trigger = FailingTrigger()
+        await creature.agent.trigger_manager.add(
+            trigger, trigger_id="failing", autostart=False
+        )
+
+        with pytest.raises(RuntimeError, match="startup failed"):
+            await creature.start()
+
+        assert trigger.is_running is False
+        assert trigger.stop_calls == 1
+        assert creature.agent.is_running is False
+        assert creature.is_running is False
+        assert creature.restoration_state == "added"
+
+        await creature.stop()
+        assert trigger.stop_calls == 1
 
 
 # ── inject_input ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Make `Creature.start()` atomic from the engine caller's perspective. If the wrapped agent raises after partially starting inputs, outputs, triggers, plugins, or other resources, the creature now rolls the agent back before re-raising the original startup error.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

`Creature` set its own `_running` flag only after `Agent.start()` completed. When agent startup failed partway through, later `Creature.stop()` returned early because the creature looked not-running, leaving the partially started agent resources live.

## Changes

- Catch failed or cancelled agent startup at the creature lifecycle boundary.
- Reset restoration state and invoke the agent's normal orderly shutdown path.
- Preserve the original startup exception if rollback itself reports an ordinary error.
- Add a real-Agent regression test with a trigger that becomes running and then fails startup.

## Validation

```bash
python -m pytest tests/unit/terrarium/test_creature_host.py tests/unit/terrarium/test_creature_host_more.py tests/unit/core/test_agent_real.py -q
python -m pytest tests/integration/test_terrarium.py tests/unit/test_file_sizes.py -q
python -m ruff check src/kohakuterrarium/terrarium/creature_host.py tests/unit/terrarium/test_creature_host.py
python -m ruff format --check src/kohakuterrarium/terrarium/creature_host.py tests/unit/terrarium/test_creature_host.py
git diff --check
```

Results: 296 focused unit tests passed; 1,690 integration and file-size checks passed; Ruff lint and format checks passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is not a feature PR, the change is limited to a bug fix
- [x] I kept this PR focused and did not include unrelated changes
- [x] No documentation update is needed; this restores lifecycle cleanup
- [x] I added or updated tests
- [x] Targeted `ruff check` passes
- [ ] Full `black --check src/ tests/` passes
- [ ] Full `pytest tests/unit/` passes locally
- [x] No frontend files changed
- [ ] CI on my fork is green

## Related Issues / Discussions

- Fixes #150

## Notes for Reviewers

The rollback is intentionally at the Creature boundary: `Agent.stop()` already owns the complete ordered cleanup sequence, and the leak occurred because Creature's early-stop guard made that sequence unreachable after a failed start.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

Repository-wide unit and lint suites are deferred to CI. Black cannot complete its configured Python 3.10-3.14 safety parse under the sandbox's Python 3.12 interpreter; Ruff format verification passed for every touched file.