### PR TITLE
fix: isolate trace streams across view changes

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTurnGroup.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTurnGroup.vue
@@ -27,14 +27,13 @@
 </template>
 
 <script setup>
-import { computed, watch } from "vue"
+import { computed, onUnmounted, watch } from "vue"
 
 import TraceEventRow from "@/components/sessions/trace/TraceEventRow.vue"
-import { useEventStreamStore } from "@/stores/eventStream"
+import { disposeEventStreamStore, useEphemeralEventStreamStore } from "@/stores/eventStream"
 import { useI18n } from "@/utils/i18n"
 
 const { t } = useI18n()
-const stream = useEventStreamStore()
 
 const props = defineProps({
   turn: { type: Object, required: true },
@@ -46,6 +45,10 @@ const props = defineProps({
   selectedEventId: { type: Number, default: null },
 })
 const emit = defineEmits(["toggle", "select-event"])
+const streamScope = `trace:${encodeURIComponent(props.sessionName)}:${encodeURIComponent(props.agent)}:${props.turn.turn_index}`
+const stream = useEphemeralEventStreamStore(streamScope)
+
+onUnmounted(() => disposeEventStreamStore(streamScope))
 
 function onToggle() {
   emit("toggle", props.turn.turn_index)
@@ -93,7 +96,7 @@ const isCompact = computed(() => Boolean(props.turn.compacted))
 // Apply filters client-side. Combines store events + the turn's slice
 // of live-attach events the parent has buffered.
 const displayedEvents = computed(() => {
-  const own = isThisTurnInStore() ? stream.events : []
+  const own = stream.events
   const live = (props.liveEvents || []).filter((e) => e.turn_index === props.turn.turn_index)
   const combined = [...own]
   for (const e of live) {
@@ -101,10 +104,6 @@ const displayedEvents = computed(() => {
   }
   return combined.filter(_passesFilter)
 })
-
-function isThisTurnInStore() {
-  return stream.turnIndex === props.turn.turn_index
-}
 
 const TYPE_GROUPS = {
   tool: new Set(["tool_call", "tool_result", "tool_error"]),
@@ -144,7 +143,7 @@ watch(
   () => [props.expanded, props.turn.turn_index, props.agent],
   ([exp, ti]) => {
     if (!exp) return
-    if (stream.turnIndex !== ti || stream.sessionName !== props.sessionName) {
+    if (stream.turnIndex !== ti || stream.sessionName !== props.sessionName || stream.agent !== (props.agent || "")) {
       stream.loadTurn(props.sessionName, {
         agent: props.agent || null,
         turnIndex: ti,

--- a/src/kohakuterrarium-frontend/src/composables/useSessionEventStream.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSessionEventStream.js
@@ -34,12 +34,12 @@ export function useSessionEventStream() {
   let ws = null
   let retryTimer = null
   let retryDelay = 500
-  let closedByCaller = false
+  let connectionGeneration = 0
   let currentName = ""
   let currentAgent = null
 
   function _disconnect() {
-    closedByCaller = true
+    connectionGeneration += 1
     if (retryTimer) {
       clearTimeout(retryTimer)
       retryTimer = null
@@ -56,33 +56,37 @@ export function useSessionEventStream() {
     subscribed.value = false
   }
 
-  function _scheduleReconnect() {
+  function _scheduleReconnect(generation) {
     if (retryTimer) clearTimeout(retryTimer)
     retryTimer = setTimeout(() => {
+      if (generation !== connectionGeneration || !currentName) return
       retryDelay = Math.min(retryDelay * 2, 5000)
-      _open(currentName, currentAgent)
+      _open(currentName, currentAgent, generation)
     }, retryDelay)
   }
 
-  function _open(sessionName, agent) {
-    closedByCaller = false
+  function _open(sessionName, agent, generation = connectionGeneration) {
     let path = `/ws/sessions/${encodeURIComponent(sessionName)}/events`
     if (agent) path += `?agent=${encodeURIComponent(agent)}`
+    let socket
     try {
-      ws = new WebSocket(_wsUrl(path))
+      socket = new WebSocket(_wsUrl(path))
+      ws = socket
     } catch (err) {
       error.value = String(err)
-      _scheduleReconnect()
+      _scheduleReconnect(generation)
       return
     }
 
-    ws.onopen = () => {
+    socket.onopen = () => {
+      if (generation !== connectionGeneration || ws !== socket) return
       connected.value = true
       error.value = ""
       retryDelay = 500
     }
 
-    ws.onmessage = (ev) => {
+    socket.onmessage = (ev) => {
+      if (generation !== connectionGeneration || ws !== socket) return
       let data
       try {
         data = JSON.parse(ev.data)
@@ -106,15 +110,17 @@ export function useSessionEventStream() {
       }
     }
 
-    ws.onerror = () => {
+    socket.onerror = () => {
+      if (generation !== connectionGeneration || ws !== socket) return
       error.value = "WebSocket error"
     }
 
-    ws.onclose = () => {
+    socket.onclose = () => {
+      if (generation !== connectionGeneration || ws !== socket) return
       connected.value = false
       subscribed.value = false
       ws = null
-      if (!closedByCaller) _scheduleReconnect()
+      _scheduleReconnect(generation)
     }
   }
 
@@ -126,7 +132,7 @@ export function useSessionEventStream() {
     events.value = []
     newSinceLastClear.value = 0
     error.value = ""
-    _open(sessionName, agent)
+    _open(sessionName, agent, connectionGeneration)
   }
 
   function detach() {

--- a/src/kohakuterrarium-frontend/src/composables/useSessionEventStream.test.js
+++ b/src/kohakuterrarium-frontend/src/composables/useSessionEventStream.test.js
@@ -1,0 +1,71 @@
+import { mount } from "@vue/test-utils"
+import { defineComponent } from "vue"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useSessionEventStream } from "@/composables/useSessionEventStream"
+
+class FakeWebSocket {
+  static instances = []
+
+  constructor(url) {
+    this.url = url
+    this.close = vi.fn()
+    FakeWebSocket.instances.push(this)
+  }
+}
+
+describe("useSessionEventStream", () => {
+  let wrapper
+  let stream
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeWebSocket.instances = []
+    vi.stubGlobal("WebSocket", FakeWebSocket)
+    wrapper = mount(
+      defineComponent({
+        setup() {
+          stream = useSessionEventStream()
+          return () => null
+        },
+      }),
+    )
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it("ignores the close event from a replaced socket", () => {
+    stream.attach("first", "agent-a")
+    const first = FakeWebSocket.instances[0]
+    stream.attach("second", "agent-b")
+    const second = FakeWebSocket.instances[1]
+
+    first.onmessage({
+      data: JSON.stringify({ type: "event", key: "old", event: { event_id: 1 } }),
+    })
+    first.onclose()
+    expect(stream.events.value).toEqual([])
+    expect(vi.getTimerCount()).toBe(0)
+
+    stream.detach()
+    expect(second.close).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("reconnects when the current socket closes", () => {
+    stream.attach("session", "agent")
+    const current = FakeWebSocket.instances[0]
+
+    current.onclose()
+    expect(vi.getTimerCount()).toBe(1)
+    vi.advanceTimersByTime(500)
+
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect(FakeWebSocket.instances[1].url).toContain("/ws/sessions/session/events")
+    expect(FakeWebSocket.instances[1].url).toContain("agent=agent")
+  })
+})

--- a/src/kohakuterrarium-frontend/src/stores/eventStream.js
+++ b/src/kohakuterrarium-frontend/src/stores/eventStream.js
@@ -5,6 +5,8 @@
  * caches the events for the *currently expanded* turn only — switching
  * to a different turn clears and refetches. This keeps memory bounded
  * even on long sessions where one turn might have thousands of events.
+ * Trace groups use one ephemeral store per mounted turn, so multiple
+ * expanded turns do not replace each other's cached events.
  *
  * **Per-scope** (scope = session name). The session-viewer macro-tab
  * provides the session name as scope, so two viewers don't trample
@@ -25,6 +27,8 @@ const _eventStreamOptions = {
     events: [],
     nextCursor: null,
     loading: false,
+    loadGeneration: 0,
+    loadingGeneration: null,
     error: "",
   }),
 
@@ -34,37 +38,49 @@ const _eventStreamOptions = {
 
   actions: {
     async loadTurn(sessionName, { agent = null, turnIndex = null } = {}) {
+      this.loadGeneration += 1
+      const generation = this.loadGeneration
       this.sessionName = sessionName
       this.agent = agent || ""
       this.turnIndex = turnIndex
       this.events = []
       this.nextCursor = null
       this.error = ""
-      await this.loadMore()
+      await this.loadMore(generation)
     },
 
-    async loadMore() {
+    async loadMore(generation = this.loadGeneration) {
       if (!this.sessionName) return
-      if (this.loading) return
+      if (this.loadingGeneration === generation) return
+      const sessionName = this.sessionName
+      const agent = this.agent
+      const turnIndex = this.turnIndex
+      const cursor = this.nextCursor
       this.loading = true
+      this.loadingGeneration = generation
       try {
-        const data = await sessionAPI.getEvents(this.sessionName, {
-          agent: this.agent || null,
-          turnIndex: this.turnIndex,
+        const data = await sessionAPI.getEvents(sessionName, {
+          agent: agent || null,
+          turnIndex,
           limit: 200,
-          cursor: this.nextCursor,
+          cursor,
         })
+        if (generation !== this.loadGeneration) return
         const incoming = data.events || []
-        if (this.nextCursor === null) {
+        if (cursor === null) {
           this.events = incoming
         } else {
           this.events.push(...incoming)
         }
         this.nextCursor = data.next_cursor ?? null
       } catch (err) {
+        if (generation !== this.loadGeneration) return
         this.error = `Failed to load events: ${err.message || err}`
       } finally {
-        this.loading = false
+        if (this.loadingGeneration === generation) {
+          this.loading = false
+          this.loadingGeneration = null
+        }
       }
     },
 
@@ -81,11 +97,14 @@ const _eventStreamOptions = {
     },
 
     clear() {
+      this.loadGeneration += 1
       this.sessionName = ""
       this.agent = ""
       this.turnIndex = null
       this.events = []
       this.nextCursor = null
+      this.loading = false
+      this.loadingGeneration = null
       this.error = ""
     },
   },
@@ -93,13 +112,13 @@ const _eventStreamOptions = {
 
 const _eventStreamFactories = new Map()
 
-function _factoryFor(scope) {
+function _factoryFor(scope, registerWithScope = true) {
   const key = scope || "default"
   let useFn = _eventStreamFactories.get(key)
   if (!useFn) {
     useFn = defineStore(`eventStream:${key}`, _eventStreamOptions)
     _eventStreamFactories.set(key, useFn)
-    if (scope) {
+    if (scope && registerWithScope) {
       registerScopeDisposer(scope, () => {
         try {
           useFn().$dispose?.()
@@ -117,4 +136,20 @@ export function useEventStreamStore(scope) {
   if (scope !== undefined) return _factoryFor(scope)()
   if (getCurrentInstance()) return _factoryFor(injectScope())()
   return _factoryFor(null)()
+}
+
+export function useEphemeralEventStreamStore(scope) {
+  return _factoryFor(scope, false)()
+}
+
+export function disposeEventStreamStore(scope) {
+  const key = scope || "default"
+  const useFn = _eventStreamFactories.get(key)
+  if (!useFn) return
+  try {
+    useFn().$dispose?.()
+  } catch {
+    /* swallow */
+  }
+  _eventStreamFactories.delete(key)
 }

--- a/src/kohakuterrarium-frontend/src/stores/eventStream.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/eventStream.test.js
@@ -1,0 +1,59 @@
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { disposeEventStreamStore, useEventStreamStore } from "@/stores/eventStream"
+import { sessionAPI } from "@/utils/api"
+
+vi.mock("@/utils/api", () => ({
+  sessionAPI: { getEvents: vi.fn() },
+}))
+
+function deferred() {
+  let resolve
+  const promise = new Promise((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe("event stream store", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    sessionAPI.getEvents.mockReset()
+  })
+
+  it("keeps expanded turns in independent stores", async () => {
+    sessionAPI.getEvents
+      .mockResolvedValueOnce({ events: [{ event_id: 1 }], next_cursor: null })
+      .mockResolvedValueOnce({ events: [{ event_id: 2 }], next_cursor: null })
+    const first = useEventStreamStore("trace:session:agent:1")
+    const second = useEventStreamStore("trace:session:agent:2")
+
+    await first.loadTurn("session", { agent: "agent", turnIndex: 1 })
+    await second.loadTurn("session", { agent: "agent", turnIndex: 2 })
+
+    expect(first.events).toEqual([{ event_id: 1 }])
+    expect(second.events).toEqual([{ event_id: 2 }])
+    disposeEventStreamStore("trace:session:agent:1")
+    disposeEventStreamStore("trace:session:agent:2")
+  })
+
+  it("ignores a stale request after switching turns", async () => {
+    const oldRequest = deferred()
+    sessionAPI.getEvents
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockResolvedValueOnce({ events: [{ event_id: 2 }], next_cursor: null })
+    const stream = useEventStreamStore("trace:race")
+
+    const firstLoad = stream.loadTurn("session", { turnIndex: 1 })
+    await Promise.resolve()
+    await stream.loadTurn("session", { turnIndex: 2 })
+    oldRequest.resolve({ events: [{ event_id: 1 }], next_cursor: null })
+    await firstLoad
+
+    expect(stream.turnIndex).toBe(2)
+    expect(stream.events).toEqual([{ event_id: 2 }])
+    expect(stream.loading).toBe(false)
+    disposeEventStreamStore("trace:race")
+  })
+})


### PR DESCRIPTION
## Summary

Fix two related session-trace races: expanded turn groups now keep independent event stores, and live WebSocket callbacks are scoped to the connection generation that created them. Rapidly expanding turns or switching live session/agent filters no longer empties an already expanded turn, applies stale fetches, or lets an old socket close the replacement connection.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Every expanded `TraceTurnGroup` inherited the same session-level Pinia store even though the UI permits multiple expanded turns. Loading another turn replaced the first turn's events, and an older request could write into the new selection.

The live stream composable also kept a single mutable `ws` and `closedByCaller` flag. A delayed `onclose` from a replaced socket could null the new socket reference and schedule a duplicate reconnect.

## Changes

- Give each mounted turn group an ephemeral event store and dispose it on unmount.
- Add request generations so stale event fetches cannot mutate a newer turn.
- Capture each WebSocket locally and ignore callbacks from superseded generations.
- Add regression tests for multi-turn store isolation, stale fetch completion, stale socket messages, stale socket close events, and normal reconnect behavior.

## Validation

```bash
npm test
npm test -- --run src/stores/eventStream.test.js src/composables/useSessionEventStream.test.js src/stores/chat.test.js src/stores/layoutPanels.test.js
npx prettier --check <five touched files>
npx eslint <five touched files>
npm run build
git diff --check
```

Results:
- Full frontend suite: 96 files, 954 tests passed.
- Focused and prior-timeout rerun: 4 files, 158 tests passed.
- Targeted Prettier and ESLint passed.
- Production build completed successfully.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is not a feature PR, the change is limited to a bug fix
- [x] I kept this PR focused
- [x] No documentation update is needed; visible behavior is restored
- [x] I added or updated tests
- [x] Targeted lint passes
- [x] Full frontend test suite passes
- [x] `npm run build` passes
- [ ] Repository-wide `npm run format:check` passes
- [ ] CI on my fork is green

## Related Issues / Discussions

- Fixes #151

## Notes for Reviewers

The per-turn stores are deliberately ephemeral rather than registered against the macro-tab scope. Their lifetime matches the rendered turn group, while the existing session-level store remains available to the parent trace view. Final audit also pinned that a current socket still reconnects normally after stale callbacks were gated.

## Screenshots / Logs (if applicable)

No visual design change.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

Repository-wide `npm run format:check` reports pre-existing CRLF formatting warnings across much of the frontend. Prettier passed for all five touched files. An initial full test run executed concurrently with the production build and timed out in two unrelated tests; both passed immediately in an isolated 158-test rerun, and the subsequent sequential full suite passed all 954 tests.