### PR TITLE
feat: add configurable DeepSeek web search backend

### DIFF
--- a/docs/en/guides/configuration.md
+++ b/docs/en/guides/configuration.md
@@ -96,10 +96,15 @@ With options:
 ```yaml
 tools:
   - name: web_search
-    options:
-      max_results: 10
-      region: us-en
+    backend: duckduckgo
+    deepseek_model: deepseek-v4-flash
+    fallback: none
 ```
+
+`web_search` keeps DuckDuckGo as its no-key default. To opt into DeepSeek,
+run `kt config key set deepseek`, then either set `backend: deepseek` in the
+creature config or switch the live creature with
+`/module set web_search backend deepseek`.
 
 Custom (local module):
 

--- a/docs/en/reference/builtins.md
+++ b/docs/en/reference/builtins.md
@@ -107,8 +107,9 @@ timeout. Direct.
 
 - Args: `url`.
 
-**`web_search`**: DuckDuckGo search returning markdown-formatted
-results. Direct.
+**`web_search`**: Web search with a DuckDuckGo default and an optional
+DeepSeek Responses backend. DeepSeek requires `kt config key set deepseek`;
+switch per creature with `/module set web_search backend deepseek`. Direct.
 
 - Args: `query`, `max_results` (int), `region` (str).
 

--- a/docs/zh-CN/guides/configuration.md
+++ b/docs/zh-CN/guides/configuration.md
@@ -90,10 +90,15 @@ tools:
 ```yaml
 tools:
   - name: web_search
-    options:
-      max_results: 10
-      region: us-en
+    backend: duckduckgo
+    deepseek_model: deepseek-v4-flash
+    fallback: none
 ```
+
+`web_search` 默认使用无需 Key 的 DuckDuckGo。若要启用 DeepSeek，先执行
+`kt config key set deepseek`，再在 Creature 配置中设置
+`backend: deepseek`，或通过 `/module set web_search backend deepseek`
+切换当前 Creature。
 
 本地 custom 模块：
 

--- a/docs/zh-CN/reference/builtins.md
+++ b/docs/zh-CN/reference/builtins.md
@@ -88,7 +88,9 @@ KohakuTerrarium 随附的所有内置工具、子代理、输入、输出、用�
 
 - 参数：`url`。
 
- **`web_search`**：使用 DuckDuckGo 搜索，返回 Markdown 格式结果。直接执行。
+ **`web_search`**：默认使用 DuckDuckGo，也可选择 DeepSeek Responses
+搜索后端。DeepSeek 需要先执行 `kt config key set deepseek`，再通过
+`/module set web_search backend deepseek` 为当前 Creature 启用。直接执行。
 
 - 参数：`query`、`max_results`（int）、`region`（str）。
 

--- a/docs/zh-TW/guides/configuration.md
+++ b/docs/zh-TW/guides/configuration.md
@@ -90,10 +90,15 @@ tools:
 ```yaml
 tools:
   - name: web_search
-    options:
-      max_results: 10
-      region: us-en
+    backend: duckduckgo
+    deepseek_model: deepseek-v4-flash
+    fallback: none
 ```
+
+`web_search` 預設使用不需 Key 的 DuckDuckGo。若要啟用 DeepSeek，先執行
+`kt config key set deepseek`，再於 Creature 設定中指定
+`backend: deepseek`，或透過 `/module set web_search backend deepseek`
+切換目前的 Creature。
 
 本地 custom 模組：
 

--- a/docs/zh-TW/reference/builtins.md
+++ b/docs/zh-TW/reference/builtins.md
@@ -91,7 +91,9 @@ KohakuTerrarium 隨附的所有內建工具、子代理、輸入、輸出、使�
 
 - 參數：`url`。
 
-**`web_search`**：使用 DuckDuckGo 搜尋，回傳 markdown 格式結果。直接執行。
+**`web_search`**：預設使用 DuckDuckGo，也可選擇 DeepSeek Responses
+搜尋後端。DeepSeek 需先執行 `kt config key set deepseek`，再透過
+`/module set web_search backend deepseek` 為目前 Creature 啟用。直接執行。
 
 - 參數：`query`、`max_results`（int）、`region`（str）。
 

--- a/src/kohakuterrarium-frontend/src/components/panels/modules/ModuleEditForm.vue
+++ b/src/kohakuterrarium-frontend/src/components/panels/modules/ModuleEditForm.vue
@@ -13,7 +13,7 @@
 
       <!-- enum -->
       <el-select v-if="entry.spec?.type === 'enum'" v-model="draft[entry.key]" size="small" :placeholder="String(entry.spec?.default ?? '')">
-        <el-option v-for="v in entry.spec?.values || []" :key="v" :value="v" :label="v" />
+        <el-option v-for="v in entry.spec?.values || []" :key="v" :value="v" :label="enumLabel(entry.spec, v)" :disabled="Boolean(entry.spec?.disabled_values?.[v])" />
       </el-select>
 
       <!-- bool -->
@@ -32,6 +32,7 @@
       <el-input v-else v-model="draft[entry.key]" size="small" :placeholder="String(entry.spec?.default ?? '')" />
 
       <p v-if="dictErrors[entry.key]" class="text-[10px] text-coral font-mono">{{ dictErrors[entry.key] }}</p>
+      <p v-for="(reason, value) in entry.spec?.disabled_values || {}" :key="`${entry.key}-${value}`" class="text-[10px] text-warm-400">{{ value }} unavailable: {{ reason }}</p>
     </div>
 
     <!-- status indicator (auto-sync) ─────────────────────────── -->
@@ -115,6 +116,10 @@ const hasDictError = computed(() => Object.values(dictErrors.value).some(Boolean
 function isWide(entry) {
   const t = entry?.spec?.type
   return t === "list" || t === "dict"
+}
+
+function enumLabel(spec, value) {
+  return spec?.disabled_values?.[value] ? `${value} — unavailable` : value
 }
 
 function deepClone(v) {

--- a/src/kohakuterrarium-frontend/src/components/panels/modules/ModulesPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/panels/modules/ModulesPanel.vue
@@ -129,6 +129,7 @@ import { moduleAPI } from "@/utils/api"
 const TYPE_LABELS = {
   plugin: "Plugins",
   native_tool: "Native tools",
+  tool: "Tools",
 }
 
 const props = defineProps({
@@ -194,7 +195,7 @@ const typeTabs = computed(() => {
   // Stable order: plugin first, native_tool second, then any future
   // types alphabetically. Tabs with zero modules are still rendered
   // (disabled) so the structure is predictable across creatures.
-  const order = ["plugin", "native_tool"]
+  const order = ["plugin", "native_tool", "tool"]
   for (const t of [...counts.keys()].sort()) {
     if (!order.includes(t)) order.push(t)
   }
@@ -344,7 +345,7 @@ function pickInitialActiveType() {
   const counts = new Map()
   for (const m of modules.value) counts.set(m.type, (counts.get(m.type) || 0) + 1)
   if (counts.get(activeType.value)) return
-  for (const t of ["plugin", "native_tool"]) {
+  for (const t of ["plugin", "native_tool", "tool"]) {
     if (counts.get(t)) {
       activeType.value = t
       return

--- a/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.vue
+++ b/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.vue
@@ -611,7 +611,8 @@ const nativeToolCatalog = ref([])
 
 const backendsWithAuth = computed(() => {
   const keyMetaByProvider = new Map(providerKeys.value.map((provider) => [provider.provider, provider]))
-  return backends.value.map((backend) => {
+  const backendNames = new Set(backends.value.map((backend) => backend.name))
+  const configuredBackends = backends.value.map((backend) => {
     const keyMeta = keyMetaByProvider.get(backend.name) || {}
     return {
       ...backend,
@@ -620,6 +621,20 @@ const backendsWithAuth = computed(() => {
       masked_key: keyMeta.masked_key || "",
     }
   })
+  const credentialOnlyProviders = providerKeys.value
+    .filter((provider) => !backendNames.has(provider.provider))
+    .map((provider) => ({
+      name: provider.provider,
+      backend_type: provider.backend_type || "credential",
+      base_url: "",
+      available: provider.available === true,
+      built_in: provider.built_in === true,
+      env_var: provider.env_var || "",
+      has_key: provider.has_key === true,
+      masked_key: provider.masked_key || "",
+      credential_only: true,
+    }))
+  return [...configuredBackends, ...credentialOnlyProviders]
 })
 
 const builtInBackends = computed(() => backendsWithAuth.value.filter((b) => b.built_in))

--- a/src/kohakuterrarium/bootstrap/tools.py
+++ b/src/kohakuterrarium/bootstrap/tools.py
@@ -104,6 +104,16 @@ def create_tool(
                     f"Unknown built-in tool: {tool_config.name!r}",
                     tool_name=tool_config.name,
                 )
+            else:
+                try:
+                    tool.validate_runtime_options()
+                except ValueError as exc:
+                    _fail(
+                        strict,
+                        f"Invalid runtime options for tool "
+                        f"{tool_config.name!r}: {exc}",
+                        tool_name=tool_config.name,
+                    )
             return tool
 
         case "trigger":

--- a/src/kohakuterrarium/builtin_skills/tools/web_search.md
+++ b/src/kohakuterrarium/builtin_skills/tools/web_search.md
@@ -7,7 +7,8 @@ tags: [web, search, network]
 
 # web_search
 
-Search the web and return structured results with titles, URLs, and snippets.
+Search the web through the creature's configured backend. DuckDuckGo is the
+default; DeepSeek Responses web search is an explicit opt-in.
 
 ## Arguments
 
@@ -19,9 +20,19 @@ Search the web and return structured results with titles, URLs, and snippets.
 
 ## Behavior
 
-- No API key needed.
-- Results include title, URL, and snippet for each match.
+- DuckDuckGo needs no API key. DeepSeek requires a configured `deepseek` key.
+- DuckDuckGo returns result rows; DeepSeek returns a grounded synthesis plus
+  provider-supplied sources when available.
 - If the search backend is not available, returns an error. Tell the user.
+
+The operator can switch the current creature at runtime:
+
+```text
+kt config key set deepseek
+/module set web_search backend deepseek
+```
+
+`/module reset web_search` restores the creature configuration baseline.
 
 ## WHEN TO USE
 
@@ -48,7 +59,7 @@ Official documentation for the asyncio module...
 
 - Search may not be available in all configurations. If you get an error, tell the user.
 - May be rate-limited under heavy usage.
-- Results depend on the search engine's index and ranking.
+- Results depend on the selected backend's index and ranking.
 
 ## TIPS
 

--- a/src/kohakuterrarium/builtins/cli_rich/dialogs/module_picker.py
+++ b/src/kohakuterrarium/builtins/cli_rich/dialogs/module_picker.py
@@ -1,5 +1,4 @@
-"""Module picker overlay — interactive runtime config for plugins +
-native tools rendered inside the Rich CLI live region.
+"""Module picker overlay for runtime-configurable modules.
 
 Pattern mirrors :class:`SettingsOverlay`:
 
@@ -36,6 +35,7 @@ from kohakuterrarium.builtins.cli_rich.dialogs.module_picker_model import (
 from kohakuterrarium.builtins.cli_rich.dialogs.module_picker_render import (
     render_overlay,
 )
+from kohakuterrarium.core.agent_tool_options import agent_tool_inventory
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -83,6 +83,7 @@ class ModulePicker:
             return
         plugins: list[ModuleEntry] = []
         natives: list[ModuleEntry] = []
+        tools: list[ModuleEntry] = []
         mgr = getattr(agent, "plugins", None)
         if mgr:
             for entry in mgr.list_plugins_with_options():
@@ -123,6 +124,18 @@ class ModulePicker:
                         priority=None,
                     )
                 )
+            for entry in agent_tool_inventory(agent):
+                tools.append(
+                    ModuleEntry(
+                        type="tool",
+                        name=entry["name"],
+                        description=entry.get("description", ""),
+                        schema=entry.get("option_schema", {}),
+                        options=entry.get("values", {}),
+                        enabled=None,
+                        priority=None,
+                    )
+                )
         plugins.sort(
             key=lambda m: (
                 0 if m.enabled else 1,
@@ -131,9 +144,11 @@ class ModulePicker:
             )
         )
         natives.sort(key=lambda m: m.name)
+        tools.sort(key=lambda m: m.name)
         self._entries_by_type = {
             "plugin": plugins,
             "native_tool": natives,
+            "tool": tools,
         }
         for tid, entries in self._entries_by_type.items():
             cur = self._cursor.get(tid, 0)
@@ -267,7 +282,13 @@ class ModulePicker:
             current = entry.options.get(key, spec.get("default"))
             value_text = _stringify(current, kind)
             options = (
-                [str(v) for v in (spec.get("values") or [])] if kind == "enum" else None
+                [
+                    str(v)
+                    for v in (spec.get("values") or [])
+                    if str(v) not in (spec.get("disabled_values") or {})
+                ]
+                if kind == "enum"
+                else None
             )
             fields.append(
                 ModuleFormField(
@@ -276,6 +297,10 @@ class ModulePicker:
                     kind=kind,
                     value=value_text,
                     options=options,
+                    unavailable={
+                        str(k): str(v)
+                        for k, v in (spec.get("disabled_values") or {}).items()
+                    },
                     doc=spec.get("doc", "") or "",
                     minimum=spec.get("min"),
                     maximum=spec.get("max"),
@@ -429,6 +454,11 @@ class ModulePicker:
                 merged = dict(helper.get(target.name))
                 merged.update(diff)
                 helper.set(target.name, merged)
+            elif target.type == "tool":
+                helper = getattr(agent, "tool_options", None)
+                if helper is None:
+                    raise RuntimeError("agent has no tool_options helper")
+                helper.set(target.name, diff)
             else:
                 raise ValueError(f"Unsupported module type: {target.type!r}")
         except Exception as e:

--- a/src/kohakuterrarium/builtins/cli_rich/dialogs/module_picker_model.py
+++ b/src/kohakuterrarium/builtins/cli_rich/dialogs/module_picker_model.py
@@ -11,7 +11,7 @@ types), a navigable list with a toggle column for plugins, and an
 edit form whose fields are derived from each module's
 ``option_schema``. Every operation routes through the same agent
 helpers (``agent.plugins`` / ``agent.plugin_options`` /
-``agent.native_tool_options``) the other surfaces use, so behaviour
+``agent.native_tool_options`` / ``agent.tool_options``) the other surfaces use, so behaviour
 stays consistent.
 """
 
@@ -22,8 +22,9 @@ from typing import Any
 TAB_LABELS = {
     "plugin": "Plugins",
     "native_tool": "Native tools",
+    "tool": "Tools",
 }
-DEFAULT_TAB_ORDER: list[str] = ["plugin", "native_tool"]
+DEFAULT_TAB_ORDER: list[str] = ["plugin", "native_tool", "tool"]
 
 
 @dataclass
@@ -48,6 +49,7 @@ class ModuleFormField:
     kind: str
     value: str = ""
     options: list[str] | None = None
+    unavailable: dict[str, str] = field(default_factory=dict)
     doc: str = ""
     minimum: float | None = None
     maximum: float | None = None

--- a/src/kohakuterrarium/builtins/cli_rich/dialogs/module_picker_render.py
+++ b/src/kohakuterrarium/builtins/cli_rich/dialogs/module_picker_render.py
@@ -203,6 +203,8 @@ def _render_value(fld: "ModuleFormField", is_current: bool) -> Text:
                 out.append(f"[{opt}]", style="cyan bold")
             else:
                 out.append(f" {opt} ", style="dim")
+        for opt in fld.unavailable:
+            out.append(f" {opt} (unavailable) ", style="dim red")
         return out
     if fld.kind == "bool":
         for opt in ("true", "false"):

--- a/src/kohakuterrarium/builtins/cli_rich/dialogs/settings.py
+++ b/src/kohakuterrarium/builtins/cli_rich/dialogs/settings.py
@@ -176,6 +176,17 @@ class SettingsOverlay:
                     "readonly": False,
                 }
             )
+        for name in sorted(set(PROVIDER_KEY_MAP) - set(backends)):
+            key = get_api_key(name)
+            rows.append(
+                {
+                    "provider": name,
+                    "masked": _mask_key(key) if key else "(not set)",
+                    "has_key": bool(key),
+                    "env": PROVIDER_KEY_MAP[name],
+                    "readonly": False,
+                }
+            )
         return rows
 
     def _load_providers(self) -> list[dict[str, Any]]:

--- a/src/kohakuterrarium/builtins/tools/web_search.py
+++ b/src/kohakuterrarium/builtins/tools/web_search.py
@@ -1,24 +1,26 @@
-"""DuckDuckGo web search with an HTTP fallback for unsupported runtimes.
-
-The optional ``ddgs`` backend is preferred where available. A pure-HTTP parser
-keeps search usable on platforms where its native dependency cannot run.
-"""
+"""Web search with selectable DuckDuckGo and DeepSeek backends."""
 
 import asyncio
 import html as _html
 import re
+import time
+from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 import httpx
 
 from kohakuterrarium.builtins.tools.registry import register_builtin
+from kohakuterrarium.llm.api_keys import get_api_key, has_api_key
 from kohakuterrarium.modules.tool.base import BaseTool, ExecutionMode, ToolResult
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 MAX_RESULTS = 10
+DEEPSEEK_RESPONSES_URL = "https://api.deepseek.com/responses"
+DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-flash"
+DEEPSEEK_MODELS = ("deepseek-v4-flash", "deepseek-v4-pro")
 
 
 # Prefer the current optional package, then its legacy predecessor; ``None``
@@ -37,9 +39,155 @@ def _has_ddg() -> bool:
     return DDGS is not None
 
 
+class SearchBackendError(RuntimeError):
+    """Base error for a configured search backend."""
+
+
+class SearchBackendUnavailable(SearchBackendError):
+    """Raised for configuration or authentication failures."""
+
+
+class SearchBackendOperationalError(SearchBackendError):
+    """Raised for transient failures eligible for explicit fallback."""
+
+
+@dataclass
+class SearchResponse:
+    """Normalized backend response rendered by ``WebSearchTool``."""
+
+    output: str
+    sources: list[dict[str, str]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class DuckDuckGoSearchBackend:
+    """Run the existing DDGS-to-HTML fallback chain."""
+
+    async def search(self, query: str, max_results: int, region: str) -> SearchResponse:
+        results: list[dict] = []
+        ddgs_error: Exception | None = None
+        if _has_ddg():
+            try:
+                results = await _search_ddg(query, max_results, region)
+            except Exception as exc:  # noqa: BLE001 - selects the HTTP fallback
+                ddgs_error = exc
+                logger.warning(
+                    "ddgs search failed, falling back to httpx scraper",
+                    error=str(exc),
+                )
+
+        if not results:
+            try:
+                results = await _search_httpx_ddg(query, max_results, region)
+            except Exception as exc:
+                detail = ddgs_error or exc
+                raise SearchBackendOperationalError(
+                    f"DuckDuckGo search failed: {detail}"
+                ) from exc
+
+        if not results:
+            return SearchResponse(
+                output="No results found.", metadata={"backend": "duckduckgo"}
+            )
+        return SearchResponse(
+            output=_render_ddg_results(query, results),
+            sources=[
+                {
+                    "title": str(result.get("title", "")),
+                    "url": str(result.get("href", result.get("url", ""))),
+                }
+                for result in results
+                if result.get("href") or result.get("url")
+            ],
+            metadata={"backend": "duckduckgo", "result_count": len(results)},
+        )
+
+
+class DeepSeekSearchBackend:
+    """Use DeepSeek Responses API server-side web search."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+
+    async def search(self, query: str, max_results: int, region: str) -> SearchResponse:
+        key = get_api_key("deepseek")
+        if not key:
+            raise SearchBackendUnavailable(
+                "DeepSeek API key is not configured. Run: kt config key set deepseek"
+            )
+        preference = f" Prefer results relevant to region {region}." if region else ""
+        prompt = (
+            f"Search the web for: {query}.{preference} "
+            f"Return a concise answer grounded in up to {max_results} sources."
+        )
+        payload = {
+            "model": self.model,
+            "input": prompt,
+            "tools": [{"type": "web_search"}],
+            "tool_choice": {"type": "web_search"},
+        }
+        headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+        try:
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                response = await client.post(
+                    DEEPSEEK_RESPONSES_URL, headers=headers, json=payload
+                )
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise SearchBackendOperationalError(
+                "DeepSeek search is temporarily unavailable"
+            ) from exc
+
+        if response.status_code in {408, 429} or response.status_code >= 500:
+            raise SearchBackendOperationalError(
+                f"DeepSeek search failed with HTTP {response.status_code}"
+            )
+        if response.status_code in {401, 403}:
+            raise SearchBackendUnavailable(
+                "DeepSeek authentication failed. Update the key with: "
+                "kt config key set deepseek"
+            )
+        if response.status_code >= 400:
+            raise SearchBackendUnavailable(
+                f"DeepSeek search request failed with HTTP {response.status_code}"
+            )
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise SearchBackendOperationalError(
+                "DeepSeek search returned an invalid response"
+            ) from exc
+        if not isinstance(data, dict):
+            raise SearchBackendOperationalError(
+                "DeepSeek search returned an invalid response"
+            )
+        _raise_for_deepseek_response_status(data)
+        normalized = _normalize_deepseek_response(data, query, max_results, self.model)
+        if data.get("status") == "incomplete":
+            reason = _deepseek_incomplete_reason(data)
+            if not _deepseek_has_partial_output(data, normalized):
+                raise SearchBackendUnavailable(
+                    f"DeepSeek search response was incomplete ({reason})"
+                )
+            normalized.output = (
+                f"Incomplete DeepSeek response: {reason}\n\n{normalized.output}"
+            )
+            normalized.metadata["response_status"] = "incomplete"
+            normalized.metadata["incomplete_reason"] = reason
+        elif isinstance(data.get("status"), str):
+            normalized.metadata["response_status"] = data["status"]
+        return normalized
+
+
 @register_builtin("web_search")
 class WebSearchTool(BaseTool):
-    """Return DuckDuckGo result titles, URLs, and snippets."""
+    """Search using a configured backend without changing the caller's LLM."""
+
+    def __init__(self, config=None):
+        super().__init__(config=config)
+        self.backend = "duckduckgo"
+        self.deepseek_model = DEFAULT_DEEPSEEK_MODEL
+        self.fallback = "none"
+        self.refresh_runtime_options(dict(self.config.extra))
 
     @property
     def tool_name(self) -> str:
@@ -53,6 +201,39 @@ class WebSearchTool(BaseTool):
     def execution_mode(self) -> ExecutionMode:
         return ExecutionMode.DIRECT
 
+    def runtime_option_schema(self) -> dict[str, dict[str, Any]]:
+        disabled: dict[str, str] = {}
+        if not has_api_key("deepseek"):
+            disabled["deepseek"] = (
+                "DeepSeek API key is not configured. Run: " "kt config key set deepseek"
+            )
+        return {
+            "backend": {
+                "type": "enum",
+                "values": ["duckduckgo", "deepseek"],
+                "default": "duckduckgo",
+                "disabled_values": disabled,
+                "doc": "Search implementation used by this creature.",
+            },
+            "deepseek_model": {
+                "type": "enum",
+                "values": list(DEEPSEEK_MODELS),
+                "default": DEFAULT_DEEPSEEK_MODEL,
+                "doc": "DeepSeek Responses model used for web search.",
+            },
+            "fallback": {
+                "type": "enum",
+                "values": ["none", "duckduckgo"],
+                "default": "none",
+                "doc": "Fallback for transient DeepSeek failures only.",
+            },
+        }
+
+    def refresh_runtime_options(self, options: dict[str, Any]) -> None:
+        self.backend = str(options.get("backend", "duckduckgo"))
+        self.deepseek_model = str(options.get("deepseek_model", DEFAULT_DEEPSEEK_MODEL))
+        self.fallback = str(options.get("fallback", "none"))
+
     async def _execute(self, args: dict[str, Any], **kwargs: Any) -> ToolResult:
         query = args.get("query", "")
         if not query:
@@ -61,43 +242,265 @@ class WebSearchTool(BaseTool):
         max_results = int(args.get("max_results", MAX_RESULTS))
         region = args.get("region", "")
 
-        results: list[dict] = []
-        ddgs_error: Exception | None = None
-        if _has_ddg():
-            try:
-                results = await _search_ddg(query, max_results, region)
-            except Exception as e:  # noqa: BLE001 - backend failure selects fallback
-                ddgs_error = e
-                logger.warning(
-                    "ddgs search failed, falling back to httpx scraper",
-                    error=str(e),
+        started_at = time.monotonic()
+        try:
+            search_backend = self._backend()
+            response = await search_backend.search(query, max_results, region)
+        except SearchBackendOperationalError as exc:
+            if self.backend == "deepseek" and self.fallback == "duckduckgo":
+                logger.warning("DeepSeek search failed, using configured fallback")
+                try:
+                    response = await DuckDuckGoSearchBackend().search(
+                        query, max_results, region
+                    )
+                except SearchBackendError as fallback_exc:
+                    return ToolResult(error=str(fallback_exc))
+                response.metadata["fallback_from"] = "deepseek"
+                response.metadata["fallback_reason"] = str(exc)
+            else:
+                return ToolResult(error=str(exc))
+        except SearchBackendError as exc:
+            return ToolResult(error=str(exc))
+
+        response.metadata["duration_ms"] = round(
+            (time.monotonic() - started_at) * 1000.0, 1
+        )
+        response.metadata["source_count"] = len(response.sources)
+        response.metadata["session_metadata"] = _search_session_metadata(
+            response.metadata
+        )
+        logger.info(
+            "Web search complete",
+            query=query[:50],
+            backend=response.metadata.get("backend", self.backend),
+        )
+        return ToolResult(
+            output=response.output,
+            exit_code=0,
+            metadata=response.metadata,
+        )
+
+    def _backend(self):
+        if self.backend == "duckduckgo":
+            return DuckDuckGoSearchBackend()
+        if self.backend == "deepseek":
+            return DeepSeekSearchBackend(self.deepseek_model)
+        raise SearchBackendUnavailable(f"Unknown web search backend: {self.backend!r}")
+
+
+def _render_ddg_results(query: str, results: list[dict]) -> str:
+    lines = [f"Search results for: {query}\n"]
+    for i, result in enumerate(results, 1):
+        title = result.get("title", "")
+        url = result.get("href", result.get("url", ""))
+        snippet = result.get("body", result.get("snippet", ""))
+        lines.append(f"## {i}. {title}")
+        lines.append(f"URL: {url}")
+        if snippet:
+            lines.append(snippet)
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _normalize_deepseek_response(
+    data: dict[str, Any], query: str, max_results: int, model: str
+) -> SearchResponse:
+    texts: list[str] = []
+    sources: list[dict[str, str]] = []
+    actions: list[dict[str, Any]] = []
+    annotation_count = 0
+    if isinstance(data.get("output_text"), str):
+        texts.append(data["output_text"])
+    for item in data.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "web_search_call":
+            action = item.get("action")
+            if isinstance(action, dict):
+                actions.append(
+                    {
+                        key: action[key]
+                        for key in ("type", "query", "url", "pattern")
+                        if key in action
+                    }
                 )
+        for part in item.get("content") or []:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") == "output_text" and isinstance(part.get("text"), str):
+                texts.append(part["text"])
+            raw_annotations = part.get("annotations")
+            annotations = raw_annotations if isinstance(raw_annotations, list) else []
+            annotation_count += len(annotations)
+            for annotation in annotations:
+                source = _source_from_annotation(annotation)
+                if source and source not in sources:
+                    sources.append(source)
+    sources = sources[:max_results]
+    body = "\n\n".join(text.strip() for text in texts if text.strip())
+    if not body and not sources:
+        body = "No results found."
+    output = f"Search results for: {query}\n\n{body}"
+    has_text_links = "http://" in body or "https://" in body
+    citation_status = (
+        "verified" if sources else "unverified_text" if has_text_links else "none"
+    )
+    if has_text_links:
+        if sources:
+            output += (
+                "\n\nCitation note: Only links in the Sources list below were "
+                "returned as structured citations; other links in the answer text "
+                "are unverified provider text."
+            )
+        else:
+            output += (
+                "\n\nCitation note: Links in the answer text are unverified provider "
+                "text because no structured citation annotations were returned."
+            )
+    if sources:
+        output += "\n\nSources:\n" + "\n".join(
+            f"{index}. [{source['title']}]({source['url']})"
+            for index, source in enumerate(sources, 1)
+        )
+    usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+    return SearchResponse(
+        output=output,
+        sources=sources,
+        metadata={
+            "backend": "deepseek",
+            "model": model,
+            "sources": sources,
+            "verified_sources": sources,
+            "source_count": len(sources),
+            "annotation_count": annotation_count,
+            "citation_status": citation_status,
+            "actions": actions,
+            "usage": usage,
+            "response_status": (
+                data["status"]
+                if isinstance(data.get("status"), str)
+                else "not_reported"
+            ),
+        },
+    )
 
-        if not results:
-            try:
-                results = await _search_httpx_ddg(query, max_results, region)
-            except Exception as e:
-                # The primary backend generally carries more actionable context
-                # than the lower-level HTTP failure.
-                detail = ddgs_error or e
-                return ToolResult(error=f"Search failed: {detail}")
 
-        if not results:
-            return ToolResult(output="No results found.", exit_code=0)
+def _search_session_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Select non-secret search diagnostics for session persistence."""
+    keys = (
+        "backend",
+        "model",
+        "response_status",
+        "citation_status",
+        "annotation_count",
+        "source_count",
+        "result_count",
+        "fallback_from",
+        "fallback_reason",
+        "duration_ms",
+    )
+    result = {key: metadata[key] for key in keys if key in metadata}
+    sources = metadata.get("verified_sources")
+    if isinstance(sources, list):
+        result["verified_sources"] = [
+            {"title": source["title"], "url": source["url"]}
+            for source in sources
+            if isinstance(source, dict)
+            and isinstance(source.get("title"), str)
+            and isinstance(source.get("url"), str)
+        ]
+    usage = metadata.get("usage")
+    if isinstance(usage, dict):
+        result["usage"] = {
+            str(key): value
+            for key, value in usage.items()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        }
+    return result
 
-        lines = [f"Search results for: {query}\n"]
-        for i, r in enumerate(results, 1):
-            title = r.get("title", "")
-            url = r.get("href", r.get("url", ""))
-            snippet = r.get("body", r.get("snippet", ""))
-            lines.append(f"## {i}. {title}")
-            lines.append(f"URL: {url}")
-            if snippet:
-                lines.append(snippet)
-            lines.append("")
 
-        logger.info("Web search complete", query=query[:50], results=len(results))
-        return ToolResult(output="\n".join(lines), exit_code=0)
+_TRANSIENT_DEEPSEEK_ERROR_MARKERS = (
+    "rate_limit",
+    "server_error",
+    "internal_error",
+    "overload",
+    "service_unavailable",
+    "temporarily_unavailable",
+    "timeout",
+)
+
+
+def _raise_for_deepseek_response_status(data: dict[str, Any]) -> None:
+    """Map terminal Responses API state into the configured fallback boundary."""
+    status = data.get("status")
+    if status in (None, "completed", "incomplete"):
+        return
+    if status == "failed":
+        code = _deepseek_error_code(data.get("error"))
+        message = f"DeepSeek search failed ({code})"
+        if any(marker in code.lower() for marker in _TRANSIENT_DEEPSEEK_ERROR_MARKERS):
+            raise SearchBackendOperationalError(message)
+        raise SearchBackendUnavailable(message)
+    if isinstance(status, str):
+        raise SearchBackendUnavailable(
+            f"DeepSeek search returned unexpected status {status!r}"
+        )
+    raise SearchBackendUnavailable("DeepSeek search returned an invalid status")
+
+
+def _deepseek_error_code(error: Any) -> str:
+    if isinstance(error, dict):
+        raw = error.get("code") or error.get("type")
+    else:
+        raw = None
+    code = str(raw or "unknown_error")[:80]
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", code)
+
+
+def _deepseek_incomplete_reason(data: dict[str, Any]) -> str:
+    details = data.get("incomplete_details")
+    raw = details.get("reason") if isinstance(details, dict) else None
+    reason = str(raw or "unknown_reason")[:80]
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", reason)
+
+
+def _deepseek_has_partial_output(
+    data: dict[str, Any], response: SearchResponse
+) -> bool:
+    if isinstance(data.get("output_text"), str) and data["output_text"].strip():
+        return True
+    if response.sources:
+        return True
+    for item in data.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        for part in item.get("content") or []:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "output_text"
+                and isinstance(part.get("text"), str)
+                and part["text"].strip()
+            ):
+                return True
+    return False
+
+
+def _source_from_annotation(annotation: Any) -> dict[str, str] | None:
+    if not isinstance(annotation, dict):
+        return None
+    citation = annotation.get("url_citation")
+    if isinstance(citation, dict):
+        source = citation
+    elif annotation.get("type") == "url_citation":
+        source = annotation
+    else:
+        return None
+    url = str(source.get("url", ""))
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    title = str(source.get("title") or parsed.netloc)
+    return {"title": title, "url": url}
 
 
 async def _search_ddg(query: str, max_results: int, region: str) -> list[dict]:

--- a/src/kohakuterrarium/builtins/tui/widgets/modules_modal.py
+++ b/src/kohakuterrarium/builtins/tui/widgets/modules_modal.py
@@ -1,4 +1,4 @@
-"""Inspect and mutate live plugin and provider-native tool configuration.
+"""Inspect and mutate live plugin and tool configuration.
 
 The inventory normalizes both module kinds into one schema-driven UI; writes go
 through the agent's option helpers so validation and prompt refresh stay centralized.
@@ -23,13 +23,14 @@ from textual.widgets import (
     TextArea,
 )
 
+from kohakuterrarium.core.agent_tool_options import agent_tool_inventory
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 
 def _list_modules(agent: Any) -> list[dict[str, Any]]:
-    """Normalize configurable plugins and provider-native tools for the UI."""
+    """Normalize configurable modules for the UI."""
     out: list[dict[str, Any]] = []
     mgr = getattr(agent, "plugins", None)
     if mgr:
@@ -46,6 +47,18 @@ def _list_modules(agent: Any) -> list[dict[str, Any]]:
                 }
             )
     registry = getattr(agent, "registry", None)
+    for entry in agent_tool_inventory(agent):
+        out.append(
+            {
+                "type": "tool",
+                "name": entry["name"],
+                "description": entry.get("description", ""),
+                "schema": entry.get("option_schema", {}),
+                "options": entry.get("values", {}),
+                "enabled": None,
+                "priority": None,
+            }
+        )
     helper = getattr(agent, "native_tool_options", None)
     if registry is not None:
         for name in sorted(registry.list_tools()):
@@ -89,6 +102,11 @@ def _apply_options(
         merged = dict(helper.get(m["name"]))
         merged.update(values)
         return helper.set(m["name"], merged)
+    if m["type"] == "tool":
+        helper = getattr(agent, "tool_options", None)
+        if helper is None:
+            raise RuntimeError("agent has no tool_options helper")
+        return helper.set(m["name"], values)
     raise ValueError(f"Unsupported module type: {m['type']!r}")
 
 
@@ -160,6 +178,8 @@ class ModulesModal(ModalScreen[None]):
                     yield DataTable(id="table-plugin", cursor_type="row")
                 with TabPane("Native tools", id="tab-native_tool"):
                     yield DataTable(id="table-native_tool", cursor_type="row")
+                with TabPane("Tools", id="tab-tool"):
+                    yield DataTable(id="table-tool", cursor_type="row")
             yield Static(
                 "enter:edit  t:toggle  /:search  r:reload  esc:close",
                 classes="hint",
@@ -167,7 +187,7 @@ class ModulesModal(ModalScreen[None]):
 
     def on_mount(self) -> None:
         self.query_one("#modules-container", Vertical).border_title = "Modules"
-        for tid in ("plugin", "native_tool"):
+        for tid in ("plugin", "native_tool", "tool"):
             tbl = self.query_one(f"#table-{tid}", DataTable)
             tbl.add_columns("●", "name", "p", "opts")
         self.reload_modules()
@@ -182,13 +202,14 @@ class ModulesModal(ModalScreen[None]):
 
     def _populate_tables(self) -> None:
         q = self._search.strip().lower()
-        for tid in ("plugin", "native_tool"):
+        for tid in ("plugin", "native_tool", "tool"):
             tbl = self.query_one(f"#table-{tid}", DataTable)
             tbl.clear()
             self._row_index[tid] = []
 
         plugins = [m for m in self._modules if m["type"] == "plugin"]
         natives = [m for m in self._modules if m["type"] == "native_tool"]
+        tools = [m for m in self._modules if m["type"] == "tool"]
 
         # Enabled plugins precede disabled plugins; priority orders each group.
         plugin_rows: list[dict[str, Any]] = []
@@ -204,12 +225,17 @@ class ModulesModal(ModalScreen[None]):
             if not _matches(m, q):
                 continue
             self._add_row("native_tool", m)
+        for m in sorted(tools, key=_sort_key):
+            if not _matches(m, q):
+                continue
+            self._add_row("tool", m)
 
         tabs = self.query_one("#modules-tabs", TabbedContent)
         tabs.get_tab("tab-plugin").label = f"Plugins ({len(self._row_index['plugin'])})"
         tabs.get_tab("tab-native_tool").label = (
             f"Native tools ({len(self._row_index['native_tool'])})"
         )
+        tabs.get_tab("tab-tool").label = f"Tools ({len(self._row_index['tool'])})"
 
     def _add_row(self, tid: str, m: dict[str, Any]) -> None:
         tbl = self.query_one(f"#table-{tid}", DataTable)
@@ -399,6 +425,8 @@ class ModuleEditModal(ModalScreen[bool]):
             )
             if doc:
                 yield Label(f"[dim]{doc}[/dim]")
+            for value, reason in (spec.get("disabled_values") or {}).items():
+                yield Label(f"[yellow]{value} unavailable:[/yellow] {reason}")
             widget = self._make_widget(key, kind, spec, current)
             self._widgets[key] = widget
             yield widget
@@ -407,8 +435,10 @@ class ModuleEditModal(ModalScreen[bool]):
         if kind == "bool":
             return Switch(value=bool(current), id=f"f-{_safe(key)}")
         if kind == "enum":
-            opts = [(str(v), str(v)) for v in (spec.get("values") or [])]
-            allowed = {str(v) for v in (spec.get("values") or [])}
+            disabled = set((spec.get("disabled_values") or {}).keys())
+            values = [str(v) for v in (spec.get("values") or [])]
+            opts = [(value, value) for value in values if value not in disabled]
+            allowed = set(values) - disabled
             initial: Any
             if current is not None and str(current) in allowed:
                 initial = str(current)

--- a/src/kohakuterrarium/builtins/user_commands/module.py
+++ b/src/kohakuterrarium/builtins/user_commands/module.py
@@ -1,4 +1,4 @@
-"""Inspect and configure runtime plugins and provider-native tools."""
+"""Inspect and configure runtime plugins and tool options."""
 
 import json
 import os
@@ -11,6 +11,7 @@ from typing import Any
 import yaml
 
 from kohakuterrarium.builtins.user_commands.registry import register_user_command
+from kohakuterrarium.core.agent_tool_options import agent_tool_inventory
 from kohakuterrarium.modules.user_command.base import (
     BaseUserCommand,
     CommandLayer,
@@ -25,7 +26,7 @@ class ModuleCommand(BaseUserCommand):
     aliases = ["modules", "mod"]
     description = (
         "List, inspect, toggle, or edit module options at runtime "
-        "(plugins + provider-native tools). "
+        "(plugins + tools + provider-native tools). "
         "/module enable|disable|set|edit|reset <name> …"
     )
     layer = CommandLayer.AGENT
@@ -78,10 +79,11 @@ class ModuleCommand(BaseUserCommand):
 
 
 def _inventory(agent: Any) -> list[dict[str, Any]]:
-    """Return normalized records for configurable plugins and native tools."""
+    """Return normalized records for every configurable module type."""
     out: list[dict[str, Any]] = []
     out.extend(_inventory_plugins(agent))
     out.extend(_inventory_native_tools(agent))
+    out.extend(_inventory_tools(agent))
     return out
 
 
@@ -135,6 +137,21 @@ def _inventory_native_tools(agent: Any) -> list[dict[str, Any]]:
     return out
 
 
+def _inventory_tools(agent: Any) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "tool",
+            "name": entry["name"],
+            "description": entry.get("description", ""),
+            "schema": entry.get("option_schema", {}),
+            "options": entry.get("values", {}),
+            "enabled": None,
+            "priority": None,
+        }
+        for entry in agent_tool_inventory(agent)
+    ]
+
+
 def _resolve_or_error(agent: Any, ref: str) -> tuple[dict[str, Any] | None, str | None]:
     """Resolve a module reference, returning either its record or an error."""
     inv = _inventory(agent)
@@ -180,6 +197,7 @@ def _render_list(agent: Any, rest: list[str]) -> str:
     out: list[str] = []
     plugins = [m for m in inv if m["type"] == "plugin"]
     native_tools = [m for m in inv if m["type"] == "native_tool"]
+    tools = [m for m in inv if m["type"] == "tool"]
 
     if plugins:
         out.append("Plugins")
@@ -196,6 +214,13 @@ def _render_list(agent: Any, rest: list[str]) -> str:
             out.append("")
         out.append("Native tools")
         for m in sorted(native_tools, key=_sort_key):
+            out.append(_format_row(m))
+
+    if tools:
+        if plugins or native_tools:
+            out.append("")
+        out.append("Tools")
+        for m in sorted(tools, key=_sort_key):
             out.append(_format_row(m))
 
     out.append("")
@@ -242,6 +267,8 @@ def _render_show_module(m: dict[str, Any]) -> str:
         out.append(f"      = {current!r}")
         if spec.get("doc"):
             out.append(f"      {spec['doc']}")
+        for value, reason in (spec.get("disabled_values") or {}).items():
+            out.append(f"      unavailable: {value} — {reason}")
 
     out.append("")
     out.append(
@@ -317,18 +344,35 @@ def _do_reset(agent: Any, rest: list[str]) -> UserCommandResult:
             return UserCommandResult(
                 output=f"Reset all options on plugin/{m['name']} to defaults."
             )
-        helper = getattr(agent, "native_tool_options", None)
+        helper_name = (
+            "native_tool_options" if m["type"] == "native_tool" else "tool_options"
+        )
+        helper = getattr(agent, helper_name, None)
         if helper is None:
-            return UserCommandResult(error="No native_tool_options helper.")
+            return UserCommandResult(error=f"No {helper_name} helper.")
         helper.set(m["name"], {})
         return UserCommandResult(
-            output=f"Cleared overrides on native_tool/{m['name']}."
+            output=f"Cleared overrides on {m['type']}/{m['name']}."
         )
 
     schema = m.get("schema") or {}
     if key not in schema:
         return UserCommandResult(
             error=f"Unknown option {key!r} for {m['type']}/{m['name']}."
+        )
+    if m["type"] == "tool":
+        helper = getattr(agent, "tool_options", None)
+        if helper is None:
+            return UserCommandResult(error="No tool_options helper.")
+        try:
+            applied = helper.set(m["name"], {key: None})
+        except (KeyError, ValueError) as exc:
+            return UserCommandResult(error=str(exc))
+        return UserCommandResult(
+            output=(
+                f"{m['type']}/{m['name']}.{key} = {applied.get(key)!r}  "
+                "(config baseline)"
+            )
         )
     default = (schema[key] or {}).get("default")
     try:
@@ -397,6 +441,11 @@ def _apply_options(
         current = dict(helper.get(m["name"]))
         current.update(values)
         return helper.set(m["name"], current)
+    if m["type"] == "tool":
+        helper = getattr(agent, "tool_options", None)
+        if helper is None:
+            raise RuntimeError("agent has no tool_options helper")
+        return helper.set(m["name"], values)
     raise ValueError(f"Unsupported module type: {m['type']!r}")
 
 

--- a/src/kohakuterrarium/core/agent.py
+++ b/src/kohakuterrarium/core/agent.py
@@ -875,6 +875,17 @@ class Agent(
                     error=str(e),
                     exc_info=True,
                 )
+        tool_options = getattr(self, "tool_options", None)
+        if tool_options is not None:
+            try:
+                tool_options.apply()
+            except Exception as e:
+                logger.warning(
+                    "tool option apply skipped",
+                    agent=self.config.name,
+                    error=str(e),
+                    exc_info=True,
+                )
         plugin_options = getattr(self, "plugin_options", None)
         if plugin_options is not None:
             try:

--- a/src/kohakuterrarium/core/agent_helpers.py
+++ b/src/kohakuterrarium/core/agent_helpers.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from kohakuterrarium.core.agent_native_tools import NativeToolOptions
 from kohakuterrarium.core.agent_plugin_options import PluginOptions
+from kohakuterrarium.core.agent_tool_options import ToolOptions
 from kohakuterrarium.core.agent_workspace import WorkspaceController
 
 if TYPE_CHECKING:
@@ -25,9 +26,12 @@ def attach_session_helpers(agent: "Agent") -> None:
       overrides (see :mod:`agent_native_tools`).
     * ``agent.plugin_options`` — plugin option overrides
       (see :mod:`agent_plugin_options`).
+    * ``agent.tool_options`` — ordinary local-tool option overrides
+      (see :mod:`agent_tool_options`).
     * ``agent.workspace`` — runtime working-directory switch
       (see :mod:`agent_workspace`).
     """
     agent.native_tool_options = NativeToolOptions(agent)
     agent.plugin_options = PluginOptions(agent)
+    agent.tool_options = ToolOptions(agent)
     agent.workspace = WorkspaceController(agent)

--- a/src/kohakuterrarium/core/agent_tool_options.py
+++ b/src/kohakuterrarium/core/agent_tool_options.py
@@ -1,0 +1,278 @@
+"""Session-scoped runtime option overrides for ordinary local tools."""
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from kohakuterrarium.modules.tool.runtime_options import validate_tool_options
+from kohakuterrarium.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from kohakuterrarium.core.agent import Agent
+
+logger = get_logger(__name__)
+
+TOOL_OPTIONS_STATE_SUFFIX = "tool_options"
+
+
+class ToolOptions:
+    """Manage validated overrides while preserving each tool's config baseline."""
+
+    def __init__(self, agent: "Agent") -> None:
+        self._agent = agent
+        self._values: dict[str, dict[str, Any]] = {}
+        self._pending_values: dict[str, dict[str, Any]] = {}
+        self._baselines: dict[str, dict[str, Any]] = {}
+
+    def get(self, tool_name: str) -> dict[str, Any]:
+        """Return effective schema values, including defaults and config baseline."""
+        tool = self._tool(tool_name)
+        schema = self._schema(tool)
+        effective = {
+            key: spec.get("default")
+            for key, spec in schema.items()
+            if isinstance(spec, dict) and "default" in spec
+        }
+        effective.update(self._baseline_values(tool_name, tool, schema))
+        effective.update(self._values.get(tool_name, {}))
+        return effective
+
+    def list(self) -> dict[str, dict[str, Any]]:
+        """Return effective values for tools that currently have overrides."""
+        return {name: self.get(name) for name in self._values}
+
+    def set(self, tool_name: str, values: dict[str, Any]) -> dict[str, Any]:
+        """Patch runtime overrides, or reset them when ``values`` is empty."""
+        tool = self._tool(tool_name)
+        schema = self._schema(tool)
+        baseline = self._baseline_values(tool_name, tool, schema)
+        defaults = {
+            key: spec.get("default")
+            for key, spec in schema.items()
+            if isinstance(spec, dict) and "default" in spec
+        }
+        base_effective = {**defaults, **baseline}
+        if not values:
+            self._values.pop(tool_name, None)
+            self._pending_values.pop(tool_name, None)
+            self._refresh(tool_name, tool, {})
+            self._persist()
+            return self.get(tool_name)
+
+        candidate_overrides = dict(self._values.get(tool_name, {}))
+        for key, value in values.items():
+            if value is None:
+                candidate_overrides.pop(key, None)
+            else:
+                candidate_overrides[key] = value
+        candidate = {**base_effective, **candidate_overrides}
+        cleaned = validate_tool_options(tool_name, candidate, schema)
+        overrides = {
+            key: value
+            for key, value in cleaned.items()
+            if key not in base_effective or value != base_effective[key]
+        }
+        if overrides:
+            self._values[tool_name] = overrides
+        else:
+            self._values.pop(tool_name, None)
+        self._pending_values.pop(tool_name, None)
+        self._refresh(tool_name, tool, overrides)
+        self._persist()
+        return self.get(tool_name)
+
+    def apply(self) -> None:
+        """Load persisted overrides and refresh every still-registered tool."""
+        data = self._load_private_state()
+        previous_tools = set(self._values) | set(self._pending_values)
+        self._values.clear()
+        self._pending_values.clear()
+        for tool_name in previous_tools:
+            try:
+                tool = self._tool(tool_name)
+            except ValueError:
+                continue
+            self._refresh(tool_name, tool, {})
+        if not isinstance(data, dict):
+            self._persist()
+            return
+        for tool_name, values in dict(data).items():
+            if not isinstance(values, dict):
+                continue
+            try:
+                self.set(str(tool_name), values)
+            except (KeyError, ValueError) as exc:
+                try:
+                    pending = self._validate_without_availability(
+                        str(tool_name), values
+                    )
+                except (KeyError, ValueError):
+                    pending = None
+                if pending:
+                    tool = self._tool(str(tool_name))
+                    self._pending_values[str(tool_name)] = pending
+                    self._refresh(str(tool_name), tool, {})
+                    logger.warning(
+                        "tool_options_unavailable_on_apply",
+                        agent_name=getattr(self._agent.config, "name", ""),
+                        tool_name=str(tool_name),
+                        error=str(exc),
+                    )
+                    continue
+                logger.warning(
+                    "tool_options_invalid_on_apply",
+                    agent_name=getattr(self._agent.config, "name", ""),
+                    tool_name=str(tool_name),
+                    error=str(exc),
+                )
+        self._persist()
+
+    def _validate_without_availability(
+        self, tool_name: str, values: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Validate persisted intent while ignoring transient availability gates."""
+        tool = self._tool(tool_name)
+        schema = self._schema(tool)
+        available_schema = {
+            key: {
+                option_key: option_value
+                for option_key, option_value in (
+                    spec.items() if isinstance(spec, dict) else []
+                )
+                if option_key != "disabled_values"
+            }
+            for key, spec in schema.items()
+        }
+        baseline = self._baseline_values(tool_name, tool, schema)
+        defaults = {
+            key: spec.get("default")
+            for key, spec in schema.items()
+            if isinstance(spec, dict) and "default" in spec
+        }
+        base_effective = {**defaults, **baseline}
+        cleaned = validate_tool_options(
+            tool_name, {**base_effective, **values}, available_schema
+        )
+        return {
+            key: value
+            for key, value in cleaned.items()
+            if key not in base_effective or value != base_effective[key]
+        }
+
+    def _tool(self, tool_name: str) -> Any:
+        registry = getattr(self._agent, "registry", None)
+        tool = registry.get_tool(tool_name) if registry is not None else None
+        if tool is None or getattr(tool, "is_provider_native", False):
+            raise ValueError(f"Unknown configurable tool: {tool_name}")
+        if not self._schema(tool):
+            raise ValueError(f"Tool has no runtime options: {tool_name}")
+        return tool
+
+    @staticmethod
+    def _schema(tool: Any) -> dict[str, dict[str, Any]]:
+        schema_fn = getattr(tool, "runtime_option_schema", None)
+        schema = schema_fn() if callable(schema_fn) else {}
+        return schema if isinstance(schema, dict) else {}
+
+    def _baseline_values(
+        self,
+        tool_name: str,
+        tool: Any,
+        schema: dict[str, dict[str, Any]],
+    ) -> dict[str, Any]:
+        if tool_name not in self._baselines:
+            config = getattr(tool, "config", None)
+            self._baselines[tool_name] = dict(getattr(config, "extra", {}) or {})
+        baseline = self._baselines[tool_name]
+        return {key: baseline[key] for key in schema if key in baseline}
+
+    def _refresh(self, tool_name: str, tool: Any, overrides: dict[str, Any]) -> None:
+        config = getattr(tool, "config", None)
+        if config is None:
+            return
+        baseline = dict(self._baselines.get(tool_name, {}))
+        config.extra = {**baseline, **overrides}
+        refresh = getattr(tool, "refresh_runtime_options", None)
+        if callable(refresh):
+            refresh(self.get(tool_name))
+
+    def _state_key(self) -> str:
+        return f"{self._agent.config.name}:{TOOL_OPTIONS_STATE_SUFFIX}"
+
+    def _load_private_state(self) -> dict[str, Any]:
+        store = getattr(self._agent, "session_store", None)
+        if store is not None:
+            try:
+                raw = store.state.get(self._state_key())
+            except (KeyError, TypeError):
+                raw = None
+            if isinstance(raw, dict):
+                return raw
+            if isinstance(raw, str):
+                try:
+                    parsed = json.loads(raw)
+                except ValueError:
+                    return {}
+                return parsed if isinstance(parsed, dict) else {}
+        session = getattr(self._agent, "session", None)
+        extra = getattr(session, "extra", None) if session is not None else None
+        raw = extra.get(TOOL_OPTIONS_STATE_SUFFIX) if isinstance(extra, dict) else None
+        return raw if isinstance(raw, dict) else {}
+
+    def _persist(self) -> None:
+        persisted = {**self._pending_values, **self._values}
+        store = getattr(self._agent, "session_store", None)
+        if store is not None:
+            store.state[self._state_key()] = dict(persisted)
+        session = getattr(self._agent, "session", None)
+        extra = getattr(session, "extra", None) if session is not None else None
+        if isinstance(extra, dict):
+            if persisted:
+                extra[TOOL_OPTIONS_STATE_SUFFIX] = dict(persisted)
+            else:
+                extra.pop(TOOL_OPTIONS_STATE_SUFFIX, None)
+
+
+def agent_tool_inventory(agent: Any) -> list[dict[str, Any]]:
+    """Return configurable ordinary tools in the shared module shape."""
+    registry = getattr(agent, "registry", None)
+    if registry is None:
+        return []
+    helper = getattr(agent, "tool_options", None)
+    out: list[dict[str, Any]] = []
+    for name in registry.list_tools():
+        tool = registry.get_tool(name)
+        if tool is None or getattr(tool, "is_provider_native", False):
+            continue
+        schema_fn = getattr(tool, "runtime_option_schema", None)
+        try:
+            schema = schema_fn() if callable(schema_fn) else {}
+        except Exception:
+            schema = {}
+        if not schema:
+            continue
+        out.append(
+            {
+                "name": name,
+                "description": getattr(tool, "description", "") or "",
+                "option_schema": schema,
+                "values": helper.get(name) if helper else {},
+            }
+        )
+    out.sort(key=lambda entry: entry["name"])
+    return out
+
+
+def agent_get_tool_options(agent: Any) -> dict[str, dict[str, Any]]:
+    """Return current effective values for overridden ordinary tools."""
+    helper = getattr(agent, "tool_options", None)
+    return helper.list() if helper is not None else {}
+
+
+def agent_set_tool_options(
+    agent: Any, tool: str, values: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply ordinary-tool option values through the agent helper."""
+    helper = getattr(agent, "tool_options", None)
+    if helper is None:
+        raise ValueError("agent has no tool_options helper")
+    return helper.set(tool, values or {})

--- a/src/kohakuterrarium/core/agent_tools.py
+++ b/src/kohakuterrarium/core/agent_tools.py
@@ -529,6 +529,9 @@ class AgentToolsMixin(AgentRuntimeToolsMixin):
         canvas_preview = tool_metadata.get("canvas_preview")
         if canvas_preview:
             metadata["canvas_preview"] = canvas_preview
+        session_metadata = tool_metadata.get("session_metadata")
+        if isinstance(session_metadata, dict):
+            metadata["tool_metadata"] = dict(session_metadata)
         self.output_router.notify_activity(
             done_activity,
             f"[{label}] {status}",

--- a/src/kohakuterrarium/llm/api_keys.py
+++ b/src/kohakuterrarium/llm/api_keys.py
@@ -29,6 +29,7 @@ PROVIDER_KEY_MAP: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "gemini": "GEMINI_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
     "mimo": "MIMO_API_KEY",
     "kimi-code": "KIMI_CODE_API_KEY",
     "glm-coding": "GLM_CODING_API_KEY",
@@ -99,6 +100,25 @@ def get_api_key(provider_or_env: str) -> str:
     if provider_or_env != env_var:
         key = os.environ.get(provider_or_env, "")
     return key
+
+
+def has_api_key(provider_or_env: str) -> bool:
+    """Check credential availability without logging resolver misses."""
+    provider = provider_or_env
+    for prov, env in PROVIDER_KEY_MAP.items():
+        if provider_or_env == env:
+            provider = prov
+            break
+    if _resolver is not None:
+        try:
+            return bool(_resolver(provider))
+        except Exception:  # pragma: no cover - resolver failures are external
+            return False
+    keys = _load_api_keys()
+    if keys.get(provider):
+        return True
+    env_var = PROVIDER_KEY_MAP.get(provider, provider_or_env)
+    return bool(os.environ.get(env_var, ""))
 
 
 def list_api_keys() -> dict[str, str]:

--- a/src/kohakuterrarium/modules/tool/base.py
+++ b/src/kohakuterrarium/modules/tool/base.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from kohakuterrarium.builtin_skills import get_builtin_tool_doc
+from kohakuterrarium.modules.tool.runtime_options import validate_tool_options
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -167,6 +168,10 @@ class BaseTool:
         """
         return {}
 
+    def runtime_option_schema(self) -> dict[str, dict[str, Any]]:
+        """Declare runtime-mutable options for an ordinary local tool."""
+        return {}
+
     # Unsafe tools share a serial lock while safe tools may remain parallel.
     is_concurrency_safe: bool = True
 
@@ -176,6 +181,18 @@ class BaseTool:
     def __init__(self, config: ToolConfig | None = None):
         self.config = config or ToolConfig()
         self._manual_read = False
+
+    def validate_runtime_options(
+        self, values: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Validate configured runtime options without changing the tool."""
+        schema = self.runtime_option_schema() or {}
+        source = self.config.extra if values is None else values
+        selected = {key: source[key] for key in schema if key in source}
+        return validate_tool_options(self.tool_name, selected, schema)
+
+    def refresh_runtime_options(self, options: dict[str, Any]) -> None:
+        """Apply validated effective options after a runtime update."""
 
     @property
     @abstractmethod

--- a/src/kohakuterrarium/modules/tool/runtime_options.py
+++ b/src/kohakuterrarium/modules/tool/runtime_options.py
@@ -1,0 +1,89 @@
+"""Validate runtime-mutable options declared by ordinary tools."""
+
+from typing import Any
+
+
+class ToolOptionError(ValueError):
+    """Raised when a runtime tool option violates its schema."""
+
+
+def validate_tool_options(
+    tool_name: str,
+    values: dict[str, Any],
+    schema: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Validate supported primitive values against a tool option schema."""
+    if not isinstance(values, dict):
+        raise ToolOptionError("values must be an object")
+
+    cleaned: dict[str, Any] = {}
+    for key, value in values.items():
+        if value in (None, ""):
+            continue
+        if key not in schema:
+            raise ToolOptionError(f"Unknown option {key!r} for {tool_name!r}")
+        spec = schema[key] or {}
+        cleaned[key] = _coerce_value(tool_name, key, value, spec)
+    return cleaned
+
+
+def _coerce_value(tool_name: str, key: str, value: Any, spec: dict[str, Any]) -> Any:
+    kind = str(spec.get("type", "string"))
+    if kind == "enum":
+        if not isinstance(value, str):
+            raise ToolOptionError(f"{key!r} must be a string enum value")
+        allowed = [str(v) for v in (spec.get("values") or [])]
+        if value not in allowed:
+            raise ToolOptionError(
+                f"{key!r} value {value!r} must be one of: {', '.join(allowed)}"
+            )
+        disabled = spec.get("disabled_values") or {}
+        if value in disabled:
+            reason = str(disabled[value] or "This value is currently unavailable")
+            raise ToolOptionError(reason)
+        return value
+    if kind == "string":
+        if not isinstance(value, str):
+            raise ToolOptionError(f"{key!r} must be a string")
+        maximum = int(spec.get("max_length", 128))
+        if len(value) > maximum:
+            raise ToolOptionError(f"{key!r} is too long")
+        return value
+    if kind == "int":
+        if isinstance(value, bool):
+            raise ToolOptionError(f"{key!r} must be an integer")
+        try:
+            coerced: int | float = int(value)
+        except (TypeError, ValueError):
+            raise ToolOptionError(f"{key!r} must be an integer")
+        _validate_bounds(key, coerced, spec)
+        return coerced
+    if kind == "float":
+        if isinstance(value, bool):
+            raise ToolOptionError(f"{key!r} must be a number")
+        try:
+            coerced = float(value)
+        except (TypeError, ValueError):
+            raise ToolOptionError(f"{key!r} must be a number")
+        _validate_bounds(key, coerced, spec)
+        return coerced
+    if kind == "bool":
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.lower()
+            if lowered in {"true", "1", "yes", "y", "on"}:
+                return True
+            if lowered in {"false", "0", "no", "n", "off"}:
+                return False
+        raise ToolOptionError(f"{key!r} must be a boolean")
+    raise ToolOptionError(f"Unsupported option type {kind!r} for {key!r}")
+
+
+def _validate_bounds(key: str, value: int | float, spec: dict[str, Any]) -> None:
+    minimum = spec.get("min")
+    maximum = spec.get("max")
+    if minimum is not None and value < minimum:
+        raise ToolOptionError(f"{key!r} must be >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise ToolOptionError(f"{key!r} must be <= {maximum}")

--- a/src/kohakuterrarium/session/output.py
+++ b/src/kohakuterrarium/session/output.py
@@ -413,6 +413,9 @@ class SessionOutput(OutputModule):
         canvas_preview = metadata.get("canvas_preview")
         if canvas_preview:
             event_data["canvas_preview"] = canvas_preview
+        tool_metadata = metadata.get("tool_metadata")
+        if isinstance(tool_metadata, dict):
+            event_data["tool_metadata"] = dict(tool_metadata)
         self._record("tool_result", event_data)
 
     def _handle_tool_error(self, name: str, detail: str, metadata: dict) -> None:

--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -281,6 +281,17 @@ def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
                 error=str(exc),
             )
 
+    tool_options = getattr(agent, "tool_options", None)
+    if tool_options is not None:
+        try:
+            tool_options.apply()
+        except Exception as exc:  # pragma: no cover - resume continues without options
+            logger.warning(
+                "Failed to reapply tool options",
+                agent=agent_name,
+                error=str(exc),
+            )
+
     resume_events = store.get_resumable_events(agent_name)
     if resume_events:
         agent._pending_resume_events = resume_events

--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -288,6 +288,17 @@ def _apply_restore_elision(agent: Any) -> None:
         elide_stale_tool_results(controller.conversation)
 
 
+def _reapply_options(agent: Any, agent_name: str, attribute: str) -> None:
+    options = getattr(agent, attribute, None)
+    if options is None:
+        return
+    try:
+        options.apply()
+    except Exception as exc:  # pragma: no cover - resume continues without options
+        message = f"Failed to reapply {attribute.replace('_', ' ')}"
+        logger.warning(message, agent=agent_name, error=str(exc))
+
+
 def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
     """Restore identity, conversation, branch state, scratchpad, and triggers.
 
@@ -333,27 +344,8 @@ def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
             visible_count += 1
         logger.info("Scratchpad restored", agent=agent_name, keys=visible_count)
 
-    native_tool_options = getattr(agent, "native_tool_options", None)
-    if native_tool_options is not None:
-        try:
-            native_tool_options.apply()
-        except Exception as exc:  # pragma: no cover - resume continues without options
-            logger.warning(
-                "Failed to reapply native tool options",
-                agent=agent_name,
-                error=str(exc),
-            )
-
-    tool_options = getattr(agent, "tool_options", None)
-    if tool_options is not None:
-        try:
-            tool_options.apply()
-        except Exception as exc:  # pragma: no cover - resume continues without options
-            logger.warning(
-                "Failed to reapply tool options",
-                agent=agent_name,
-                error=str(exc),
-            )
+    _reapply_options(agent, agent_name, "native_tool_options")
+    _reapply_options(agent, agent_name, "tool_options")
 
     resume_events = store.get_resumable_events(agent_name)
     if resume_events:

--- a/src/kohakuterrarium/studio/identity/api_keys.py
+++ b/src/kohakuterrarium/studio/identity/api_keys.py
@@ -15,19 +15,35 @@ from kohakuterrarium.llm.profiles import (
 KEYS_FILE_PATH = KEYS_PATH
 
 
+def _provider_credentials(
+    backends: dict[str, Any] | None = None,
+) -> dict[str, tuple[str, str]]:
+    """Return provider -> (backend type, env var), including tool-only keys."""
+    resolved_backends = load_backends() if backends is None else backends
+    credentials = {
+        name: (backend.backend_type, backend.api_key_env or "")
+        for name, backend in resolved_backends.items()
+    }
+    for name, env_var in PROVIDER_KEY_MAP.items():
+        credentials.setdefault(name, ("credential", env_var))
+    return credentials
+
+
 def list_keys_payload() -> list[dict[str, Any]]:
     """Return the HTTP-facing API-key status for each configured provider."""
     masked = list_api_keys()
     entries: list[dict[str, Any]] = []
-    for name, backend in load_backends().items():
+    backends = load_backends()
+    for name, (backend_type, env_var) in _provider_credentials(backends).items():
+        has_key = bool(get_api_key(name))
         entries.append(
             {
                 "provider": name,
-                "backend_type": backend.backend_type,
-                "env_var": backend.api_key_env,
-                "has_key": bool(get_api_key(name)),
+                "backend_type": backend_type,
+                "env_var": env_var,
+                "has_key": has_key,
                 "masked_key": masked.get(name, ""),
-                "available": _is_available(name),
+                "available": _is_available(name) if name in backends else has_key,
                 "built_in": name in {"codex", *PROVIDER_KEY_MAP.keys()},
             }
         )
@@ -38,9 +54,8 @@ def list_keys_for_cli() -> list[dict[str, Any]]:
     """Return masked keys and environment resolution for the CLI listing."""
     masked = list_api_keys()
     rows: list[dict[str, Any]] = []
-    for provider, backend in sorted(load_backends().items()):
+    for provider, (_, env_var) in sorted(_provider_credentials().items()):
         value = masked.get(provider, "")
-        env_var = backend.api_key_env or ""
         if value:
             source = "stored"
         elif env_var and os.environ.get(env_var):
@@ -63,14 +78,14 @@ def set_key(provider: str, key: str) -> None:
     """Persist an API key, rejecting missing values or unknown providers."""
     if not provider or not key:
         raise ValueError("Provider and key are required")
-    if provider not in load_backends():
+    if provider not in _provider_credentials():
         raise LookupError(f"Provider not found: {provider}")
     save_api_key(provider, key)
 
 
 def remove_key(provider: str) -> None:
     """Delete a provider's stored key, rejecting unknown providers."""
-    if provider not in load_backends():
+    if provider not in _provider_credentials():
         raise LookupError(f"Provider not found: {provider}")
     save_api_key(provider, "")
 

--- a/src/kohakuterrarium/studio/sessions/creature_modules.py
+++ b/src/kohakuterrarium/studio/sessions/creature_modules.py
@@ -1,7 +1,7 @@
 """Dispatch per-creature module configuration across supported types.
 
-A module is any runtime-configurable creature component, such as a plugin or
-provider-native tool. All types expose a common shape::
+A module is any runtime-configurable creature component, such as a plugin,
+ordinary tool, or provider-native tool. All types expose a common shape::
 
     {
         "type": "plugin" | "native_tool" | ...,
@@ -59,6 +59,22 @@ def _inventory_native_tools(
     ]
 
 
+def _inventory_tools(
+    engine: Terrarium, session_id: str, creature_id: str
+) -> list[dict]:
+    return [
+        {
+            "type": "tool",
+            "name": entry["name"],
+            "description": entry.get("description", ""),
+            "schema": entry.get("option_schema", {}),
+            "options": entry.get("values", {}),
+            "enabled": None,
+        }
+        for entry in creature_state.tool_inventory(engine, session_id, creature_id)
+    ]
+
+
 def _get_options_plugin(
     engine: Terrarium, session_id: str, creature_id: str, name: str
 ) -> dict:
@@ -78,6 +94,20 @@ def _get_options_native_tool(
         if entry["name"] == name:
             return {
                 "type": "native_tool",
+                "name": name,
+                "schema": entry.get("option_schema", {}),
+                "options": entry.get("values", {}),
+            }
+    raise KeyError(name)
+
+
+def _get_options_tool(
+    engine: Terrarium, session_id: str, creature_id: str, name: str
+) -> dict:
+    for entry in creature_state.tool_inventory(engine, session_id, creature_id):
+        if entry["name"] == name:
+            return {
+                "type": "tool",
                 "name": name,
                 "schema": entry.get("option_schema", {}),
                 "options": entry.get("values", {}),
@@ -109,6 +139,18 @@ def _set_options_native_tool(
     )
 
 
+def _set_options_tool(
+    engine: Terrarium,
+    session_id: str,
+    creature_id: str,
+    name: str,
+    values: dict[str, Any],
+) -> dict[str, Any]:
+    return creature_state.set_tool_options(
+        engine, session_id, creature_id, name, values or {}
+    )
+
+
 async def _toggle_plugin(
     engine: Terrarium, session_id: str, creature_id: str, name: str
 ) -> dict:
@@ -132,6 +174,12 @@ _TYPE_DISPATCH: dict[str, dict[str, Any]] = {
         "inventory": _inventory_native_tools,
         "get_options": _get_options_native_tool,
         "set_options": _set_options_native_tool,
+        "toggle": _toggle_unsupported,
+    },
+    "tool": {
+        "inventory": _inventory_tools,
+        "get_options": _get_options_tool,
+        "set_options": _set_options_tool,
         "toggle": _toggle_unsupported,
     },
 }

--- a/src/kohakuterrarium/studio/sessions/creature_state.py
+++ b/src/kohakuterrarium/studio/sessions/creature_state.py
@@ -1,13 +1,14 @@
 """Expose mutable and read-only state from live creature agents.
 
 This module covers scratchpads, triggers, environment views, system prompts,
-working directories, and provider-native tool options.
+working directories, and tool options.
 """
 
 import os
 from typing import Any
 
 from kohakuterrarium.core.scratchpad import is_reserved_scratchpad_key
+from kohakuterrarium.core.agent_tool_options import agent_tool_inventory
 from kohakuterrarium.studio.sessions.lifecycle import find_creature
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium import TerrariumService
@@ -188,4 +189,27 @@ def set_native_tool_options(
     helper = getattr(agent, "native_tool_options", None)
     if helper is None:
         raise ValueError(f"Creature {creature_id!r} has no native_tool_options helper")
+    return helper.set(tool, values or {})
+
+
+def tool_inventory(
+    service: "TerrariumService", session_id: str, creature_id: str
+) -> list[dict]:
+    engine = as_engine(service)
+    agent = _get_agent(engine, session_id, creature_id)
+    return agent_tool_inventory(agent)
+
+
+def set_tool_options(
+    service: "TerrariumService",
+    session_id: str,
+    creature_id: str,
+    tool: str,
+    values: dict[str, Any],
+) -> dict:
+    engine = as_engine(service)
+    agent = _get_agent(engine, session_id, creature_id)
+    helper = getattr(agent, "tool_options", None)
+    if helper is None:
+        raise ValueError(f"Creature {creature_id!r} has no tool_options helper")
     return helper.set(tool, values or {})

--- a/src/kohakuterrarium/terrarium/creature_ops.py
+++ b/src/kohakuterrarium/terrarium/creature_ops.py
@@ -26,6 +26,11 @@ import kohakuterrarium.terrarium.topology as _terrarium_topology
 import kohakuterrarium.terrarium.topology_snapshot as _terrarium_topology_snap
 from kohakuterrarium.builtins.user_commands import get_builtin_user_command
 from kohakuterrarium.core.agent_selection import persist_plugin_selection
+from kohakuterrarium.core.agent_tool_options import (
+    agent_get_tool_options,
+    agent_set_tool_options,
+    agent_tool_inventory,
+)
 from kohakuterrarium.core.scratchpad import is_reserved_scratchpad_key
 from kohakuterrarium.modules.user_command.base import UserCommandContext
 from kohakuterrarium.session.history import project_branch_metadata
@@ -309,6 +314,7 @@ def agent_list_modules(agent: Any) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     out.extend(_inventory_plugins(agent))
     out.extend(_inventory_native_tools(agent))
+    out.extend(_inventory_tools(agent))
     return out
 
 
@@ -331,6 +337,16 @@ def agent_get_module_options(agent: Any, module_type: str, name: str) -> dict[st
                     "options": entry.get("values", {}),
                 }
         raise KeyError(name)
+    if module_type == "tool":
+        for entry in agent_tool_inventory(agent):
+            if entry["name"] == name:
+                return {
+                    "type": "tool",
+                    "name": name,
+                    "schema": entry.get("option_schema", {}),
+                    "options": entry.get("values", {}),
+                }
+        raise KeyError(name)
     raise ValueError(f"Unknown module type: {module_type!r}")
 
 
@@ -344,6 +360,8 @@ def agent_set_module_options(
         return agent_set_plugin_options(agent, name, values or {})
     if module_type == "native_tool":
         return agent_set_native_tool_options(agent, name, values or {})
+    if module_type == "tool":
+        return agent_set_tool_options(agent, name, values or {})
     raise ValueError(f"Unknown module type: {module_type!r}")
 
 
@@ -352,7 +370,7 @@ async def agent_toggle_module(
 ) -> dict[str, Any]:
     if module_type == "plugin":
         return await agent_toggle_plugin(agent, name)
-    if module_type == "native_tool":
+    if module_type in {"native_tool", "tool"}:
         raise ValueError("Module type does not support toggle")
     raise ValueError(f"Unknown module type: {module_type!r}")
 
@@ -383,6 +401,20 @@ def _inventory_native_tools(agent: Any) -> list[dict[str, Any]]:
             "enabled": None,
         }
         for entry in agent_native_tool_inventory(agent)
+    ]
+
+
+def _inventory_tools(agent: Any) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "tool",
+            "name": entry["name"],
+            "description": entry.get("description", ""),
+            "schema": entry.get("option_schema", {}),
+            "options": entry.get("values", {}),
+            "enabled": None,
+        }
+        for entry in agent_tool_inventory(agent)
     ]
 
 
@@ -904,6 +936,7 @@ __all__ = [
     "agent_get_module_options",
     "agent_get_native_tool_options",
     "agent_get_plugin_options",
+    "agent_get_tool_options",
     "agent_list_modules",
     "agent_list_plugins",
     "agent_native_tool_inventory",
@@ -913,10 +946,12 @@ __all__ = [
     "agent_set_module_options",
     "agent_set_native_tool_options",
     "agent_set_plugin_options",
+    "agent_set_tool_options",
     "agent_set_working_dir",
     "agent_system_prompt",
     "agent_toggle_module",
     "agent_toggle_plugin",
+    "agent_tool_inventory",
     "agent_triggers",
     "agent_working_dir",
     "attach_policies_for",

--- a/tests/integration/test_modules.py
+++ b/tests/integration/test_modules.py
@@ -1556,7 +1556,8 @@ class TestModulesIntegration:
         search_result = next(
             event
             for event in store.get_events("modules_agent")
-            if event["type"] == "tool_result" and event["name"] == "web_search"
+            if event["type"] == "tool_result"
+            and event["call_id"].startswith("web_search_")
         )
         assert search_result["tool_metadata"]["backend"] == "deepseek"
         assert search_result["tool_metadata"]["citation_status"] == "verified"

--- a/tests/integration/test_modules.py
+++ b/tests/integration/test_modules.py
@@ -32,6 +32,9 @@ import pytest
 
 from kohakuterrarium.bootstrap import agent_init as _agent_init
 from kohakuterrarium.bootstrap import llm as _bootstrap_llm
+from kohakuterrarium.builtins.subagents.research import RESEARCH_CONFIG
+from kohakuterrarium.builtins.tools import web_search
+from kohakuterrarium.builtins.tools.web_search import WebSearchTool
 from kohakuterrarium.core.agent import Agent
 from kohakuterrarium.core.config_types import (
     AgentConfig,
@@ -49,6 +52,7 @@ from kohakuterrarium.modules.plugin.base import (
     PluginContext as RuntimePluginContext,
 )
 from kohakuterrarium.modules.plugin.manager import PluginManager
+from kohakuterrarium.modules.subagent.base import SubAgent
 from kohakuterrarium.modules.subagent.config import (
     ContextUpdateMode,
     OutputTarget,
@@ -63,6 +67,7 @@ from kohakuterrarium.modules.tool.base import (
     ToolContext,
     ToolResult,
 )
+from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.modules.trigger.timer import TimerTrigger
 from kohakuterrarium.modules.user_command.base import (
     BaseUserCommand,
@@ -125,6 +130,51 @@ class RecordingTool(BaseTool):
                 error="recorder failed: deliberate explosion", exit_code=1
             )
         return ToolResult(output=f"recorder saw: {msg}")
+
+
+class _DeepSeekResponse:
+    status_code = 200
+
+    def json(self):
+        return {
+            "output": [
+                {
+                    "type": "web_search_call",
+                    "action": {"type": "search", "query": "kt"},
+                },
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Grounded answer",
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "url": "https://example.com/source",
+                                    "title": "Source",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ]
+        }
+
+
+class _DeepSeekClient:
+    def __init__(self, capture):
+        self.capture = capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def post(self, url, **kwargs):
+        self.capture.append((url, kwargs["json"]))
+        return _DeepSeekResponse()
 
 
 class GuardrailPlugin(BasePlugin):
@@ -1444,6 +1494,92 @@ class TestModulesIntegration:
             assert "handled the failure" in last.get_text_content()
         finally:
             await agent.stop()
+
+    async def test_web_search_backend_switch_executes_and_resumes(
+        self, make_agent, monkeypatch, tmp_path
+    ):
+        """Ordinary tool options switch DeepSeek live and persist by session."""
+        capture = []
+        monkeypatch.setattr(web_search, "has_api_key", lambda provider: True)
+        monkeypatch.setattr(web_search, "get_api_key", lambda provider: "ds-secret")
+        monkeypatch.setattr(
+            web_search.httpx,
+            "AsyncClient",
+            lambda **kwargs: _DeepSeekClient(capture),
+        )
+        store = SessionStore(str(tmp_path / "modules.kohakutr"))
+        store.init_meta(
+            session_id="modules",
+            config_type="agent",
+            config_path="test",
+            pwd=str(tmp_path),
+            agents=["modules_agent"],
+        )
+        agent = make_agent(
+            script=[
+                ScriptEntry(
+                    "[/web_search]@@query=kt search\n[web_search/]",
+                    match="search now",
+                ),
+                ScriptEntry("search complete", match="Grounded answer"),
+            ]
+        )
+        tool = WebSearchTool()
+        agent.registry.register_tool(tool)
+        agent.executor.register_tool(tool)
+        agent.attach_session_store(store)
+        command = agent.list_user_commands()["module"]
+
+        changed = await command.execute(
+            "set web_search backend deepseek", agent._user_command_context
+        )
+        assert changed.success
+        assert tool.backend == "deepseek"
+        research = SubAgent(
+            config=RESEARCH_CONFIG,
+            parent_registry=agent.registry,
+            llm=agent.llm,
+            agent_path=tmp_path,
+        )
+        assert research.registry.get_tool("web_search") is tool
+        assert research.registry.get_tool("web_search").backend == "deepseek"
+
+        await agent.start()
+        try:
+            await agent._process_event(create_user_input_event("search now"))
+            assert capture
+            assert capture[0][1]["model"] == "deepseek-v4-flash"
+            assert "ds-secret" not in repr(capture[0][1])
+        finally:
+            await agent.stop()
+
+        search_result = next(
+            event
+            for event in store.get_events("modules_agent")
+            if event["type"] == "tool_result" and event["name"] == "web_search"
+        )
+        assert search_result["tool_metadata"]["backend"] == "deepseek"
+        assert search_result["tool_metadata"]["citation_status"] == "verified"
+        assert search_result["tool_metadata"]["annotation_count"] == 1
+        assert search_result["tool_metadata"]["verified_sources"] == [
+            {"title": "Source", "url": "https://example.com/source"}
+        ]
+        assert "ds-secret" not in repr(search_result)
+
+        resumed = make_agent(script=["ok"])
+        resumed_tool = WebSearchTool()
+        resumed.registry.register_tool(resumed_tool)
+        resumed.executor.register_tool(resumed_tool)
+        resumed.attach_session_store(store)
+        assert resumed_tool.backend == "deepseek"
+
+        resumed_command = resumed.list_user_commands()["module"]
+        reset = await resumed_command.execute(
+            "reset web_search", resumed._user_command_context
+        )
+        assert reset.success
+        assert resumed_tool.backend == "duckduckgo"
+        store.close()
 
     async def test_drive_tools_injected_and_execute_through_engine(
         self, llm_box, tmp_path

--- a/tests/unit/bootstrap/test_tools.py
+++ b/tests/unit/bootstrap/test_tools.py
@@ -95,6 +95,21 @@ class TestCreateToolBuiltin:
         assert tool.config.max_output == 1024
         assert tool.config.timeout == 30.0
 
+    def test_lenient_web_search_keeps_unavailable_config_editable(self, monkeypatch):
+        from kohakuterrarium.builtins.tools import web_search
+
+        monkeypatch.setattr(web_search, "has_api_key", lambda provider: False)
+        cfg = ToolConfigItem(
+            name="web_search",
+            type="builtin",
+            options={"backend": "deepseek"},
+        )
+
+        tool = create_tool(cfg, loader=None, strict=False)
+
+        assert tool is not None
+        assert tool.backend == "deepseek"
+
 
 # ── create_tool: trigger ────────────────────────────────────────
 
@@ -236,6 +251,20 @@ class TestStrictMode:
 
         cfg = ToolConfigItem(name="bash", type="builtin", options={"timeout": "soon"})
         with pytest.raises(ConfigError, match="Invalid config value"):
+            create_tool(cfg, loader=None, strict=True)
+
+    def test_deepseek_search_without_key_raises(self, monkeypatch):
+        from kohakuterrarium.builtins.tools import web_search
+        from kohakuterrarium.errors import ConfigError
+
+        monkeypatch.setattr(web_search, "has_api_key", lambda provider: False)
+        cfg = ToolConfigItem(
+            name="web_search",
+            type="builtin",
+            options={"backend": "deepseek"},
+        )
+
+        with pytest.raises(ConfigError, match="DeepSeek API key"):
             create_tool(cfg, loader=None, strict=True)
 
     def test_init_tools_strict_raises_on_first_bad(self):

--- a/tests/unit/builtins/cli_rich/dialogs/test_module_picker.py
+++ b/tests/unit/builtins/cli_rich/dialogs/test_module_picker.py
@@ -1,0 +1,55 @@
+"""Unit tests for ordinary tools in the Rich module picker."""
+
+from types import SimpleNamespace
+
+from kohakuterrarium.builtins.cli_rich.dialogs.module_picker import ModulePicker
+
+
+class _Tool:
+    is_provider_native = False
+    description = "search"
+
+    def runtime_option_schema(self):
+        return {
+            "backend": {
+                "type": "enum",
+                "values": ["duckduckgo", "deepseek"],
+                "default": "duckduckgo",
+                "disabled_values": {"deepseek": "configure key"},
+            }
+        }
+
+
+class _Registry:
+    def list_tools(self):
+        return ["web_search"]
+
+    def get_tool(self, name):
+        return _Tool()
+
+
+class _Options:
+    def get(self, name):
+        return {"backend": "duckduckgo"}
+
+    def set(self, name, values):
+        return values
+
+
+class TestModulePickerToolTab:
+    def test_opens_tool_form_and_excludes_unavailable_enum_value(self):
+        agent = SimpleNamespace(
+            plugins=None,
+            registry=_Registry(),
+            native_tool_options=None,
+            tool_options=_Options(),
+        )
+        picker = ModulePicker(lambda: agent)
+
+        picker.open(edit_target="tool/web_search")
+
+        assert picker.active_type == "tool"
+        assert picker._form is not None
+        field = picker._form.fields[0]
+        assert field.options == ["duckduckgo"]
+        assert field.unavailable == {"deepseek": "configure key"}

--- a/tests/unit/builtins/cli_rich/dialogs/test_settings_keys.py
+++ b/tests/unit/builtins/cli_rich/dialogs/test_settings_keys.py
@@ -1,0 +1,21 @@
+"""Unit tests for credential-only providers in the Rich settings overlay."""
+
+from kohakuterrarium.builtins.cli_rich.dialogs import settings
+from kohakuterrarium.builtins.cli_rich.dialogs.settings import SettingsOverlay
+
+
+class TestSettingsCredentialProviders:
+    def test_deepseek_key_is_visible_without_an_llm_backend(self, monkeypatch):
+        monkeypatch.setattr(settings, "load_backends", lambda: {})
+        monkeypatch.setattr(
+            settings,
+            "get_api_key",
+            lambda provider: "ds-secret" if provider == "deepseek" else "",
+        )
+
+        rows = SettingsOverlay()._load_keys()
+        deepseek = next(row for row in rows if row["provider"] == "deepseek")
+
+        assert deepseek["has_key"] is True
+        assert deepseek["env"] == "DEEPSEEK_API_KEY"
+        assert "ds-secret" not in deepseek["masked"]

--- a/tests/unit/builtins/tools/test_web_search.py
+++ b/tests/unit/builtins/tools/test_web_search.py
@@ -10,7 +10,11 @@ import pytest
 
 from kohakuterrarium.builtins.tools import web_search
 from kohakuterrarium.builtins.tools.web_search import (
+    DeepSeekSearchBackend,
+    SearchBackendOperationalError,
+    SearchBackendUnavailable,
     WebSearchTool,
+    _normalize_deepseek_response,
     _parse_ddg_html,
     _unwrap_ddg_redirect,
 )
@@ -190,3 +194,298 @@ class TestWebSearchFallback:
         result = await tool._execute({"query": ""})
         assert result.error is not None
         assert called == []
+
+
+class _Response:
+    def __init__(self, status_code=200, data=None):
+        self.status_code = status_code
+        self._data = data if data is not None else {}
+
+    def json(self):
+        return self._data
+
+
+class _Client:
+    def __init__(self, response, capture):
+        self.response = response
+        self.capture = capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def post(self, url, **kwargs):
+        self.capture.append((url, kwargs))
+        return self.response
+
+
+class TestDeepSeekSearch:
+    @pytest.mark.asyncio
+    async def test_sends_forced_search_and_normalizes_sources(self, monkeypatch):
+        capture = []
+        data = {
+            "output": [
+                {
+                    "type": "web_search_call",
+                    "action": {"type": "search", "query": "kt search"},
+                },
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Grounded answer.",
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "url": "https://example.com/source",
+                                    "title": "Source",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        monkeypatch.setattr(web_search, "get_api_key", lambda provider: "secret-key")
+        monkeypatch.setattr(
+            web_search.httpx,
+            "AsyncClient",
+            lambda **kwargs: _Client(_Response(data=data), capture),
+        )
+
+        response = await DeepSeekSearchBackend("deepseek-v4-flash").search(
+            "kt search", 3, "cn-zh"
+        )
+
+        _, request = capture[0]
+        assert request["json"]["tools"] == [{"type": "web_search"}]
+        assert request["json"]["tool_choice"] == {"type": "web_search"}
+        assert request["headers"]["Authorization"] == "Bearer secret-key"
+        assert response.sources == [
+            {"title": "Source", "url": "https://example.com/source"}
+        ]
+        assert "Grounded answer" in response.output
+        assert response.metadata["citation_status"] == "verified"
+        assert response.metadata["annotation_count"] == 1
+        assert "secret-key" not in repr(response.metadata)
+
+    @pytest.mark.asyncio
+    async def test_missing_key_does_not_use_configured_fallback(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(web_search, "get_api_key", lambda provider: "")
+
+        async def fake_ddg(*args):
+            called.append("ddg")
+            return []
+
+        monkeypatch.setattr(web_search, "_search_httpx_ddg", fake_ddg)
+        tool = WebSearchTool(
+            ToolConfig(extra={"backend": "deepseek", "fallback": "duckduckgo"})
+        )
+
+        result = await tool._execute({"query": "anything"})
+
+        assert "API key is not configured" in result.error
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_non_object_response_is_a_controlled_operational_error(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(web_search, "get_api_key", lambda provider: "configured")
+        monkeypatch.setattr(
+            web_search.httpx,
+            "AsyncClient",
+            lambda **kwargs: _Client(_Response(data=[]), []),
+        )
+
+        with pytest.raises(SearchBackendOperationalError, match="invalid response"):
+            await DeepSeekSearchBackend("deepseek-v4-flash").search("q", 3, "")
+
+    @pytest.mark.asyncio
+    async def test_failed_response_status_is_not_reported_as_empty_success(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(web_search, "get_api_key", lambda provider: "configured")
+        data = {
+            "status": "failed",
+            "error": {
+                "code": "authentication_error",
+                "message": "invalid credential",
+            },
+            "output": [],
+        }
+        monkeypatch.setattr(
+            web_search.httpx,
+            "AsyncClient",
+            lambda **kwargs: _Client(_Response(data=data), []),
+        )
+
+        with pytest.raises(SearchBackendUnavailable, match="authentication_error"):
+            await DeepSeekSearchBackend("deepseek-v4-flash").search("q", 3, "")
+
+    @pytest.mark.asyncio
+    async def test_transient_failed_response_status_is_fallback_eligible(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(web_search, "get_api_key", lambda provider: "configured")
+        data = {
+            "status": "failed",
+            "error": {"code": "rate_limit_error", "message": "try later"},
+            "output": [],
+        }
+        monkeypatch.setattr(
+            web_search.httpx,
+            "AsyncClient",
+            lambda **kwargs: _Client(_Response(data=data), []),
+        )
+
+        with pytest.raises(SearchBackendOperationalError, match="rate_limit_error"):
+            await DeepSeekSearchBackend("deepseek-v4-flash").search("q", 3, "")
+
+    @pytest.mark.asyncio
+    async def test_incomplete_response_with_partial_output_is_explicit(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(web_search, "get_api_key", lambda provider: "configured")
+        data = {
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output_text": "Partial grounded answer.",
+        }
+        monkeypatch.setattr(
+            web_search.httpx,
+            "AsyncClient",
+            lambda **kwargs: _Client(_Response(data=data), []),
+        )
+
+        response = await DeepSeekSearchBackend("deepseek-v4-flash").search("q", 3, "")
+
+        assert "Partial grounded answer" in response.output
+        assert "Incomplete DeepSeek response: max_output_tokens" in response.output
+        assert response.metadata["response_status"] == "incomplete"
+        assert response.metadata["incomplete_reason"] == "max_output_tokens"
+
+    @pytest.mark.asyncio
+    async def test_incomplete_response_without_output_is_not_empty_success(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(web_search, "get_api_key", lambda provider: "configured")
+        data = {
+            "status": "incomplete",
+            "incomplete_details": {"reason": "content_filter"},
+            "output": [],
+        }
+        monkeypatch.setattr(
+            web_search.httpx,
+            "AsyncClient",
+            lambda **kwargs: _Client(_Response(data=data), []),
+        )
+
+        with pytest.raises(SearchBackendUnavailable, match="content_filter"):
+            await DeepSeekSearchBackend("deepseek-v4-flash").search("q", 3, "")
+
+    @pytest.mark.asyncio
+    async def test_operational_failure_uses_explicit_fallback(self, monkeypatch):
+        async def fail_search(*args):
+            raise SearchBackendOperationalError("rate limited")
+
+        async def fallback_search(*args):
+            return [{"href": "https://fallback", "title": "fallback", "body": ""}]
+
+        class _FailingBackend:
+            search = staticmethod(fail_search)
+
+        monkeypatch.setattr(WebSearchTool, "_backend", lambda self: _FailingBackend())
+        monkeypatch.setattr(web_search, "_has_ddg", lambda: False)
+        monkeypatch.setattr(web_search, "_search_httpx_ddg", fallback_search)
+        tool = WebSearchTool(
+            ToolConfig(extra={"backend": "deepseek", "fallback": "duckduckgo"})
+        )
+
+        result = await tool._execute({"query": "anything"})
+
+        assert "fallback" in result.output
+        assert result.metadata["fallback_from"] == "deepseek"
+
+    def test_schema_marks_deepseek_unavailable_without_key(self, monkeypatch):
+        monkeypatch.setattr(web_search, "has_api_key", lambda provider: False)
+
+        schema = WebSearchTool().runtime_option_schema()
+
+        assert "deepseek" in schema["backend"]["disabled_values"]
+        assert schema["backend"]["default"] == "duckduckgo"
+
+    def test_untrusted_annotation_url_is_not_exposed(self):
+        response = _normalize_deepseek_response(
+            {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "answer",
+                                "annotations": [
+                                    {"url": "javascript:alert(1)", "title": "bad"}
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            },
+            "q",
+            10,
+            "deepseek-v4-flash",
+        )
+
+        assert response.sources == []
+        assert "javascript:" not in response.output
+
+    def test_provider_text_links_remain_visible_but_are_not_verified(self):
+        response = _normalize_deepseek_response(
+            {"output_text": "Read https://example.com/provider-text"},
+            "q",
+            10,
+            "deepseek-v4-flash",
+        )
+
+        assert "https://example.com/provider-text" in response.output
+        assert "unverified provider text" in response.output
+        assert response.sources == []
+        assert response.metadata["citation_status"] == "unverified_text"
+
+    def test_non_citation_annotation_with_http_url_is_not_trusted(self):
+        response = _normalize_deepseek_response(
+            {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "answer",
+                                "annotations": [
+                                    {
+                                        "type": "file_reference",
+                                        "url": "https://example.com/not-a-citation",
+                                        "title": "not a citation",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            },
+            "q",
+            10,
+            "deepseek-v4-flash",
+        )
+
+        assert response.sources == []
+        assert "not-a-citation" not in response.output
+        assert response.metadata["annotation_count"] == 1

--- a/tests/unit/builtins/tui/test_modules_modal.py
+++ b/tests/unit/builtins/tui/test_modules_modal.py
@@ -1,0 +1,54 @@
+"""Unit tests for ordinary tools in the Textual modules modal."""
+
+from types import SimpleNamespace
+
+from kohakuterrarium.builtins.tui.widgets.modules_modal import (
+    _apply_options,
+    _list_modules,
+)
+
+
+class _Tool:
+    is_provider_native = False
+    description = "search"
+
+    def runtime_option_schema(self):
+        return {"backend": {"type": "enum", "values": ["duckduckgo", "deepseek"]}}
+
+
+class _Registry:
+    def list_tools(self):
+        return ["web_search"]
+
+    def get_tool(self, name):
+        return _Tool()
+
+
+class _Options:
+    def __init__(self):
+        self.values = {"backend": "duckduckgo"}
+
+    def get(self, name):
+        return dict(self.values)
+
+    def set(self, name, values):
+        self.values.update(values)
+        return dict(self.values)
+
+
+class TestToolModulesModal:
+    def test_inventory_and_apply_use_tool_options(self):
+        helper = _Options()
+        agent = SimpleNamespace(
+            plugins=None,
+            registry=_Registry(),
+            native_tool_options=None,
+            tool_options=helper,
+        )
+
+        module = _list_modules(agent)[0]
+        applied = _apply_options(agent, module, {"backend": "deepseek"})
+
+        assert module["type"] == "tool"
+        assert applied["backend"] == "deepseek"
+        assert helper.values["backend"] == "deepseek"

--- a/tests/unit/builtins/user_commands/test_module_command.py
+++ b/tests/unit/builtins/user_commands/test_module_command.py
@@ -1,0 +1,73 @@
+"""Unit tests for the runtime module command's ordinary-tool path."""
+
+from types import SimpleNamespace
+
+from kohakuterrarium.builtins.user_commands import module as module_command
+
+
+class _Tool:
+    is_provider_native = False
+    description = "search"
+
+    def runtime_option_schema(self):
+        return {
+            "backend": {
+                "type": "enum",
+                "values": ["duckduckgo", "deepseek"],
+                "default": "duckduckgo",
+                "disabled_values": {"deepseek": "configure key"},
+            }
+        }
+
+
+class _Registry:
+    def list_tools(self):
+        return ["web_search"]
+
+    def get_tool(self, name):
+        return _Tool() if name == "web_search" else None
+
+
+class _Options:
+    def __init__(self):
+        self.values = {"backend": "duckduckgo"}
+
+    def get(self, name):
+        return dict(self.values)
+
+    def set(self, name, values):
+        if values:
+            self.values.update(values)
+        else:
+            self.values = {"backend": "duckduckgo"}
+        return dict(self.values)
+
+
+def _agent():
+    return SimpleNamespace(
+        plugins=None,
+        registry=_Registry(),
+        native_tool_options=None,
+        tool_options=_Options(),
+    )
+
+
+class TestOrdinaryToolModuleCommand:
+    def test_inventory_and_show_include_tool_and_unavailable_reason(self):
+        agent = _agent()
+        module = module_command._inventory(agent)[0]
+
+        assert module["type"] == "tool"
+        rendered = module_command._render_show_module(module)
+        assert "tool/web_search" in rendered
+        assert "deepseek — configure key" in rendered
+
+    def test_set_and_reset_route_through_tool_options(self):
+        agent = _agent()
+
+        changed = module_command._do_set(agent, ["web_search", "backend", "deepseek"])
+        reset = module_command._do_reset(agent, ["web_search"])
+
+        assert "deepseek" in changed.output
+        assert "tool/web_search" in reset.output
+        assert agent.tool_options.values == {"backend": "duckduckgo"}

--- a/tests/unit/core/test_agent_helpers_modules.py
+++ b/tests/unit/core/test_agent_helpers_modules.py
@@ -17,6 +17,7 @@ from kohakuterrarium.core.agent_observability import (
     wire_scratchpad_observer,
 )
 from kohakuterrarium.core.agent_plugin_options import PluginOptions
+from kohakuterrarium.core.agent_tool_options import ToolOptions
 from kohakuterrarium.core.agent_tools_metrics import emit_completion_metrics
 from kohakuterrarium.core.agent_workspace import WorkspaceController
 
@@ -30,11 +31,12 @@ def _fake_agent(**kw):
 
 
 class TestAttachSessionHelpers:
-    def test_attaches_three_helpers(self):
+    def test_attaches_session_helpers(self):
         agent = _fake_agent(config=types.SimpleNamespace(name="a"))
         attach_session_helpers(agent)
         assert isinstance(agent.native_tool_options, NativeToolOptions)
         assert isinstance(agent.plugin_options, PluginOptions)
+        assert isinstance(agent.tool_options, ToolOptions)
         assert isinstance(agent.workspace, WorkspaceController)
 
 

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -3044,6 +3044,25 @@ class TestAttachSessionStoreOptionsApply:
         agent.plugin_options.apply = boom  # type: ignore[method-assign]
         agent.attach_session_store(store)
 
+    async def test_tool_options_apply_failure_swallowed(self, make_agent, tmp_path):
+        from kohakuterrarium.session.store import SessionStore
+
+        store = SessionStore(str(tmp_path / "s.kohakutr.v2"))
+        store.init_meta(
+            session_id="x",
+            config_type="agent",
+            config_path="x",
+            pwd=str(tmp_path),
+            agents=["test_agent"],
+        )
+        agent = make_agent()
+
+        def boom():
+            raise RuntimeError("tool apply failed")
+
+        agent.tool_options.apply = boom  # type: ignore[method-assign]
+        agent.attach_session_store(store)
+
     async def test_attach_compact_count_invalid_skipped(self, make_agent, tmp_path):
         from kohakuterrarium.session.store import SessionStore
 

--- a/tests/unit/core/test_agent_tool_options.py
+++ b/tests/unit/core/test_agent_tool_options.py
@@ -1,0 +1,145 @@
+"""Unit tests for :mod:`kohakuterrarium.core.agent_tool_options`."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from kohakuterrarium.core.agent_tool_options import (
+    TOOL_OPTIONS_STATE_SUFFIX,
+    ToolOptions,
+)
+
+
+class _Tool:
+    is_provider_native = False
+    description = "search"
+
+    def __init__(self, *, disabled=False):
+        self.config = SimpleNamespace(extra={"backend": "duckduckgo", "opaque": "keep"})
+        self.disabled = disabled
+        self.applied = None
+
+    def runtime_option_schema(self):
+        disabled = {"deepseek": "missing key"} if self.disabled else {}
+        return {
+            "backend": {
+                "type": "enum",
+                "values": ["duckduckgo", "deepseek"],
+                "default": "duckduckgo",
+                "disabled_values": disabled,
+            },
+            "fallback": {
+                "type": "enum",
+                "values": ["none", "duckduckgo"],
+                "default": "none",
+            },
+        }
+
+    def refresh_runtime_options(self, options):
+        self.applied = dict(options)
+
+
+class _Registry:
+    def __init__(self, tool):
+        self.tool = tool
+
+    def get_tool(self, name):
+        return self.tool if name == "web_search" else None
+
+
+class _Store:
+    def __init__(self):
+        self.state = {}
+
+
+def _agent(tool, store=None):
+    return SimpleNamespace(
+        config=SimpleNamespace(name="a"),
+        registry=_Registry(tool),
+        session=None,
+        session_store=store,
+    )
+
+
+class TestToolOptions:
+    def test_patch_persists_only_override_and_refreshes_effective_values(self):
+        tool = _Tool()
+        store = _Store()
+        options = ToolOptions(_agent(tool, store))
+
+        applied = options.set("web_search", {"backend": "deepseek"})
+
+        assert applied == {"backend": "deepseek", "fallback": "none"}
+        assert tool.applied == applied
+        assert tool.config.extra == {
+            "backend": "deepseek",
+            "opaque": "keep",
+        }
+        saved = store.state[f"a:{TOOL_OPTIONS_STATE_SUFFIX}"]
+        assert saved == {"web_search": {"backend": "deepseek"}}
+
+    def test_reset_restores_yaml_baseline_and_preserves_non_schema_config(self):
+        tool = _Tool()
+        options = ToolOptions(_agent(tool))
+        options.set("web_search", {"backend": "deepseek", "fallback": "duckduckgo"})
+
+        applied = options.set("web_search", {})
+
+        assert applied == {"backend": "duckduckgo", "fallback": "none"}
+        assert tool.config.extra == {"backend": "duckduckgo", "opaque": "keep"}
+        assert options.list() == {}
+
+    def test_unavailable_value_is_rejected_without_changing_current_backend(self):
+        tool = _Tool(disabled=True)
+        options = ToolOptions(_agent(tool))
+
+        with pytest.raises(ValueError, match="missing key"):
+            options.set("web_search", {"backend": "deepseek"})
+
+        assert options.get("web_search")["backend"] == "duckduckgo"
+        assert tool.config.extra["backend"] == "duckduckgo"
+
+    def test_apply_restores_session_override_on_new_tool_instance(self):
+        store = _Store()
+        first = ToolOptions(_agent(_Tool(), store))
+        first.set("web_search", {"backend": "deepseek"})
+        resumed_tool = _Tool()
+        resumed = ToolOptions(_agent(resumed_tool, store))
+
+        resumed.apply()
+
+        assert resumed.get("web_search")["backend"] == "deepseek"
+        assert resumed_tool.applied["backend"] == "deepseek"
+
+    def test_apply_empty_session_clears_previous_session_override(self):
+        tool = _Tool()
+        store = _Store()
+        options = ToolOptions(_agent(tool, store))
+        options.set("web_search", {"backend": "deepseek"})
+        store.state[f"a:{TOOL_OPTIONS_STATE_SUFFIX}"] = {}
+
+        options.apply()
+
+        assert options.get("web_search")["backend"] == "duckduckgo"
+        assert tool.applied["backend"] == "duckduckgo"
+        assert options.list() == {}
+
+    def test_apply_preserves_unavailable_desired_override_without_activating_it(self):
+        store = _Store()
+        first = ToolOptions(_agent(_Tool(), store))
+        first.set("web_search", {"backend": "deepseek"})
+        resumed_tool = _Tool(disabled=True)
+        resumed = ToolOptions(_agent(resumed_tool, store))
+
+        resumed.apply()
+
+        assert resumed.get("web_search")["backend"] == "duckduckgo"
+        assert resumed_tool.applied["backend"] == "duckduckgo"
+        saved = store.state[f"a:{TOOL_OPTIONS_STATE_SUFFIX}"]
+        assert saved == {"web_search": {"backend": "deepseek"}}
+
+        resumed_tool.disabled = False
+        resumed.apply()
+
+        assert resumed.get("web_search")["backend"] == "deepseek"
+        assert resumed_tool.applied["backend"] == "deepseek"

--- a/tests/unit/core/test_agent_tools.py
+++ b/tests/unit/core/test_agent_tools.py
@@ -178,6 +178,32 @@ class TestEmitDirectCompletion:
         assert meta["output_preview"] == big[:5000]
         assert len(meta["output_preview"]) == 5000
 
+    def test_tool_done_only_forwards_explicit_session_metadata(self, agent):
+        agent._register_direct_job("web_search_x", kind="tool", name="web_search")
+        result = JobResult(
+            job_id="web_search_x",
+            output="answer",
+            exit_code=0,
+            metadata={
+                "secret": "must-not-persist",
+                "session_metadata": {
+                    "backend": "deepseek",
+                    "citation_status": "verified",
+                },
+            },
+        )
+
+        agent._emit_direct_completion_activity("web_search_x", result)
+
+        meta = next(
+            c[2] for c in agent.output_router.activity_calls if c[0] == "tool_done"
+        )
+        assert meta["tool_metadata"] == {
+            "backend": "deepseek",
+            "citation_status": "verified",
+        }
+        assert "must-not-persist" not in repr(meta)
+
     def test_tool_error(self, agent):
         agent._register_direct_job("bash_x", kind="tool", name="bash")
         result = JobResult(job_id="bash_x", error="boom", output="")

--- a/tests/unit/llm/test_api_keys.py
+++ b/tests/unit/llm/test_api_keys.py
@@ -15,6 +15,7 @@ from kohakuterrarium.llm.api_keys import (
     PROVIDER_KEY_MAP,
     clear_api_key_resolver,
     get_api_key,
+    has_api_key,
     list_api_keys,
     register_api_key_resolver,
     save_api_key,
@@ -118,6 +119,11 @@ class TestResolutionOrder:
     def test_not_found_anywhere_returns_empty(self, keys_file):
         assert get_api_key("nonexistent") == ""
 
+    def test_availability_uses_stored_deepseek_key(self, keys_file):
+        assert has_api_key("deepseek") is False
+        save_api_key("deepseek", "ds-secret")
+        assert has_api_key("DEEPSEEK_API_KEY") is True
+
 
 # ---------------------------------------------------------------------------
 # Registered resolver (worker mode) — authoritative
@@ -148,6 +154,13 @@ class TestResolver:
         # docstring: worker-mode miss returns "" — never falls through to
         # the worker's own file/env (host-canonical identity design)
         assert get_api_key("openai") == ""
+
+    def test_availability_respects_authoritative_resolver(self, keys_file):
+        register_api_key_resolver(
+            lambda provider: "present" if provider == "deepseek" else ""
+        )
+        assert has_api_key("deepseek") is True
+        assert has_api_key("openai") is False
 
     def test_resolver_exception_treated_as_miss(self, keys_file, monkeypatch):
         save_api_key("openai", "file-key")
@@ -218,6 +231,7 @@ class TestProviderKeyMap:
         assert PROVIDER_KEY_MAP["anthropic"] == "ANTHROPIC_API_KEY"
         assert PROVIDER_KEY_MAP["openrouter"] == "OPENROUTER_API_KEY"
         assert PROVIDER_KEY_MAP["gemini"] == "GEMINI_API_KEY"
+        assert PROVIDER_KEY_MAP["deepseek"] == "DEEPSEEK_API_KEY"
         assert PROVIDER_KEY_MAP["mimo"] == "MIMO_API_KEY"
         assert PROVIDER_KEY_MAP["kimi-code"] == "KIMI_CODE_API_KEY"
         assert PROVIDER_KEY_MAP["glm-coding"] == "GLM_CODING_API_KEY"

--- a/tests/unit/modules/tool/test_runtime_options.py
+++ b/tests/unit/modules/tool/test_runtime_options.py
@@ -1,0 +1,37 @@
+"""Unit tests for ordinary-tool runtime option validation."""
+
+import pytest
+
+from kohakuterrarium.modules.tool.runtime_options import (
+    ToolOptionError,
+    validate_tool_options,
+)
+
+
+class TestValidateToolOptions:
+    schema = {
+        "backend": {
+            "type": "enum",
+            "values": ["duckduckgo", "deepseek"],
+            "disabled_values": {"deepseek": "configure the DeepSeek key"},
+        },
+        "limit": {"type": "int", "min": 1, "max": 10},
+        "enabled": {"type": "bool"},
+    }
+
+    def test_coerces_supported_values(self):
+        assert validate_tool_options(
+            "search",
+            {"backend": "duckduckgo", "limit": "3", "enabled": "yes"},
+            self.schema,
+        ) == {"backend": "duckduckgo", "limit": 3, "enabled": True}
+
+    def test_rejects_disabled_enum_with_actionable_reason(self):
+        with pytest.raises(ToolOptionError, match="configure the DeepSeek key"):
+            validate_tool_options("search", {"backend": "deepseek"}, self.schema)
+
+    def test_rejects_unknown_and_out_of_bounds_values(self):
+        with pytest.raises(ToolOptionError, match="Unknown option"):
+            validate_tool_options("search", {"bogus": 1}, self.schema)
+        with pytest.raises(ToolOptionError, match=">= 1"):
+            validate_tool_options("search", {"limit": 0}, self.schema)

--- a/tests/unit/session/test_output.py
+++ b/tests/unit/session/test_output.py
@@ -504,13 +504,20 @@ class TestActivityHandlers:
         store, out = _make(tmp_path)
         try:
             out.on_activity_with_metadata(
-                "tool_done", "[bash] done", {"job_id": "j1", "result": "ok"}
+                "tool_done",
+                "[bash] done",
+                {
+                    "job_id": "j1",
+                    "result": "ok",
+                    "tool_metadata": {"backend": "deepseek"},
+                },
             )
             store.flush()
             evts = [e for e in store.get_events("alice") if e["type"] == "tool_result"]
             assert len(evts) == 1
             assert evts[0]["exit_code"] == 0
             assert evts[0]["output"] == "ok"
+            assert evts[0]["tool_metadata"] == {"backend": "deepseek"}
         finally:
             store.close()
 

--- a/tests/unit/session/test_resume.py
+++ b/tests/unit/session/test_resume.py
@@ -795,6 +795,22 @@ class TestInjectSavedState:
         finally:
             store.close()
 
+    def test_tool_options_apply_failure_is_swallowed(self, tmp_path):
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.save_state("alice", triggers=[{"name": "t1"}])
+
+            class _BoomOptions:
+                def apply(self):
+                    raise RuntimeError("tool reapply failed")
+
+            agent = _FakeAgentForInject()
+            agent.tool_options = _BoomOptions()
+            inject_saved_state(agent, store, "alice")
+            assert agent._pending_resume_triggers == [{"name": "t1"}]
+        finally:
+            store.close()
+
 
 # -- _open_store_with_migration ------------------------------------
 

--- a/tests/unit/studio/test_api_keys.py
+++ b/tests/unit/studio/test_api_keys.py
@@ -69,6 +69,15 @@ class TestListKeysPayload:
         assert openai_entry["has_key"] is True
         assert openai_entry["masked_key"] == "sk-...***"
 
+    def test_includes_credential_only_provider(self):
+        out = list_keys_payload()
+
+        deepseek = next(e for e in out if e["provider"] == "deepseek")
+        assert deepseek["backend_type"] == "credential"
+        assert deepseek["env_var"] == "DEEPSEEK_API_KEY"
+        assert deepseek["has_key"] is False
+        assert deepseek["available"] is False
+
 
 # ── list_keys_for_cli ────────────────────────────────────────────
 
@@ -94,6 +103,19 @@ class TestListKeysForCli:
         assert anth_row["source"] == "env"
         assert "(from env)" in anth_row["shown"]
 
+    def test_includes_credential_only_provider(self, monkeypatch):
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+        rows = list_keys_for_cli()
+
+        deepseek = next(r for r in rows if r["provider"] == "deepseek")
+        assert deepseek == {
+            "provider": "deepseek",
+            "env_var": "DEEPSEEK_API_KEY",
+            "source": "missing",
+            "shown": "",
+        }
+
 
 # ── set_key ──────────────────────────────────────────────────────
 
@@ -115,6 +137,11 @@ class TestSetKey:
         set_key("anthropic", "new-key")
         assert _mock_backend_layer["stored_keys"]["anthropic"] == "new-key"
 
+    def test_credential_only_provider_success(self, _mock_backend_layer):
+        set_key("deepseek", "ds-key")
+
+        assert _mock_backend_layer["stored_keys"]["deepseek"] == "ds-key"
+
 
 class TestRemoveKey:
     def test_unknown_provider(self):
@@ -124,6 +151,13 @@ class TestRemoveKey:
     def test_success(self, _mock_backend_layer):
         remove_key("openai")
         assert "openai" not in _mock_backend_layer["stored_keys"]
+
+    def test_credential_only_provider_success(self, _mock_backend_layer):
+        _mock_backend_layer["stored_keys"]["deepseek"] = "ds-key"
+
+        remove_key("deepseek")
+
+        assert "deepseek" not in _mock_backend_layer["stored_keys"]
 
 
 class TestGetExistingKey:

--- a/tests/unit/studio/test_creature_modules.py
+++ b/tests/unit/studio/test_creature_modules.py
@@ -14,7 +14,9 @@ class _FakeService:
         self.engine = object()
 
 
-def _patch_adapter_inventory(monkeypatch, plugin_rows=None, native_rows=None):
+def _patch_adapter_inventory(
+    monkeypatch, plugin_rows=None, native_rows=None, tool_rows=None
+):
     monkeypatch.setattr(
         mod.creature_plugins,
         "plugin_inventory",
@@ -25,6 +27,11 @@ def _patch_adapter_inventory(monkeypatch, plugin_rows=None, native_rows=None):
         "native_tool_inventory",
         lambda e, sid, cid: native_rows or [],
     )
+    monkeypatch.setattr(
+        mod.creature_state,
+        "tool_inventory",
+        lambda e, sid, cid: tool_rows or [],
+    )
 
 
 # ── supported_types ─────────────────────────────────────────────
@@ -32,8 +39,7 @@ def _patch_adapter_inventory(monkeypatch, plugin_rows=None, native_rows=None):
 
 class TestSupportedTypes:
     def test_basic(self):
-        # The dispatch table currently registers exactly these two types.
-        assert mod.supported_types() == ["plugin", "native_tool"]
+        assert mod.supported_types() == ["plugin", "native_tool", "tool"]
 
 
 # ── _adapter ────────────────────────────────────────────────────
@@ -64,6 +70,13 @@ class TestListModules:
             native_rows=[
                 {"name": "nt1", "description": "nd", "option_schema": {"k": 1}}
             ],
+            tool_rows=[
+                {
+                    "name": "web_search",
+                    "description": "search",
+                    "values": {"backend": "duckduckgo"},
+                }
+            ],
         )
         svc = _FakeService()
         out = mod.list_modules(svc, "sid", "cid")
@@ -77,6 +90,8 @@ class TestListModules:
         assert by_name["nt1"]["type"] == "native_tool"
         assert by_name["nt1"]["enabled"] is None
         assert by_name["nt1"]["schema"] == {"k": 1}
+        assert by_name["web_search"]["type"] == "tool"
+        assert by_name["web_search"]["options"] == {"backend": "duckduckgo"}
 
     def test_swallows_per_type_errors(self, monkeypatch):
         def raise_runtime(*args, **kwargs):
@@ -85,6 +100,9 @@ class TestListModules:
         monkeypatch.setattr(mod.creature_plugins, "plugin_inventory", raise_runtime)
         monkeypatch.setattr(
             mod.creature_state, "native_tool_inventory", lambda e, sid, cid: []
+        )
+        monkeypatch.setattr(
+            mod.creature_state, "tool_inventory", lambda e, sid, cid: []
         )
         svc = _FakeService()
         # plugin path raises, but native_tool succeeds → returns empty list.
@@ -143,6 +161,22 @@ class TestGetModuleOptions:
                 _FakeService(), "sid", "cid", "native_tool", "missing"
             )
 
+    def test_tool_known(self, monkeypatch):
+        monkeypatch.setattr(
+            mod.creature_state,
+            "tool_inventory",
+            lambda e, sid, cid: [
+                {
+                    "name": "web_search",
+                    "option_schema": {"backend": {"type": "enum"}},
+                    "values": {"backend": "duckduckgo"},
+                }
+            ],
+        )
+        out = mod.get_module_options(_FakeService(), "sid", "cid", "tool", "web_search")
+        assert out["type"] == "tool"
+        assert out["options"] == {"backend": "duckduckgo"}
+
     def test_unknown_type(self):
         with pytest.raises(ValueError):
             mod.get_module_options(_FakeService(), "sid", "cid", "ghost", "p1")
@@ -181,6 +215,25 @@ class TestSetModuleOptions:
         # None values become empty dict before passthrough.
         assert called == [{}]
 
+    def test_tool(self, monkeypatch):
+        called = []
+
+        def fake_set(e, sid, cid, name, values):
+            called.append((name, values))
+            return {"backend": "deepseek"}
+
+        monkeypatch.setattr(mod.creature_state, "set_tool_options", fake_set)
+        out = mod.set_module_options(
+            _FakeService(),
+            "sid",
+            "cid",
+            "tool",
+            "web_search",
+            {"backend": "deepseek"},
+        )
+        assert out == {"backend": "deepseek"}
+        assert called == [("web_search", {"backend": "deepseek"})]
+
 
 # ── toggle_module ───────────────────────────────────────────────
 
@@ -197,3 +250,7 @@ class TestToggleModule:
     async def test_native_tool_unsupported(self):
         with pytest.raises(ValueError, match="does not support toggle"):
             await mod.toggle_module(_FakeService(), "sid", "cid", "native_tool", "nt1")
+
+    async def test_tool_unsupported(self):
+        with pytest.raises(ValueError, match="does not support toggle"):
+            await mod.toggle_module(_FakeService(), "sid", "cid", "tool", "web_search")

--- a/tests/unit/terrarium/test_creature_ops_branches.py
+++ b/tests/unit/terrarium/test_creature_ops_branches.py
@@ -164,6 +164,21 @@ class TestSetModuleOptionsDispatch:
         assert out == {"a": 1}
         assert store == {"t1": {"a": 1}}
 
+    def test_tool_dispatch(self):
+        store = {}
+
+        class _Helper:
+            def set(self, name, values):
+                store[name] = values
+                return values
+
+        agent = SimpleNamespace(tool_options=_Helper())
+        out = co.agent_set_module_options(
+            agent, "tool", "web_search", {"backend": "deepseek"}
+        )
+        assert out == {"backend": "deepseek"}
+        assert store == {"web_search": {"backend": "deepseek"}}
+
 
 # ---------------------------------------------------------------------------
 # _resumable_events — store raising


### PR DESCRIPTION
## Summary

Add a configurable backend strategy to the built-in `web_search` tool, with opt-in DeepSeek Responses API search alongside the existing DuckDuckGo implementation. DuckDuckGo remains the default, and users without a DeepSeek API key keep the current behavior with no additional validation, requests, dependencies, or cost.

## PR Type

- [ ] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Users may want provider-hosted search without coupling search to the creature's primary LLM provider. This change lets a Codex, Claude, OpenAI, or other creature independently opt into DeepSeek search while preserving the existing `web_search` contract and leaving `web_fetch` unchanged.

The public proposal was opened in #156 on 2026-08-14 before this PR. The scope was approved on 2026-08-14 in the project QQ community group by maintainer/group owner **珑珀青葉**. After reviewing the proposal, they replied “可以看看” and “后面把更多 backend 塞进来”; when asked whether to prepare the PR, they replied “ok”. This PR matches that approved scope: it adds DeepSeek as an optional backend and keeps the strategy surface extensible for future backends.

## Changes

- Add `duckduckgo` and `deepseek` strategies to `WebSearchTool`, with configurable DeepSeek model and narrowly scoped DuckDuckGo fallback.
- Use a dedicated async DeepSeek Responses API client and resolve its key only through the credential resolver.
- Add generic runtime `agent.tool_options` with code defaults, Creature YAML baselines, and session overrides.
- Expose configurable ordinary tools through the existing Modules architecture across text commands, Rich CLI, TUI, Studio/API, and the web UI.
- Persist session overrides and a safe allowlisted subset of search provenance metadata without credentials or arbitrary provider payloads.
- Preserve verified structured URL citations while keeping unverified provider-text links visible without fabricating sources.
- Ensure research sub-agents reusing the parent tool observe live backend changes.
- Document configuration and compatibility behavior in English, Simplified Chinese, and Traditional Chinese.
- Add unit and integration coverage for defaults, validation, fallback boundaries, credentials, session restore/reset, UI surfaces, sub-agent reuse, citation parsing, and secret redaction.

## Validation

```bash
.venv/bin/ruff check src/ tests/
.venv/bin/black --check src/ tests/

.venv/bin/python -m pytest \
  tests/unit/builtins/tools/test_web_search.py \
  tests/unit/core/test_agent_tool_options.py \
  tests/unit/core/test_agent_tools.py \
  tests/unit/session/test_output.py \
  tests/unit/modules/tool/test_runtime_options.py \
  tests/unit/studio/test_creature_modules.py \
  tests/integration/test_modules.py -q

.venv/bin/python -m pytest tests/unit/ -q \
  --ignore=tests/unit/test_file_sizes.py \
  --ignore=tests/unit/test_dep_graph_lint.py
.venv/bin/python -m pytest \
  tests/unit/test_file_sizes.py \
  tests/unit/test_dep_graph_lint.py -q
.venv/bin/python -m pytest tests/integration/ -q
.venv/bin/python -m pytest tests/e2e/ -q

cd src/kohakuterrarium-frontend
npm run format:check
CHOKIDAR_USEPOLLING=1 npm run build
npm test -- --run
```

Results:

- Targeted DeepSeek/Modules workflows: 203 passed.
- Unit suite: 11,896 passed, 1 skipped. The 17 loopback-binding cases blocked by the local sandbox were rerun outside it; all 54 tests in those files passed.
- File-size and dependency-graph guards: 1,686 passed.
- Integration suite: 173 passed.
- Frontend Vitest suite: 955 passed.
- Ruff, Black, frontend format check, and production build passed.
- E2E: 77 of 80 journeys passed. See the documented exceptions below.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Closes #156
- Approved in the project QQ community group by maintainer/group owner 珑珀青葉 on 2026-08-14, as quoted in Motivation / Context.

## Notes for Reviewers

Suggested review focus:

- the generic ordinary-tool option boundary in `core/agent_tool_options.py` and `modules/tool/runtime_options.py`;
- fallback classification and DeepSeek response/citation parsing in `builtins/tools/web_search.py`;
- session override precedence and reset/restore behavior;
- the safe metadata allowlist and credential-redaction boundary.

The DeepSeek client is intentionally independent of the creature's primary LLM profile. Missing credentials reject only an explicit switch to DeepSeek; they do not affect startup or DuckDuckGo search.

## Screenshots / Logs (if applicable)

The Modules surfaces show the effective backend, DeepSeek model, fallback, and credential availability. CLI, TUI, Studio/API, and web UI behavior is covered by the tests listed above.

## Breaking Changes (if applicable)

None. Existing Creature configurations and sessions require no migration. DuckDuckGo remains the default, `web_fetch` is unchanged, and no required dependency was added.

## Exceptions / Not Run

The fork's CI workflow only triggers on a `main` push or a pull request, so the feature branch itself has no fork CI run; this upstream draft PR will trigger the configured matrix.

The local E2E run had three failures on existing unrelated surfaces:

- Two API journey assertions expected the transient `regenerating` state, but the scripted response had already completed and returned `completed`.
- The multi-node journey reported its existing cross-worker graph/session failures, including the cases labeled in that test as BUG #134, #143, and #145.

This branch does not modify those API status transitions, cross-worker topology paths, or E2E tests. Unit, integration, guard, frontend, and static checks covering the changed behavior passed.
