### PR TITLE
fix: refresh CLI state from current runtime

### DIFF
--- a/src/kohakuterrarium/cli/run.py
+++ b/src/kohakuterrarium/cli/run.py
@@ -426,16 +426,9 @@ def _resolve_session(query: str | None, last: bool = False) -> Path | None:
         return None
 
     sessions = sorted(
-        _SESSION_DIR.glob("*.kohakutr"),
+        [*_SESSION_DIR.glob("*.kohakutr"), *_SESSION_DIR.glob("*.kt")],
         key=lambda p: p.stat().st_mtime,
         reverse=True,
-    )
-    sessions.extend(
-        sorted(
-            _SESSION_DIR.glob("*.kt"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
     )
 
     if not sessions:

--- a/src/kohakuterrarium/terrarium/engine_cli.py
+++ b/src/kohakuterrarium/terrarium/engine_cli.py
@@ -302,7 +302,6 @@ async def run_engine_with_tui(
         _refresh_tui_on_topology_change(
             engine,
             tui,
-            graph_id,
             focus_creature_id,
             wired_channels,
             routed_creatures,
@@ -506,7 +505,6 @@ def _wire_new_channels(env, tui: "TUISession", wired: set[str]) -> None:
 async def _refresh_tui_on_topology_change(
     engine: Terrarium,
     tui: "TUISession",
-    graph_id: str,
     focus_creature_id: str,
     wired_channels: set[str],
     routed_creatures: set[str],
@@ -531,6 +529,9 @@ async def _refresh_tui_on_topology_change(
     )
     try:
         async for _ev in engine.subscribe(filt):
+            graph_id = engine._topology.creature_to_graph.get(focus_creature_id)
+            if graph_id is None:
+                continue
             graph = engine._topology.graphs.get(graph_id)
             if graph is None:
                 continue

--- a/tests/unit/cli/test_resolve_then_run.py
+++ b/tests/unit/cli/test_resolve_then_run.py
@@ -6,6 +6,8 @@ no-path runs the picker on a TTY; a cancelled picker is a clean no-op; a
 non-TTY refuses instead of hanging.
 """
 
+import os
+
 from kohakuterrarium.cli import run as runmod
 
 
@@ -86,3 +88,20 @@ class TestResolveThenRun:
         rc = runmod.resolve_then_run(None, io_mode="cli")
         assert rc == 2
         assert called == []
+
+
+class TestResolveSession:
+    def test_last_compares_current_and_legacy_extensions_together(
+        self, monkeypatch, tmp_path
+    ):
+        current = tmp_path / "older.kohakutr"
+        legacy = tmp_path / "newer.kt"
+        current.touch()
+        legacy.touch()
+        os.utime(current, (100, 100))
+        os.utime(legacy, (200, 200))
+        monkeypatch.setattr(runmod, "_SESSION_DIR", tmp_path)
+
+        resolved = runmod._resolve_session(None, last=True)
+
+        assert resolved == legacy

--- a/tests/unit/terrarium/test_engine_cli_topology_refresh.py
+++ b/tests/unit/terrarium/test_engine_cli_topology_refresh.py
@@ -1,0 +1,55 @@
+"""Regression tests for dynamic TUI topology refresh."""
+
+from types import SimpleNamespace
+
+from kohakuterrarium.terrarium import engine_cli
+
+
+class _Engine:
+    def __init__(self):
+        graph = SimpleNamespace(creature_ids={"focus"}, channels={})
+        self._topology = SimpleNamespace(
+            creature_to_graph={"focus": "merged"},
+            graphs={"merged": graph},
+        )
+        self._environments = {"merged": object()}
+        self.creature = SimpleNamespace(creature_id="focus")
+
+    async def subscribe(self, _filter):
+        yield object()
+
+    def get_creature(self, creature_id):
+        assert creature_id == "focus"
+        return self.creature
+
+
+class _TUI:
+    def __init__(self):
+        self.tabs = []
+
+    def set_terrarium_tabs(self, tabs):
+        self.tabs = tabs
+
+
+async def test_refresh_follows_focus_creature_after_graph_merge(monkeypatch):
+    engine = _Engine()
+    tui = _TUI()
+    seen = []
+    monkeypatch.setattr(engine_cli, "_seed_tab_models", lambda *_args: None)
+    monkeypatch.setattr(engine_cli, "_wire_new_channels", lambda *_args: None)
+    monkeypatch.setattr(
+        engine_cli,
+        "_update_terrarium_panel",
+        lambda _tui, _creatures, env, focus: seen.append((env, focus)),
+    )
+
+    await engine_cli._refresh_tui_on_topology_change(
+        engine,
+        tui,
+        "focus",
+        set(),
+        {"focus"},
+    )
+
+    assert tui.tabs == ["focus"]
+    assert seen == [(engine._environments["merged"], "focus")]


### PR DESCRIPTION
## Summary

Fix two stale-state bugs in the terminal surfaces. `kt resume --last` now chooses the newest supported session regardless of whether it uses the current or legacy extension, and the TUI topology subscriber now follows the focused creature's current graph after merges or splits.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The session resolver sorted `*.kohakutr` and `*.kt` independently, then appended all legacy files after current files. A newer legacy session could therefore lose to any current-extension session.

The TUI refresh task captured the graph id at startup. Cross-graph wiring may delete that graph id while keeping the focused creature in the merge survivor, leaving the subscriber alive but permanently skipping refreshes.

## Changes

- Combine both supported session extensions before sorting by modification time.
- Resolve the focused creature's graph from `creature_to_graph` on every topology event.
- Add regression coverage for mixed-extension `--last` selection.
- Add regression coverage for refreshing against the focused creature's merge-survivor graph.

## Validation

```bash
python -m pytest tests/unit/cli/test_resolve_then_run.py tests/unit/cli/test_run_drive.py tests/unit/terrarium/test_engine_cli_topology_refresh.py tests/unit/terrarium/test_engine_cli_active_dispatch.py tests/unit/terrarium/test_engine_cli_drive_intercept.py -q
python -m pytest tests/unit/cli tests/unit/terrarium tests/integration/test_terrarium.py tests/unit/test_file_sizes.py -q
python -m ruff check <four touched files>
python -m ruff format --check <four touched files>
git diff --check
```

Results: 23 targeted tests passed; broader CLI/Terrarium run passed 4,039 tests with 3 skips; Ruff lint and format checks passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is not a feature PR, the change is limited to a bug fix
- [x] I kept this PR focused on CLI/TUI runtime state
- [x] No documentation update is needed; commands and UI behavior are unchanged
- [x] I added or updated tests
- [x] Targeted `ruff check` passes
- [ ] Full `black --check src/ tests/` passes
- [ ] Full repository unit suite passes locally
- [x] No frontend files changed
- [ ] CI on my fork is green

## Related Issues / Discussions

- Fixes #152

## Notes for Reviewers

The TUI deliberately re-resolves by the stable focused creature id rather than trying to interpret each topology delta. This covers graph merge and split outcomes with one source of truth.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None. Legacy `.kt` sessions remain supported.

## Exceptions / Not Run

The broader affected-area suite passed. Repository-wide tests are deferred to CI. Black cannot complete the repository's Python 3.10-3.14 safety parse under the sandbox's Python 3.12 interpreter; Ruff formatting passed for every touched file.