### PR TITLE
perf(frontend): fix long-session chat rendering degradation

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
@@ -37,7 +37,7 @@
   </div>
 
   <!-- Processing error -->
-  <div v-else-if="message.role === 'error'" class="rounded-lg bg-coral/8 dark:bg-coral/12 border border-coral/25 dark:border-coral/30 overflow-hidden">
+  <div v-else-if="message.role === 'error'" class="rounded-lg bg-coral/8 dark:bg-coral/12 border border-coral/25 dark:border-coral/30 overflow-hidden chat-cv">
     <div role="button" tabindex="0" :aria-expanded="errorExpanded" class="flex items-center gap-2 py-2 px-3 cursor-pointer select-none hover:bg-coral/12 dark:hover:bg-coral/18" @click="errorExpanded = !errorExpanded" @keydown.enter="errorExpanded = !errorExpanded" @keydown.space.prevent="errorExpanded = !errorExpanded">
       <span class="text-coral font-bold text-sm">&#x2717;</span>
       <span class="text-coral dark:text-coral-light font-semibold text-xs flex-1">
@@ -91,7 +91,7 @@
 
   <!-- User message -->
   <div v-else-if="message.role === 'user'" class="ml-auto group relative" :class="editing ? 'w-[min(760px,92%)] max-w-[92%]' : 'max-w-[80%]'">
-    <div class="user-message" :class="{ 'opacity-70': message.queued, 'user-message-editing': editing }">
+    <div class="user-message chat-cv" :class="{ 'opacity-70': message.queued, 'user-message-editing': editing }">
       <div class="text-xs text-warm-400 mb-1 flex items-center gap-1.5">
         <span>You</span>
         <span v-if="message.queued" class="px-1.5 py-0.5 rounded text-[9px] font-medium bg-amber/15 text-amber leading-none">Queued</span>
@@ -177,26 +177,28 @@
        keyed on the first tool's id so streaming new tools into an
        in-progress batch doesn't reshuffle ``expandedTools`` state. -->
   <div v-else-if="message.role === 'assistant' && message.parts" class="max-w-[90%] group relative">
-    <template v-for="(group, gi) in renderGroups" :key="gi">
-      <!-- Pass-through part -->
-      <template v-if="group.type === 'part'">
-        <div v-if="group.part.type === 'text' && group.part.content" class="text-body mb-1">
-          <MarkdownRenderer :content="group.part.content" />
-        </div>
-        <div v-else-if="group.part.type === 'tool'" class="mb-1.5">
-          <ToolCallBlock :tc="group.part" :expanded="expandedTools[group.part.id]" @toggle="toggleTool(group.part.id)" />
-        </div>
-        <div v-else-if="group.part.type === 'image_url'" class="mb-1.5">
-          <img :src="group.part.image_url?.url" class="chat-inline-image" :alt="group.part.meta?.source_name || 'generated image'" />
-        </div>
-      </template>
-      <!-- Tool-batch group (collapsed by default; per-tool expand state
+    <div class="chat-cv">
+      <template v-for="(group, gi) in renderGroups" :key="groupKey(group, gi)">
+        <!-- Pass-through part -->
+        <template v-if="group.type === 'part'">
+          <div v-if="group.part.type === 'text' && group.part.content" class="text-body mb-1">
+            <MarkdownRenderer :content="group.part.content" />
+          </div>
+          <div v-else-if="group.part.type === 'tool'" class="mb-1.5">
+            <ToolCallBlock :tc="group.part" :expanded="expandedTools[group.part.id]" @toggle="toggleTool(group.part.id)" />
+          </div>
+          <div v-else-if="group.part.type === 'image_url'" class="mb-1.5">
+            <img :src="group.part.image_url?.url" class="chat-inline-image" :alt="group.part.meta?.source_name || 'generated image'" />
+          </div>
+        </template>
+        <!-- Tool-batch group (collapsed by default; per-tool expand state
            lives in the same ``expandedTools`` map keyed by tool id, so
            opening the batch doesn't open the tools and vice-versa). -->
-      <div v-else-if="group.type === 'tool-batch'" class="mb-1.5">
-        <ToolCallBatch :tools="group.tools" :expanded="!!expandedTools[group.id]" :tool-expanded="expandedTools" @toggle="toggleTool(group.id)" @tool-toggle="toggleTool" />
-      </div>
-    </template>
+        <div v-else-if="group.type === 'tool-batch'" class="mb-1.5">
+          <ToolCallBatch :tools="group.tools" :expanded="!!expandedTools[group.id]" :tool-expanded="expandedTools" @toggle="toggleTool(group.id)" @tool-toggle="toggleTool" />
+        </div>
+      </template>
+    </div>
     <!-- Hover actions -->
     <div class="absolute -bottom-5 left-2 flex gap-1 items-center hover-only-action chat-msg-actions chat-msg-actions--left">
       <!-- Branch navigator on the assistant bubble: shown only when
@@ -226,7 +228,7 @@
   </div>
 
   <!-- Assistant message (legacy: content + tool_calls) -->
-  <div v-else-if="message.role === 'assistant'" class="max-w-[90%]">
+  <div v-else-if="message.role === 'assistant'" class="max-w-[90%] chat-cv">
     <div v-if="message.tool_calls?.length" class="mb-2 flex flex-col gap-1.5">
       <ToolCallBlock v-for="tc in message.tool_calls" :key="tc.id" :tc="tc" :expanded="expandedTools[tc.id]" @toggle="toggleTool(tc.id)" />
     </div>
@@ -236,7 +238,7 @@
   </div>
 
   <!-- Channel message (group chat style) -->
-  <div v-else-if="message.role === 'channel'" class="max-w-[90%]">
+  <div v-else-if="message.role === 'channel'" class="max-w-[90%] chat-cv">
     <div v-if="showSenderHeader" class="flex items-center gap-2 mb-1" :class="{ 'mt-2': !isFirst }">
       <span class="w-5 h-5 rounded-md flex items-center justify-center text-[10px] font-bold text-white" :style="{ background: senderGemColor }">
         {{ message.sender.charAt(0).toUpperCase() }}
@@ -329,6 +331,14 @@ const editing = ref(false)
 // Sub-agent parts and any text / image break the run; runs below the
 // threshold (default 3) render flat.  See utils/chatToolGrouping.js.
 const renderGroups = computed(() => computeRenderGroups(props.message.parts || []))
+
+// Batch groups carry a stable id (first tool's id); pass-through groups
+// key on the part's own id when it has one so appending tools mid-stream
+// doesn't reshuffle subsequent group keys.
+function groupKey(group, gi) {
+  if (group.type === "tool-batch") return group.id
+  return group.part?.id ?? `g_${gi}`
+}
 
 const editText = ref("")
 const editAttachments = ref([])

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
@@ -90,6 +90,28 @@ describe("ChatPanel render window", () => {
     expect(wrapper.find("button.self-center").exists()).toBe(false)
   })
 
+  it("shrinkage below an expanded window start falls back to the tail window", async () => {
+    const chat = useChatStore("graph_1")
+    seedMessages(chat, 450)
+    const wrapper = mountPanel(chat)
+    await flushPromises()
+
+    // Expand once: explicit window start at index 0.
+    await wrapper.find("button.self-center").trigger("click")
+    await flushPromises()
+    expect(renderedIds(wrapper).length).toBe(450)
+
+    // A resync replaces the transcript with a much shorter one.
+    seedMessages(chat, 30)
+    await flushPromises()
+
+    // Without the out-of-range fallback the view would collapse to a
+    // single message (clamp to total - 1).
+    expect(renderedIds(wrapper).length).toBe(30)
+    expect(renderedIds(wrapper)[0]).toBe("m_0")
+    expect(wrapper.find("button.self-center").exists()).toBe(false)
+  })
+
   it("new tail messages stay mounted inside the window while streaming", async () => {
     const chat = useChatStore("graph_1")
     seedMessages(chat, 420)

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
@@ -17,6 +17,94 @@ beforeEach(() => {
   setActivePinia(createPinia())
 })
 
+describe("ChatPanel render window", () => {
+  function mountPanel(chat) {
+    chat._instanceId = "graph_1"
+    chat._instanceGraphId = "graph_1"
+    chat.activeTab = "kohaku"
+    chat.tabs = ["kohaku"]
+    chat.commandInventoryByTab = { kohaku: { commands: [], skills: [] } }
+    chat._commandInventoryFetchedAtByTab = { kohaku: Date.now() }
+    return mount(ChatPanel, {
+      props: {
+        instance: {
+          id: "graph_1",
+          graph_id: "graph_1",
+          creatures: [{ name: "kohaku", status: "idle" }],
+        },
+      },
+      global: {
+        provide: { chatStore: chat },
+        stubs: {
+          ChatMessage: {
+            props: ["message", "prevMessage", "messageIdx", "tabId"],
+            template: '<div class="chat-message-stub">{{ message?.id }}</div>',
+          },
+          ModelSwitcher: true,
+          SiteChip: true,
+          StatusDot: true,
+        },
+      },
+    })
+  }
+
+  function renderedIds(wrapper) {
+    return wrapper.findAll(".chat-message-stub").map((el) => el.text())
+  }
+
+  function seedMessages(chat, count) {
+    chat.messagesByTab = {
+      kohaku: Array.from({ length: count }, (_, i) => ({
+        id: `m_${i}`,
+        role: i % 2 ? "assistant" : "user",
+        content: `message ${i}`,
+      })),
+    }
+  }
+
+  it("renders only the newest window for a very long transcript", async () => {
+    const chat = useChatStore("graph_1")
+    seedMessages(chat, 450)
+    const wrapper = mountPanel(chat)
+    await flushPromises()
+
+    expect(renderedIds(wrapper).length).toBe(400)
+    expect(renderedIds(wrapper)[0]).toBe("m_50")
+    expect(renderedIds(wrapper).at(-1)).toBe("m_449")
+    const earlier = wrapper.find("button.self-center")
+    expect(earlier.exists()).toBe(true)
+    expect(earlier.text()).toContain("50")
+  })
+
+  it("load-earlier expands the window toward the start", async () => {
+    const chat = useChatStore("graph_1")
+    seedMessages(chat, 450)
+    const wrapper = mountPanel(chat)
+    await flushPromises()
+
+    await wrapper.find("button.self-center").trigger("click")
+    await flushPromises()
+
+    expect(renderedIds(wrapper).length).toBe(450)
+    expect(renderedIds(wrapper)[0]).toBe("m_0")
+    expect(wrapper.find("button.self-center").exists()).toBe(false)
+  })
+
+  it("new tail messages stay mounted inside the window while streaming", async () => {
+    const chat = useChatStore("graph_1")
+    seedMessages(chat, 420)
+    const wrapper = mountPanel(chat)
+    await flushPromises()
+
+    chat.messagesByTab.kohaku.push({ id: "m_420", role: "user", content: "live" })
+    await flushPromises()
+
+    expect(renderedIds(wrapper).length).toBe(400)
+    expect(renderedIds(wrapper).at(-1)).toBe("m_420")
+    expect(renderedIds(wrapper)).not.toContain("m_0")
+  })
+})
+
 describe("ChatPanel command results", () => {
   it("keeps clear behind the existing composer button", async () => {
     const command = vi.spyOn(terrariumAPI, "executeCreatureCommand").mockResolvedValue({

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -526,7 +526,15 @@ const windowStartIndex = ref(null)
 const windowStart = computed(() => {
   const total = viewMessages.value.length
   if (windowStartIndex.value == null) return Math.max(0, total - RENDER_WINDOW_STEP)
-  return Math.min(windowStartIndex.value, Math.max(0, total - 1))
+  // Shrinkage (branch filter / compact_replace / retry splice) can push
+  // an explicit start past the end of the list; clamping to total - 1
+  // would collapse the view to one message. Fall back to the tail window
+  // and let ``loadEarlierMessages`` re-establish an explicit start.
+  if (windowStartIndex.value >= total) {
+    windowStartIndex.value = null
+    return Math.max(0, total - RENDER_WINDOW_STEP)
+  }
+  return windowStartIndex.value
 })
 const windowMessages = computed(() => viewMessages.value.slice(windowStart.value))
 

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -78,7 +78,10 @@
               <p class="text-warm-300 dark:text-warm-600 text-xs mt-1">{{ resolvedEmptySubtitle }}</p>
             </div>
           </template>
-          <ChatMessage v-for="(msg, idx) in viewMessages" :key="msg.id" :message="msg" :prev-message="idx > 0 ? viewMessages[idx - 1] : null" :is-first="idx === 0" :message-idx="idx" :is-last-assistant="msg.role === 'assistant' && idx === viewMessages.length - 1" :tab-id="viewActiveTab" />
+          <button v-if="windowStart > 0" class="self-center text-xs text-iolite dark:text-iolite-light hover:underline" @click="loadEarlierMessages">
+            {{ t("chat.showEarlier", { count: windowStart }) }}
+          </button>
+          <ChatMessage v-for="(msg, idx) in windowMessages" :key="msg.id" :message="msg" :prev-message="windowStart + idx > 0 ? viewMessages[windowStart + idx - 1] : null" :is-first="windowStart + idx === 0" :message-idx="windowStart + idx" :is-last-assistant="msg.role === 'assistant' && windowStart + idx === viewMessages.length - 1" :tab-id="viewActiveTab" />
           <div v-if="showKohakUwUingIndicator" class="flex items-center gap-2.5 py-2 pl-1">
             <span class="w-2 h-2 rounded-full bg-amber kohaku-pulse" />
             <span class="text-sm text-amber/80 kohaku-pulse">{{ kohakuwuingLabel }}</span>
@@ -410,12 +413,17 @@ const kohakuwuingLabel = computed(() => {
   return t("chat.processing")
 })
 
-function scrollToPending() {
+async function scrollToPending() {
   const tab = viewActiveTab.value
   if (!tab) return
   const list = chat.messagesByTab?.[tab] || []
   const target = list.filter((m) => m.role === "ui_event" && m.interactive && !m.replied && !m.superseded && !m.timedOut).pop()
   if (!target) return
+  const targetIdx = list.indexOf(target)
+  if (targetIdx >= 0 && targetIdx < windowStart.value) {
+    windowStartIndex.value = targetIdx
+    await nextTick()
+  }
   const el = messagesEl.value
   if (!el) return
   const node = el.querySelector(`[data-message-id="${target.id}"]`)
@@ -508,6 +516,30 @@ const isNearBottom = ref(true)
 const forceScrollOnNextMessageUpdate = ref(true)
 const scrollPositions = new Map()
 
+// Tail-anchored render window: very long transcripts mount only the
+// newest RENDER_WINDOW_STEP messages. ``windowStartIndex`` stays null
+// (auto tail) until the user expands upward; once explicit, new
+// messages never shift the top of the rendered slice.
+const RENDER_WINDOW_STEP = 400
+const windowStartIndex = ref(null)
+
+const windowStart = computed(() => {
+  const total = viewMessages.value.length
+  if (windowStartIndex.value == null) return Math.max(0, total - RENDER_WINDOW_STEP)
+  return Math.min(windowStartIndex.value, Math.max(0, total - 1))
+})
+const windowMessages = computed(() => viewMessages.value.slice(windowStart.value))
+
+async function loadEarlierMessages() {
+  const el = messagesEl.value
+  const prevHeight = el ? el.scrollHeight : 0
+  windowStartIndex.value = Math.max(0, windowStart.value - RENDER_WINDOW_STEP)
+  await nextTick()
+  // Compensate the prepended height so the content the user was
+  // reading stays under the cursor.
+  if (el && prevHeight) el.scrollTop += el.scrollHeight - prevHeight
+}
+
 function getScrollKey(instanceId = props.instance?.id || chat._instanceId, tab = viewActiveTab.value) {
   if (!instanceId || !tab) return ""
   const suffix = props.groupId ? `:${props.groupId}` : ""
@@ -593,6 +625,7 @@ watch(
   ([instanceId, tab], previous) => {
     const [prevInstanceId, prevTab] = previous || []
     if (prevInstanceId && prevTab) saveScrollPosition(prevInstanceId, prevTab)
+    windowStartIndex.value = null
     restoreDraft()
     nextTick(() => {
       const hadSavedScroll = restoreScrollPosition(instanceId, tab)

--- a/src/kohakuterrarium-frontend/src/components/chat/chat-panel.css
+++ b/src/kohakuterrarium-frontend/src/components/chat/chat-panel.css
@@ -53,3 +53,18 @@
     height: 2.75rem;
   }
 }
+
+/* Long-session rendering: message bodies are skipped entirely (layout,
+ * style, paint) while off-screen, so a transcript with thousands of
+ * messages only pays render cost for the visible viewport plus scroll
+ * estimates. ``auto`` in contain-intrinsic-size lets the browser remember
+ * each message's real height after its first paint, keeping scrollbar
+ * estimates accurate without forcing a layout of the whole list.
+ *
+ * Applied to inner content wrappers (never to roots carrying the
+ * absolutely-positioned hover action rows): paint containment clips
+ * descendants to the element's box. */
+.chat-cv {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 6rem;
+}

--- a/src/kohakuterrarium-frontend/src/components/common/MarkdownRenderer.test.js
+++ b/src/kohakuterrarium-frontend/src/components/common/MarkdownRenderer.test.js
@@ -1,0 +1,67 @@
+import { mount } from "@vue/test-utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import MarkdownRenderer from "./MarkdownRenderer.vue"
+
+describe("MarkdownRenderer streaming", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function renderedHtml(wrapper) {
+    return wrapper.find(".md-content").html()
+  }
+
+  it("renders initial content synchronously", () => {
+    const wrapper = mount(MarkdownRenderer, { props: { content: "hello **world**" } })
+    expect(renderedHtml(wrapper)).toContain("<strong>world</strong>")
+  })
+
+  it("re-renders appended content after the throttle window", async () => {
+    const wrapper = mount(MarkdownRenderer, { props: { content: "first paragraph" } })
+    expect(renderedHtml(wrapper)).toContain("first paragraph")
+
+    await wrapper.setProps({ content: "first paragraph\n\nsecond paragraph" })
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(renderedHtml(wrapper)).toContain("first paragraph")
+    expect(renderedHtml(wrapper)).toContain("second paragraph")
+  })
+
+  it("keeps the earlier paragraph html stable while a code fence streams closed", async () => {
+    const wrapper = mount(MarkdownRenderer, { props: { content: "intro\n\n```js\nconst a = 1;" } })
+    const before = renderedHtml(wrapper)
+    expect(before).toContain("intro")
+    expect(before).toContain("const a = 1;")
+
+    await wrapper.setProps({ content: "intro\n\n```js\nconst a = 1;\nconst b = 2;\n```\n\noutro" })
+    await vi.advanceTimersByTimeAsync(200)
+
+    const after = renderedHtml(wrapper)
+    expect(after).toContain("const b = 2;")
+    expect(after).toContain("outro")
+    // The untouched leading paragraph must survive byte-for-byte across the
+    // stream — that stability is what keeps incremental rendering correct.
+    expect(after).toContain("<p>intro</p>")
+  })
+
+  it("renders empty for empty content", () => {
+    const wrapper = mount(MarkdownRenderer, { props: { content: "" } })
+    expect(renderedHtml(wrapper)).not.toContain("<p>")
+  })
+
+  it("recovers when content is replaced wholesale", async () => {
+    const wrapper = mount(MarkdownRenderer, { props: { content: "long\n\nstreaming\n\nanswer" } })
+    expect(renderedHtml(wrapper)).toContain("streaming")
+
+    await wrapper.setProps({ content: "brand new content" })
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(renderedHtml(wrapper)).toContain("brand new content")
+    expect(renderedHtml(wrapper)).not.toContain("streaming")
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/common/MarkdownRenderer.vue
+++ b/src/kohakuterrarium-frontend/src/components/common/MarkdownRenderer.vue
@@ -9,6 +9,8 @@ import MarkdownIt from "markdown-it"
 import markdownItKatex from "@vscode/markdown-it-katex"
 import hljs from "highlight.js"
 
+import { IncrementalMarkdownRenderer } from "@/utils/markdownIncremental"
+
 const props = defineProps({
   content: { type: String, default: "" },
   // ``breaks: true`` matches the chat-app convention: a single newline
@@ -155,6 +157,10 @@ function renderMarkdown(content) {
   }
 }
 
+// Reuse rendered HTML for the unchanged block prefix of streamed content;
+// only the changed tail block re-renders each throttle window.
+const incremental = new IncrementalMarkdownRenderer(renderMarkdown)
+
 /*
  * Throttled rendering.
  *
@@ -182,9 +188,10 @@ let pendingContent = null
 function doRender(content) {
   if (!content) {
     rendered.value = ""
+    incremental.reset()
     return
   }
-  rendered.value = renderMarkdown(preprocessLatex(content))
+  rendered.value = incremental.render(preprocessLatex(content))
   lastRenderAt = performance.now()
 }
 

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -415,10 +415,22 @@ export function _replayEvents(messages, events, branchView = null) {
   const startedJobs = {} // jobId -> tool part reference
   const completedJobs = new Set() // jobIds that received done/error
 
+  // Positional ids ("h_" + result.length) shift whenever an earlier
+  // event is hidden (compact_replace ranges, branch filtering), which
+  // remounts every later message on each resync. Events carry stable
+  // numeric ids — derive message/part ids from the originating event so
+  // rebuilds reuse component instances. Falls back to the positional
+  // form for synthetic events without an event_id.
+  let curEventKey = null
+
+  function stableId(prefix) {
+    return prefix + (curEventKey ?? String(result.length))
+  }
+
   function ensureCur() {
     if (!cur) {
       cur = {
-        id: "h_" + result.length,
+        id: stableId("h_"),
         role: "assistant",
         parts: [],
         timestamp: "",
@@ -434,7 +446,7 @@ export function _replayEvents(messages, events, branchView = null) {
     if (tail && tail.type === "text") {
       tail.content += content
     } else {
-      c.parts.push({ type: "text", content })
+      c.parts.push({ type: "text", content, id: stableId("txt_") })
     }
   }
 
@@ -456,7 +468,7 @@ export function _replayEvents(messages, events, branchView = null) {
     const initialStatus = kind === "subagent" ? "running" : "done"
     const tool = {
       type: "tool",
-      id: `tool_${_n++}`,
+      id: curEventKey ? "tool_" + curEventKey : `tool_${_n++}`,
       jobId: jobId || "",
       name,
       kind,
@@ -517,7 +529,7 @@ export function _replayEvents(messages, events, branchView = null) {
     if (sa) {
       const tool = {
         type: "tool",
-        id: `tool_${_n++}`,
+        id: curEventKey ? "tool_" + curEventKey : `tool_${_n++}`,
         name,
         kind: "tool",
         args: args || {},
@@ -635,7 +647,7 @@ export function _replayEvents(messages, events, branchView = null) {
       return existing
     }
     const compact = {
-      id: "compact_" + result.length,
+      id: stableId("compact_"),
       role: "compact",
       round,
       summary,
@@ -649,6 +661,7 @@ export function _replayEvents(messages, events, branchView = null) {
 
   for (const evt of events) {
     const t = evt.type
+    curEventKey = typeof evt.event_id === "number" ? `e${evt.event_id}` : null
 
     // Skip events on a non-selected branch of their turn (siblings of
     // regen / edit+rerun stay on disk for the <1/N> navigator but
@@ -690,7 +703,7 @@ export function _replayEvents(messages, events, branchView = null) {
       cur = null
       const normalized = normalizeMessageContent(evt.content)
       const userMessage = {
-        id: "h_" + result.length,
+        id: stableId("h_"),
         role: "user",
         content: normalized.content,
         contentParts: normalized.contentParts,
@@ -723,7 +736,7 @@ export function _replayEvents(messages, events, branchView = null) {
       cur = null
       const normalized = normalizeMessageContent(evt.content)
       result.push({
-        id: "h_" + result.length,
+        id: stableId("h_"),
         role: "user",
         content: normalized.content,
         contentParts: normalized.contentParts,
@@ -734,7 +747,7 @@ export function _replayEvents(messages, events, branchView = null) {
       })
     } else if (t === "processing_start") {
       cur = {
-        id: "h_" + result.length,
+        id: stableId("h_"),
         role: "assistant",
         parts: [],
         timestamp: "",
@@ -762,7 +775,7 @@ export function _replayEvents(messages, events, branchView = null) {
         const ch = evt.channel || ""
         const sender = evt.sender || ""
         result.push({
-          id: "h_" + result.length,
+          id: stableId("h_"),
           role: "trigger",
           content: ch ? `channel: ${ch}${sender ? ` from ${sender}` : ""}` : evt.name,
           triggerContent: evt.content || "",
@@ -775,7 +788,7 @@ export function _replayEvents(messages, events, branchView = null) {
       } else if (at === "context_cleared") {
         cur = null
         result.push({
-          id: "clear_" + result.length,
+          id: stableId("clear_"),
           role: "clear",
           messagesCleared: evt.messages_cleared || 0,
           timestamp: "",
@@ -783,7 +796,7 @@ export function _replayEvents(messages, events, branchView = null) {
       } else if (at === "processing_error") {
         cur = null
         result.push({
-          id: "err_" + result.length,
+          id: stableId("err_"),
           role: "error",
           errorType: evt.error_type || "Error",
           content: evt.error || evt.detail || "Unknown error",
@@ -870,7 +883,7 @@ export function _replayEvents(messages, events, branchView = null) {
       // explanation.
       cur = null
       result.push({
-        id: "h_" + result.length,
+        id: stableId("h_"),
         role: "wire_inbound",
         from: evt.from || evt.detail || "",
         to: evt.to || "",
@@ -888,7 +901,7 @@ export function _replayEvents(messages, events, branchView = null) {
       const ch = evt.channel || ""
       const sender = evt.sender || ""
       result.push({
-        id: "h_" + result.length,
+        id: stableId("h_"),
         role: "trigger",
         content: ch ? `channel: ${ch}${sender ? ` from ${sender}` : ""}` : "",
         triggerContent: evt.content || "",
@@ -950,7 +963,7 @@ export function _replayEvents(messages, events, branchView = null) {
     } else if (t === "channel_message") {
       const normalized = normalizeMessageContent(evt.content)
       result.push({
-        id: "ch_" + result.length,
+        id: stableId("ch_"),
         role: "channel",
         sender: evt.sender || "",
         content: normalized.content,
@@ -985,7 +998,7 @@ export function _replayEvents(messages, events, branchView = null) {
       // A combined delivery banner carries `labels` (one per folded
       // completion); older single-event frames carry only `label`.
       result.push({
-        id: "bgres_" + result.length,
+        id: stableId("bgres_"),
         role: "bg_result",
         label: (Array.isArray(evt.labels) ? evt.labels.join(", ") : evt.label) || evt.job_id || "",
         kind: evt.kind || "tool",
@@ -1004,7 +1017,7 @@ export function _replayEvents(messages, events, branchView = null) {
     } else if (t === "processing_error") {
       cur = null
       result.push({
-        id: "err_" + result.length,
+        id: stableId("err_"),
         role: "error",
         errorType: evt.error_type || "Error",
         content: evt.error || "",
@@ -1013,7 +1026,7 @@ export function _replayEvents(messages, events, branchView = null) {
     } else if (t === "context_cleared") {
       cur = null
       result.push({
-        id: "clear_" + result.length,
+        id: stableId("clear_"),
         role: "clear",
         messagesCleared: evt.messages_cleared || 0,
         timestamp: "",
@@ -1028,6 +1041,7 @@ export function _replayEvents(messages, events, branchView = null) {
       }
       c.parts.push({
         type: "image_url",
+        id: stableId("img_"),
         image_url: {
           url: evt.url,
           detail: evt.detail || "auto",
@@ -3240,8 +3254,16 @@ const _chatStoreOptions = {
       if (expected?.baselineFromCache && !Object.hasOwn(next, "baselineMaxEventId")) {
         const physical = (this.eventsByTab[tab] || []).filter((evt) => !evt?._optimistic)
         next.baselineMaxEventId = this._maxEventId(physical)
+        // Length, not content: the fingerprint only needs to detect that
+        // the physical log advanced; stringifying full content
+        // re-serializes megabytes on branch-heavy tabs.
         next.baselinePhysicalFingerprint = JSON.stringify(
-          physical.map((evt) => [evt?.type, evt?.turn_index, evt?.branch_id, evt?.content]),
+          physical.map((evt) => [
+            evt?.type,
+            evt?.turn_index,
+            evt?.branch_id,
+            typeof evt?.content === "string" ? evt.content.length : 0,
+          ]),
         )
       }
       this._branchResyncPendingByTab[tab] = next

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -1,5 +1,5 @@
 import { ElMessage } from "element-plus"
-import { getCurrentInstance } from "vue"
+import { getCurrentInstance, markRaw } from "vue"
 
 import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
 import { injectScope, registerScopeDisposer, scopeOfStoreId } from "@/composables/useScope"
@@ -71,6 +71,57 @@ function contentSignature(content) {
   return JSON.stringify(normalized)
 }
 
+// ── Per-tab message indexes (module-level by design) ──
+// Live WS frames look up tool parts by job_id on every tool event;
+// scanning every message×part per frame is O(N) and dominates long
+// sessions. The indexes are pure caches over the message arrays,
+// rebuilt on every wholesale replacement (``_setMessages``), so they
+// stay out of Pinia state — reactive, devtools-visible copies would
+// cost more than the scans they replace.
+const _indexesByStore = new WeakMap()
+
+function _tabIndexes(store, tab) {
+  let byTab = _indexesByStore.get(store)
+  if (!byTab) {
+    byTab = new Map()
+    _indexesByStore.set(store, byTab)
+  }
+  let idx = byTab.get(tab)
+  if (!idx) {
+    idx = { tools: new Map(), channelIds: new Set() }
+    byTab.set(tab, idx)
+  }
+  return idx
+}
+
+function _indexMsgToolsInto(idx, msg) {
+  if (!Array.isArray(msg?.parts)) return
+  for (const p of msg.parts) {
+    if (p?.type === "tool" && p.jobId) idx.tools.set(p.jobId, p)
+  }
+}
+
+/** Reuse the previous message object (and matching per-part objects)
+ * when a rebuild produces a message with the same id, so ChatMessage
+ * props keep their identity across resyncs and Vue can skip whole
+ * re-renders of unchanged messages. */
+function _mergeMessageInPlace(oldMsg, freshMsg) {
+  const freshParts = Array.isArray(freshMsg.parts) ? freshMsg.parts : null
+  if (freshParts && Array.isArray(oldMsg.parts)) {
+    const partById = new Map()
+    for (const p of oldMsg.parts) if (p?.id != null) partById.set(p.id, p)
+    for (let i = 0; i < freshParts.length; i++) {
+      const fp = freshParts[i]
+      const op = fp?.id != null ? partById.get(fp.id) : undefined
+      if (op && op !== fp) {
+        Object.assign(op, fp)
+        freshParts[i] = op
+      }
+    }
+  }
+  Object.assign(oldMsg, freshMsg)
+}
+
 export function _parseSlashCommand(content) {
   let text = null
   if (typeof content === "string") {
@@ -121,10 +172,11 @@ function toolResultPayload(result, data = {}) {
   if (data.canvas_preview && (!resultMeta || !resultMeta.canvas_preview)) {
     resultMeta = { ...(resultMeta || {}), canvas_preview: data.canvas_preview }
   }
+  const parts = normalizeContentParts(result)
   return {
     result,
-    resultParts: normalizeContentParts(result),
-    resultMeta,
+    resultParts: parts ? markRaw(parts) : parts,
+    resultMeta: resultMeta ? markRaw(resultMeta) : resultMeta,
   }
 }
 
@@ -472,7 +524,7 @@ export function _replayEvents(messages, events, branchView = null) {
       jobId: jobId || "",
       name,
       kind,
-      args: args || {},
+      args: markRaw(args || {}),
       status: initialStatus,
       result: "",
       tools_used: [],
@@ -532,7 +584,7 @@ export function _replayEvents(messages, events, branchView = null) {
         id: curEventKey ? "tool_" + curEventKey : `tool_${_n++}`,
         name,
         kind: "tool",
-        args: args || {},
+        args: markRaw(args || {}),
         status: "done",
         result: "",
         tools_used: [],
@@ -1911,7 +1963,7 @@ const _chatStoreOptions = {
     _addTab(key) {
       if (!this.tabs.includes(key)) {
         this.tabs.push(key)
-        this.messagesByTab[key] = []
+        this._setMessages(key, [])
       }
       // When groups are active, also drop the tab into the focused
       // group so backend ``creature_added`` events surface in the
@@ -3031,19 +3083,21 @@ const _chatStoreOptions = {
         }
         const toolId = data.id || "tc_" + Date.now()
         const jobId = data.job_id || ""
-        last.parts.push({
+        const startedPart = {
           type: "tool",
           id: toolId,
           jobId,
           name,
           kind: at === "subagent_start" ? "subagent" : "tool",
-          args: data.args || { info: data.detail },
+          args: markRaw(data.args || { info: data.detail }),
           status: "running",
           result: "",
           tools_used: data.tools_used || [],
           children: [],
           startedAt: Date.now(),
-        })
+        }
+        last.parts.push(startedPart)
+        this._indexToolPart(source, startedPart)
         // Track all tasks as running jobs (direct tasks are promotable)
         const runKey = jobId || toolId
         const isBg = data.background || false
@@ -3056,7 +3110,7 @@ const _chatStoreOptions = {
         }
         this._ensureJobTimer()
       } else if (at === "tool_done" || at === "subagent_done") {
-        let tc = this._findToolPart(msgs, name, data.job_id)
+        let tc = this._findToolPart(source, msgs, name, data.job_id)
         if (!tc) {
           const last = this._ensureAssistantMsg(msgs)
           tc = {
@@ -3072,6 +3126,7 @@ const _chatStoreOptions = {
             children: [],
           }
           last.parts.push(tc)
+          this._indexToolPart(source, tc)
         }
         tc.status = "done"
         const payload = toolResultPayload(data.result || data.output || data.detail || "", data)
@@ -3088,7 +3143,7 @@ const _chatStoreOptions = {
         delete this.runningJobs[tc.jobId || tc.id]
         this._checkJobTimer()
       } else if (at === "tool_error" || at === "subagent_error") {
-        let tc = this._findToolPart(msgs, name, data.job_id)
+        let tc = this._findToolPart(source, msgs, name, data.job_id)
         if (!tc) {
           const last = this._ensureAssistantMsg(msgs)
           tc = {
@@ -3104,6 +3159,7 @@ const _chatStoreOptions = {
             children: [],
           }
           last.parts.push(tc)
+          this._indexToolPart(source, tc)
         }
         tc.status = data.interrupted || data.final_state === "interrupted" ? "interrupted" : "error"
         const payload = toolResultPayload(data.result || data.error || data.detail || "", data)
@@ -3124,7 +3180,7 @@ const _chatStoreOptions = {
         const saName = data.subagent || ""
         const saJobId = data.job_id || ""
         this._recordSubagentUsage(source, saJobId, data)
-        const sa = this._findSubagentPart(msgs, saName, saJobId)
+        const sa = this._findSubagentPart(source, msgs, saName, saJobId)
         if (sa) {
           if (data.total_tokens) sa.total_tokens = data.total_tokens
           if (data.prompt_tokens) sa.prompt_tokens = data.prompt_tokens
@@ -3134,7 +3190,7 @@ const _chatStoreOptions = {
         // Sub-agent internal tool activity: find parent by job_id or name
         const saName = data.subagent || ""
         const saJobId = data.job_id || ""
-        const sa = this._findSubagentPart(msgs, saName, saJobId)
+        const sa = this._findSubagentPart(source, msgs, saName, saJobId)
         if (sa) {
           if (!sa.children) sa.children = []
           if (!sa.tools_used) sa.tools_used = []
@@ -3617,7 +3673,10 @@ const _chatStoreOptions = {
           cutAt = i
         }
       }
-      if (cutAt < msgs.length) msgs.splice(cutAt)
+      if (cutAt < msgs.length) {
+        msgs.splice(cutAt)
+        this._rebuildMessageIndexes(tab)
+      }
       // Snapshot state BEFORE the optimistic mutation so the catch
       // block can roll back cleanly when the API call fails. Without
       // this the tab gets stuck showing KohakUwUing forever (no WS
@@ -3844,6 +3903,7 @@ const _chatStoreOptions = {
           contentParts: normalized.contentParts,
         }
         msgs.splice(messageIdx, msgs.length - messageIdx, editedRow)
+        if (tab) this._rebuildMessageIndexes(tab)
       }
       if (predictedBranch != null && tab) {
         const injected = this._injectOptimisticBranch(tab, {
@@ -3903,7 +3963,7 @@ const _chatStoreOptions = {
             return this._branchOperationResult(true, tab, this.branchOperationByTab[tab])
           }
           delete this._branchResyncPendingByTab[tab]
-          if (previousMessages && tab) this.messagesByTab[tab] = previousMessages
+          if (previousMessages && tab) this._restoreMessages(tab, previousMessages)
           if (optimisticApplied && tab) {
             if (previousEvents !== undefined) {
               if (previousEvents == null) delete this.eventsByTab[tab]
@@ -4021,10 +4081,13 @@ const _chatStoreOptions = {
               this._localCommandResultsByTab[tab],
               branchSelection,
             )
-            this.messagesByTab[tab] = mergeLocalCommandResults(
-              _convertHistory(data.messages),
-              this._localCommandResultsByTab[tab],
-              branchSelection,
+            this._setMessages(
+              tab,
+              mergeLocalCommandResults(
+                _convertHistory(data.messages),
+                this._localCommandResultsByTab[tab],
+                branchSelection,
+              ),
             )
           }
           if (data?.is_processing) this.processingByTab[tab] = true
@@ -4040,10 +4103,13 @@ const _chatStoreOptions = {
             this._localCommandResultsByTab[tab],
             branchSelection,
           )
-          this.messagesByTab[tab] = mergeLocalCommandResults(
-            messages,
-            this._localCommandResultsByTab[tab],
-            branchSelection,
+          this._setMessages(
+            tab,
+            mergeLocalCommandResults(
+              messages,
+              this._localCommandResultsByTab[tab],
+              branchSelection,
+            ),
           )
           if (data?.is_processing) this.processingByTab[tab] = true
           return true
@@ -4172,10 +4238,9 @@ const _chatStoreOptions = {
         this._localCommandResultsByTab[tab],
         branchSelection,
       )
-      this.messagesByTab[tab] = mergeLocalCommandResults(
-        messages,
-        this._localCommandResultsByTab[tab],
-        branchSelection,
+      this._setMessages(
+        tab,
+        mergeLocalCommandResults(messages, this._localCommandResultsByTab[tab], branchSelection),
       )
       // Canonical history is authoritative for this tab's running jobs.
       // ``fetchedAt`` (set only by _resyncHistory) unlocks removals of
@@ -4209,10 +4274,82 @@ const _chatStoreOptions = {
     },
 
     /**
-     * Find a tool part by job_id (reliable, any status) or name (running only).
-     * Searches all messages backwards.
+     * Replace a tab's message array wholesale — the single choke point
+     * every rebuild goes through. Reuses previous message/part objects
+     * by id so component props keep their identity, then refreshes the
+     * per-tab lookup indexes.
      */
-    _findToolPart(msgs, name, jobId) {
+    _setMessages(tab, next) {
+      const prev = this.messagesByTab[tab]
+      if (Array.isArray(prev) && Array.isArray(next)) {
+        const byId = new Map()
+        for (const m of prev) if (m?.id != null) byId.set(m.id, m)
+        for (let i = 0; i < next.length; i++) {
+          const fresh = next[i]
+          const old = fresh?.id != null ? byId.get(fresh.id) : undefined
+          if (old && old !== fresh) {
+            _mergeMessageInPlace(old, fresh)
+            next[i] = old
+          }
+        }
+      }
+      this.messagesByTab[tab] = next
+      this._rebuildMessageIndexes(tab)
+    },
+
+    /** Restore a previously captured array (rollback) — identities are
+     * already correct; only the indexes need a rebuild. */
+    _restoreMessages(tab, arr) {
+      this.messagesByTab[tab] = arr
+      this._rebuildMessageIndexes(tab)
+    },
+
+    _rebuildMessageIndexes(tab) {
+      if (!tab) return
+      const idx = _tabIndexes(this, tab)
+      idx.tools.clear()
+      idx.channelIds.clear()
+      const msgs = this.messagesByTab[tab]
+      if (!Array.isArray(msgs)) return
+      if (tab.startsWith("ch:")) {
+        for (const m of msgs) if (m?.id != null) idx.channelIds.add(m.id)
+      }
+      for (const m of msgs) _indexMsgToolsInto(idx, m)
+    },
+
+    _indexMessage(tab, msg) {
+      if (!tab || !msg) return
+      const idx = _tabIndexes(this, tab)
+      if (tab.startsWith("ch:") && msg.id != null) idx.channelIds.add(msg.id)
+      _indexMsgToolsInto(idx, msg)
+    },
+
+    _indexToolPart(tab, part) {
+      if (!tab) return
+      if (part?.type === "tool" && part.jobId) _tabIndexes(this, tab).tools.set(part.jobId, part)
+    },
+
+    _hasChannelMessage(tab, id) {
+      const idx = _tabIndexes(this, tab)
+      if (idx.channelIds.size === 0) {
+        const msgs = this.messagesByTab[tab]
+        if (Array.isArray(msgs)) {
+          for (const m of msgs) if (m?.id != null) idx.channelIds.add(m.id)
+        }
+      }
+      return idx.channelIds.has(id)
+    },
+
+    /**
+     * Find a tool part by job_id (reliable, any status) or name (running only).
+     * Job-id lookups hit the per-tab index; the scans below are the
+     * fallback for parts the index hasn't seen (and reseed it).
+     */
+    _findToolPart(tab, msgs, name, jobId) {
+      if (jobId) {
+        const hit = _tabIndexes(this, tab).tools.get(jobId)
+        if (hit) return hit
+      }
       for (let i = msgs.length - 1; i >= 0; i--) {
         const msg = msgs[i]
         if (!msg.parts) continue
@@ -4220,7 +4357,10 @@ const _chatStoreOptions = {
           const p = msg.parts[j]
           if (p.type !== "tool") continue
           // Match by job_id: any status (handles replay "running" + live "running")
-          if (jobId && p.jobId === jobId) return p
+          if (jobId && p.jobId === jobId) {
+            if (tab) _tabIndexes(this, tab).tools.set(jobId, p)
+            return p
+          }
         }
       }
       // Fallback: match by name, running status only
@@ -4236,11 +4376,15 @@ const _chatStoreOptions = {
     },
 
     /**
-     * Find a sub-agent part. Match by job_id first, then name, then any running sub-agent.
+     * Find a sub-agent part. Indexed job_id match first, then name,
+     * then any running sub-agent (scans below double as the index
+     * seeding fallback).
      */
-    _findSubagentPart(msgs, saName, saJobId) {
+    _findSubagentPart(tab, msgs, saName, saJobId) {
       // 1. Match by job_id (most reliable - connects sub-agent tool events to parent)
       if (saJobId) {
+        const hit = _tabIndexes(this, tab).tools.get(saJobId)
+        if (hit && hit.kind === "subagent") return hit
         for (let i = msgs.length - 1; i >= 0; i--) {
           const msg = msgs[i]
           if (!msg.parts) continue
@@ -4400,18 +4544,20 @@ const _chatStoreOptions = {
 
       if (this.messagesByTab[tabKey]) {
         const existing = this.messagesByTab[tabKey]
-        if (data.message_id && existing.some((m) => m.id === data.message_id)) {
+        if (data.message_id && this._hasChannelMessage(tabKey, data.message_id)) {
           return
         }
         const normalized = normalizeMessageContent(data.content)
-        this.messagesByTab[tabKey].push({
+        const pushed = {
           id: data.message_id || "ch_" + Date.now(),
           role: "channel",
           sender: data.sender,
           content: normalized.content,
           contentParts: normalized.contentParts,
           timestamp: data.timestamp,
-        })
+        }
+        existing.push(pushed)
+        this._indexMessage(tabKey, pushed)
         if (this.activeTab !== tabKey) {
           this.unreadCounts[tabKey] = (this.unreadCounts[tabKey] || 0) + 1
         }
@@ -4551,6 +4697,7 @@ const _chatStoreOptions = {
         }
       }
       this.messagesByTab[tabKey].push(msg)
+      this._indexMessage(tabKey, msg)
       this._historyMutationSeqByTab[tabKey] = (this._historyMutationSeqByTab[tabKey] || 0) + 1
     },
 
@@ -4611,10 +4758,13 @@ const _chatStoreOptions = {
         this.eventsByTab[tabKey],
         this.branchViewByTab[tabKey] || null,
       )
-      this.messagesByTab[tabKey] = mergeLocalCommandResults(
-        canonical,
-        this._localCommandResultsByTab[tabKey],
-        currentSelection,
+      this._setMessages(
+        tabKey,
+        mergeLocalCommandResults(
+          canonical,
+          this._localCommandResultsByTab[tabKey],
+          currentSelection,
+        ),
       )
       if (
         Number.isInteger(resultContext?.dispatchSeq) &&

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -1153,6 +1153,85 @@ describe("chat store — interrupted task handling", () => {
     expect(assistant2After.id).toBe(assistant2Before.id)
   })
 
+  it("_setMessages reuses message and part object identity by id", () => {
+    const events = [
+      { type: "user_input", event_id: 1, content: "q1" },
+      { type: "processing_start", event_id: 2 },
+      { type: "text", event_id: 3, content: "a1" },
+      { type: "tool_call", event_id: 4, name: "bash", call_id: "job_1", args: {} },
+      { type: "tool_result", event_id: 5, name: "bash", call_id: "job_1", output: "ok" },
+      { type: "processing_end", event_id: 6 },
+    ]
+    const chat = useChatStore()
+    chat.eventsByTab = { main: events }
+    chat._rebuildMessages("main")
+    const first = chat.messagesByTab.main.map((m) => m)
+    const firstTool = chat.messagesByTab.main[1].parts[1]
+
+    chat._rebuildMessages("main")
+    const second = chat.messagesByTab.main
+
+    expect(second[0]).toBe(first[0])
+    expect(second[1]).toBe(first[1])
+    expect(second[1].parts[1]).toBe(firstTool)
+    expect(second[1].parts[1].result).toBe("ok")
+  })
+
+  it("_findToolPart misses a job the latest rebuild dropped (no stale index hits)", () => {
+    const chat = useChatStore()
+    const withTool = [
+      { type: "processing_start", event_id: 2 },
+      { type: "tool_call", event_id: 3, name: "bash", call_id: "job_1", args: {} },
+      { type: "processing_end", event_id: 4 },
+    ]
+    chat.eventsByTab = { main: withTool }
+    chat._rebuildMessages("main")
+    expect(chat._findToolPart("main", chat.messagesByTab.main, "bash", "job_1")).toBeTruthy()
+
+    chat.eventsByTab = {
+      main: [
+        { type: "processing_start", event_id: 10 },
+        { type: "text", event_id: 11, content: "plain" },
+        { type: "processing_end", event_id: 12 },
+      ],
+    }
+    chat._rebuildMessages("main")
+    expect(chat._findToolPart("main", chat.messagesByTab.main, "bash", "job_1")).toBeNull()
+  })
+
+  it("_findToolPart still finds tools when the index was never seeded (fallback scan)", () => {
+    const chat = useChatStore()
+    // Bypass _setMessages: direct assignment simulates a code path that
+    // skipped index maintenance; the fallback scan must still answer.
+    chat.messagesByTab = {
+      main: [
+        {
+          id: "h_0",
+          role: "assistant",
+          parts: [{ type: "tool", id: "tool_0", jobId: "job_x", name: "bash", status: "done" }],
+        },
+      ],
+    }
+    const tool = chat._findToolPart("main", chat.messagesByTab.main, "bash", "job_x")
+    expect(tool.jobId).toBe("job_x")
+  })
+
+  it("_handleChannelMessage dedupes by message_id via the id set", () => {
+    const chat = useChatStore()
+    chat.messagesByTab = { "ch:tasks": [] }
+    chat._rebuildMessageIndexes("ch:tasks")
+    const frame = {
+      channel: "tasks",
+      message_id: "m1",
+      sender: "a",
+      content: "hello",
+      timestamp: "t",
+    }
+    chat._handleChannelMessage(frame)
+    chat._handleChannelMessage(frame)
+    expect(chat.messagesByTab["ch:tasks"].length).toBe(1)
+  })
+
   it("falls back to positional ids for events without event_id", () => {
     const events = [
       { type: "user_input", content: "q1" },
@@ -1288,7 +1367,7 @@ describe("chat store — interrupted task handling", () => {
       result: "User manually interrupted this job.",
     })
 
-    const tool = chat._findToolPart(chat.messagesByTab.main, "bash", "job_1")
+    const tool = chat._findToolPart("main", chat.messagesByTab.main, "bash", "job_1")
     expect(tool.status).toBe("interrupted")
     expect(tool.result).toBe("User manually interrupted this job.")
     expect(chat.runningJobs.job_1).toBeUndefined()

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -1084,6 +1084,88 @@ describe("chat store — interrupted task handling", () => {
     expect(pendingJobs.agent_explore_1).toBeTruthy()
   })
 
+  it("derives replay message/part ids from the originating event_id", () => {
+    const events = [
+      { type: "user_input", event_id: 1, content: "q1" },
+      { type: "processing_start", event_id: 2 },
+      { type: "text", event_id: 3, content: "answer " },
+      { type: "tool_call", event_id: 4, name: "bash", call_id: "job_1", args: {} },
+      { type: "tool_result", event_id: 5, name: "bash", call_id: "job_1", output: "ok" },
+      { type: "processing_end", event_id: 6 },
+      { type: "user_input", event_id: 7, content: "q2" },
+      { type: "processing_start", event_id: 8 },
+      { type: "text", event_id: 9, content: "answer2" },
+      { type: "processing_end", event_id: 10 },
+    ]
+
+    const { messages: replayed } = _replayEvents([], events)
+    const [user1, assistant1, user2, assistant2] = replayed
+
+    expect(user1.id).toBe("h_e1")
+    expect(assistant1.id).toBe("h_e2")
+    expect(assistant1.parts[0].id).toBe("txt_e3")
+    expect(assistant1.parts[0].content).toBe("answer ")
+    expect(assistant1.parts[1].id).toBe("tool_e4")
+    expect(user2.id).toBe("h_e7")
+    expect(assistant2.id).toBe("h_e8")
+    expect(assistant2.parts[0].id).toBe("txt_e9")
+  })
+
+  it("keeps later message ids stable when an earlier range is hidden by compact_replace", () => {
+    const baseEvents = [
+      { type: "user_input", event_id: 1, content: "q1" },
+      { type: "processing_start", event_id: 2 },
+      { type: "text", event_id: 3, content: "long answer body" },
+      { type: "processing_end", event_id: 4 },
+      { type: "user_input", event_id: 7, content: "q2" },
+      { type: "processing_start", event_id: 8 },
+      { type: "text", event_id: 9, content: "answer2" },
+      { type: "processing_end", event_id: 10 },
+    ]
+    const { messages: before } = _replayEvents([], baseEvents)
+    const user2Before = before.find((m) => m.content === "q2")
+    const assistant2Before = before.find((m) => m.role === "assistant" && m.id !== before[1].id)
+
+    const compactedEvents = [
+      ...baseEvents,
+      {
+        type: "compact_replace",
+        event_id: 11,
+        replaced_from_event_id: 2,
+        replaced_to_event_id: 4,
+        round: 1,
+        summary_text: "summary",
+        messages_compacted: 2,
+      },
+    ]
+    const { messages: after } = _replayEvents([], compactedEvents)
+
+    // The compacted range disappears, but ids of every message that still
+    // renders must be unchanged — otherwise each resync remounts the whole
+    // tail of the conversation (positional ids shift by the hidden count).
+    const user2After = after.find((m) => m.content === "q2")
+    const assistant2After = after.find(
+      (m) => m.role === "assistant" && m.parts?.[0]?.content === "answer2",
+    )
+    expect(after.some((m) => m.role === "compact")).toBe(true)
+    expect(after.some((m) => m.parts?.[0]?.content === "long answer body")).toBe(false)
+    expect(user2After.id).toBe(user2Before.id)
+    expect(assistant2After.id).toBe(assistant2Before.id)
+  })
+
+  it("falls back to positional ids for events without event_id", () => {
+    const events = [
+      { type: "user_input", content: "q1" },
+      { type: "processing_start" },
+      { type: "text", content: "a1" },
+      { type: "processing_end" },
+    ]
+    const { messages: replayed } = _replayEvents([], events)
+    expect(replayed[0].id).toBe("h_0")
+    expect(replayed[1].id).toBe("h_1")
+    expect(replayed[1].parts[0].id).toBe("txt_2")
+  })
+
   it("background subagent without job_id still rebuilds as running, not interrupted", () => {
     // The same scenario but with a legacy / buggy backend that emitted
     // ``subagent_call`` without a ``job_id`` field. Pre-fix this fell
@@ -4939,7 +5021,12 @@ describe("chat store — concurrent history resyncs apply in order", () => {
       active: true,
       baselineMaxEventId: null,
     })
-    expect(chat._branchResyncPendingByTab.main.baselinePhysicalFingerprint).toContain("old")
+    // The baseline fingerprints content LENGTH, not content — it must
+    // detect that the physical log advanced without re-serializing
+    // megabytes of message text.
+    const baseline = chat._branchResyncPendingByTab.main.baselinePhysicalFingerprint
+    expect(baseline).toBe(JSON.stringify([["user_input", null, null, 3]]))
+    expect(baseline).not.toContain("old")
     chat._clearBranchResyncTimers()
   })
 

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -444,6 +444,7 @@ export default {
   "chat.disconnected": "Disconnected — reconnecting…",
   "chat.dropToAttach": "Drop files to attach",
   "chat.queueShowMore": ({ count }) => `+${count} more queued`,
+  "chat.showEarlier": ({ count }) => `Show ${count} earlier messages`,
   "chat.queueCollapse": "Show fewer",
   "chat.queueEdit": "Edit queued message",
   "chat.queueCancel": "Cancel queued message",

--- a/src/kohakuterrarium-frontend/src/utils/markdownIncremental.js
+++ b/src/kohakuterrarium-frontend/src/utils/markdownIncremental.js
@@ -1,0 +1,159 @@
+/**
+ * Block-level incremental markdown rendering.
+ *
+ * ``MarkdownRenderer`` re-renders streamed assistant text on a throttle
+ * window. Rendering the whole accumulated document every window makes a
+ * single long generation quadratic: window cost grows with total message
+ * length while only the tail changed.
+ *
+ * The document is split at blank-line boundaries into blocks that render
+ * independently, and finished blocks are cached. While streaming, only the
+ * (usually single) changed tail block re-renders, so each window costs
+ * O(changed tail) instead of O(total).
+ *
+ * Splitting must not change what markdown-it would produce for the whole
+ * document. Two safeguards keep block-local rendering equivalent:
+ *
+ *   - Fenced code (``` / ~~~) and ``$$`` display math swallow blank lines,
+ *     so they never split mid-construct. An unterminated fence runs to the
+ *     end of the input (matching markdown-it's implicit close at EOF).
+ *   - Blank-line-separated runs of list items are ONE loose list in
+ *     CommonMark, so adjacent list blocks are merged back before render.
+ *     Mixed unordered markers (``-`` then ``*``) start a new list in
+ *     CommonMark and are therefore NOT merged.
+ *
+ * Reference-style link definitions (``[ref]: url``) can be referenced from
+ * any later block, so content containing them is not safe to split:
+ * ``splitMarkdownBlocks`` returns ``null`` and callers fall back to a
+ * full-document render.
+ */
+
+const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/
+const FENCE_CLOSE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
+const MATH_DELIM_RE = /^\s*\$\$\s*$/
+const REF_DEF_RE = /^ {0,3}\[[^\]]*\]:/
+const LIST_ITEM_RE = /^ {0,3}(?:[-*+]|[0-9]{1,9}[.)])(?:[ \t]+|$)/
+
+function firstLine(block) {
+  return block.split("\n", 1)[0] || ""
+}
+
+function unorderedMarker(line) {
+  const m = /^ {0,3}([-*+])(?:[ \t]+|$)/.exec(line)
+  return m ? m[1] : null
+}
+
+function isOrderedStart(line) {
+  return /^[0-9]{1,9}[.)](?:[ \t]+|$)/.test(line.replace(/^ {0,3}/, ""))
+}
+
+/** Merge two consecutive blocks when CommonMark renders them as one list. */
+function mergeableLists(a, b) {
+  const la = firstLine(a)
+  const lb = firstLine(b)
+  const ma = unorderedMarker(la)
+  const mb = unorderedMarker(lb)
+  if (ma && mb) return ma === mb
+  return isOrderedStart(la) && isOrderedStart(lb)
+}
+
+/**
+ * Split preprocessed markdown into independently renderable blocks.
+ * Returns ``[]`` for empty input and ``null`` when the content is not
+ * safe to split (reference-style link definitions).
+ */
+export function splitMarkdownBlocks(text) {
+  if (!text) return []
+  const lines = text.split("\n")
+  const raw = []
+  let cur = []
+  let fenceChar = null
+  let fenceLen = 0
+  let inMath = false
+  let sawRefDef = false
+
+  for (const line of lines) {
+    if (fenceChar) {
+      cur.push(line)
+      const close = FENCE_CLOSE_RE.exec(line)
+      if (close && close[1][0] === fenceChar && close[1].length >= fenceLen) {
+        fenceChar = null
+      }
+      continue
+    }
+    if (inMath) {
+      cur.push(line)
+      if (MATH_DELIM_RE.test(line)) inMath = false
+      continue
+    }
+    if (REF_DEF_RE.test(line)) sawRefDef = true
+    if (line.trim() === "") {
+      if (cur.length) {
+        raw.push(cur.join("\n"))
+        cur = []
+      }
+      continue
+    }
+    const open = FENCE_OPEN_RE.exec(line)
+    if (open) {
+      cur.push(line)
+      fenceChar = open[1][0]
+      fenceLen = open[1].length
+      continue
+    }
+    if (MATH_DELIM_RE.test(line)) {
+      cur.push(line)
+      inMath = true
+      continue
+    }
+    cur.push(line)
+  }
+  if (cur.length) raw.push(cur.join("\n"))
+  if (sawRefDef) return null
+
+  const blocks = []
+  for (const block of raw) {
+    const prev = blocks[blocks.length - 1]
+    if (prev !== undefined && mergeableLists(prev, block)) {
+      blocks[blocks.length - 1] = prev + "\n\n" + block
+    } else {
+      blocks.push(block)
+    }
+  }
+  return blocks
+}
+
+/**
+ * Cache-assisted renderer over ``splitMarkdownBlocks`` output.
+ *
+ * ``renderFn`` renders one markdown string to HTML (the same function the
+ * caller uses for full-document fallback). Successive calls with appended
+ * content reuse the cached HTML of the unchanged prefix; the first
+ * differing block and everything after it re-render.
+ */
+export class IncrementalMarkdownRenderer {
+  constructor(renderFn) {
+    this._renderFn = renderFn
+    this._cache = []
+  }
+
+  reset() {
+    this._cache = []
+  }
+
+  render(text) {
+    const blocks = splitMarkdownBlocks(text)
+    if (blocks === null) {
+      this._cache = []
+      return this._renderFn(text)
+    }
+    let i = 0
+    while (i < this._cache.length && i < blocks.length && this._cache[i].text === blocks[i]) i++
+    while (i < blocks.length) {
+      this._cache[i] = { text: blocks[i], html: this._renderFn(blocks[i]) }
+      i++
+    }
+    if (this._cache.length > blocks.length) this._cache.length = blocks.length
+    return this._cache.map((b) => b.html).join("")
+  }
+}

--- a/src/kohakuterrarium-frontend/src/utils/markdownIncremental.js
+++ b/src/kohakuterrarium-frontend/src/utils/markdownIncremental.js
@@ -32,7 +32,6 @@ const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/
 const FENCE_CLOSE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 const MATH_DELIM_RE = /^\s*\$\$\s*$/
 const REF_DEF_RE = /^ {0,3}\[[^\]]*\]:/
-const LIST_ITEM_RE = /^ {0,3}(?:[-*+]|[0-9]{1,9}[.)])(?:[ \t]+|$)/
 
 function firstLine(block) {
   return block.split("\n", 1)[0] || ""

--- a/src/kohakuterrarium-frontend/src/utils/markdownIncremental.test.js
+++ b/src/kohakuterrarium-frontend/src/utils/markdownIncremental.test.js
@@ -1,0 +1,161 @@
+import MarkdownIt from "markdown-it"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { IncrementalMarkdownRenderer, splitMarkdownBlocks } from "./markdownIncremental.js"
+
+const md = new MarkdownIt({ html: false, linkify: true, typographer: false })
+
+function normalize(html) {
+  return html.replace(/\n+/g, "\n").trim()
+}
+
+function assertRenderEquivalence(text) {
+  const renderer = new IncrementalMarkdownRenderer((t) => md.render(t))
+  expect(normalize(renderer.render(text))).toBe(normalize(md.render(text)))
+}
+
+describe("splitMarkdownBlocks", () => {
+  it("returns [] for empty input", () => {
+    expect(splitMarkdownBlocks("")).toEqual([])
+    expect(splitMarkdownBlocks(null)).toEqual([])
+  })
+
+  it("splits paragraphs at blank lines", () => {
+    expect(splitMarkdownBlocks("alpha\n\nbeta")).toEqual(["alpha", "beta"])
+  })
+
+  it("collapses blank-line runs and drops leading/trailing blanks", () => {
+    expect(splitMarkdownBlocks("\n\none\n\n\n\ntwo\n\n")).toEqual(["one", "two"])
+  })
+
+  it("keeps fenced code with internal blank lines as one block", () => {
+    const text = ["para", "", "```js", "const a = 1", "", "const b = 2", "```", "", "tail"].join(
+      "\n",
+    )
+    expect(splitMarkdownBlocks(text)).toEqual([
+      "para",
+      "```js\nconst a = 1\n\nconst b = 2\n```",
+      "tail",
+    ])
+  })
+
+  it("keeps an unterminated fence as one block to the end", () => {
+    const text = ["```py", "x = 1", "", "y = 2"].join("\n")
+    expect(splitMarkdownBlocks(text)).toEqual(["```py\nx = 1\n\ny = 2"])
+  })
+
+  it("does not split inside $$ display math", () => {
+    const text = ["intro", "", "$$", "a + b", "", "= c", "$$", "", "outro"].join("\n")
+    expect(splitMarkdownBlocks(text)).toEqual(["intro", "$$\na + b\n\n= c\n$$", "outro"])
+  })
+
+  it("merges adjacent same-marker unordered list blocks", () => {
+    expect(splitMarkdownBlocks("- one\n\n- two")).toEqual(["- one\n\n- two"])
+  })
+
+  it("does not merge mixed unordered markers", () => {
+    expect(splitMarkdownBlocks("- one\n\n* two")).toEqual(["- one", "* two"])
+  })
+
+  it("merges adjacent ordered list blocks", () => {
+    expect(splitMarkdownBlocks("1. one\n\n2. two")).toEqual(["1. one\n\n2. two"])
+  })
+
+  it("does not treat emphasis or negative numbers as list starts", () => {
+    expect(splitMarkdownBlocks("*emphasis*\n\n-1 degrees")).toEqual(["*emphasis*", "-1 degrees"])
+  })
+
+  it("returns null for reference-style link definitions", () => {
+    expect(splitMarkdownBlocks("see [ref]\n\n[ref]: https://example.com")).toBeNull()
+  })
+
+  it("ignores reference-like lines inside code fences", () => {
+    const text = "```\n[not]: a ref\n```\n\npara"
+    expect(splitMarkdownBlocks(text)).toEqual(["```\n[not]: a ref\n```", "para"])
+  })
+})
+
+describe("IncrementalMarkdownRenderer equivalence", () => {
+  it("matches whole-document rendering for paragraphs", () => {
+    assertRenderEquivalence("first paragraph\n\nsecond paragraph")
+  })
+
+  it("matches for headings, lists, tables, quotes, and rules", () => {
+    assertRenderEquivalence(
+      "# Title\n\n- a\n- b\n\n> quoted\n\n| a | b |\n| - | - |\n| 1 | 2 |\n\n---\n\n1. one\n\n2. two",
+    )
+  })
+
+  it("matches for fenced code with blank lines inside", () => {
+    assertRenderEquivalence("before\n\n```js\nconst a = 1\n\nconst b = 2\n```\n\nafter")
+  })
+
+  it("matches for display math blocks", () => {
+    assertRenderEquivalence("text\n\n$$\nx^2\n$$\n\ntail")
+  })
+
+  it("matches for unterminated fence during streaming", () => {
+    assertRenderEquivalence("text\n\n```python\ndef f():")
+  })
+
+  it("matches when blocks need no merging and no trailing newline", () => {
+    assertRenderEquivalence("single")
+  })
+
+  it("falls back to a full render for reference definitions", () => {
+    const renderFn = vi.fn((t) => md.render(t))
+    const renderer = new IncrementalMarkdownRenderer(renderFn)
+    const text = "see [ref]\n\n[ref]: https://example.com"
+    renderer.render(text)
+    expect(renderFn).toHaveBeenCalledWith(text)
+  })
+})
+
+describe("IncrementalMarkdownRenderer caching", () => {
+  let renderFn
+  let renderer
+
+  beforeEach(() => {
+    renderFn = vi.fn((t) => md.render(t))
+    renderer = new IncrementalMarkdownRenderer(renderFn)
+  })
+
+  it("re-renders only the changed tail block on append", () => {
+    renderer.render("one\n\ntwo")
+    expect(renderFn).toHaveBeenCalledTimes(2)
+    renderer.render("one\n\ntwo three")
+    expect(renderFn).toHaveBeenCalledTimes(3)
+    expect(renderFn).toHaveBeenLastCalledWith("two three")
+  })
+
+  it("re-renders one block when a new block is appended", () => {
+    renderer.render("one")
+    renderFn.mockClear()
+    renderer.render("one\n\ntwo")
+    expect(renderFn).toHaveBeenCalledTimes(1)
+    expect(renderFn).toHaveBeenCalledWith("two")
+  })
+
+  it("re-renders from the first changed block on a middle edit", () => {
+    renderer.render("one\n\ntwo\n\nthree")
+    renderFn.mockClear()
+    renderer.render("ONE\n\ntwo\n\nthree")
+    expect(renderFn).toHaveBeenCalledTimes(3)
+  })
+
+  it("truncates the cache when the document shrinks", () => {
+    renderer.render("one\n\ntwo\n\nthree")
+    renderFn.mockClear()
+    renderer.render("one")
+    expect(renderFn).toHaveBeenCalledTimes(0)
+    expect(renderer.render("one")).toBe(md.render("one"))
+  })
+
+  it("reset drops the cache", () => {
+    renderer.render("one\n\ntwo")
+    renderer.reset()
+    renderFn.mockClear()
+    renderer.render("one\n\ntwo")
+    expect(renderFn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the web chat panel's progressive slowdown in long sessions: with hundreds-to-thousands of messages, every streaming chunk, tool event, and post-turn history resync did work proportional to the total transcript length (full markdown re-parse, full message-list re-render, O(N) tool-part scans per frame). This PR makes per-frame and per-resync costs independent of transcript length.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

See #159 for the full investigation. In a long session the panel degrades through four compounding mechanisms:

1. History replay used positional ids (`"h_" + result.length`), so any hidden event range (compaction, branch filtering) shifted every later id and remounted the whole conversation tail on each resync.
2. `MarkdownRenderer` re-parsed the entire accumulated streaming text every 80 ms throttle window.
3. Every message stayed fully mounted: no off-screen culling, and `_findToolPart`/`_findSubagentPart` scanned all messages × parts on every tool frame.
4. Each resync replaced `messagesByTab[tab]` with fresh objects, forcing a re-render of every `ChatMessage`, and branch fingerprints `JSON.stringify`'d full event contents.

## Changes

**Rendering**
- `utils/markdownIncremental.js` (new): splits markdown at blank-line boundaries (fences / `$$` blocks swallow blank lines; adjacent same-marker lists merge; reference-style definitions fall back to full render) and caches finished block HTML — streaming windows now cost O(changed tail). Equivalence vs. whole-document `markdown-it` output pinned by tests; `MarkdownRenderer.vue` uses it with the existing 80 ms throttle.
- Message/part ids in history replay are derived from the originating `event_id` (`h_e1` / `tool_e4` / `txt_e3`), positional fallback for synthetic events.
- `content-visibility: auto` (with `contain-intrinsic-size: auto`) on message bodies; hover action rows stay outside the contained wrapper.
- Render groups in `ChatMessage` key on batch/part ids instead of group index.
- `ChatPanel` render window: transcripts over 400 messages mount only the newest slice; a "Show N earlier messages" stepper (scroll-compensated) expands upward, `scrollToPending` auto-expands to its target, window resets on tab switch.

**Store**
- Per-tab jobId→tool-part index (module-level `WeakMap`, intentionally non-reactive): live tool/subagent frames resolve in O(1); index rebuilt at the single replacement choke point and after retry/edit splices; channel `message_id` dedupe moves from `.some()` to a Set.
- `_setMessages` merges rebuilt arrays into the previous one by id (message + part level), preserving object identity across resyncs — unchanged messages skip re-render and keep expand/edit state.
- `markRaw` on tool `args` / `resultParts` / `resultMeta` at every creation point.
- Branch baseline fingerprint uses content *length* instead of serializing full event contents.
- New i18n key `chat.showEarlier` (en only; other locales fall back, matching existing pattern e.g. `chat.queueShowMore`).

## Validation

```bash
cd src/kohakuterrarium-frontend
npx vitest run                 # 974 passed / 994; 20 failures in 4 files
                               # (studio/layoutPanels/StudioHomePage) reproduce
                               # on a clean checkout (verified via git stash) —
                               # pre-existing local-env issue, unrelated
npx eslint src/stores/chat.js src/components/chat/  # 0 problems
npx prettier --check <all touched files>            # pass
npm run build                                       # ✓ built
```

New tests (+39 total): block-splitter equivalence against real `markdown-it`, incremental cache behavior, streamed component rendering, stable-id regression (ids unchanged when an earlier range is hidden by `compact_replace` — fails on the old positional ids), identity reuse across `_setMessages`, stale-index miss, index-unseeded fallback scan, channel dedupe, render-window clamp/expand/streaming tail.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [ ] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Refs #159 (web frontend rendering; this PR implements the proposed directions)
- Relates to #158 (backend session-core / history-transport costs — the lazy full tool-output fetch proposed in #159 needs the `output_preview` work there)

## Notes for Reviewers

- The windowed rendering (400-message slice + stepper) was chosen over a dependency-based virtual scroller to avoid a new runtime dependency and the dynamic-height/scroll-pinning edge cases; `content-visibility` handles off-screen layout/paint within the window. Happy to revisit with a scroller library if preferred.
- `pendingCount` still filters the full list, but only recomputes on length/flag changes (not per streaming chunk); left as-is deliberately.
- The 20 failing tests mentioned above fail identically on `main` in my environment (vitest `vi` auto-import not resolved in those files); I'd appreciate a pointer if there's a known local setup step I'm missing.

## Exceptions / Not Run

- `ruff` / `black` / `pytest`: not applicable — this PR touches only `src/kohakuterrarium-frontend/`.
- Maintainer approval for #159 is not yet recorded on the issue; the issue was opened before this PR per CONTRIBUTING, and I'm happy to hold the PR until it's triaged.
- Fork CI was not awaited before opening; will monitor and address failures.
