### PR TITLE
fix(frontend): settle tool call status indicators after terminal

### DIFF
--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -2926,6 +2926,12 @@ const _chatStoreOptions = {
       // pass through (legacy / non-per-turn activity).
       if (!this._frameMatchesViewedBranch(source, data)) return
       const msgs = this.messagesByTab[source]
+      // Every remaining activity mutates live chat state. Bump the
+      // mutation generation so an in-flight /history fetch that was
+      // snapshotted before this frame cannot clobber the fresher live
+      // state when it resolves (e.g. a tool_done landing during the
+      // fetch must not be reverted to "running" by the stale replay).
+      this._historyMutationSeqByTab[source] = (this._historyMutationSeqByTab[source] || 0) + 1
 
       if (at === "wire_inbound") {
         // Output-wiring delivery from another creature. The fields
@@ -3097,7 +3103,7 @@ const _chatStoreOptions = {
           startedAt: Date.now(),
         }
         last.parts.push(startedPart)
-        this._indexToolPart(source, startedPart)
+        this._indexToolPart(source, startedPart, msgs)
         // Track all tasks as running jobs (direct tasks are promotable)
         const runKey = jobId || toolId
         const isBg = data.background || false
@@ -3126,7 +3132,7 @@ const _chatStoreOptions = {
             children: [],
           }
           last.parts.push(tc)
-          this._indexToolPart(source, tc)
+          this._indexToolPart(source, tc, msgs)
         }
         tc.status = "done"
         const payload = toolResultPayload(data.result || data.output || data.detail || "", data)
@@ -3159,7 +3165,7 @@ const _chatStoreOptions = {
             children: [],
           }
           last.parts.push(tc)
-          this._indexToolPart(source, tc)
+          this._indexToolPart(source, tc, msgs)
         }
         tc.status = data.interrupted || data.final_state === "interrupted" ? "interrupted" : "error"
         const payload = toolResultPayload(data.result || data.error || data.detail || "", data)
@@ -4324,9 +4330,23 @@ const _chatStoreOptions = {
       _indexMsgToolsInto(idx, msg)
     },
 
-    _indexToolPart(tab, part) {
+    _indexToolPart(tab, part, msgs = null) {
       if (!tab) return
-      if (part?.type === "tool" && part.jobId) _tabIndexes(this, tab).tools.set(part.jobId, part)
+      if (part?.type !== "tool" || !part.jobId) return
+      // ``part`` is the raw object the caller constructed; the array
+      // push makes Vue create a reactive proxy around it. The job-id
+      // index must hold that proxy — mutating the raw target bypasses
+      // Vue's triggers and leaves computed status icons cached as
+      // "running" even after tool_done/tool_error.
+      if (Array.isArray(msgs) && msgs.length) {
+        const tail = msgs[msgs.length - 1]
+        const parts = tail?.parts
+        const rendered = Array.isArray(parts) ? parts[parts.length - 1] : null
+        if (rendered && (rendered.id === part.id || rendered.jobId === part.jobId)) {
+          part = rendered
+        }
+      }
+      _tabIndexes(this, tab).tools.set(part.jobId, part)
     },
 
     _hasChannelMessage(tab, id) {

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -1,4 +1,5 @@
 import { createPinia, setActivePinia } from "pinia"
+import { computed, isReactive } from "vue"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { _parseSlashCommand, _replayEvents, useChatStore } from "./chat.js"
@@ -1371,6 +1372,39 @@ describe("chat store — interrupted task handling", () => {
     expect(tool.status).toBe("interrupted")
     expect(tool.result).toBe("User manually interrupted this job.")
     expect(chat.runningJobs.job_1).toBeUndefined()
+  })
+
+  it("tool_done mutates the reactive part the UI renders (index holds the proxy)", () => {
+    const chat = useChatStore()
+    chat.messagesByTab = { main: [{ id: "m1", role: "assistant", parts: [] }] }
+    chat.activeTab = "main"
+
+    chat._handleActivity("main", {
+      activity_type: "tool_start",
+      name: "bash",
+      job_id: "job_1",
+      args: { command: "sleep 10" },
+      background: false,
+      id: "tc_1",
+    })
+
+    const rendered = chat.messagesByTab.main.at(-1).parts[0]
+    const indexed = chat._findToolPart("main", chat.messagesByTab.main, "bash", "job_1")
+    expect(indexed).toBe(rendered)
+    expect(isReactive(indexed)).toBe(true)
+
+    const status = computed(() => rendered.status)
+    expect(status.value).toBe("running")
+
+    chat._handleActivity("main", {
+      activity_type: "tool_done",
+      name: "bash",
+      job_id: "job_1",
+      output: "ok",
+    })
+
+    expect(rendered.status).toBe("done")
+    expect(status.value).toBe("done")
   })
 })
 
@@ -5071,6 +5105,57 @@ describe("chat store — concurrent history resyncs apply in order", () => {
 
     expect(await load).toBe(false)
     expect(chat.messagesByTab.main.map((message) => message.content)).toEqual(["live"])
+    getHistorySpy.mockRestore()
+  })
+
+  it("an in-flight load cannot clobber a tool result that landed during the fetch", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "agent_1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    let resolveHistory
+    const importActual = await vi.importActual("@/utils/api")
+    const getHistorySpy = vi
+      .spyOn(importActual.terrariumAPI, "getHistory")
+      .mockImplementation(() => new Promise((resolve) => (resolveHistory = resolve)))
+
+    const load = chat._loadHistory("main")
+    // ``_loadHistory`` reaches ``terrariumAPI.getHistory`` through a
+    // dynamic import; one macrotask is enough for the deferred promise
+    // to settle and the mock resolver to be installed.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(resolveHistory).toBeTypeOf("function")
+    chat._handleActivity("main", {
+      activity_type: "tool_start",
+      name: "bash",
+      job_id: "job_1",
+      args: { command: "sleep 10" },
+      background: false,
+      id: "tc_1",
+    })
+    chat._handleActivity("main", {
+      activity_type: "tool_done",
+      name: "bash",
+      job_id: "job_1",
+      output: "ok",
+    })
+    resolveHistory({
+      events: [
+        { type: "processing_start", event_id: 1 },
+        { type: "tool_call", name: "bash", call_id: "job_1", event_id: 2, args: {} },
+        { type: "processing_end", event_id: 3 },
+      ],
+      is_processing: false,
+    })
+
+    expect(await load).toBe(false)
+    const part = chat.messagesByTab.main[0].parts[0]
+    expect(part.status).toBe("done")
+    expect(part.result).toBe("ok")
+    expect(chat.runningJobs.job_1).toBeUndefined()
     getHistorySpy.mockRestore()
   })
 


### PR DESCRIPTION
## Summary

Fix the intermittent web-chat bug where a tool call's status icon stays on the pulsing "running" state after `tool_done` / `tool_error` has already been delivered, until the tab is reloaded or the tool batch is collapsed/expanded.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The regression was introduced by the indexed tool lookup from #160. Two independent races can leave the same visible symptom:

1. `_indexToolPart` stored the raw part object constructed by `tool_start`. Vue renders the reactive proxy created when that object is pushed into `messagesByTab`, but `tool_done` / `tool_error` then mutated the raw object found in the index. The data changed, but Vue's trigger never fired, so `ToolCallBlock.statusIcon` (a computed) stayed cached as `running`. Remounting a collapsed tool batch re-created the computed and read the correct status, which matches the reported workaround.
2. Live tool activities did not bump `_historyMutationSeqByTab`. An in-flight `/history` resync snapshotted before the terminal event could therefore apply its stale replay over the freshly terminal live part, reverting it to `running`.

## Changes

- `_indexToolPart` now resolves the part that was actually pushed into `messagesByTab` (the reactive proxy) before inserting it into the per-tab job-id index; all call sites pass the message list.
- `_handleActivity` bumps the per-tab history mutation generation after branch filtering, so a concurrent history resync refuses to clobber newer live tool/sub-agent state.
- Added two regression tests:
  - the indexed part is the same reactive object the UI renders and a `computed` on `status` flips to `done` on `tool_done`;
  - a stale history response cannot overwrite a `tool_done` that landed while the fetch was in flight.

## Validation

```bash
cd src/kohakuterrarium-frontend
node node_modules/vitest/vitest.mjs run src/stores/chat.test.js
node node_modules/eslint/bin/eslint.js src/stores/chat.js src/stores/chat.test.js
node node_modules/prettier/bin/prettier.cjs --check src/stores/chat.js src/stores/chat.test.js
node node_modules/vite/bin/vite.js build
node scripts/fix-surrogate-escapes.mjs
```

- `src/stores/chat.test.js`: 162 passed.
- ESLint and Prettier pass for both changed files.
- Production frontend build succeeds.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

N/A — frontend bug fix, no pre-existing issue/discussion required by `CONTRIBUTING.md`.

## Notes for Reviewers

The bug is in the frontend-only job-id index introduced in #160. The fix keeps the index O(1) (it re-reads only the just-pushed tail part) and keeps the existing history resync sequencing behavior intact.

## Screenshots / Logs (if applicable)

N/A

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- Frontend-only change: Python `ruff`, `black`, and `pytest tests/unit/` were not run locally because no Python files are touched.
- CI on the fork does not run for feature-branch pushes because the workflow only triggers on `push` to `main` and on `pull_request`; the PR's upstream CI is the first run available for this branch.
- Local `npm run format:check` across the whole tree reports pre-existing formatting warnings in files unrelated to this PR (the working tree has unrelated `package.json`/`package-lock.json` drift), so the combined frontend checklist item is left unchecked. Prettier check passes for both files changed by this PR, and `vite build` + the surrogate-escape fix script (the exact `npm run build` steps) succeed.
