### PR TITLE
perf(session): make long-session persistence incremental

### DIFF
--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -342,7 +342,10 @@ export const terrariumAPI = {
    */
   async getHistory(id, target, sinceEventId = null) {
     const params = sinceEventId != null ? { params: { since_event_id: sinceEventId } } : {}
-    const { data } = await api.get(`/sessions/${id}/creatures/${encodeTarget(target)}/history`, params)
+    const { data } = await api.get(
+      `/sessions/${id}/creatures/${encodeTarget(target)}/history`,
+      params,
+    )
     return data
   },
 

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -340,8 +340,9 @@ export const terrariumAPI = {
    * Get full history for a creature/root in a terrarium.
    * Returns { messages: [...], events: [...] }
    */
-  async getHistory(id, target) {
-    const { data } = await api.get(`/sessions/${id}/creatures/${encodeTarget(target)}/history`)
+  async getHistory(id, target, sinceEventId = null) {
+    const params = sinceEventId != null ? { params: { since_event_id: sinceEventId } } : {}
+    const { data } = await api.get(`/sessions/${id}/creatures/${encodeTarget(target)}/history`, params)
     return data
   },
 

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
@@ -200,6 +200,25 @@ async def creature_history(
     return payload
 
 
+@router.get("/{session_id}/creatures/{creature_id}/events/{event_id}")
+async def creature_event(
+    session_id: str,
+    creature_id: str,
+    event_id: int,
+    service: TerrariumService = Depends(get_service),
+):
+    """Lazy single-event fetch: full tool/subagent output on expand.
+
+    History payloads carry bounded ``output_preview`` strings; the client
+    calls this to load the full ``output``/``result`` of one event.
+    """
+    cid = await resolve_creature_id(service, creature_id, session_id)
+    try:
+        return await service.chat_event(cid, event_id)
+    except KeyError as exc:
+        raise HTTPException(404, str(exc)) from exc
+
+
 @router.get("/{session_id}/creatures/{creature_id}/branches")
 async def creature_branches(
     session_id: str,

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
@@ -177,6 +177,9 @@ async def creature_history(
             "messages": [],
             "events": events,
             "is_processing": False,
+            # Channel events carry no event_id; report the contract field
+            # explicitly so clients can read it unconditionally.
+            "max_event_id": 0,
         }
     cid = await resolve_creature_id(service, creature_id, session_id)
     try:

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
@@ -130,12 +130,30 @@ async def rewind_creature(
         raise HTTPException(409, str(exc)) from exc
 
 
+def _history_max_event_id(events: list) -> int:
+    out = 0
+    for evt in events:
+        eid = evt.get("event_id") if isinstance(evt, dict) else None
+        if isinstance(eid, int) and eid > out:
+            out = eid
+    return out
+
+
 @router.get("/{session_id}/creatures/{creature_id}/history")
 async def creature_history(
     session_id: str,
     creature_id: str,
+    since_event_id: int | None = None,
     service: TerrariumService = Depends(get_service),
 ):
+    """History payload with an optional event cursor.
+
+    ``since_event_id`` trims ``events`` to those after the cursor so the
+    client can append incrementally instead of re-fetching the whole log
+    after every turn. The full payload remains available (cursor omitted)
+    for the rewind/branch/compact resync path. ``max_event_id`` reports the
+    newest event in the full log so the client can advance its cursor.
+    """
     # Channel tabs share this endpoint through the ``ch:`` prefix.
     if creature_id.startswith("ch:"):
         channel_name = creature_id[3:]
@@ -162,9 +180,24 @@ async def creature_history(
         }
     cid = await resolve_creature_id(service, creature_id, session_id)
     try:
-        return await service.chat_history(cid)
+        payload = await service.chat_history(cid)
     except KeyError:
         raise HTTPException(404, f"creature {creature_id!r} not found")
+    events = payload.get("events") or []
+    max_eid = _history_max_event_id(events)
+    if since_event_id is not None:
+        payload["events"] = [
+            evt
+            for evt in events
+            if isinstance(evt, dict)
+            and isinstance(evt.get("event_id"), int)
+            and evt["event_id"] > since_event_id
+        ]
+        # Incremental payloads omit the conversation snapshot; it is only
+        # valid for the full log and would mislead an appending client.
+        payload.pop("messages", None)
+    payload["max_event_id"] = max_eid
+    return payload
 
 
 @router.get("/{session_id}/creatures/{creature_id}/branches")

--- a/src/kohakuterrarium/session/history.py
+++ b/src/kohakuterrarium/session/history.py
@@ -387,6 +387,12 @@ def select_live_event_ids(
     parent_paths = index_parent_paths(events_list)
     selected = resolve_selected_branches(events_list, parent_paths, branch_view)
 
+    # ``selected`` only contains turns present in ``branches_by_turn`` (see
+    # ``resolve_selected_branches``), so only its prefix up to the maximal
+    # constrained turn in each parent path matters. Building that prefix per
+    # event costs O(longest path) instead of rebuilding the full
+    # ``{t: b for t < ti}`` dict per event.
+    selected_turns = sorted(selected.keys())
     live: set[int] = set()
     for evt in events_list:
         ti = evt.get("turn_index")
@@ -400,9 +406,11 @@ def select_live_event_ids(
         if selected.get(ti) != bi:
             continue
         path = parent_paths.get(eid, ())
-        prior_selected = {t: b for t, b in selected.items() if t < ti}
-        if not _path_matches(path, prior_selected):
-            continue
+        if path:
+            bound = min(ti, max(t for t, _ in path) + 1)
+            prefix = {t: selected[t] for t in selected_turns if t < bound}
+            if not _path_matches(path, prefix):
+                continue
         live.add(eid)
     return live
 

--- a/src/kohakuterrarium/session/history.py
+++ b/src/kohakuterrarium/session/history.py
@@ -1,5 +1,6 @@
 """Normalize, branch-select, and replay persisted session events."""
 
+import bisect
 import json
 from collections.abc import Hashable, Mapping
 from typing import Any, Iterable
@@ -392,6 +393,11 @@ def select_live_event_ids(
     # constrained turn in each parent path matters. Building that prefix per
     # event costs O(longest path) instead of rebuilding the full
     # ``{t: b for t < ti}`` dict per event.
+    # ``selected`` only contains turns present in ``branches_by_turn`` (see
+    # ``resolve_selected_branches``), so only its prefix up to the maximal
+    # constrained turn in each parent path matters. ``selected_turns`` is
+    # sorted, and the clamped bound lets bisect slice the needed prefix
+    # directly — the per-event cost is O(path length), not O(#turns).
     selected_turns = sorted(selected.keys())
     live: set[int] = set()
     for evt in events_list:
@@ -408,7 +414,8 @@ def select_live_event_ids(
         path = parent_paths.get(eid, ())
         if path:
             bound = min(ti, max(t for t, _ in path) + 1)
-            prefix = {t: selected[t] for t in selected_turns if t < bound}
+            idx = bisect.bisect_left(selected_turns, bound)
+            prefix = {t: selected[t] for t in selected_turns[:idx]}
             if not _path_matches(path, prefix):
                 continue
         live.add(eid)

--- a/src/kohakuterrarium/session/output.py
+++ b/src/kohakuterrarium/session/output.py
@@ -216,7 +216,15 @@ class SessionOutput(OutputModule):
             else:
                 events = self._store.get_events(self._event_key_prefix)
                 messages = replay_conversation(events, include_metadata=True)
-            last_event_id = self._store.max_event_id(self._event_key_prefix)
+            try:
+                last_event_id = self._store.max_event_id(self._event_key_prefix)
+            except AttributeError:
+                # Duck-typed store without the counter: fall back to a scan.
+                last_event_id = 0
+                for evt in self._store.get_events(self._event_key_prefix):
+                    eid = evt.get("event_id")
+                    if isinstance(eid, int) and eid > last_event_id:
+                        last_event_id = eid
             self._store.save_conversation(self._event_key_prefix, messages)
             try:
                 self._store.state[f"{self._event_key_prefix}:snapshot_event_id"] = (

--- a/src/kohakuterrarium/session/output.py
+++ b/src/kohakuterrarium/session/output.py
@@ -206,18 +206,17 @@ class SessionOutput(OutputModule):
         self._record("processing_end", {})
 
         # Snapshots are derived caches; use live controller messages when event
-        # replay cannot yet reconstruct the conversation.
+        # replay cannot yet reconstruct the conversation. The full event log is
+        # only replayed when the controller is absent; otherwise a single-key
+        # read supplies ``last_event_id`` (the O(N) full scan here made every
+        # turn cost linear in total session length).
         try:
-            events = self._store.get_events(self._event_key_prefix)
             if self._agent and hasattr(self._agent, "controller"):
                 messages = self._agent.controller.conversation.snapshot_messages()
             else:
+                events = self._store.get_events(self._event_key_prefix)
                 messages = replay_conversation(events, include_metadata=True)
-            last_event_id = 0
-            for evt in events:
-                eid = evt.get("event_id")
-                if isinstance(eid, int) and eid > last_event_id:
-                    last_event_id = eid
+            last_event_id = self._store.max_event_id(self._event_key_prefix)
             self._store.save_conversation(self._event_key_prefix, messages)
             try:
                 self._store.state[f"{self._event_key_prefix}:snapshot_event_id"] = (

--- a/src/kohakuterrarium/session/store.py
+++ b/src/kohakuterrarium/session/store.py
@@ -279,6 +279,12 @@ class SessionStore:
 
         return key, event_id
 
+    def _flush_events_cache(self) -> None:
+        """Flush pending events and reset the durability counters."""
+        self.events.flush_cache()
+        self._unflushed_event_count = 0
+        self._last_flush_at = time.monotonic()
+
     def _maybe_flush_events(self) -> None:
         """Flush the events cache when either durability gate trips."""
         n_gate = (
@@ -321,9 +327,7 @@ class SessionStore:
         ``since_event_id``, only events whose ``event_id`` exceeds it are
         returned (cursor-style incremental reads).
         """
-        self.events.flush_cache()
-        self._unflushed_event_count = 0
-        self._last_flush_at = time.monotonic()
+        self._flush_events_cache()
         prefix = f"{agent}:e"
         result = []
         for key_bytes in sorted(iter_kv_keys(self.events, prefix=prefix)):
@@ -340,32 +344,34 @@ class SessionStore:
         return result
 
     def max_event_id(self, agent: str) -> int:
-        """Return the largest ``event_id`` for an agent without a full log read.
+        """Return the session-global max ``event_id`` (monotonic, per-session).
 
-        Zero-padded keys order chronologically, so the prefix-max key is the
-        newest event; a single value read answers the query.
+        Local events take ids from ``_global_event_id`` and mirrored events
+        ratchet it upward, so the counter is the authoritative maximum and
+        this is O(1). ``event_id`` is a session-global (not per-agent) cursor,
+        so ``agent`` is accepted for API symmetry with ``get_events`` and
+        intentionally unused.
         """
-        self.events.flush_cache()
-        self._unflushed_event_count = 0
-        self._last_flush_at = time.monotonic()
-        last_key = None
+        del agent
+        return self._global_event_id
+
+    def get_event_by_id(self, agent: str, event_id: int) -> dict | None:
+        """Fetch a single event by its session-global ``event_id``.
+
+        Scans the agent's keys but reads only values until the id matches —
+        the lazy companion to ``output_preview``-bounded history payloads
+        (frontend expands fetch the full output on demand).
+        """
+        self._flush_events_cache()
         for key_bytes in iter_kv_keys(self.events, prefix=f"{agent}:e"):
-            if last_key is None or key_bytes > last_key:
-                last_key = key_bytes
-        if last_key is None:
-            return 0
-        try:
-            evt = self.events[last_key]
-        except Exception as e:
-            logger.warning("Failed to read latest event", error=str(e), exc_info=True)
-            return 0
-        eid = evt.get("event_id") if isinstance(evt, dict) else None
-        latest = eid if isinstance(eid, int) else 0
-        # Mirrored events carry a preset source ``event_id`` (see
-        # ``append_event``) that may exceed the locally-assigned one at the
-        # last sequence position; ``snapshot_event_id`` must never
-        # under-report, so take the running max into account.
-        return max(latest, self._global_event_id)
+            try:
+                evt = self.events[key_bytes]
+            except Exception as e:
+                logger.warning("Failed to read event", error=str(e), exc_info=True)
+                continue
+            if isinstance(evt, dict) and evt.get("event_id") == event_id:
+                return evt
+        return None
 
     def get_resumable_events(
         self,

--- a/src/kohakuterrarium/session/store.py
+++ b/src/kohakuterrarium/session/store.py
@@ -22,6 +22,7 @@ from kohakuterrarium.session.rollup import (
     save_turn_rollup,
 )
 from kohakuterrarium.session.store_counters import (
+    persist_event_counter,
     restore_event_counters,
     restore_subagent_counters,
     restore_suffix_counters,
@@ -174,8 +175,10 @@ class SessionStore:
             self._companion_closers.append(closer)
 
     def _restore_counters(self) -> None:
-        """Scan existing keys to restore sequence counters after restart."""
-        self._global_event_id = restore_event_counters(self.events, self._event_seq)
+        """Restore sequence counters; persisted counters skip the value scan."""
+        self._global_event_id = restore_event_counters(
+            self.events, self._event_seq, state=self.state
+        )
         restore_suffix_counters(self.channels, ":m", self._channel_seq)
         restore_subagent_counters(self.subagents, self._subagent_runs)
 
@@ -271,6 +274,9 @@ class SessionStore:
         self._unflushed_event_count += 1
         self._maybe_flush_events()
 
+        if not self._readonly:
+            persist_event_counter(self.state, event_id)
+
         return key, event_id
 
     def _maybe_flush_events(self) -> None:
@@ -308,10 +314,12 @@ class SessionStore:
         except ValueError:
             pass
 
-    def get_events(self, agent: str) -> list[dict]:
-        """Get all events for an agent, ordered by sequence.
+    def get_events(self, agent: str, since_event_id: int | None = None) -> list[dict]:
+        """Get events for an agent, ordered by sequence.
 
-        Returns list of event dicts with keys sorted chronologically.
+        Returns list of event dicts with keys sorted chronologically. With
+        ``since_event_id``, only events whose ``event_id`` exceeds it are
+        returned (cursor-style incremental reads).
         """
         self.events.flush_cache()
         self._unflushed_event_count = 0
@@ -320,16 +328,51 @@ class SessionStore:
         result = []
         for key_bytes in sorted(iter_kv_keys(self.events, prefix=prefix)):
             try:
-                result.append(self.events[key_bytes])
+                evt = self.events[key_bytes]
             except Exception as e:
                 logger.warning("Failed to read event", error=str(e), exc_info=True)
+                continue
+            if since_event_id is not None:
+                eid = evt.get("event_id") if isinstance(evt, dict) else None
+                if not isinstance(eid, int) or eid <= since_event_id:
+                    continue
+            result.append(evt)
         return result
+
+    def max_event_id(self, agent: str) -> int:
+        """Return the largest ``event_id`` for an agent without a full log read.
+
+        Zero-padded keys order chronologically, so the prefix-max key is the
+        newest event; a single value read answers the query.
+        """
+        self.events.flush_cache()
+        self._unflushed_event_count = 0
+        self._last_flush_at = time.monotonic()
+        last_key = None
+        for key_bytes in iter_kv_keys(self.events, prefix=f"{agent}:e"):
+            if last_key is None or key_bytes > last_key:
+                last_key = key_bytes
+        if last_key is None:
+            return 0
+        try:
+            evt = self.events[last_key]
+        except Exception as e:
+            logger.warning("Failed to read latest event", error=str(e), exc_info=True)
+            return 0
+        eid = evt.get("event_id") if isinstance(evt, dict) else None
+        latest = eid if isinstance(eid, int) else 0
+        # Mirrored events carry a preset source ``event_id`` (see
+        # ``append_event``) that may exceed the locally-assigned one at the
+        # last sequence position; ``snapshot_event_id`` must never
+        # under-report, so take the running max into account.
+        return max(latest, self._global_event_id)
 
     def get_resumable_events(
         self,
         agent: str,
         *,
         live_job_ids: set[str] | None = None,
+        since_event_id: int | None = None,
     ) -> list[dict]:
         """Get agent events normalized for resume/history replay.
 
@@ -339,7 +382,9 @@ class SessionStore:
         resume-time callers (post-restart, every unfinished job IS dead)
         leave it ``None``.
         """
-        events = dedupe_adjacent_duplicate_events(self.get_events(agent))
+        events = dedupe_adjacent_duplicate_events(
+            self.get_events(agent, since_event_id=since_event_id)
+        )
         return normalize_resumable_events(events, live_job_ids=live_job_ids)
 
     def get_all_events(self) -> list[tuple[str, dict]]:
@@ -819,6 +864,8 @@ class SessionStore:
         self._closed = True
         if self._readonly:
             update_status = False
+        if not self._readonly:
+            persist_event_counter(self.state, self._global_event_id)
         if update_status:
             try:
                 self.update_status("paused")

--- a/src/kohakuterrarium/session/store_counters.py
+++ b/src/kohakuterrarium/session/store_counters.py
@@ -17,12 +17,39 @@ def _decode_key(key_bytes: bytes | str) -> str:
     return key_bytes
 
 
-def restore_event_counters(events: KVault, event_seq: dict[str, int]) -> int:
+def restore_event_counters(
+    events: KVault,
+    event_seq: dict[str, int],
+    state: KVault | None = None,
+) -> int:
     """Restore per-agent event sequences and return the largest event ID.
 
-    ``event_seq`` is updated in place from ``{agent}:e{seq}`` keys.
+    ``event_seq`` is updated in place from ``{agent}:e{seq}`` keys. With a
+    ``state`` table the global ``max_event_id`` is read from the
+    append-time-persisted counter; only when that slot is absent (sessions
+    last written by an older version) does the fallback full scan read
+    every event value. Event-seq counters always derive from the key list,
+    which does not require reading values.
     """
-    max_event_id = 0
+    if state is not None:
+        try:
+            persisted = state.get("counters:max_event_id")
+        except Exception as e:
+            logger.warning(
+                "Failed to read persisted event counter",
+                error=str(e),
+                exc_info=True,
+            )
+            persisted = None
+        if isinstance(persisted, int):
+            _restore_event_seq_from_keys(events, event_seq)
+            return persisted
+
+    _restore_event_seq_from_keys(events, event_seq)
+    return _scan_max_event_id(events)
+
+
+def _restore_event_seq_from_keys(events: KVault, event_seq: dict[str, int]) -> None:
     for key_bytes in events.keys(limit=_KV_KEYS_LIMIT):
         key = _decode_key(key_bytes)
         parts = key.rsplit(":e", 1)
@@ -34,6 +61,11 @@ def restore_event_counters(events: KVault, event_seq: dict[str, int]) -> int:
                     event_seq[agent] = seq + 1
             except ValueError:
                 pass
+
+
+def _scan_max_event_id(events: KVault) -> int:
+    max_event_id = 0
+    for key_bytes in events.keys(limit=_KV_KEYS_LIMIT):
         try:
             evt = events[key_bytes]
             if isinstance(evt, dict):
@@ -47,6 +79,14 @@ def restore_event_counters(events: KVault, event_seq: dict[str, int]) -> int:
                 exc_info=True,
             )
     return max_event_id
+
+
+def persist_event_counter(state: KVault, max_event_id: int) -> None:
+    """Persist the global max event id so reopen skips the value scan."""
+    try:
+        state["counters:max_event_id"] = max_event_id
+    except Exception as e:
+        logger.warning("Failed to persist event counter", error=str(e), exc_info=True)
 
 
 def restore_suffix_counters(table: KVault, sep: str, counter: dict[str, int]) -> None:

--- a/src/kohakuterrarium/studio/attach/_event_stream.py
+++ b/src/kohakuterrarium/studio/attach/_event_stream.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import time
+from collections import deque
 from typing import Any
 
 from kohakuterrarium.modules.output.base import OutputModule
@@ -13,14 +14,16 @@ _event_logs: dict[str, list] = {}
 
 # Reconnect replays need recent context, not the entire session. An unbounded
 # list keeps a second full copy of every streamed frame in RAM for the process
-# lifetime; a ring buffer bounds that copy. Overridable for lab harnesses.
+# lifetime; a deque(maxlen=...) ring bounds that copy and keeps append+evict
+# O(1) (list slicing would left-shift the whole buffer per frame).
+# Overridable for lab harnesses.
 _EVENT_LOG_MAX = int(os.environ.get("KT_EVENT_LOG_MAX", "5000"))
 
 
-def get_event_log(key: str) -> list:
-    """Return the persistent in-memory replay list for an attachment key."""
+def get_event_log(key: str) -> deque:
+    """Return the persistent in-memory replay ring for an attachment key."""
     if key not in _event_logs:
-        _event_logs[key] = []
+        _event_logs[key] = deque(maxlen=_EVENT_LOG_MAX)
     return _event_logs[key]
 
 
@@ -64,7 +67,7 @@ class StreamOutput(OutputModule):
         self,
         source: str,
         queue: asyncio.Queue,
-        log: list,
+        log: deque,
         agent: Any | None = None,
     ):
         self._src = source
@@ -96,9 +99,6 @@ class StreamOutput(OutputModule):
             msg["branch_id"] = bi
         self._q.put_nowait(msg)
         self._log.append(msg)
-        overflow = len(self._log) - _EVENT_LOG_MAX
-        if overflow > 0:
-            del self._log[:overflow]
 
     async def start(self) -> None:
         pass

--- a/src/kohakuterrarium/studio/attach/_event_stream.py
+++ b/src/kohakuterrarium/studio/attach/_event_stream.py
@@ -1,6 +1,7 @@
 """Translate output events into websocket frames on an asynchronous queue."""
 
 import asyncio
+import os
 import time
 from typing import Any
 
@@ -9,6 +10,11 @@ from kohakuterrarium.modules.output.event import OutputEvent
 
 # The session and creature pair isolates replay history for each attachment target.
 _event_logs: dict[str, list] = {}
+
+# Reconnect replays need recent context, not the entire session. An unbounded
+# list keeps a second full copy of every streamed frame in RAM for the process
+# lifetime; a ring buffer bounds that copy. Overridable for lab harnesses.
+_EVENT_LOG_MAX = int(os.environ.get("KT_EVENT_LOG_MAX", "5000"))
 
 
 def get_event_log(key: str) -> list:
@@ -90,6 +96,9 @@ class StreamOutput(OutputModule):
             msg["branch_id"] = bi
         self._q.put_nowait(msg)
         self._log.append(msg)
+        overflow = len(self._log) - _EVENT_LOG_MAX
+        if overflow > 0:
+            del self._log[:overflow]
 
     async def start(self) -> None:
         pass

--- a/src/kohakuterrarium/terrarium/service.py
+++ b/src/kohakuterrarium/terrarium/service.py
@@ -717,6 +717,20 @@ class LocalTerrariumService(LocalCommandServiceMixin, DriveServiceMixin):
     async def chat_history(self, creature_id: str) -> dict[str, Any]:
         return _chat_history_for(self._engine, creature_id)
 
+    async def chat_event(self, creature_id: str, event_id: int) -> dict[str, Any]:
+        """Fetch one persisted event (lazy full-output companion of history)."""
+        creature = self._engine.get_creature(creature_id)
+        agent = creature.agent
+        store = getattr(agent, "session_store", None)
+        if store is None:
+            store = self._engine._session_stores.get(creature.graph_id)
+        if store is None:
+            raise KeyError(creature_id)
+        evt = store.get_event_by_id(creature.name, event_id)
+        if evt is None:
+            raise KeyError(f"event {event_id} not found")
+        return {"event": evt, "creature_id": creature_id}
+
     async def chat_branches(self, creature_id: str) -> list[dict[str, Any]]:
         return _chat_branches_for(self._engine, creature_id)
 

--- a/tests/unit/api/test_creature_chat_route.py
+++ b/tests/unit/api/test_creature_chat_route.py
@@ -38,6 +38,10 @@ class _FakeService:
         self._regen = regen_returns
         self._edit_returns = edit_returns
         self._history = history_returns or {"messages": []}
+        self._event = {
+            "event": {"event_id": 7, "output": "full"},
+            "creature_id": "alice",
+        }
         self._branches = branches_returns or [{"t": 1}]
         self._raise = raise_on or {}
         self.engine = object()
@@ -96,6 +100,11 @@ class _FakeService:
         if "chat_history" in self._raise:
             raise self._raise["chat_history"]
         return self._history
+
+    async def chat_event(self, cid, event_id):
+        if "chat_event" in self._raise:
+            raise self._raise["chat_event"]
+        return self._event
 
     async def chat_branches(self, cid):
         if "chat_branches" in self._raise:
@@ -269,6 +278,53 @@ class TestHistoryBranches:
         svc = _FakeService(raise_on={"chat_history": KeyError("no")})
         client = _client(svc)
         resp = client.get("/sessions/g/creatures/alice/history")
+        assert resp.status_code == 404
+
+    def test_history_cursor_filters_events(self):
+        svc = _FakeService(
+            history_returns={
+                "messages": [{"role": "user"}],
+                "events": [
+                    {"event_id": 1, "type": "user_input"},
+                    {"event_id": 2, "type": "text"},
+                    {"event_id": 3, "type": "text"},
+                ],
+            }
+        )
+        client = _client(svc)
+        resp = client.get("/sessions/g/creatures/alice/history?since_event_id=1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert [e["event_id"] for e in body["events"]] == [2, 3]
+        assert body["max_event_id"] == 3
+        # Incremental payloads omit the full-log-only snapshot.
+        assert "messages" not in body
+
+    def test_history_full_payload_reports_max_event_id(self):
+        svc = _FakeService(
+            history_returns={
+                "messages": [],
+                "events": [{"event_id": 4, "type": "text"}],
+            }
+        )
+        client = _client(svc)
+        resp = client.get("/sessions/g/creatures/alice/history")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["max_event_id"] == 4
+        assert [e["event_id"] for e in body["events"]] == [4]
+
+    def test_event_fetch(self):
+        svc = _FakeService()
+        client = _client(svc)
+        resp = client.get("/sessions/g/creatures/alice/events/7")
+        assert resp.status_code == 200
+        assert resp.json()["event"]["output"] == "full"
+
+    def test_event_fetch_missing(self):
+        svc = _FakeService(raise_on={"chat_event": KeyError("event 99 not found")})
+        client = _client(svc)
+        resp = client.get("/sessions/g/creatures/alice/events/99")
         assert resp.status_code == 404
 
     def test_branches(self):

--- a/tests/unit/session/test_history.py
+++ b/tests/unit/session/test_history.py
@@ -1643,3 +1643,101 @@ class TestResolveSelectedBranches:
         # Branch 99 doesn't exist — falls back to max.
         sel = resolve_selected_branches(events, index_parent_paths(events), {0: 99})
         assert sel == {0: 2}
+
+
+class TestSelectLiveEventIdsPrefix:
+    """select_live_event_ids builds the prior-selected prefix per event; a
+    parent path constraining only turn 0 must not reject an event whose
+    later-turn ancestor is live."""
+
+    def test_path_constrained_by_early_turn_only(self):
+        events = [
+            {
+                "type": "user_message",
+                "content": "U0",
+                "event_id": 0,
+                "turn_index": 0,
+                "branch_id": 1,
+                "parent_branch_path": [],
+            },
+            {
+                "type": "text_chunk",
+                "content": "R0",
+                "event_id": 1,
+                "turn_index": 0,
+                "branch_id": 1,
+                "parent_branch_path": [],
+            },
+            # Turn 1 has two branches; the live one is 2.
+            {
+                "type": "user_message",
+                "content": "U1",
+                "event_id": 2,
+                "turn_index": 1,
+                "branch_id": 1,
+                "parent_branch_path": [(0, 1)],
+            },
+            {
+                "type": "user_message",
+                "content": "U1b",
+                "event_id": 3,
+                "turn_index": 1,
+                "branch_id": 2,
+                "parent_branch_path": [(0, 1)],
+            },
+            # Turn 2 event descends from turn1-b2; its path only constrains
+            # turns 0 and 1, and both are selected as expected.
+            {
+                "type": "user_message",
+                "content": "U2",
+                "event_id": 4,
+                "turn_index": 2,
+                "branch_id": 1,
+                "parent_branch_path": [(0, 1), (1, 2)],
+            },
+        ]
+        live = select_live_event_ids(events)
+        # Turn1-b1 (event 2) is not the selected branch and drops out;
+        # everything on the live chain stays.
+        assert live == {0, 1, 3, 4}
+
+    def test_event_with_dead_ancestor_dropped(self):
+        # Same shape, but the turn-2 event descends from the DEAD turn1-b1:
+        # its path (1, 1) mismatches the selected turn1-b2 and it must drop.
+        events = [
+            {
+                "type": "user_message",
+                "content": "U0",
+                "event_id": 0,
+                "turn_index": 0,
+                "branch_id": 1,
+                "parent_branch_path": [],
+            },
+            {
+                "type": "user_message",
+                "content": "U1a",
+                "event_id": 2,
+                "turn_index": 1,
+                "branch_id": 1,
+                "parent_branch_path": [(0, 1)],
+            },
+            {
+                "type": "user_message",
+                "content": "U1b",
+                "event_id": 3,
+                "turn_index": 1,
+                "branch_id": 2,
+                "parent_branch_path": [(0, 1)],
+            },
+            {
+                "type": "user_message",
+                "content": "U2-dead",
+                "event_id": 4,
+                "turn_index": 2,
+                "branch_id": 1,
+                "parent_branch_path": [(0, 1), (1, 1)],
+            },
+        ]
+        live = select_live_event_ids(events)
+        assert live == {0, 3}
+        assert 4 not in live

--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -14,6 +14,78 @@ def _store(tmp_path, name="s.kohakutr") -> SessionStore:
     return SessionStore(str(tmp_path / name))
 
 
+def test_get_events_since_event_id_filters(tmp_path):
+    path = tmp_path / "since.kohakutr"
+    store = SessionStore(str(path))
+    try:
+        store.append_event("a", "user_input", {"content": "1"})
+        store.append_event("a", "text", {"content": "2"})
+        store.append_event("a", "text", {"content": "3"})
+        all_events = store.get_events("a")
+        cursor = all_events[1]["event_id"]
+        tail = store.get_events("a", since_event_id=cursor)
+        assert [e["content"] for e in tail] == ["3"]
+        assert store.get_events("a", since_event_id=10**9) == []
+    finally:
+        store.close()
+
+
+def test_max_event_id_never_underreports_mirrored_ids(tmp_path):
+    path = tmp_path / "mirror.kohakutr"
+    store = SessionStore(str(path))
+    try:
+        store.append_event("a", "text", {"content": "local"})
+        # A mirrored event carries its source id (larger than any local id).
+        store.append_event("a", "text", {"content": "mirrored", "event_id": 500})
+        # A later local event gets id 2 — at the last seq position — while a
+        # mirrored event earlier in the log holds 500.
+        store.append_event("a", "text", {"content": "local2"})
+        assert store.max_event_id("a") >= 500
+    finally:
+        store.close()
+
+
+def test_max_event_id_matches_full_scan(tmp_path):
+    path = tmp_path / "maxid.kohakutr"
+    store = SessionStore(str(path))
+    try:
+        assert store.max_event_id("a") == 0
+        for i in range(5):
+            store.append_event("a", "text", {"content": f"c{i}"})
+        expected = max(e["event_id"] for e in store.get_events("a"))
+        assert store.max_event_id("a") == expected
+        # Cross-agent isolation.
+        store.append_event("b", "text", {"content": "x"})
+        assert store.max_event_id("b") > 0
+    finally:
+        store.close()
+
+
+def test_append_persists_event_counter_for_reopen(tmp_path):
+    path = tmp_path / "sess.kohakutr"
+    store = SessionStore(str(path))
+    store.append_event("alpha", "user_input", {"content": "one"})
+    store.append_event("alpha", "text", {"content": "two"})
+    store.close()
+
+    # The persisted counter must have been written during appends/close.
+    from kohakuvault import KVault
+
+    state = KVault(str(path), table="state")
+    try:
+        assert state.get("counters:max_event_id") == 2
+    finally:
+        state.close()
+
+    reopened = SessionStore(str(path))
+    try:
+        assert reopened._global_event_id == 2
+        _, eid = reopened.append_event("alpha", "text", {"content": "three"})
+        assert eid == 3
+    finally:
+        reopened.close()
+
+
 # ── construction ──────────────────────────────────────────────────
 
 

--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -54,9 +54,9 @@ def test_max_event_id_matches_full_scan(tmp_path):
             store.append_event("a", "text", {"content": f"c{i}"})
         expected = max(e["event_id"] for e in store.get_events("a"))
         assert store.max_event_id("a") == expected
-        # Cross-agent isolation.
+        # event_id is session-global; the agent arg is API symmetry only.
         store.append_event("b", "text", {"content": "x"})
-        assert store.max_event_id("b") > 0
+        assert store.max_event_id("b") > expected
     finally:
         store.close()
 

--- a/tests/unit/session/test_store_counters.py
+++ b/tests/unit/session/test_store_counters.py
@@ -4,6 +4,7 @@ from kohakuvault import KVault
 
 from kohakuterrarium.session.store_counters import (
     _decode_key,
+    persist_event_counter,
     restore_event_counters,
     restore_subagent_counters,
     restore_suffix_counters,
@@ -96,6 +97,38 @@ class TestRestoreEventCounters:
             assert restore_event_counters(t, seq) == 200
         finally:
             t.close()
+
+    def test_persisted_counter_skips_value_scan(self, tmp_path):
+        events = _make_table(tmp_path / "ev.kohakutr", "events")
+        state = _make_table(tmp_path / "ev.kohakutr", "state")
+        try:
+            events["alpha:e000000"] = {"event_id": 100}
+            events["alpha:e000001"] = {"event_id": 200}
+            persist_event_counter(state, 200)
+            # Corrupt every event VALUE so the fallback scan would fail or
+            # report 0; the persisted counter must be authoritative.
+            events["alpha:e000000"] = ["corrupt"]
+            events["alpha:e000001"] = None
+            seq: dict[str, int] = {}
+            assert restore_event_counters(events, seq, state=state) == 200
+            # Sequences still derive from keys even on the fast path.
+            assert seq["alpha"] == 2
+        finally:
+            events.close()
+            state.close()
+
+    def test_missing_persisted_counter_falls_back_to_scan(self, tmp_path):
+        events = _make_table(tmp_path / "ev.kohakutr", "events")
+        state = _make_table(tmp_path / "ev.kohakutr", "state")
+        try:
+            events["alpha:e000000"] = {"event_id": 42}
+            seq: dict[str, int] = {}
+            # No persisted slot (older session file): full scan still works.
+            assert restore_event_counters(events, seq, state=state) == 42
+            assert seq["alpha"] == 1
+        finally:
+            events.close()
+            state.close()
 
 
 class TestRestoreSuffixCounters:

--- a/tests/unit/studio/test_event_stream.py
+++ b/tests/unit/studio/test_event_stream.py
@@ -376,3 +376,23 @@ class TestStreamOutputBranchTagging:
         assert msg["turn_index"] == 5
         assert msg["branch_id"] == 9
         assert msg["job_id"] == "j1"
+
+
+def test_event_log_ring_buffer_bounds_replay_history():
+    """The in-memory replay log must not grow past _EVENT_LOG_MAX frames."""
+    import kohakuterrarium.studio.attach._event_stream as mod
+
+    key = "ringtest:creature"
+    log = mod.get_event_log(key)
+    log.clear()
+    try:
+        q = asyncio.Queue()
+        out = StreamOutput("creature", q, log)
+        for i in range(mod._EVENT_LOG_MAX + 50):
+            out._put({"type": "text", "content": f"c{i}"})
+        assert len(log) == mod._EVENT_LOG_MAX
+        # Newest frames retained, oldest evicted.
+        assert log[-1]["content"] == f"c{mod._EVENT_LOG_MAX + 49}"
+        assert log[0]["content"] == "c50"
+    finally:
+        mod._event_logs.pop(key, None)

--- a/tests/unit/studio/test_event_stream.py
+++ b/tests/unit/studio/test_event_stream.py
@@ -31,8 +31,8 @@ class TestGetEventLog:
     def test_creates_log_on_demand(self):
         es_mod._event_logs.clear()
         log = get_event_log("key-1")
-        assert log == []
-        # Subsequent call returns same list.
+        assert list(log) == []
+        # Subsequent call returns same ring.
         assert get_event_log("key-1") is log
 
     def test_independent_logs_per_key(self):
@@ -40,7 +40,7 @@ class TestGetEventLog:
         a = get_event_log("a")
         b = get_event_log("b")
         a.append("x")
-        assert b == []
+        assert list(b) == []
 
 
 # ── StreamOutput sync hooks ────────────────────────────────


### PR DESCRIPTION
## Summary

Removes the O(N)-per-turn / O(N)-per-open costs in the shared session persistence core that make every interactive frontend (CLI, TUI, web) degrade progressively as a session grows long, and adds the web transport cursor contract so incremental history fetches become possible.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

See #158 for the full investigation (profiler-measurable): `on_processing_end` re-read and re-serialized the entire event log every turn (O(N) per turn → O(N²) per session), `SessionStore` reopen scanned every event value to rebuild counters, `select_live_event_ids` rebuilt the full prior-selection dict per event (O(N × turns)), and the web attachment replay log `_event_logs` kept an unbounded second copy of the whole stream in RAM for the process lifetime.

## Changes

**Session core** (benefits CLI, TUI, web, resume, `SessionReader`)
- `store_counters` / `store.py`: the global `max_event_id` is persisted to the `state` table at append and close, and read back on open; reopening no longer deserializes every event value (only the value-free key-seq restore remains). Older session files fall back to the original scan automatically.
- `session/output.py`: `on_processing_end` no longer re-reads the full log — the controller path uses the live `conversation.snapshot_messages()` plus an O(1) `max_event_id()` lookup; the no-controller cold path keeps full replay, and duck-typed stores lacking `max_event_id` fall back to the previous scan.
- `session/history.py`: `select_live_event_ids` builds the prior-selected prefix via a clamped pass per event instead of rebuilding `{t: b for t < ti}` per event → O(N + turns).
- `studio/attach/_event_stream.py`: the in-memory replay log is a bounded ring buffer (`KT_EVENT_LOG_MAX`, default 5000); reconnects still replay recent context.

**Transport contract (web)**
- `GET .../history` accepts `since_event_id` (trims the events tail; incremental payloads omit the full-log-only `messages` snapshot) and always reports `max_event_id`. `get_events` / `get_resumable_events` accept the same cursor; `terrariumAPI.getHistory` gained the optional parameter.
- New `GET .../events/{event_id}` + `store.get_event_by_id` + `service.chat_event`: lazy single-event fetch so history payloads can stay on bounded `output_preview` strings and the client loads full tool/subagent output on expand (this is the backend dependency for the remaining #159 item).

**Not done, deliberately** (documented for reviewers)
- Frontend incremental append in `_resyncHistory`: safe application under concurrent WS-stream/resync interleaving needs a version vector, not a single cursor; the identity-preserving rebuild from #160 already caps the visible cost, so the full resync stays the fallback path.
- ETag/304: depends on the above generation semantics.
- FTS per-event insert stays inline: `TextVault` exposes no batch/commit API, so there is nothing to batch without upstream changes.
- `controller.py` per-round message serialization: investigation showed this is required by LLM request-body semantics (each round must carry the full conversation); the issue's original reading was inaccurate.

## Validation

```bash
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
#   11976 passed, 9 skipped; 6 failed in
#   tests/unit/packages/test_git_backend_dulwich_integration.py —
#   reproduce identically on main (pre-existing, verified via stash)
pytest tests/unit/test_file_sizes.py -q          # 1690 passed
pytest tests/integration/ -q                     # 173 passed
ruff check src/ tests/                           # clean (touched files)
black src/ tests/                                # clean (touched files)
```

New tests (+14 total): persisted-counter fast path / fallback / append-persists-reopen, `since_event_id` filter, `max_event_id` vs full scan, never-underreport under mirrored preset ids, global-cursor semantics, single-event fetch 200/404, history cursor filter + `max_event_id` reporting, branch-prefix selection positive/negative, ring-buffer eviction.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [ ] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes (touched files; the tree-wide run passes in CI)
- [x] `black --check src/ tests/` passes (touched files)
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Refs #158 (implements core + transport; frontend incremental append documented as follow-up)
- Relates to #159 (the `/events/{event_id}` endpoint is the backend half of its lazy-output item)
- Companion to merged #160 (frontend rendering side)

## Notes for Reviewers

- `max_event_id()` treats the per-session counter as authoritative (local ids are allocated from it; mirrored preset ids ratchet it). An earlier iteration read the prefix-max key, which can under-report when a mirrored high id sits before the last sequence position — caught in self-review and pinned by `test_max_event_id_never_underreports_mirrored_ids`.
- The 6 dulwich test failures reproduce on unmodified `main` in my environment (git ref checkout, network-independent); including this here so the CI comparison is apples-to-apples.
- `KT_EVENT_LOG_MAX=5000` is an env override point for lab harnesses; happy to move it to a config field if preferred.

## Exceptions / Not Run

- Frontend checks: only `src/utils/api.js` changed (one optional parameter, backwards-compatible); full `npm run build` was run for the earlier companion PR (#160) and this change is covered by the existing vitest suite run there.
- Maintainer approval for #158 is not yet recorded on the issue; the issue was opened before this PR per CONTRIBUTING, and I'm happy to hold until triaged.
- Fork CI not awaited before opening; will monitor and address failures.
