### PR TITLE
fix(bash): avoid serial lock head-of-line blocking

### DIFF
--- a/src/kohakuterrarium/builtin_skills/tools/bash.md
+++ b/src/kohakuterrarium/builtin_skills/tools/bash.md
@@ -28,7 +28,8 @@ Using dedicated tools gives structured output and enables safety guards.
 | ------- | ------ | ------------------------------------------------------------------------------------------------ |
 | command | string | Shell command to execute (required)                                                              |
 | type    | string | Shell type: bash, zsh, sh, fish, pwsh, powershell (default: bash)                                |
-| timeout | number | Maximum execution time in seconds for this call (default: tool config timeout; `0` = no timeout) |
+| timeout | number | Maximum total call time in seconds, including concurrency-lock waiting (default: tool config timeout; `0` = no timeout) |
+| allow_concurrent | boolean | Skip the unsafe-tool concurrency lock; use only when this call is safe to run concurrently |
 
 ## Shell Type
 
@@ -63,8 +64,9 @@ Shell executable overrides are checked in this order:
 - Commands run in bash on all platforms (Git Bash on Windows) unless `type` selects another shell.
 - Use the `type` parameter to switch shells explicitly.
 - stdout and stderr are combined in the output.
-- Commands have a configurable timeout; pass `timeout` per call to override the tool default.
-- `timeout: 0` disables the execution timeout for long-running commands.
+- Commands have a configurable total timeout; `timeout` includes concurrency-lock waiting and command execution.
+- `timeout: 0` disables the total timeout for long-running commands.
+- Unsafe Bash calls wait for the shared concurrency lock by default. Set `allow_concurrent=true` only when the command is safe to run concurrently; this skips that lock at your own risk.
 - Large outputs may be truncated to the configured max size.
 
 ## WHEN TO USE
@@ -80,6 +82,6 @@ Returns combined stdout/stderr. Exit code is included in the result metadata.
 
 ## LIMITATIONS
 
-- Commands have timeout (default: 60 seconds; override per call with `timeout`)
+- Commands have a total timeout (default: 60 seconds; override per call with `timeout`), including concurrency-lock waiting
 - Large outputs may be truncated
 - Shell availability varies by platform (bash via git bash on Windows)

--- a/src/kohakuterrarium/builtin_skills/tools/bash.md
+++ b/src/kohakuterrarium/builtin_skills/tools/bash.md
@@ -66,7 +66,7 @@ Shell executable overrides are checked in this order:
 - stdout and stderr are combined in the output.
 - Commands have a configurable total timeout; `timeout` includes concurrency-lock waiting and command execution.
 - `timeout: 0` disables the total timeout for long-running commands.
-- Unsafe Bash calls wait for the shared concurrency lock by default. Set `allow_concurrent=true` only when the command is safe to run concurrently; this skips that lock at your own risk.
+- Unsafe tool calls wait for the shared concurrency lock by default. Set `allow_concurrent=true` only when the call is safe to run concurrently; this skips that lock at your own risk. This is an executor-level override and applies to any unsafe tool, although this manual documents its Bash use.
 - Large outputs may be truncated to the configured max size.
 
 ## WHEN TO USE

--- a/src/kohakuterrarium/builtins/tools/bash.py
+++ b/src/kohakuterrarium/builtins/tools/bash.py
@@ -1,6 +1,7 @@
 """Cross-platform shell command execution with bounded output and timeouts."""
 
 import asyncio
+import math
 import os
 import shutil
 import subprocess
@@ -158,6 +159,8 @@ def _resolve_timeout_arg(
         timeout = float(raw_timeout)
     except (TypeError, ValueError):
         return 0.0, f"timeout must be numeric, got {raw_timeout!r}"
+    if not math.isfinite(timeout):
+        return 0.0, "timeout must be finite"
     if timeout < 0:
         return 0.0, "timeout must be >= 0"
     return timeout, None
@@ -289,7 +292,17 @@ class ShellTool(BaseTool):
                 },
                 "timeout": {
                     "type": "number",
-                    "description": "Maximum execution time in seconds (0 = no timeout).",
+                    "description": (
+                        "Maximum total call time in seconds, including lock waiting "
+                        "(0 = no timeout)."
+                    ),
+                },
+                "allow_concurrent": {
+                    "type": "boolean",
+                    "description": (
+                        "Skip the unsafe-tool concurrency lock only when it is safe "
+                        "to run concurrently."
+                    ),
                 },
             },
             "required": ["command"],

--- a/src/kohakuterrarium/builtins/tools/bash.py
+++ b/src/kohakuterrarium/builtins/tools/bash.py
@@ -1,7 +1,6 @@
 """Cross-platform shell command execution with bounded output and timeouts."""
 
 import asyncio
-import math
 import os
 import shutil
 import subprocess
@@ -29,6 +28,7 @@ from kohakuterrarium.utils.mobile_sandbox import (
     sandbox_bin_dir,
     sandbox_binary,
 )
+from kohakuterrarium.utils.timeouts import resolve_timeout_arg
 
 logger = get_logger(__name__)
 
@@ -146,24 +146,6 @@ def _get_available_shells() -> list[str]:
             name for name in _SHELL_SPECS if _resolve_shell_executable(name)
         ]
     return _AVAILABLE_SHELLS
-
-
-def _resolve_timeout_arg(
-    args: dict[str, Any], default_timeout: float
-) -> tuple[float, str | None]:
-    """Resolve per-call timeout, falling back to the configured default."""
-    raw_timeout = args.get("timeout", default_timeout)
-    if raw_timeout in (None, ""):
-        raw_timeout = default_timeout
-    try:
-        timeout = float(raw_timeout)
-    except (TypeError, ValueError):
-        return 0.0, f"timeout must be numeric, got {raw_timeout!r}"
-    if not math.isfinite(timeout):
-        return 0.0, "timeout must be finite"
-    if timeout < 0:
-        return 0.0, "timeout must be >= 0"
-    return timeout, None
 
 
 def _wait_timeout(timeout: float) -> float | None:
@@ -314,7 +296,7 @@ class ShellTool(BaseTool):
         command = args.get("command", "")
         if not command:
             return ToolResult(error="No command provided")
-        timeout, timeout_error = _resolve_timeout_arg(args, self.config.timeout)
+        timeout, timeout_error = resolve_timeout_arg(args, self.config.timeout)
         if timeout_error is not None:
             return ToolResult(error=timeout_error)
 

--- a/src/kohakuterrarium/builtins/tools/python.py
+++ b/src/kohakuterrarium/builtins/tools/python.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from kohakuterrarium.builtins.tools.bash import (
     _format_timeout,
-    _resolve_timeout_arg,
     _subprocess_runner,
     _wait_timeout,
 )
@@ -23,6 +22,7 @@ from kohakuterrarium.builtins.tools.subprocess.shell_utils import (
     windows_process_kwargs,
 )
 from kohakuterrarium.modules.tool.base import BaseTool, ExecutionMode, ToolResult
+from kohakuterrarium.utils.timeouts import resolve_timeout_arg
 from kohakuterrarium.utils.logging import get_logger
 from kohakuterrarium.utils.mobile_sandbox import is_mobile_profile
 
@@ -66,7 +66,7 @@ class PythonTool(BaseTool):
         code = args.get("code", "")
         if not code:
             return ToolResult(error="No code provided")
-        timeout, timeout_error = _resolve_timeout_arg(args, self.config.timeout)
+        timeout, timeout_error = resolve_timeout_arg(args, self.config.timeout)
         if timeout_error is not None:
             return ToolResult(error=timeout_error)
 

--- a/src/kohakuterrarium/core/executor.py
+++ b/src/kohakuterrarium/core/executor.py
@@ -4,6 +4,7 @@ import asyncio
 from pathlib import Path
 from typing import Any, Callable
 
+from kohakuterrarium.builtins.tools.bash import _resolve_timeout_arg
 from kohakuterrarium.core.events import TriggerEvent, create_tool_complete_event
 from kohakuterrarium.core.job import (
     JobResult,
@@ -14,7 +15,7 @@ from kohakuterrarium.core.job import (
     generate_job_id,
 )
 from kohakuterrarium.core.tool_output import normalize_tool_output
-from kohakuterrarium.modules.tool.base import BaseTool, Tool, ToolContext
+from kohakuterrarium.modules.tool.base import BaseTool, Tool, ToolContext, ToolResult
 from kohakuterrarium.parsing.events import ToolCallEvent
 from kohakuterrarium.utils.logging import get_logger
 from kohakuterrarium.utils.mobile_sandbox import default_workdir
@@ -201,6 +202,70 @@ class Executor:
             return False
         return True
 
+    async def _run_bash(
+        self,
+        tool: Tool,
+        args: dict[str, Any],
+        exec_fn: Callable[..., Any],
+        context: ToolContext,
+        needs_lock: bool,
+        allow_concurrent: bool,
+    ) -> ToolResult:
+        """Run Bash with one timeout budget shared by lock and subprocess."""
+        timeout, timeout_error = _resolve_timeout_arg(
+            args, tool.config.timeout if isinstance(tool, BaseTool) else 60.0
+        )
+        if timeout_error is not None:
+            return ToolResult(error=timeout_error)
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout if timeout > 0 else None
+        execute_args = dict(args)
+        lock_acquired = False
+        wait_start = loop.time()
+        try:
+            if needs_lock and not allow_concurrent:
+                if self._serial_lock is None:
+                    self._serial_lock = asyncio.Lock()
+                remaining = deadline - loop.time() if deadline is not None else None
+                try:
+                    if remaining is None:
+                        await self._serial_lock.acquire()
+                    else:
+                        await asyncio.wait_for(
+                            self._serial_lock.acquire(), timeout=max(0, remaining)
+                        )
+                except asyncio.TimeoutError:
+                    wait_ms = (loop.time() - wait_start) * 1000.0
+                    self._emit_tool_wait(tool.tool_name, wait_ms, "serial_lock")
+                    return ToolResult(
+                        error="Concurrency lock timeout; command not started; "
+                        "retry with allow_concurrent=true if safe.",
+                        metadata={
+                            "blocked": True,
+                            "blocked_by": "concurrency_lock",
+                            "command_started": False,
+                        },
+                    )
+                lock_acquired = True
+                wait_ms = (loop.time() - wait_start) * 1000.0
+                if wait_ms >= 1.0:
+                    self._emit_tool_wait(tool.tool_name, wait_ms, "serial_lock")
+
+            remaining = deadline - loop.time() if deadline is not None else None
+            if remaining is not None:
+                if remaining <= 0:
+                    return ToolResult(
+                        error="Command timed out before it started.",
+                        exit_code=-1,
+                        metadata={"timed_out": True, "command_started": False},
+                    )
+                execute_args["timeout"] = remaining
+            return await exec_fn(execute_args, context=context)
+        finally:
+            if lock_acquired:
+                self._serial_lock.release()
+
     async def _run_tool(
         self,
         job_id: str,
@@ -247,7 +312,19 @@ class Executor:
 
             # Only tools that declare unsafe shared-state access are serialized.
             needs_lock = isinstance(tool, BaseTool) and not tool.is_concurrency_safe
-            if needs_lock:
+            allow_concurrent = (
+                str(args.get("allow_concurrent", "")).strip().lower() == "true"
+            )
+            if tool.tool_name == "bash":
+                result = await self._run_bash(
+                    tool,
+                    args,
+                    exec_fn,
+                    context,
+                    needs_lock,
+                    allow_concurrent,
+                )
+            elif needs_lock and not allow_concurrent:
                 if self._serial_lock is None:
                     self._serial_lock = asyncio.Lock()
                 wait_start = asyncio.get_event_loop().time()

--- a/src/kohakuterrarium/core/executor.py
+++ b/src/kohakuterrarium/core/executor.py
@@ -4,7 +4,6 @@ import asyncio
 from pathlib import Path
 from typing import Any, Callable
 
-from kohakuterrarium.builtins.tools.bash import _resolve_timeout_arg
 from kohakuterrarium.core.events import TriggerEvent, create_tool_complete_event
 from kohakuterrarium.core.job import (
     JobResult,
@@ -19,6 +18,7 @@ from kohakuterrarium.modules.tool.base import BaseTool, Tool, ToolContext, ToolR
 from kohakuterrarium.parsing.events import ToolCallEvent
 from kohakuterrarium.utils.logging import get_logger
 from kohakuterrarium.utils.mobile_sandbox import default_workdir
+from kohakuterrarium.utils.timeouts import resolve_timeout_arg
 
 logger = get_logger(__name__)
 
@@ -212,7 +212,7 @@ class Executor:
         allow_concurrent: bool,
     ) -> ToolResult:
         """Run Bash with one timeout budget shared by lock and subprocess."""
-        timeout, timeout_error = _resolve_timeout_arg(
+        timeout, timeout_error = resolve_timeout_arg(
             args, tool.config.timeout if isinstance(tool, BaseTool) else 60.0
         )
         if timeout_error is not None:

--- a/src/kohakuterrarium/llm/tool_schemas.py
+++ b/src/kohakuterrarium/llm/tool_schemas.py
@@ -17,7 +17,17 @@ _BUILTIN_SCHEMAS: dict[str, dict] = {
             },
             "timeout": {
                 "type": "number",
-                "description": "Maximum execution time in seconds (0 = no timeout).",
+                "description": (
+                    "Maximum total call time in seconds, including lock waiting "
+                    "(0 = no timeout)."
+                ),
+            },
+            "allow_concurrent": {
+                "type": "boolean",
+                "description": (
+                    "Skip the unsafe-tool concurrency lock only when it is safe "
+                    "to run concurrently."
+                ),
             },
         },
         "required": ["command"],

--- a/src/kohakuterrarium/utils/timeouts.py
+++ b/src/kohakuterrarium/utils/timeouts.py
@@ -1,0 +1,22 @@
+"""Shared timeout argument parsing helpers."""
+
+import math
+from typing import Any
+
+
+def resolve_timeout_arg(
+    args: dict[str, Any], default_timeout: float
+) -> tuple[float, str | None]:
+    """Resolve a per-call timeout, falling back to the configured default."""
+    raw_timeout = args.get("timeout", default_timeout)
+    if raw_timeout in (None, ""):
+        raw_timeout = default_timeout
+    try:
+        timeout = float(raw_timeout)
+    except (TypeError, ValueError):
+        return 0.0, f"timeout must be numeric, got {raw_timeout!r}"
+    if not math.isfinite(timeout):
+        return 0.0, "timeout must be finite"
+    if timeout < 0:
+        return 0.0, "timeout must be >= 0"
+    return timeout, None

--- a/tests/unit/core/test_executor.py
+++ b/tests/unit/core/test_executor.py
@@ -75,14 +75,15 @@ class _ManualReadTool(BaseTool):
 class _UnsafeTool(BaseTool):
     is_concurrency_safe = False
 
-    def __init__(self, hold_seconds=0.05):
-        super().__init__()
+    def __init__(self, hold_seconds=0.05, *, timeout=60.0, name="unsafe"):
+        super().__init__(ToolConfig(timeout=timeout))
         self.hold = hold_seconds
+        self.name = name
         self.starts: list[float] = []
 
     @property
     def tool_name(self):
-        return "unsafe"
+        return self.name
 
     @property
     def description(self):
@@ -373,13 +374,92 @@ class TestSerialLock:
             ex.submit("unsafe", {}),
             ex.submit("unsafe", {}),
         )
-        # Wait all.
         results = await ex.wait_all(timeout=5.0)
         assert len(results) == 3
-        # Each run started AT LEAST hold_seconds after the previous one.
         starts = sorted(tool.starts)
         for a, b in zip(starts, starts[1:]):
-            assert b - a >= 0.02  # roughly the hold time
+            assert b - a >= 0.02
+
+    async def test_allow_concurrent_skips_serial_lock(self):
+        ex = Executor()
+        tool = _UnsafeTool(hold_seconds=0.03)
+        ex.register_tool(tool)
+        await ex.submit("unsafe", {})
+        await asyncio.sleep(0)
+        concurrent = await ex.submit("unsafe", {"allow_concurrent": True})
+        await ex.wait_for(concurrent, timeout=1.0)
+
+        assert len(tool.starts) == 2
+        assert tool.starts[1] - tool.starts[0] < 0.02
+
+    async def test_text_allow_concurrent_skips_serial_lock(self):
+        ex = Executor()
+        tool = _UnsafeTool(hold_seconds=0.03)
+        ex.register_tool(tool)
+        await ex.submit("unsafe", {})
+        await asyncio.sleep(0)
+        concurrent = await ex.submit("unsafe", {"allow_concurrent": "true"})
+        await ex.wait_for(concurrent, timeout=1.0)
+
+        assert len(tool.starts) == 2
+
+    async def test_bash_timeout_includes_lock_wait(self):
+        ex = Executor()
+        tool = _UnsafeTool(hold_seconds=0.08, timeout=0.02, name="bash")
+        ex.register_tool(tool)
+        await ex.submit("bash", {})
+        await asyncio.sleep(0)
+        blocked = await ex.submit("bash", {"timeout": 0.01})
+        result = await ex.wait_for(blocked, timeout=1.0)
+
+        assert result is not None
+        assert result.metadata["blocked"] is True
+        assert result.metadata["command_started"] is False
+        assert len(tool.starts) == 1
+
+    async def test_bash_timeout_budget_is_forwarded_after_lock(self):
+        ex = Executor()
+        tool = _UnsafeTool(hold_seconds=0.01, timeout=0.2, name="bash")
+        ex.register_tool(tool)
+        first = await ex.submit("bash", {})
+        await ex.wait_for(first, timeout=1.0)
+        second = await ex.submit("bash", {"timeout": 0.2})
+        await ex.wait_for(second, timeout=1.0)
+
+        assert len(tool.starts) == 2
+
+    async def test_bash_timeout_rejects_negative_values(self):
+        ex = Executor()
+        tool = _UnsafeTool(name="bash")
+        ex.register_tool(tool)
+        job_id = await ex.submit("bash", {"timeout": -1})
+        result = await ex.wait_for(job_id, timeout=1.0)
+
+        assert result is not None
+        assert result.error == "timeout must be >= 0"
+        assert tool.starts == []
+
+    async def test_bash_timeout_rejects_non_finite_values(self):
+        ex = Executor()
+        tool = _UnsafeTool(name="bash")
+        ex.register_tool(tool)
+        job_id = await ex.submit("bash", {"timeout": "nan"})
+        result = await ex.wait_for(job_id, timeout=1.0)
+
+        assert result is not None
+        assert result.error == "timeout must be finite"
+        assert tool.starts == []
+
+    async def test_allow_concurrent_can_bypass_any_unsafe_tool(self):
+        ex = Executor()
+        tool = _UnsafeTool(hold_seconds=0.03)
+        ex.register_tool(tool)
+        await ex.submit("unsafe", {})
+        await asyncio.sleep(0)
+        concurrent = await ex.submit("unsafe", {"allow_concurrent": True})
+        await ex.wait_for(concurrent, timeout=1.0)
+
+        assert len(tool.starts) == 2
 
 
 # ── wait_for / wait_all timeouts ─────────────────────────────────

--- a/tests/unit/core/test_executor.py
+++ b/tests/unit/core/test_executor.py
@@ -450,17 +450,6 @@ class TestSerialLock:
         assert result.error == "timeout must be finite"
         assert tool.starts == []
 
-    async def test_allow_concurrent_can_bypass_any_unsafe_tool(self):
-        ex = Executor()
-        tool = _UnsafeTool(hold_seconds=0.03)
-        ex.register_tool(tool)
-        await ex.submit("unsafe", {})
-        await asyncio.sleep(0)
-        concurrent = await ex.submit("unsafe", {"allow_concurrent": True})
-        await ex.wait_for(concurrent, timeout=1.0)
-
-        assert len(tool.starts) == 2
-
 
 # ── wait_for / wait_all timeouts ─────────────────────────────────
 


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Fixes #154. Long-running background Bash jobs currently hold the shared unsafe-tool serial lock for their full subprocess lifetime, preventing later Bash calls from starting. This is especially problematic for development servers, watchers, and other long-running commands that must be probed by subsequent tool calls.

## Changes

- Reuse Bash's existing `timeout` as a total call budget that includes unsafe-lock waiting and command execution.
- Support explicit `allow_concurrent=true` to skip the unsafe-tool lock when the caller accepts the concurrency risk.
- Return a structured blocked result when the lock wait consumes the total timeout, without starting the command.
- Move timeout argument parsing into `utils/timeouts.py`, shared by Bash, Python, and the Executor, so core does not depend on a built-in tool implementation.
- Document `allow_concurrent` as an executor-level override for unsafe tools while documenting its Bash usage in the Bash manual.
- Update Bash documentation and native tool schemas.
- Add regression coverage for serial execution, explicit concurrent execution, text-form booleans, lock-timeout blocking, timeout budget propagation, and invalid timeout values; remove redundant coverage identified during review.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
python -m pytest -q tests/unit/core/test_executor.py tests/unit/builtins/tools/test_bash_mobile.py tests/unit/builtins/tools/test_python_tool.py tests/unit/builtins/tools/test_python_tool_mobile.py tests/unit/llm/test_tool_schemas.py tests/unit/test_file_sizes.py
```

Results:

- Ruff passed.
- Black passed (`1491 files would be left unchanged` on the initial change; focused follow-up files also pass `black --check`).
- Focused tests after the Copilot follow-ups passed: `1754 passed`.
- Full `tests/unit/` was run locally on the original implementation: `13551 passed, 9 skipped, 2 failed`.
- The two failures are pre-existing unrelated Studio durability-warning tests on this Windows environment:
  - `tests/unit/studio/test_drive_settings.py::TestSaveDurability::test_dir_barrier_einval_reports_file_only_and_warns`
  - `tests/unit/studio/test_drive_settings_io.py::TestAtomicWriteDirBarrier::test_dir_fsync_einval_is_tolerated_but_signalled`

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #154 (opened before this PR)

## Notes for Reviewers

- Copilot review follow-ups are addressed in commit `83e942b8`.
- `allow_concurrent=true` is intentionally an explicit use-at-your-own-risk override for any unsafe tool. It only changes executor lock scheduling; it does not bypass sandbox or other tool policies.
- `timeout=0` retains the existing no-timeout behavior.
- The change is scoped to the existing shared unsafe-tool lock and Bash's existing timeout path; it does not add a new timeout configuration field or alter Job/Event APIs.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None intended. Existing calls remain serialized unless they explicitly pass `allow_concurrent=true`; Bash timeout semantics now include time spent waiting for the unsafe-tool lock.

## Exceptions / Not Run

- The full unit tier was run before the Copilot follow-up refactor. Two unrelated Studio durability-warning tests fail on this Windows environment; the modified-file focused tests pass after the follow-up.
- Frontend checks were not run locally because no frontend files changed.
- Fork CI for the follow-up commit is running; the initial PR workflow was green before the follow-up commit.
