### PR TITLE
feat(plugins): add per-request tool catalog visibility contributions

### DIFF
--- a/docs/en/guides/plugins.md
+++ b/docs/en/guides/plugins.md
@@ -88,6 +88,7 @@ Subclass `BasePlugin` and implement any of these hooks. All are async unless not
 | `post_subagent_run(result, **kwargs)` | return result or `None` | Replace sub-agent result |
 | `contribute_commands()` | return `dict[name, BaseCommand]` | Add controller `##command##` handlers |
 | `contribute_termination_check()` | return callable or `None` | Vote on whether the run should stop |
+| `get_tool_visibility(context)` | return `ToolVisibility \| None` | Restrict the per-request native tool catalog (`allowed_tools` / `allowed_subagents`; `None` = unrestricted) |
 
 Fire-and-forget callbacks (no return value, no ability to modify):
 

--- a/docs/en/reference/plugin-hooks.md
+++ b/docs/en/reference/plugin-hooks.md
@@ -64,6 +64,27 @@ When a `post_llm_call` rewrite changes the final assistant text, the runtime emi
 
 ---
 
+## Tool visibility contributions
+
+Plugins can restrict the catalog exposed to the model on each native
+request without touching the registry. `PluginManager` intersects
+multiple contributions per category, so each plugin can only narrow the
+catalog.
+
+| Hook | Signature | Fired when | Return semantics |
+|---|---|---|---|
+| `get_tool_visibility` | `def get_tool_visibility(context: PluginContext) -> ToolVisibility \| None` | Before each native request's tool schemas and provider-native tools are built. | `None` keeps the catalog unrestricted. A `ToolVisibility(allowed_tools=..., allowed_subagents=...)` keeps only the named members; an empty `frozenset` hides the whole category. |
+
+`ToolVisibility` fields:
+
+- `allowed_tools: frozenset[str] | None` — `None` means unrestricted.
+- `allowed_subagents: frozenset[str] | None` — `None` means unrestricted.
+
+This contribution only affects native tool schemas; text-mode prompt
+filtering is left to prompt contributions.
+
+---
+
 ## Tool hooks
 
 | Hook | Signature | Fired when | Return semantics |

--- a/docs/zh-CN/guides/plugins.md
+++ b/docs/zh-CN/guides/plugins.md
@@ -60,6 +60,8 @@ class ProjectHeaderPlugin(BasePlugin):
 
 运行时插件也可以实现 `get_prompt_content(context) -> str | None` 来贡献 prompt 文本。这些内容会被聚合到框架提示之前，并同时适用于父代理与子代理。
 
+运行时插件还可以实现 `get_tool_visibility(context) -> ToolVisibility | None`，按请求裁剪暴露给模型的原生工具目录（`allowed_tools` / `allowed_subagents`，`None` 表示不限制）。
+
 除了 prompt 插件以外，工具本身也可以通过 `prompt_contribution()` 贡献短的 prompt 指引；位置同样在框架提示之前。
 
 Priority 越低越早执行。你可以借此把插件插到正确位置。

--- a/docs/zh-CN/reference/plugin-hooks.md
+++ b/docs/zh-CN/reference/plugin-hooks.md
@@ -44,6 +44,16 @@ tags:
 
 ---
 
+## 工具可见性贡献
+
+插件可以在不修改 registry 的前提下，按请求裁剪暴露给模型的原生工具目录。多个插件的限制按类别取交集。
+
+| Hook | 签名 | 触发时机 | 返回值 |
+|---|---|---|---|
+| `get_tool_visibility` | `def get_tool_visibility(context: PluginContext) -> ToolVisibility \| None` | 每次构建原生请求的工具 schema 与 provider-native 工具前。 | `None` 不限制；返回 `ToolVisibility(allowed_tools=..., allowed_subagents=...)` 只保留指定名称，空 `frozenset` 隐藏整个类别。 |
+
+---
+
 ## 工具 Hook
 
 | Hook | 签名 | 触发时机 | 返回值 |

--- a/docs/zh-TW/guides/plugins.md
+++ b/docs/zh-TW/guides/plugins.md
@@ -61,6 +61,8 @@ class ProjectHeaderPlugin(BasePlugin):
 
 執行期外掛也可以實作 `get_prompt_content(context) -> str | None` 來貢獻 prompt 文字。這些內容會被聚合到框架提示之前，並同時適用於父代理與子代理。
 
+執行期外掛也可以實作 `get_tool_visibility(context) -> ToolVisibility | None`，按請求裁切暴露給模型的原生工具目錄（`allowed_tools` / `allowed_subagents`，`None` 表示不限制）。
+
 除了 prompt 外掛以外，工具本身也可以透過 `prompt_contribution()` 貢獻短的 prompt 指引；位置同樣在框架提示之前。
 
 Priority 越低越早執行。你可以藉此把外掛插到正確位置。

--- a/docs/zh-TW/reference/plugin-hooks.md
+++ b/docs/zh-TW/reference/plugin-hooks.md
@@ -44,6 +44,16 @@ tags:
 
 ---
 
+## 工具可見性貢獻
+
+外掛可以在不修改 registry 的前提下，按請求裁切暴露給模型的原生工具目錄。多個外掛的限制會依類別取交集。
+
+| Hook | 簽章 | 觸發時機 | 回傳語意 |
+|---|---|---|---|
+| `get_tool_visibility` | `def get_tool_visibility(context: PluginContext) -> ToolVisibility \| None` | 每次建構原生請求的 tool schemas 與 provider-native tools 之前。 | `None` 不限制；回傳 `ToolVisibility(allowed_tools=..., allowed_subagents=...)` 只保留指定名稱，空 `frozenset` 隱藏整個類別。 |
+
+---
+
 ## 工具 hooks
 
 | Hook | 簽章 | 觸發時機 | 回傳語意 |

--- a/src/kohakuterrarium/core/controller.py
+++ b/src/kohakuterrarium/core/controller.py
@@ -37,6 +37,7 @@ from kohakuterrarium.core.tool_output import materialize_image_part
 from kohakuterrarium.llm.base import LLMProvider
 from kohakuterrarium.llm.message import ContentPart, FilePart, ImagePart, TextPart
 from kohakuterrarium.llm.tools import build_provider_native_tools, build_tool_schemas
+from kohakuterrarium.modules.plugin.base import ToolVisibility
 from kohakuterrarium.modules.tool.base import ToolInfo
 from kohakuterrarium.parsing import (
     AssistantImageEvent,
@@ -67,6 +68,18 @@ def _merge_text_and_parts(
         merged.append(TextPart(text=text))
     merged.extend(structured_parts)
     return merged
+
+
+def _schema_allowed(
+    name: str, subagent_names: set[str], visibility: ToolVisibility
+) -> bool:
+    """Check one schema name against the applicable visibility category."""
+    allowed = (
+        visibility.allowed_subagents
+        if name in subagent_names
+        else visibility.allowed_tools
+    )
+    return allowed is None or name in allowed
 
 
 @dataclass
@@ -226,15 +239,35 @@ class Controller:
         """Check if using native API tool calling."""
         return self.config.tool_format == "native"
 
+    def _get_tool_visibility(self) -> ToolVisibility | None:
+        """Collect active plugins' per-request tool catalog restrictions."""
+        plugins = getattr(self, "plugins", None)
+        if plugins is None:
+            return None
+        return plugins.collect_tool_visibility()
+
     def _get_native_tool_schemas(self) -> "list[ToolSchema]":
-        """Build native tool schemas from registry."""
-        return build_tool_schemas(self.registry)
+        """Build callable schemas, applying plugin tool-visibility restrictions."""
+        schemas = build_tool_schemas(self.registry)
+        visibility = self._get_tool_visibility()
+        if visibility is None:
+            return schemas
+        subagent_names = set(self.registry.list_subagents())
+        return [
+            schema
+            for schema in schemas
+            if _schema_allowed(schema.name, subagent_names, visibility)
+        ]
 
     def _get_provider_native_tools(self) -> list:
         """Collect tools the active provider should translate into
         wire-format built-in tool specs. See
         :func:`build_provider_native_tools`."""
-        return build_provider_native_tools(self.registry)
+        tools = build_provider_native_tools(self.registry)
+        visibility = self._get_tool_visibility()
+        if visibility is None or visibility.allowed_tools is None:
+            return tools
+        return [tool for tool in tools if tool.tool_name in visibility.allowed_tools]
 
     def _setup_system_prompt(self) -> None:
         """Setup initial system prompt."""

--- a/src/kohakuterrarium/modules/plugin/base.py
+++ b/src/kohakuterrarium/modules/plugin/base.py
@@ -4,6 +4,7 @@ Hooks run linearly by priority; callbacks observe lifecycle events without nesti
 """
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -31,6 +32,22 @@ logger = get_logger(__name__)
 
 class PluginBlockError(Exception):
     """Block a tool or sub-agent call and expose the reason as its result."""
+
+
+@dataclass(frozen=True)
+class ToolVisibility:
+    """Per-request tool catalog restriction contributed by a plugin.
+
+    ``None`` means the category stays unrestricted; an empty ``frozenset``
+    hides every member of that category from the current request.
+    """
+
+    allowed_tools: frozenset[str] | None = None
+    allowed_subagents: frozenset[str] | None = None
+
+    def is_unrestricted(self) -> bool:
+        """Return True when neither tool nor sub-agent names are restricted."""
+        return self.allowed_tools is None and self.allowed_subagents is None
 
 
 class PluginContext:
@@ -272,6 +289,10 @@ class BasePlugin:
 
     def get_prompt_content(self, context: PluginContext) -> str | None:
         """Return optional runtime prompt prose collected in plugin priority order."""
+        return None
+
+    def get_tool_visibility(self, context: PluginContext) -> ToolVisibility | None:
+        """Return per-request tool catalog restrictions, or None for no opinion."""
         return None
 
     def runtime_services(self, context: Any) -> dict[str, Any]:

--- a/src/kohakuterrarium/modules/plugin/manager.py
+++ b/src/kohakuterrarium/modules/plugin/manager.py
@@ -12,6 +12,7 @@ from kohakuterrarium.modules.plugin.base import (
     BasePlugin,
     PluginBlockError,
     PluginContext,
+    ToolVisibility,
 )
 from kohakuterrarium.modules.plugin.dispatch import (
     call_method as _call_method,
@@ -39,6 +40,31 @@ def _plugin_applies(plugin: BasePlugin, context: PluginContext | None) -> bool:
             exc_info=True,
         )
         return True
+
+
+def _intersect_names(
+    left: frozenset[str] | None, right: frozenset[str] | None
+) -> frozenset[str] | None:
+    """Intersect two per-category name restrictions; None means unrestricted."""
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return left & right
+
+
+def _merge_visibility(
+    current: ToolVisibility | None, extra: ToolVisibility
+) -> ToolVisibility:
+    """Merge an extra restriction into the running restriction set."""
+    if current is None:
+        return extra
+    return ToolVisibility(
+        allowed_tools=_intersect_names(current.allowed_tools, extra.allowed_tools),
+        allowed_subagents=_intersect_names(
+            current.allowed_subagents, extra.allowed_subagents
+        ),
+    )
 
 
 class PluginManager(PluginCommandRefreshMixin):
@@ -214,6 +240,41 @@ class PluginManager(PluginCommandRefreshMixin):
                 continue
             services.update(contributed)
         return services
+
+    def collect_tool_visibility(
+        self, context: PluginContext | None = None
+    ) -> ToolVisibility | None:
+        """Merge per-plugin tool catalog restrictions.
+
+        Multiple restrictions intersect per category so every contributor
+        can only narrow, never widen, the catalog. Plugins that return
+        None are unrestricted; failing plugins are skipped.
+        """
+        merged: ToolVisibility | None = None
+        for plugin in self._applicable_plugins():
+            try:
+                contributed = plugin.get_tool_visibility(
+                    context if context is not None else self._load_context
+                )
+            except Exception as e:
+                logger.warning(
+                    "Plugin get_tool_visibility raised",
+                    plugin_name=getattr(plugin, "name", "?"),
+                    error=str(e),
+                    exc_info=True,
+                )
+                continue
+            if contributed is None:
+                continue
+            if not isinstance(contributed, ToolVisibility):
+                logger.warning(
+                    "Plugin returned non-ToolVisibility; ignoring",
+                    plugin_name=getattr(plugin, "name", "?"),
+                    returned_type=type(contributed).__name__,
+                )
+                continue
+            merged = _merge_visibility(merged, contributed)
+        return merged
 
     def collect_prompt_contributions(self, context: PluginContext) -> list[str]:
         """Collect runtime prompt prose in plugin priority order."""

--- a/src/kohakuterrarium/modules/plugin/manager.py
+++ b/src/kohakuterrarium/modules/plugin/manager.py
@@ -12,7 +12,6 @@ from kohakuterrarium.modules.plugin.base import (
     BasePlugin,
     PluginBlockError,
     PluginContext,
-    ToolVisibility,
 )
 from kohakuterrarium.modules.plugin.dispatch import (
     call_method as _call_method,
@@ -20,6 +19,9 @@ from kohakuterrarium.modules.plugin.dispatch import (
 )
 from kohakuterrarium.modules.plugin.manager_commands import (
     PluginCommandRefreshMixin,
+)
+from kohakuterrarium.modules.plugin.tool_visibility import (
+    ToolVisibilityCollectorMixin,
 )
 from kohakuterrarium.utils.logging import get_logger
 
@@ -42,68 +44,7 @@ def _plugin_applies(plugin: BasePlugin, context: PluginContext | None) -> bool:
         return True
 
 
-def _intersect_names(
-    left: frozenset[str] | None, right: frozenset[str] | None
-) -> frozenset[str] | None:
-    """Intersect two per-category name restrictions; None means unrestricted."""
-    if left is None:
-        return right
-    if right is None:
-        return left
-    return left & right
-
-
-def _merge_visibility(
-    current: ToolVisibility | None, extra: ToolVisibility
-) -> ToolVisibility:
-    """Merge an extra restriction into the running restriction set."""
-    if current is None:
-        return extra
-    return ToolVisibility(
-        allowed_tools=_intersect_names(current.allowed_tools, extra.allowed_tools),
-        allowed_subagents=_intersect_names(
-            current.allowed_subagents, extra.allowed_subagents
-        ),
-    )
-
-
-def _request_context(base: PluginContext | None) -> PluginContext | None:
-    """Copy a load context with the host's current model, when available."""
-    if base is None:
-        return None
-    model = base.model
-    host_agent = base._host_agent
-    if host_agent is not None:
-        llm = getattr(host_agent, "llm", None)
-        current_model = getattr(llm, "model", "")
-        if current_model:
-            model = current_model
-    return PluginContext(
-        agent_name=base.agent_name,
-        working_dir=base.working_dir,
-        session_id=base.session_id,
-        model=model,
-        _host_agent=host_agent,
-        _spawn_child_agent_helper=base._spawn_child_agent_helper,
-    )
-
-
-def _scoped_context(base: PluginContext | None, plugin: BasePlugin) -> PluginContext:
-    """Build a plugin-scoped context so get_state/set_state are namespaced."""
-    if base is None:
-        return PluginContext(_plugin_name=getattr(plugin, "name", "unnamed"))
-    return PluginContext(
-        agent_name=base.agent_name,
-        working_dir=base.working_dir,
-        session_id=base.session_id,
-        model=base.model,
-        _host_agent=base._host_agent,
-        _plugin_name=getattr(plugin, "name", "unnamed"),
-        _spawn_child_agent_helper=base._spawn_child_agent_helper,
-    )
-
-
-class PluginManager(PluginCommandRefreshMixin):
+class PluginManager(PluginCommandRefreshMixin, ToolVisibilityCollectorMixin):
     """Manages plugin lifecycle, hook wrapping, and callback dispatch."""
 
     def __init__(self) -> None:
@@ -276,46 +217,6 @@ class PluginManager(PluginCommandRefreshMixin):
                 continue
             services.update(contributed)
         return services
-
-    def collect_tool_visibility(
-        self, context: PluginContext | None = None
-    ) -> ToolVisibility | None:
-        """Merge per-plugin tool catalog restrictions.
-
-        Multiple restrictions intersect per category so every contributor
-        can only narrow, never widen, the catalog. Applicability and the
-        plugin hook are evaluated against the current host model and a
-        plugin-scoped context; failing plugins are skipped.
-        """
-        request_ctx = _request_context(
-            context if context is not None else self._load_context
-        )
-        merged: ToolVisibility | None = None
-        for plugin in self._active_plugins():
-            if not _plugin_applies(plugin, request_ctx):
-                continue
-            plugin_ctx = _scoped_context(request_ctx, plugin)
-            try:
-                contributed = plugin.get_tool_visibility(plugin_ctx)
-            except Exception as e:
-                logger.warning(
-                    "Plugin get_tool_visibility raised",
-                    plugin_name=getattr(plugin, "name", "?"),
-                    error=str(e),
-                    exc_info=True,
-                )
-                continue
-            if contributed is None:
-                continue
-            if not isinstance(contributed, ToolVisibility):
-                logger.warning(
-                    "Plugin returned non-ToolVisibility; ignoring",
-                    plugin_name=getattr(plugin, "name", "?"),
-                    returned_type=type(contributed).__name__,
-                )
-                continue
-            merged = _merge_visibility(merged, contributed)
-        return merged
 
     def collect_prompt_contributions(self, context: PluginContext) -> list[str]:
         """Collect runtime prompt prose in plugin priority order."""

--- a/src/kohakuterrarium/modules/plugin/manager.py
+++ b/src/kohakuterrarium/modules/plugin/manager.py
@@ -67,6 +67,42 @@ def _merge_visibility(
     )
 
 
+def _request_context(base: PluginContext | None) -> PluginContext | None:
+    """Copy a load context with the host's current model, when available."""
+    if base is None:
+        return None
+    model = base.model
+    host_agent = base._host_agent
+    if host_agent is not None:
+        llm = getattr(host_agent, "llm", None)
+        current_model = getattr(llm, "model", "")
+        if current_model:
+            model = current_model
+    return PluginContext(
+        agent_name=base.agent_name,
+        working_dir=base.working_dir,
+        session_id=base.session_id,
+        model=model,
+        _host_agent=host_agent,
+        _spawn_child_agent_helper=base._spawn_child_agent_helper,
+    )
+
+
+def _scoped_context(base: PluginContext | None, plugin: BasePlugin) -> PluginContext:
+    """Build a plugin-scoped context so get_state/set_state are namespaced."""
+    if base is None:
+        return PluginContext(_plugin_name=getattr(plugin, "name", "unnamed"))
+    return PluginContext(
+        agent_name=base.agent_name,
+        working_dir=base.working_dir,
+        session_id=base.session_id,
+        model=base.model,
+        _host_agent=base._host_agent,
+        _plugin_name=getattr(plugin, "name", "unnamed"),
+        _spawn_child_agent_helper=base._spawn_child_agent_helper,
+    )
+
+
 class PluginManager(PluginCommandRefreshMixin):
     """Manages plugin lifecycle, hook wrapping, and callback dispatch."""
 
@@ -247,15 +283,20 @@ class PluginManager(PluginCommandRefreshMixin):
         """Merge per-plugin tool catalog restrictions.
 
         Multiple restrictions intersect per category so every contributor
-        can only narrow, never widen, the catalog. Plugins that return
-        None are unrestricted; failing plugins are skipped.
+        can only narrow, never widen, the catalog. Applicability and the
+        plugin hook are evaluated against the current host model and a
+        plugin-scoped context; failing plugins are skipped.
         """
+        request_ctx = _request_context(
+            context if context is not None else self._load_context
+        )
         merged: ToolVisibility | None = None
-        for plugin in self._applicable_plugins():
+        for plugin in self._active_plugins():
+            if not _plugin_applies(plugin, request_ctx):
+                continue
+            plugin_ctx = _scoped_context(request_ctx, plugin)
             try:
-                contributed = plugin.get_tool_visibility(
-                    context if context is not None else self._load_context
-                )
+                contributed = plugin.get_tool_visibility(plugin_ctx)
             except Exception as e:
                 logger.warning(
                     "Plugin get_tool_visibility raised",

--- a/src/kohakuterrarium/modules/plugin/tool_visibility.py
+++ b/src/kohakuterrarium/modules/plugin/tool_visibility.py
@@ -1,0 +1,131 @@
+"""Per-request tool catalog visibility contributions for PluginManager."""
+
+from kohakuterrarium.modules.plugin.base import (
+    BasePlugin,
+    PluginContext,
+    ToolVisibility,
+)
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _intersect_names(
+    left: frozenset[str] | None, right: frozenset[str] | None
+) -> frozenset[str] | None:
+    """Intersect two per-category name restrictions; None means unrestricted."""
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return left & right
+
+
+def _merge_visibility(
+    current: ToolVisibility | None, extra: ToolVisibility
+) -> ToolVisibility:
+    """Merge an extra restriction into the running restriction set."""
+    if current is None:
+        return extra
+    return ToolVisibility(
+        allowed_tools=_intersect_names(current.allowed_tools, extra.allowed_tools),
+        allowed_subagents=_intersect_names(
+            current.allowed_subagents, extra.allowed_subagents
+        ),
+    )
+
+
+def _request_context(base: PluginContext | None) -> PluginContext | None:
+    """Copy a load context with the host's current model, when available."""
+    if base is None:
+        return None
+    model = base.model
+    host_agent = base._host_agent
+    if host_agent is not None:
+        llm = getattr(host_agent, "llm", None)
+        current_model = getattr(llm, "model", "")
+        if current_model:
+            model = current_model
+    return PluginContext(
+        agent_name=base.agent_name,
+        working_dir=base.working_dir,
+        session_id=base.session_id,
+        model=model,
+        _host_agent=host_agent,
+        _spawn_child_agent_helper=base._spawn_child_agent_helper,
+    )
+
+
+def _scoped_context(base: PluginContext | None, plugin: BasePlugin) -> PluginContext:
+    """Build a plugin-scoped context so get_state/set_state are namespaced."""
+    if base is None:
+        return PluginContext(_plugin_name=getattr(plugin, "name", "unnamed"))
+    return PluginContext(
+        agent_name=base.agent_name,
+        working_dir=base.working_dir,
+        session_id=base.session_id,
+        model=base.model,
+        _host_agent=base._host_agent,
+        _plugin_name=getattr(plugin, "name", "unnamed"),
+        _spawn_child_agent_helper=base._spawn_child_agent_helper,
+    )
+
+
+def _plugin_applies(plugin: BasePlugin, context: PluginContext | None) -> bool:
+    """Evaluate applicability, defaulting to enabled when context or evaluation fails."""
+    if context is None:
+        return True
+    try:
+        return bool(plugin.should_apply(context))
+    except Exception as e:  # pragma: no cover — defensive
+        logger.warning(
+            "Plugin should_apply raised; defaulting to True",
+            plugin_name=getattr(plugin, "name", "?"),
+            error=str(e),
+            exc_info=True,
+        )
+        return True
+
+
+class ToolVisibilityCollectorMixin:
+    """Collect and merge enabled plugins' tool-visibility contributions."""
+
+    def collect_tool_visibility(
+        self, context: PluginContext | None = None
+    ) -> ToolVisibility | None:
+        """Merge per-plugin tool catalog restrictions.
+
+        Multiple restrictions intersect per category so every contributor
+        can only narrow, never widen, the catalog. Applicability and the
+        plugin hook are evaluated against the current host model and a
+        plugin-scoped context; failing plugins are skipped.
+        """
+        request_ctx = _request_context(
+            context if context is not None else self._load_context
+        )
+        merged: ToolVisibility | None = None
+        for plugin in self._active_plugins():
+            if not _plugin_applies(plugin, request_ctx):
+                continue
+            plugin_ctx = _scoped_context(request_ctx, plugin)
+            try:
+                contributed = plugin.get_tool_visibility(plugin_ctx)
+            except Exception as e:
+                logger.warning(
+                    "Plugin get_tool_visibility raised",
+                    plugin_name=getattr(plugin, "name", "?"),
+                    error=str(e),
+                    exc_info=True,
+                )
+                continue
+            if contributed is None:
+                continue
+            if not isinstance(contributed, ToolVisibility):
+                logger.warning(
+                    "Plugin returned non-ToolVisibility; ignoring",
+                    plugin_name=getattr(plugin, "name", "?"),
+                    returned_type=type(contributed).__name__,
+                )
+                continue
+            merged = _merge_visibility(merged, contributed)
+        return merged

--- a/src/kohakuterrarium/modules/subagent/base.py
+++ b/src/kohakuterrarium/modules/subagent/base.py
@@ -140,6 +140,15 @@ class SubAgent:
 
         return limited
 
+    def _apply_tool_visibility(self, schemas: Any) -> Any:
+        """Apply plugin tool-visibility restrictions to native schemas."""
+        if self.plugins is None:
+            return schemas
+        visibility = self.plugins.collect_tool_visibility()
+        if visibility is None or visibility.allowed_tools is None:
+            return schemas
+        return [schema for schema in schemas if schema.name in visibility.allowed_tools]
+
     def _build_system_prompt(self) -> str:
         """Build complete system prompt through the shared aggregator."""
         base_prompt = self.config.load_prompt(self.agent_path)
@@ -236,7 +245,9 @@ class SubAgent:
 
         native_tool_schemas = None
         if self._is_native:
-            native_tool_schemas = build_tool_schemas(self.registry)
+            native_tool_schemas = self._apply_tool_visibility(
+                build_tool_schemas(self.registry)
+            )
 
         output_parts: list[str] = []
         tools_used: list[str] = []

--- a/tests/integration/test_modules.py
+++ b/tests/integration/test_modules.py
@@ -50,6 +50,7 @@ from kohakuterrarium.modules.plugin.base import (
     BasePlugin,
     PluginBlockError,
     PluginContext as RuntimePluginContext,
+    ToolVisibility,
 )
 from kohakuterrarium.modules.plugin.manager import PluginManager
 from kohakuterrarium.modules.subagent.base import SubAgent
@@ -130,6 +131,25 @@ class RecordingTool(BaseTool):
                 error="recorder failed: deliberate explosion", exit_code=1
             )
         return ToolResult(output=f"recorder saw: {msg}")
+
+
+class VisibilityProbeTool(BaseTool):
+    """A second DIRECT-mode tool used only to observe catalog filtering."""
+
+    @property
+    def tool_name(self) -> str:
+        return "visibility_probe"
+
+    @property
+    def description(self) -> str:
+        return "Probe whether the tool is visible to the model."
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _execute(self, args: dict[str, Any], **kwargs: Any) -> ToolResult:
+        return ToolResult(output="visibility probe ran")
 
 
 class _DeepSeekResponse:
@@ -272,6 +292,19 @@ class ScopedPlugin(BasePlugin):
     async def pre_tool_execute(self, args: dict, **kwargs: Any) -> dict | None:
         self.pre_calls.append(kwargs.get("tool_name", ""))
         return {**args, "msg": "SCOPED-SHOULD-NOT-RUN"}
+
+
+class ToolVisibilityPlugin(BasePlugin):
+    """Restrict the native catalog to ``recorder`` — the probe tool and
+    every sub-agent must disappear from the request until disabled."""
+
+    name = "tool_visibility"
+
+    def get_tool_visibility(self, context: Any) -> ToolVisibility:
+        return ToolVisibility(
+            allowed_tools=frozenset({"recorder"}),
+            allowed_subagents=frozenset(),
+        )
 
 
 class PingCommand(BaseUserCommand):
@@ -468,12 +501,17 @@ class TestModulesIntegration:
         tool = RecordingTool()
         agent.registry.register_tool(tool)
         agent.executor.register_tool(tool)
+        probe = VisibilityProbeTool()
+        agent.registry.register_tool(probe)
+        agent.executor.register_tool(probe)
 
         plugin = GuardrailPlugin()
         scoped = ScopedPlugin()  # gated OUT — agent name does not match.
+        visibility_plugin = ToolVisibilityPlugin()
         mgr = PluginManager()
         mgr.register(plugin)
         mgr.register(scoped)
+        mgr.register(visibility_plugin)
         agent.plugins = mgr
         agent.controller.plugins = mgr
         # load_all wires the load-context so ``applies_to`` gating is
@@ -488,6 +526,26 @@ class TestModulesIntegration:
         contributions = mgr.collect_prompt_contributions(ctx)
         assert "GUARDRAIL-PLUGIN-BANNER: tool calls are policed." in contributions
         assert all("SCOPED" not in c for c in contributions)
+
+        # Tool-visibility contributions merge through the manager and the
+        # real Controller applies them to the native schema surface.
+        visibility = mgr.collect_tool_visibility(ctx)
+        assert visibility == ToolVisibility(
+            allowed_tools=frozenset({"recorder"}), allowed_subagents=frozenset()
+        )
+        assert [s.name for s in agent.controller._get_native_tool_schemas()] == [
+            "recorder"
+        ]
+        assert mgr.disable("tool_visibility") is True
+        assert {s.name for s in agent.controller._get_native_tool_schemas()} == {
+            "recorder",
+            "skill",
+            "visibility_probe",
+        }
+        assert mgr.enable("tool_visibility") is True
+        assert [s.name for s in agent.controller._get_native_tool_schemas()] == [
+            "recorder"
+        ]
 
         await agent.start()
         # on_agent_start fired on agent.start().
@@ -565,14 +623,19 @@ class TestModulesIntegration:
             assert agent.controller._event_queue.qsize() == before_q + 1
 
             # ── Manager introspection + enable/disable surface ──
-            # Both plugins are registered; list_plugins reports them with
-            # enabled flags, ordered by priority (guardrail=10 < scoped=20).
+            # All three plugins are registered; list_plugins reports them
+            # with enabled flags, ordered by priority (guardrail=10 <
+            # scoped=20 < tool_visibility=50).
             listed = mgr.list_plugins()
-            assert [p["name"] for p in listed] == ["guardrail", "scoped"]
+            assert [p["name"] for p in listed] == [
+                "guardrail",
+                "scoped",
+                "tool_visibility",
+            ]
             assert all(p["enabled"] for p in listed)
             assert mgr.get_plugin("guardrail") is plugin
             assert mgr.get_plugin("no_such") is None
-            assert len(mgr) == 2 and bool(mgr) is True
+            assert len(mgr) == 3 and bool(mgr) is True
             # Disable then re-enable the guardrail plugin.
             assert mgr.disable("guardrail") is True
             assert mgr.is_enabled("guardrail") is False
@@ -583,7 +646,11 @@ class TestModulesIntegration:
             assert mgr.disable("ghost") is False
             # list_plugins_with_options surfaces the (empty) option schema.
             with_opts = mgr.list_plugins_with_options()
-            assert {p["name"] for p in with_opts} == {"guardrail", "scoped"}
+            assert {p["name"] for p in with_opts} == {
+                "guardrail",
+                "scoped",
+                "tool_visibility",
+            }
             assert all(p["schema"] == {} and p["options"] == {} for p in with_opts)
             # set_plugin_options on an unknown plugin raises KeyError.
             with pytest.raises(KeyError):

--- a/tests/unit/core/test_controller_tool_visibility.py
+++ b/tests/unit/core/test_controller_tool_visibility.py
@@ -1,0 +1,144 @@
+"""Unit tests for tool-visibility filtering in :mod:`kohakuterrarium.core.controller`.
+
+Behavior-first: plugin contributions restrict native tool schemas by
+category (tools vs sub-agents), provider-native tools obey the tool
+restriction, and a missing manager leaves the catalog untouched.
+"""
+
+from types import SimpleNamespace
+
+from kohakuterrarium.core.controller import Controller, _schema_allowed
+from kohakuterrarium.core.registry import Registry
+from kohakuterrarium.modules.plugin.base import ToolVisibility
+from kohakuterrarium.modules.tool.base import BaseTool, ExecutionMode, ToolResult
+
+
+class _PlainTool(BaseTool):
+    @property
+    def tool_name(self) -> str:
+        return "plain"
+
+    @property
+    def description(self) -> str:
+        return "Plain tool."
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _execute(self, args, **kwargs):
+        return ToolResult(output="ok")
+
+
+class _NativeTool(_PlainTool):
+    is_provider_native = True
+
+    @property
+    def tool_name(self) -> str:
+        return "native"
+
+    @property
+    def description(self) -> str:
+        return "Provider-native tool."
+
+
+class _VisibilityManager:
+    def __init__(self, visibility):
+        self._visibility = visibility
+
+    def collect_tool_visibility(self):
+        return self._visibility
+
+
+class _NoVisibilityManager:
+    def collect_tool_visibility(self):
+        return None
+
+
+def _make_controller():
+    registry = Registry()
+    registry.register_tool(_PlainTool())
+    registry.register_tool(_NativeTool())
+    registry.register_subagent("worker", SimpleNamespace(description="Worker."))
+    controller = Controller(llm=object(), registry=registry)
+    return controller, registry
+
+
+class TestSchemaAllowed:
+    def test_tool_category_uses_allowed_tools(self):
+        visibility = ToolVisibility(allowed_tools=frozenset({"plain"}))
+        subagents = {"worker"}
+        assert _schema_allowed("plain", subagents, visibility) is True
+        assert _schema_allowed("other", subagents, visibility) is False
+
+    def test_subagent_category_uses_allowed_subagents(self):
+        visibility = ToolVisibility(allowed_subagents=frozenset({"worker"}))
+        subagents = {"worker"}
+        assert _schema_allowed("worker", subagents, visibility) is True
+        # A non-subagent name belongs to the tool category, which is
+        # unrestricted here — sub-agent restrictions never leak sideways.
+        assert _schema_allowed("other", subagents, visibility) is True
+
+    def test_none_category_means_unrestricted(self):
+        visibility = ToolVisibility()
+        assert _schema_allowed("anything", {"worker"}, visibility) is True
+
+
+class TestControllerVisibility:
+    def test_native_schemas_filtered_by_category(self):
+        controller, _registry = _make_controller()
+        controller.plugins = _VisibilityManager(
+            ToolVisibility(
+                allowed_tools=frozenset({"plain"}),
+                allowed_subagents=frozenset({"worker"}),
+            )
+        )
+        names = [schema.name for schema in controller._get_native_tool_schemas()]
+        assert names == ["plain", "worker"]
+
+    def test_empty_subagent_restriction_hides_subagents(self):
+        controller, _registry = _make_controller()
+        controller.plugins = _VisibilityManager(
+            ToolVisibility(
+                allowed_tools=frozenset({"plain"}),
+                allowed_subagents=frozenset(),
+            )
+        )
+        names = [schema.name for schema in controller._get_native_tool_schemas()]
+        assert names == ["plain"]
+
+    def test_provider_native_tools_obey_tool_restriction(self):
+        controller, _registry = _make_controller()
+        controller.plugins = _VisibilityManager(
+            ToolVisibility(allowed_tools=frozenset({"plain"}))
+        )
+        assert [
+            tool.tool_name for tool in controller._get_provider_native_tools()
+        ] == []
+
+    def test_provider_native_tools_pass_with_allowed_name(self):
+        controller, _registry = _make_controller()
+        controller.plugins = _VisibilityManager(
+            ToolVisibility(allowed_tools=frozenset({"native"}))
+        )
+        assert [tool.tool_name for tool in controller._get_provider_native_tools()] == [
+            "native"
+        ]
+
+    def test_manager_returning_none_keeps_full_catalog(self):
+        controller, _registry = _make_controller()
+        controller.plugins = _NoVisibilityManager()
+        names = [schema.name for schema in controller._get_native_tool_schemas()]
+        assert names == ["plain", "worker"]
+        assert [tool.tool_name for tool in controller._get_provider_native_tools()] == [
+            "native"
+        ]
+
+    def test_no_plugins_keeps_full_catalog(self):
+        controller, _registry = _make_controller()
+        controller.plugins = None
+        names = [schema.name for schema in controller._get_native_tool_schemas()]
+        assert names == ["plain", "worker"]
+        assert [tool.tool_name for tool in controller._get_provider_native_tools()] == [
+            "native"
+        ]

--- a/tests/unit/modules/plugin/test_plugin_base.py
+++ b/tests/unit/modules/plugin/test_plugin_base.py
@@ -6,6 +6,7 @@ into the session store, declarative ``applies_to`` gating works, and
 option set/get round-trips through validation.
 """
 
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ from kohakuterrarium.modules.plugin.base import (
     BasePlugin,
     PluginBlockError,
     PluginContext,
+    ToolVisibility,
 )
 from kohakuterrarium.modules.plugin.option_validation import PluginOptionError
 
@@ -369,6 +371,7 @@ class TestBasePluginDefaultHooks:
     def test_contribution_hooks_default_empty(self):
         plugin = BasePlugin()
         assert plugin.get_prompt_content(PluginContext()) is None
+        assert plugin.get_tool_visibility(PluginContext()) is None
         assert plugin.runtime_services(None) == {}
         assert plugin.contribute_commands() == {}
         assert plugin.contribute_termination_check() is None
@@ -378,6 +381,32 @@ class TestBasePluginDefaultHooks:
         # the default user-command contribution is an empty mapping so a
         # plain plugin adds no slash commands.
         assert BasePlugin().contribute_user_commands() == {}
+
+
+class TestToolVisibility:
+    def test_defaults_are_unrestricted(self):
+        visibility = ToolVisibility()
+        assert visibility.allowed_tools is None
+        assert visibility.allowed_subagents is None
+        assert visibility.is_unrestricted() is True
+
+    def test_partial_restriction_is_not_unrestricted(self):
+        visibility = ToolVisibility(allowed_tools=frozenset({"read"}))
+        assert visibility.is_unrestricted() is False
+        assert visibility.allowed_subagents is None
+
+    def test_empty_set_hides_every_member(self):
+        visibility = ToolVisibility(
+            allowed_tools=frozenset(), allowed_subagents=frozenset()
+        )
+        assert visibility.is_unrestricted() is False
+        assert "read" not in visibility.allowed_tools
+        assert "worker" not in visibility.allowed_subagents
+
+    def test_is_frozen(self):
+        visibility = ToolVisibility(allowed_tools=frozenset({"read"}))
+        with pytest.raises(FrozenInstanceError):
+            visibility.allowed_tools = None  # type: ignore[misc]
 
 
 class TestPluginBlockError:

--- a/tests/unit/modules/plugin/test_plugin_manager.py
+++ b/tests/unit/modules/plugin/test_plugin_manager.py
@@ -12,6 +12,7 @@ from kohakuterrarium.modules.plugin.base import (
     BasePlugin,
     PluginBlockError,
     PluginContext,
+    ToolVisibility,
 )
 from kohakuterrarium.modules.plugin.manager import PluginManager
 
@@ -81,6 +82,16 @@ class _VetoPlugin(BasePlugin):
 
     async def on_compact_start(self, context_length):
         return self._vote
+
+
+class _VisibilityPlugin(BasePlugin):
+    def __init__(self, name, visibility):
+        super().__init__()
+        self.name = name
+        self._visibility = visibility
+
+    def get_tool_visibility(self, context):
+        return self._visibility
 
 
 # ── Registration / enable / disable ────────────────────────────────
@@ -475,6 +486,93 @@ class TestCollectors:
         mgr.register(_ServicePlugin("b", {"svc_b": 2}))
         merged = mgr.collect_runtime_services(None)
         assert merged == {"svc_a": 1, "svc_b": 2}
+
+    def test_collect_tool_visibility_empty_without_contributors(self):
+        assert PluginManager().collect_tool_visibility() is None
+
+    def test_collect_tool_visibility_returns_single_restriction(self):
+        mgr = PluginManager()
+        mgr.register(
+            _VisibilityPlugin(
+                "one",
+                ToolVisibility(
+                    allowed_tools=frozenset({"read", "bash"}),
+                    allowed_subagents=frozenset(),
+                ),
+            )
+        )
+        visibility = mgr.collect_tool_visibility()
+        assert visibility == ToolVisibility(
+            allowed_tools=frozenset({"bash", "read"}),
+            allowed_subagents=frozenset(),
+        )
+
+    def test_collect_tool_visibility_intersects_per_category(self):
+        # None = unrestricted; empty = hide all. Two plugins narrow by
+        # intersection without either one being able to widen.
+        mgr = PluginManager()
+        mgr.register(
+            _VisibilityPlugin(
+                "tools_only",
+                ToolVisibility(allowed_tools=frozenset({"read", "bash", "edit"})),
+            )
+        )
+        mgr.register(
+            _VisibilityPlugin(
+                "bash_only",
+                ToolVisibility(
+                    allowed_tools=frozenset({"bash"}),
+                    allowed_subagents=frozenset({"worker"}),
+                ),
+            )
+        )
+        visibility = mgr.collect_tool_visibility()
+        assert visibility is not None
+        assert visibility.allowed_tools == frozenset({"bash"})
+        assert visibility.allowed_subagents == frozenset({"worker"})
+
+    def test_collect_tool_visibility_none_never_widens(self):
+        mgr = PluginManager()
+        mgr.register(
+            _VisibilityPlugin(
+                "restricted", ToolVisibility(allowed_tools=frozenset({"read"}))
+            )
+        )
+        mgr.register(_VisibilityPlugin("unrestricted", None))
+        visibility = mgr.collect_tool_visibility()
+        assert visibility == ToolVisibility(allowed_tools=frozenset({"read"}))
+
+    def test_collect_tool_visibility_skips_disabled_and_raising(self):
+        class _RaisingVisibility(BasePlugin):
+            name = "bad"
+
+            def get_tool_visibility(self, context):
+                raise RuntimeError("boom")
+
+        mgr = PluginManager()
+        mgr.register(
+            _VisibilityPlugin(
+                "disabled", ToolVisibility(allowed_tools=frozenset({"read"}))
+            )
+        )
+        mgr.disable("disabled")
+        mgr.register(_RaisingVisibility())
+        mgr.register(
+            _VisibilityPlugin("kept", ToolVisibility(allowed_tools=frozenset({"bash"})))
+        )
+        visibility = mgr.collect_tool_visibility()
+        assert visibility == ToolVisibility(allowed_tools=frozenset({"bash"}))
+
+    def test_collect_tool_visibility_ignores_wrong_return_type(self):
+        class _WrongShape(BasePlugin):
+            name = "wrong"
+
+            def get_tool_visibility(self, context):
+                return frozenset({"read"})
+
+        mgr = PluginManager()
+        mgr.register(_WrongShape())
+        assert mgr.collect_tool_visibility() is None
 
 
 # ── Lifecycle: load / unload ───────────────────────────────────────

--- a/tests/unit/modules/plugin/test_plugin_manager.py
+++ b/tests/unit/modules/plugin/test_plugin_manager.py
@@ -7,6 +7,7 @@ honour a single False, and collectors aggregate per-plugin output.
 """
 
 import pytest
+from types import SimpleNamespace
 
 from kohakuterrarium.modules.plugin.base import (
     BasePlugin,
@@ -573,6 +574,51 @@ class TestCollectors:
         mgr = PluginManager()
         mgr.register(_WrongShape())
         assert mgr.collect_tool_visibility() is None
+
+    async def test_collect_tool_visibility_uses_plugin_scoped_context(self):
+        class _StateStore:
+            def __init__(self):
+                self.state: dict[str, object] = {}
+
+        class _StatefulVisibility(BasePlugin):
+            name = "stateful"
+
+            def get_tool_visibility(self, context):
+                if context.get_state("promoted"):
+                    return None
+                return ToolVisibility(allowed_tools=frozenset({"read"}))
+
+            async def on_load(self, context):
+                context.set_state("promoted", True)
+
+        store = _StateStore()
+        host = SimpleNamespace(session_store=store)
+        mgr = PluginManager()
+        mgr.register(_StatefulVisibility())
+        await mgr.load_all(PluginContext(agent_name="a", _host_agent=host))
+        # on_load wrote plugin:stateful:promoted; the visibility hook must
+        # receive a context scoped to the same plugin name.
+        assert mgr.collect_tool_visibility() is None
+
+    def test_collect_tool_visibility_applies_against_current_model(self):
+        class _ModelVisibility(BasePlugin):
+            name = "modeled"
+            applies_to = {"model_patterns": ["^slow/"]}
+
+            def get_tool_visibility(self, context):
+                return ToolVisibility(allowed_tools=frozenset({"read"}))
+
+        host = SimpleNamespace(llm=SimpleNamespace(model="fast/x"))
+        mgr = PluginManager()
+        mgr.register(_ModelVisibility())
+        mgr._load_context = PluginContext(
+            agent_name="a", model="fast/x", _host_agent=host
+        )
+        assert mgr.collect_tool_visibility() is None
+        host.llm.model = "slow/x"
+        assert mgr.collect_tool_visibility() == ToolVisibility(
+            allowed_tools=frozenset({"read"})
+        )
 
 
 # ── Lifecycle: load / unload ───────────────────────────────────────

--- a/tests/unit/modules/subagent/test_base.py
+++ b/tests/unit/modules/subagent/test_base.py
@@ -9,6 +9,8 @@ raising.
 
 from kohakuterrarium.core.budget import IterationBudget
 from kohakuterrarium.core.registry import Registry
+from kohakuterrarium.modules.plugin.base import BasePlugin, ToolVisibility
+from kohakuterrarium.modules.plugin.manager import PluginManager
 from kohakuterrarium.modules.subagent.base import SubAgent
 from kohakuterrarium.modules.subagent.config import SubAgentConfig
 from kohakuterrarium.modules.tool.base import BaseTool, ToolResult
@@ -301,6 +303,41 @@ class TestNativeMode:
         # Token usage from last_usage is accumulated across turns.
         assert result.total_tokens == 30  # 15 per turn × 2 turns
         assert result.cached_tokens == 6
+
+    async def test_native_turn_applies_plugin_tool_visibility(self):
+        class _CaptureLLM(_NativeLLM):
+            def __init__(self):
+                super().__init__()
+                self.request_tools: list[list[str]] = []
+
+            async def chat(self, messages, *, stream=True, tools=None, **kwargs):
+                self.request_tools.append([tool.name for tool in (tools or [])])
+                async for chunk in super().chat(
+                    messages, stream=stream, tools=tools, **kwargs
+                ):
+                    yield chunk
+
+        class _Visibility(BasePlugin):
+            name = "vis"
+
+            def get_tool_visibility(self, context):
+                return ToolVisibility(allowed_tools=frozenset({"echo"}))
+
+        mgr = PluginManager()
+        mgr.register(_Visibility())
+        echo = _EchoTool()
+        fail = _FailTool()
+        llm = _CaptureLLM()
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["echo", "failtool"], max_turns=5),
+            _registry(echo, fail),
+            llm,
+            tool_format="native",
+            plugin_manager=mgr,
+        )
+        result = await sa.run("native task")
+        assert result.success is True
+        assert llm.request_tools[0] == ["echo"]
 
     async def test_native_same_name_tool_calls_keep_own_results(self):
         # Regression: several calls to the SAME tool in one turn must each


### PR DESCRIPTION
## Summary

Add a declarative plugin contribution for per-request native tool catalog visibility. Plugins can return `ToolVisibility(allowed_tools=..., allowed_subagents=...)`; `PluginManager` intersects contributions, and `Controller` applies them to native tool schemas and provider-native tools. This is the generic framework seam behind the two-phase "anchored" DeepSeek bootstrap (issue #162).

## PR Type

- [ ] Bug fix
- [x] Documentation
- [x] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Plugins currently cannot influence which tools a native request exposes without mutating the registry, which touches private state and leaves stale state when the plugin is disabled at runtime. The proposed contribution is evaluated at schema-build time, so disabling a plugin immediately restores the full catalog. See issue #162 for alternatives considered.

## Changes

- Add `ToolVisibility` frozen dataclass and `BasePlugin.get_tool_visibility()` in `modules/plugin/base.py`
- Add `PluginManager.collect_tool_visibility()` with per-category intersection in `modules/plugin/manager.py`
- Apply visibility to `_get_native_tool_schemas()` and `_get_provider_native_tools()` in `core/controller.py`
- Add unit tests for the dataclass, manager merge semantics, and controller filtering
- Extend the existing `tests/integration/test_modules.py` plugin workflow to cover enable/disable behavior
- Document the new contribution in `docs/en|zh-CN|zh-TW` plugin hooks references and guides

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/modules/plugin/test_plugin_base.py \
      tests/unit/modules/plugin/test_plugin_manager.py \
      tests/unit/core/test_controller_tool_visibility.py -q
pytest tests/integration/test_core.py tests/integration/test_modules.py -q
pytest tests/integration/ -q
```

Results:

- `ruff check` / `black --check` pass
- New/changed unit tests: 123 passed
- Full integration tier: 173 passed
- Full unit tier: 13671 passed; 7 failures are pre-existing and unrelated to this change (6 `test_git_backend_dulwich_integration.py` failures from `init.defaultBranch=main` vs the tests' hard-coded `master`, and 1 `test_no_real_config_pollution.py` failure where an existing suite test touched `~/.kohakuterrarium/app.log`)

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Feature request: #162 (opened 2026-08-15)
- Approval: pending maintainer approval before this PR should be reviewed

## Notes for Reviewers

- The seam intentionally only filters native tool schemas and provider-native tools; text-mode prompt filtering is left out and documented as native-only.
- Multiple plugin restrictions merge by intersection, so contributors can only narrow the catalog.
- A consumer example lives outside this repo at `SLAPaper/kt-dsh-anchored` and uses the seam for the two-phase DeepSeek bootstrap.

## Screenshots / Logs (if applicable)

N/A

## Breaking Changes (if applicable)

None. Default `BasePlugin.get_tool_visibility()` returns `None`, so existing plugins are unaffected.

## Exceptions / Not Run

- e2e tier not run: no multi-node / Studio / serving changes.
- Frontend build not run: no frontend files changed.
- Fork CI not green yet: workflow runs were not available when this PR body was drafted; see "Validation" for local results.
