### PR TITLE
feat(sessions): expose ordered chain-of-thought in chat, trace, and inspector

### DIFF
--- a/scripts/inspect_session.py
+++ b/scripts/inspect_session.py
@@ -161,6 +161,33 @@ def _reasoning_entries(message: dict) -> list[tuple[str, str]]:
     entries: list[tuple[str, str]] = []
     fields = {**(message.get("extra_fields") or {}), **message}
 
+    segments = fields.get("_kt_assistant_segments")
+    if isinstance(segments, list) and segments:
+        for idx, segment in enumerate(segments):
+            if not isinstance(segment, dict):
+                continue
+            stype = segment.get("type")
+            if stype == "reasoning":
+                text = segment.get("text") or ""
+                signature = segment.get("signature") or ""
+                if signature:
+                    text = f"{text}\n[signature: {signature}]"
+                if text:
+                    label = (
+                        f"segments[{idx}] reasoning:{segment.get('source', 'unknown')}"
+                    )
+                    entries.append((label, text))
+            elif stype == "text":
+                text = segment.get("text") or ""
+                if text:
+                    entries.append((f"segments[{idx}] text", text))
+            elif stype == "tool_call_ref":
+                call_id = segment.get("call_id") or ""
+                if call_id:
+                    entries.append((f"segments[{idx}] tool_call_ref", call_id))
+        if entries:
+            return entries
+
     for key in _REASONING_TEXT_KEYS:
         value = fields.get(key)
         if isinstance(value, str) and value:

--- a/scripts/inspect_session.py
+++ b/scripts/inspect_session.py
@@ -144,23 +144,102 @@ def print_state(store: SessionStore) -> None:
     print()
 
 
-def print_conversations(store: SessionStore) -> None:
-    """Print bounded previews of persisted conversation snapshots."""
+_REASONING_TEXT_KEYS = ("reasoning_content", "reasoning", "reasoning_summary")
+_ANTHROPIC_REASONING_TYPES = {"thinking", "redacted_thinking"}
+_REASONING_PREVIEW_CHARS = 1200
+
+
+def _bounded_text(text: str, limit: int) -> str:
+    """Return ``text`` with a trailing truncation marker when over ``limit``."""
+    if limit <= 0 or len(text) <= limit:
+        return text
+    return f"{text[:limit]}\n... [{len(text) - limit} more chars]"
+
+
+def _reasoning_entries(message: dict) -> list[tuple[str, str]]:
+    """Extract chain-of-thought fields from one raw conversation message."""
+    entries: list[tuple[str, str]] = []
+    fields = {**(message.get("extra_fields") or {}), **message}
+
+    for key in _REASONING_TEXT_KEYS:
+        value = fields.get(key)
+        if isinstance(value, str) and value:
+            entries.append((key, value))
+
+    for idx, block in enumerate(fields.get("reasoning_details") or []):
+        if not isinstance(block, dict):
+            continue
+        text = block.get("text") or block.get("thinking") or block.get("data") or ""
+        signature = block.get("signature") or ""
+        if signature:
+            text = f"{text}\n[signature: {signature}]"
+        if text:
+            label = f"reasoning_details[{idx}]:{block.get('type', 'unknown')}"
+            entries.append((label, text))
+
+    native = fields.get("_kt_anthropic_content")
+    if isinstance(native, list):
+        for idx, block in enumerate(native):
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") not in _ANTHROPIC_REASONING_TYPES:
+                continue
+            text = block.get("thinking") or block.get("data") or ""
+            signature = block.get("signature") or ""
+            if signature:
+                text = f"{text}\n[signature: {signature}]"
+            if text:
+                entries.append((f"anthropic:{block.get('type')}[{idx}]", text))
+
+    return entries
+
+
+def print_conversations(
+    store: SessionStore,
+    *,
+    show_reasoning: bool = False,
+    full_reasoning: bool = False,
+) -> None:
+    """Print bounded previews of persisted conversation snapshots.
+
+    With ``show_reasoning``, assistant messages additionally print their
+    captured chain-of-thought fields. ``full_reasoning`` disables the
+    per-field preview truncation.
+    """
     print("=== Conversation Snapshots ===")
     for key_bytes in sorted(store.conversation.keys()):
         key = key_bytes.decode() if isinstance(key_bytes, bytes) else key_bytes
         messages = store.load_conversation(key)
-        if messages:
-            print(f"  {key}: {len(messages)} messages")
-            for msg in messages[:3]:
-                role = msg.get("role", "?")
-                content = str(msg.get("content", ""))[:60]
-                tc = " [+tool_calls]" if msg.get("tool_calls") else ""
-                print(f"    [{role}]{tc} {content}")
-            if len(messages) > 3:
-                print(f"    ... ({len(messages) - 3} more)")
-        else:
+        if not messages:
             print(f"  {key}: (empty)")
+            continue
+
+        print(f"  {key}: {len(messages)} messages")
+        for msg in messages[:3]:
+            role = msg.get("role", "?")
+            content = str(msg.get("content", ""))[:60]
+            tc = " [+tool_calls]" if msg.get("tool_calls") else ""
+            print(f"    [{role}]{tc} {content}")
+        if len(messages) > 3:
+            print(f"    ... ({len(messages) - 3} more)")
+
+        if show_reasoning:
+            found = False
+            for idx, msg in enumerate(messages):
+                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                    continue
+                for label, text in _reasoning_entries(msg):
+                    found = True
+                    rendered = (
+                        text
+                        if full_reasoning
+                        else _bounded_text(text, _REASONING_PREVIEW_CHARS)
+                    )
+                    print(f"    [msg {idx}] {label}:")
+                    for line in rendered.splitlines() or [""]:
+                        print(f"        {line}")
+            if not found:
+                print("    (no reasoning fields found in snapshot)")
     print()
 
 
@@ -228,6 +307,16 @@ def main():
     parser.add_argument(
         "--conversations", action="store_true", help="Show conversation snapshots"
     )
+    parser.add_argument(
+        "--reasoning",
+        action="store_true",
+        help="Show chain-of-thought fields from conversation snapshots",
+    )
+    parser.add_argument(
+        "--full-reasoning",
+        action="store_true",
+        help="Print complete reasoning text instead of bounded previews",
+    )
     parser.add_argument("--search", help="Search session content")
     parser.add_argument("--all", action="store_true", help="Show everything")
     args = parser.parse_args()
@@ -262,8 +351,13 @@ def main():
             print_state(store)
             shown = True
 
-        if show_all or args.conversations:
-            print_conversations(store)
+        show_reasoning = args.reasoning or args.full_reasoning
+        if show_all or args.conversations or show_reasoning:
+            print_conversations(
+                store,
+                show_reasoning=show_reasoning or show_all,
+                full_reasoning=args.full_reasoning,
+            )
             shown = True
 
         if args.search:
@@ -275,7 +369,8 @@ def main():
 
         if not shown and not show_all:
             print(
-                "Use --events, --channels, --subagents, --state, --conversations, --search, or --all"
+                "Use --events, --channels, --subagents, --state, --conversations, "
+                "--reasoning, --search, or --all"
             )
 
     finally:

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.test.js
@@ -58,6 +58,35 @@ describe("ChatMessage branch operations", () => {
     setActivePinia(pinia)
   })
 
+  it("renders reasoning segments inline in assistant parts", () => {
+    const store = useChatStore()
+    const message = {
+      id: "a1",
+      role: "assistant",
+      parts: [
+        { type: "reasoning", id: "r1", source: "reasoning_content", text: "think 1" },
+        { type: "text", id: "t1", content: "answer" },
+      ],
+    }
+    store.messagesByTab.main = [message]
+    store.activeTab = "main"
+    const wrapper = mount(ChatMessage, {
+      props: { message, messageIdx: 0, tabId: "main" },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          MarkdownRenderer: true,
+          ToolCallBlock: true,
+          ToolCallBatch: true,
+          UIEventBlock: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain("Thinking")
+    expect(wrapper.text()).toContain("think 1")
+  })
+
   it("keeps Save & Rerun bound to the message tab after the active tab changes", async () => {
     const store = useChatStore()
     store._instanceId = "instance"

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatMessage.vue
@@ -181,6 +181,14 @@
       <template v-for="(group, gi) in renderGroups" :key="groupKey(group, gi)">
         <!-- Pass-through part -->
         <template v-if="group.type === 'part'">
+          <div v-if="group.part.type === 'reasoning'" class="mb-1.5">
+            <details class="rounded-lg border border-iolite/20 dark:border-iolite/25 bg-iolite/5 dark:bg-iolite/10 px-2 py-1">
+              <summary class="text-xs text-iolite dark:text-iolite-light cursor-pointer select-none">
+                Thinking<span v-if="group.part.source" class="ml-1 text-warm-400">· {{ group.part.source }}</span>
+              </summary>
+              <pre class="mt-2 text-xs whitespace-pre-wrap break-words font-mono text-warm-700 dark:text-warm-300 max-h-60 overflow-y-auto">{{ reasoningText(group.part) }}</pre>
+            </details>
+          </div>
           <div v-if="group.part.type === 'text' && group.part.content" class="text-body mb-1">
             <MarkdownRenderer :content="group.part.content" />
           </div>
@@ -358,6 +366,11 @@ const errorFirstLine = computed(() => {
 
 function toggleTool(id) {
   expandedTools[id] = !expandedTools[id]
+}
+
+function reasoningText(part) {
+  if (!part?.text) return ""
+  return part.signature ? `${part.text}\n[signature: ${part.signature}]` : part.text
 }
 
 // Phase B UI event reply: forward to chat store, which sends

--- a/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
@@ -27,6 +27,19 @@
           </div>
         </div>
 
+        <div v-if="reasoningEntries.length" class="shrink-0 card p-3">
+          <button class="flex items-center gap-2 text-xs font-medium text-iolite dark:text-iolite-light" @click="showReasoning = !showReasoning">
+            <span class="i-carbon-chevron-down transition-transform" :class="{ 'rotate-180': showReasoning }" />
+            {{ showReasoning ? "Hide" : "Show" }} chain-of-thought ({{ reasoningEntries.length }})
+          </button>
+          <div v-if="showReasoning" class="mt-2 max-h-80 overflow-y-auto flex flex-col gap-2">
+            <details v-for="(entry, i) in reasoningEntries" :key="i" class="rounded-lg border border-warm-200 dark:border-warm-700 p-2">
+              <summary class="text-xs cursor-pointer select-none">[msg {{ entry.messageIndex }}] {{ entry.label }}</summary>
+              <pre class="mt-2 text-xs whitespace-pre-wrap font-mono">{{ entry.text }}</pre>
+            </details>
+          </div>
+        </div>
+
         <div class="flex-1 min-h-0 overflow-hidden">
           <div v-if="loading" class="card h-full flex items-center justify-center text-secondary">Loading history...</div>
           <div v-else-if="error" class="card h-full flex flex-col items-center justify-center text-center p-6">
@@ -50,6 +63,7 @@ import { useDensity } from "@/composables/useDensity"
 import { useChatStore, _convertHistory, _replayEvents } from "@/stores/chat"
 import { useSessionDetailStore } from "@/stores/sessionDetail"
 import { sessionAPI } from "@/utils/api"
+import { extractReasoning } from "@/utils/chatReasoning"
 
 const props = defineProps({
   embedded: { type: Boolean, default: false },
@@ -114,6 +128,8 @@ const loading = ref(false)
 const error = ref("")
 const viewerMeta = ref(null)
 const historyTargets = ref([])
+const reasoningEntries = ref([])
+const showReasoning = ref(false)
 
 const viewerInstance = computed(() => {
   const meta = viewerMeta.value || {}
@@ -132,6 +148,8 @@ function goBack() {
 }
 
 function resetViewer() {
+  reasoningEntries.value = []
+  showReasoning.value = false
   chat._cleanup()
   chat._instanceId = `session:${sessionName.value}`
   chat._instanceType = viewerInstance.value.type
@@ -159,7 +177,13 @@ function ensureTabs(tabs) {
 
 async function loadTarget(tab) {
   if (!tab) return
+  reasoningEntries.value = []
   const data = await sessionAPI.getHistory(sessionName.value, tab)
+  for (const [messageIndex, message] of (data.messages || []).entries()) {
+    for (const entry of extractReasoning(message)) {
+      reasoningEntries.value.push({ messageIndex, ...entry })
+    }
+  }
   if (data.events?.length) {
     // Read-only saved history: never populate ``runningJobs`` — a frozen
     // session has no live work, and its unfinished jobs already replay as

--- a/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
@@ -27,13 +27,13 @@
           </div>
         </div>
 
-        <div v-if="reasoningEntries.length" class="shrink-0 card p-3">
+        <div v-if="activeReasoningEntries.length" class="shrink-0 card p-3">
           <button class="flex items-center gap-2 text-xs font-medium text-iolite dark:text-iolite-light" @click="showReasoning = !showReasoning">
             <span class="i-carbon-chevron-down transition-transform" :class="{ 'rotate-180': showReasoning }" />
-            {{ showReasoning ? "Hide" : "Show" }} chain-of-thought ({{ reasoningEntries.length }})
+            {{ showReasoning ? "Hide" : "Show" }} chain-of-thought ({{ activeReasoningEntries.length }})
           </button>
           <div v-if="showReasoning" class="mt-2 max-h-80 overflow-y-auto flex flex-col gap-2">
-            <details v-for="(entry, i) in reasoningEntries" :key="i" class="rounded-lg border border-warm-200 dark:border-warm-700 p-2">
+            <details v-for="(entry, i) in activeReasoningEntries" :key="i" class="rounded-lg border border-warm-200 dark:border-warm-700 p-2">
               <summary class="text-xs cursor-pointer select-none">[msg {{ entry.messageIndex }}] {{ entry.label }}</summary>
               <pre class="mt-2 text-xs whitespace-pre-wrap font-mono">{{ entry.text }}</pre>
             </details>
@@ -128,8 +128,9 @@ const loading = ref(false)
 const error = ref("")
 const viewerMeta = ref(null)
 const historyTargets = ref([])
-const reasoningEntries = ref([])
+const reasoningEntriesByTab = reactive({})
 const showReasoning = ref(false)
+const activeReasoningEntries = computed(() => reasoningEntriesByTab[chat.activeTab] || [])
 
 const viewerInstance = computed(() => {
   const meta = viewerMeta.value || {}
@@ -148,7 +149,9 @@ function goBack() {
 }
 
 function resetViewer() {
-  reasoningEntries.value = []
+  for (const key of Object.keys(reasoningEntriesByTab)) {
+    delete reasoningEntriesByTab[key]
+  }
   showReasoning.value = false
   chat._cleanup()
   chat._instanceId = `session:${sessionName.value}`
@@ -177,16 +180,17 @@ function ensureTabs(tabs) {
 
 async function loadTarget(tab) {
   if (!tab) return
-  reasoningEntries.value = []
+  const entries = []
   const data = await sessionAPI.getHistory(sessionName.value, tab)
   for (const [messageIndex, message] of (data.messages || []).entries()) {
     // New sessions render segments inline through ChatMessage; the
     // fallback panel only serves old snapshots without ordered segments.
     if (Array.isArray(message?._kt_assistant_segments)) continue
     for (const entry of extractReasoning(message)) {
-      reasoningEntries.value.push({ messageIndex, ...entry })
+      entries.push({ messageIndex, ...entry })
     }
   }
+  reasoningEntriesByTab[tab] = entries
   if (data.events?.length) {
     // Read-only saved history: never populate ``runningJobs`` — a frozen
     // session has no live work, and its unfinished jobs already replay as

--- a/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
@@ -180,6 +180,9 @@ async function loadTarget(tab) {
   reasoningEntries.value = []
   const data = await sessionAPI.getHistory(sessionName.value, tab)
   for (const [messageIndex, message] of (data.messages || []).entries()) {
+    // New sessions render segments inline through ChatMessage; the
+    // fallback panel only serves old snapshots without ordered segments.
+    if (Array.isArray(message?._kt_assistant_segments)) continue
     for (const entry of extractReasoning(message)) {
       reasoningEntries.value.push({ messageIndex, ...entry })
     }

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.vue
@@ -55,6 +55,17 @@
       </div>
     </div>
 
+    <!-- Ordered reasoning segments -->
+    <div v-if="reasoningSegments.length" class="shrink-0 flex flex-col gap-1">
+      <div class="text-[10px] uppercase tracking-wider text-warm-400">{{ t("sessionViewer.detail.reasoning") }}</div>
+      <div class="flex flex-col gap-2">
+        <details v-for="(segment, i) in reasoningSegments" :key="i" class="rounded border border-iolite/20 bg-iolite/5 p-2">
+          <summary class="text-[11px] text-iolite cursor-pointer select-none">{{ segment.source || "reasoning" }}<span v-if="segment.signature" class="text-warm-400"> · signed</span></summary>
+          <pre class="mt-2 text-[11px] font-mono text-warm-700 dark:text-warm-300 whitespace-pre-wrap break-words max-h-48 overflow-y-auto">{{ reasoningSegmentText(segment) }}</pre>
+        </details>
+      </div>
+    </div>
+
     <!-- Raw JSON (full) -->
     <div class="flex-1 min-h-0 flex flex-col gap-1 overflow-hidden">
       <div class="text-[10px] uppercase tracking-wider text-warm-400 shrink-0">{{ t("sessionViewer.detail.rawJson") }}</div>
@@ -197,6 +208,20 @@ const subagentRef = computed(() => {
   const namespace = e.namespace || (run != null ? `${name}:${run}` : name)
   return { label, namespace }
 })
+
+const reasoningSegments = computed(() => {
+  const segments = props.event?._kt_assistant_segments
+  if (!Array.isArray(segments)) return []
+  return segments.filter((segment) => segment?.type === "reasoning")
+})
+
+function reasoningSegmentText(segment) {
+  if (!segment?.text) return ""
+  return segment.signature
+    ? `${segment.text}
+[signature: ${segment.signature}]`
+    : segment.text
+}
 
 const durationMs = computed(() => {
   const e = props.event

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventRow.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventRow.vue
@@ -42,6 +42,7 @@ const TYPE_TONE = {
   text_chunk: "text-warm-500",
   turn_token_usage: "text-taaffeite",
   token_usage: "text-taaffeite",
+  assistant_reasoning: "text-iolite",
   processing_error: "text-coral",
 }
 
@@ -62,6 +63,7 @@ const ICON_MAP = {
   text_chunk: "i-carbon-text-creation",
   turn_token_usage: "i-carbon-chart-bar",
   token_usage: "i-carbon-chart-bar",
+  assistant_reasoning: "i-carbon-idea",
   processing_error: "i-carbon-warning-alt",
 }
 
@@ -82,6 +84,10 @@ const summary = computed(() => {
   if (fromOutput) return fromOutput
   if (e.tool) return String(e.tool)
   if (e.name) return String(e.name)
+  if (Array.isArray(e._kt_assistant_segments)) {
+    const first = e._kt_assistant_segments.find((s) => s?.type === "reasoning")
+    if (first?.text) return first.text
+  }
   if (e.error) return String(e.error)
   if (e.summary) return String(e.summary)
   return ""

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceFilters.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceFilters.vue
@@ -57,6 +57,7 @@ const TYPE_CHIPS = [
   { id: "compact", label: "compact", matches: ["compact_start", "compact_complete", "compact_decision", "compact_replace"] },
   { id: "tokens", label: "tokens", matches: ["token_usage", "turn_token_usage"] },
   { id: "text", label: "text", matches: ["text_chunk", "text"] },
+  { id: "reasoning", label: "reasoning", matches: ["assistant_reasoning"] },
 ]
 
 const agentModel = computed({

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTurnGroup.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTurnGroup.vue
@@ -112,6 +112,7 @@ const TYPE_GROUPS = {
   compact: new Set(["compact_start", "compact_complete", "compact_decision", "compact_replace"]),
   tokens: new Set(["token_usage", "turn_token_usage", "subagent_token_usage"]),
   text: new Set(["text_chunk", "text"]),
+  reasoning: new Set(["assistant_reasoning"]),
 }
 
 function _passesFilter(ev) {

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/InspectorHeader.test.js
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/InspectorHeader.test.js
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import InspectorHeader from "./InspectorHeader.vue"
 import { useChatStore } from "@/stores/chat"
 import { useSessionDetailStore } from "@/stores/sessionDetail"
+import { useStatusStore } from "@/stores/status"
 
 beforeEach(() => {
   const storage = new Map()
@@ -16,12 +17,12 @@ beforeEach(() => {
   setActivePinia(createPinia())
 })
 
-function mountHeader() {
+function mountHeader(instance = null) {
   return mount(InspectorHeader, {
     props: {
       target: "g1",
       sessionName: "g1",
-      instance: {
+      instance: instance || {
         id: "g1",
         session_id: "g1",
         config_name: "root",
@@ -53,6 +54,21 @@ describe("InspectorHeader — token total source (Bug 1)", () => {
     // single restored creature the chat store knows about).
     expect(text).toContain("450 tok")
     expect(text).not.toContain("150 tok")
+    wrapper.unmount()
+  })
+
+  it("prefers the active tab runtime model over the instance default", () => {
+    const chat = useChatStore("g1")
+    chat.modelByTab["g1"] = {
+      llmName: "openai/gpt-5",
+      model: "gpt-5",
+    }
+    const status = useStatusStore("g1")
+    status.sessionInfo.model = "default-model"
+
+    const wrapper = mountHeader({ id: "g1", model: "default-model" })
+    expect(wrapper.text()).toContain("openai/gpt-5")
+    expect(wrapper.text()).not.toContain("default-model")
     wrapper.unmount()
   })
 

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/InspectorHeader.vue
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/InspectorHeader.vue
@@ -66,7 +66,11 @@ const statusColor = computed(
     })[props.instance?.status] ?? "bg-warm-400",
 )
 
-const model = computed(() => status.sessionInfo.llmName || status.sessionInfo.model || props.instance?.model || "")
+const model = computed(() => {
+  const target = props.target || chat.activeTab
+  const perTab = (target && chat.modelByTab[target]) || {}
+  return perTab.llmName || perTab.model || chat.sessionInfo.llmName || chat.sessionInfo.model || status.sessionInfo.llmName || status.sessionInfo.model || props.instance?.model || ""
+})
 
 const contextPercent = computed(() => Math.round(status.tokenUsage.contextPercent || 0))
 

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -64,6 +64,45 @@ function normalizeMessageContent(content) {
   }
 }
 
+function _insertReasoningSegments(message, segments, idPrefix = "reasoning_") {
+  if (!message || !Array.isArray(segments) || !segments.length) return
+  const parts = Array.isArray(message.parts) ? message.parts : []
+  const out = []
+  let cursor = 0
+  let n = 0
+
+  const nextText = (from) => parts.findIndex((part, idx) => idx >= from && part?.type === "text")
+  const nextTool = (from, callId) =>
+    parts.findIndex((part, idx) => idx >= from && part?.type === "tool" && part.jobId === callId)
+
+  for (const segment of segments) {
+    if (!segment || typeof segment !== "object") continue
+    if (segment.type === "reasoning") {
+      const part = {
+        type: "reasoning",
+        id: `${idPrefix}${n++}`,
+        source: segment.source || "reasoning",
+        text: segment.text || "",
+      }
+      if (segment.signature) part.signature = segment.signature
+      out.push(part)
+      continue
+    }
+    const anchor =
+      segment.type === "text"
+        ? nextText(cursor)
+        : segment.type === "tool_call_ref"
+          ? nextTool(cursor, segment.call_id)
+          : -1
+    if (anchor === -1) continue
+    while (cursor < anchor) out.push(parts[cursor++])
+    out.push(parts[cursor++])
+  }
+  while (cursor < parts.length) out.push(parts[cursor++])
+
+  if (out.length) message.parts = out
+}
+
 function contentSignature(content) {
   if (typeof content === "string") return `text:${content}`
   const normalized = normalizeContentParts(content)
@@ -210,14 +249,63 @@ export function _convertHistory(messages) {
         result: toolResults[tc.id] || "",
       }))
       const normalized = normalizeMessageContent(msg.content)
-      result.push({
+      const message = {
         id: "h_" + result.length,
         role: "assistant",
         content: normalized.content,
         contentParts: normalized.contentParts,
         timestamp: "",
         tool_calls: tcs.length ? tcs : undefined,
-      })
+      }
+      if (Array.isArray(msg._kt_assistant_segments) && msg._kt_assistant_segments.length) {
+        const tcById = new Map(tcs.map((tc) => [tc.id, tc]))
+        const parts = []
+        for (const segment of msg._kt_assistant_segments) {
+          if (!segment || typeof segment !== "object") continue
+          if (segment.type === "reasoning") {
+            const part = {
+              type: "reasoning",
+              id: `h_${result.length}_r${parts.length}`,
+              source: segment.source || "reasoning",
+              text: segment.text || "",
+            }
+            if (segment.signature) part.signature = segment.signature
+            parts.push(part)
+          } else if (segment.type === "text" && segment.text) {
+            parts.push({
+              type: "text",
+              id: `h_${result.length}_c${parts.length}`,
+              content: segment.text,
+            })
+          } else if (segment.type === "tool_call_ref" && tcById.has(segment.call_id)) {
+            const tc = tcById.get(segment.call_id)
+            parts.push({
+              type: "tool",
+              id: `h_${result.length}_t${tc.id}`,
+              jobId: tc.id,
+              name: tc.name,
+              kind: tc.kind,
+              args: tc.args,
+              status: tc.status,
+              result: tc.result,
+              tools_used: [],
+              children: [],
+            })
+          }
+        }
+        for (const part of normalized.contentParts || []) {
+          if (part.type === "image_url") {
+            parts.push({
+              type: "image_url",
+              id: `h_${result.length}_img${parts.length}`,
+              image_url: part.image_url,
+              meta: part.meta,
+            })
+          }
+        }
+        message.parts = parts
+      }
+      result.push(message)
     }
   }
   return result
@@ -1104,6 +1192,13 @@ export function _replayEvents(messages, events, branchView = null) {
           revised_prompt: evt.revised_prompt,
         },
       })
+    } else if (t === "assistant_reasoning") {
+      const c = ensureCur()
+      _insertReasoningSegments(
+        c,
+        evt._kt_assistant_segments || [],
+        typeof evt.event_id === "number" ? `h_${evt.event_id}_r` : "h_reasoning_",
+      )
     } else if (t === "token_usage" || t === "processing_complete") {
       // skip
     }
@@ -2837,6 +2932,20 @@ const _chatStoreOptions = {
       // so recover scope from this store's $id and pass it through.
       const statusStore = useStatusStore(scopeOfStoreId(this.$id))
       statusStore.handleActivity(data)
+
+      if (at === "assistant_reasoning") {
+        const tab = source || data.agent_name || this.activeTab
+        const list = this.messagesByTab[tab] || []
+        const target = [...list].reverse().find((message) => message?.role === "assistant")
+        if (target) {
+          _insertReasoningSegments(
+            target,
+            data._kt_assistant_segments || [],
+            `live_${data.id || "reasoning"}_r`,
+          )
+        }
+        return
+      }
 
       if (at === "session_info") {
         // Session id is global regardless of which creature emitted.

--- a/src/kohakuterrarium-frontend/src/stores/chat.reasoning.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.reasoning.test.js
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+
+import { _convertHistory, _replayEvents } from "./chat"
+
+function reasoningMessage() {
+  return {
+    role: "assistant",
+    content: "answer 1answer 2",
+    tool_calls: [
+      {
+        id: "call_1",
+        type: "function",
+        function: { name: "read", arguments: '{"path":"a.md"}' },
+      },
+    ],
+    _kt_assistant_segments: [
+      { type: "reasoning", source: "reasoning_content", text: "think 1" },
+      { type: "text", text: "answer 1" },
+      { type: "tool_call_ref", call_id: "call_1" },
+      { type: "reasoning", source: "reasoning_content", text: "think 2" },
+      { type: "text", text: "answer 2" },
+    ],
+  }
+}
+
+describe("_convertHistory reasoning segments", () => {
+  it("builds ordered parts for assistant snapshots", () => {
+    const messages = [
+      { role: "user", content: "q" },
+      reasoningMessage(),
+      { role: "tool", content: "file contents", tool_call_id: "call_1" },
+    ]
+    const out = _convertHistory(messages)
+    const assistant = out.find((message) => message.role === "assistant")
+    expect(assistant.parts.map((part) => part.type)).toEqual([
+      "reasoning",
+      "text",
+      "tool",
+      "reasoning",
+      "text",
+    ])
+    expect(assistant.parts[0].text).toBe("think 1")
+    expect(assistant.parts[2].jobId).toBe("call_1")
+  })
+})
+
+describe("_replayEvents reasoning segments", () => {
+  it("inserts persisted assistant_reasoning into the current message", () => {
+    const events = [
+      { type: "user_input", content: "q", event_id: 1, turn_index: 1, branch_id: 1 },
+      { type: "processing_start", event_id: 2, turn_index: 1, branch_id: 1 },
+      { type: "text_chunk", content: "answer 1", event_id: 3, turn_index: 1, branch_id: 1 },
+      {
+        type: "tool_call",
+        name: "read",
+        args: {},
+        call_id: "call_1",
+        event_id: 4,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      {
+        type: "tool_result",
+        name: "read",
+        output: "ok",
+        call_id: "call_1",
+        event_id: 5,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      {
+        type: "assistant_reasoning",
+        event_id: 6,
+        turn_index: 1,
+        branch_id: 1,
+        _kt_assistant_segments: [
+          { type: "reasoning", source: "reasoning_content", text: "think 1" },
+          { type: "text", text: "answer 1" },
+          { type: "tool_call_ref", call_id: "call_1" },
+        ],
+      },
+      { type: "text_chunk", content: "answer 2", event_id: 7, turn_index: 1, branch_id: 1 },
+      { type: "processing_end", event_id: 8, turn_index: 1, branch_id: 1 },
+    ]
+    const { messages } = _replayEvents([], events)
+    const assistant = messages.find((message) => message.role === "assistant")
+    expect(assistant.parts.map((part) => part.type)).toEqual(["reasoning", "text", "tool", "text"])
+    expect(assistant.parts[0].text).toBe("think 1")
+    expect(assistant.parts[2].jobId).toBe("call_1")
+  })
+})

--- a/src/kohakuterrarium-frontend/src/utils/chatReasoning.js
+++ b/src/kohakuterrarium-frontend/src/utils/chatReasoning.js
@@ -1,0 +1,42 @@
+/**
+ * Extract provider-owned chain-of-thought fields from a raw conversation
+ * message dict (OpenAI-format snapshot).
+ *
+ * @param {object|null} message
+ * @returns {{label: string, text: string}[]}
+ */
+export function extractReasoning(message) {
+  if (!message || message.role !== "assistant") return []
+
+  const entries = []
+  const push = (label, text) => {
+    if (typeof text === "string" && text) entries.push({ label, text })
+  }
+
+  // Legacy serialized snapshots may keep provider fields in ``extra_fields``.
+  const fields = { ...(message.extra_fields || {}), ...message }
+
+  push("reasoning_content", fields.reasoning_content)
+  push("reasoning", fields.reasoning)
+  push("reasoning_summary", fields.reasoning_summary)
+
+  for (const [index, block] of (fields.reasoning_details || []).entries()) {
+    if (!block || typeof block !== "object") continue
+    let text = block.text || block.thinking || block.data || ""
+    const signature = block.signature || ""
+    if (signature) text = `${text}\n[signature: ${signature}]`
+    if (text) entries.push({ label: `reasoning_details[${index}]:${block.type || "?"}`, text })
+  }
+
+  for (const [index, block] of (fields._kt_anthropic_content || []).entries()) {
+    if (!block || !["thinking", "redacted_thinking"].includes(block.type)) continue
+    let text = block.thinking || block.data || ""
+    const signature = block.signature || ""
+    if (signature) text = `${text}\n[signature: ${signature}]`
+    if (text) entries.push({ label: `anthropic:${block.type}[${index}]`, text })
+  }
+
+  return entries
+}
+
+export default extractReasoning

--- a/src/kohakuterrarium-frontend/src/utils/chatReasoning.test.js
+++ b/src/kohakuterrarium-frontend/src/utils/chatReasoning.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+
+import { extractReasoning } from "./chatReasoning"
+
+describe("extractReasoning", () => {
+  it("ignores non-assistant messages", () => {
+    expect(extractReasoning(null)).toEqual([])
+    expect(extractReasoning({ role: "user", reasoning_content: "hidden" })).toEqual([])
+  })
+
+  it("extracts flat OpenAI-compatible reasoning fields", () => {
+    const out = extractReasoning({
+      role: "assistant",
+      content: "answer",
+      reasoning_content: "private",
+      reasoning: "plain",
+      reasoning_summary: "brief",
+    })
+    expect(out).toEqual([
+      { label: "reasoning_content", text: "private" },
+      { label: "reasoning", text: "plain" },
+      { label: "reasoning_summary", text: "brief" },
+    ])
+  })
+
+  it("reads legacy nested extra_fields", () => {
+    const out = extractReasoning({
+      role: "assistant",
+      content: "answer",
+      extra_fields: { reasoning_content: "nested" },
+    })
+    expect(out).toEqual([{ label: "reasoning_content", text: "nested" }])
+  })
+
+  it("extracts reasoning_details text and signature", () => {
+    const out = extractReasoning({
+      role: "assistant",
+      content: "",
+      reasoning_details: [{ type: "reasoning.text", index: 0, text: "think", signature: "sig1" }],
+    })
+    expect(out).toEqual([
+      {
+        label: "reasoning_details[0]:reasoning.text",
+        text: "think\n[signature: sig1]",
+      },
+    ])
+  })
+
+  it("extracts native Anthropic thinking blocks", () => {
+    const out = extractReasoning({
+      role: "assistant",
+      content: "",
+      _kt_anthropic_content: [
+        { type: "text", text: "answer" },
+        { type: "thinking", thinking: "hmm", signature: "sig2" },
+        { type: "redacted_thinking", data: "redacted" },
+      ],
+    })
+    expect(out).toEqual([
+      { label: "anthropic:thinking[1]", text: "hmm\n[signature: sig2]" },
+      { label: "anthropic:redacted_thinking[2]", text: "redacted" },
+    ])
+  })
+})

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -1072,6 +1072,7 @@ export default {
   "sessionViewer.detail.content": "Content",
   "sessionViewer.detail.image": "Image",
   "sessionViewer.detail.tokens": "Tokens",
+  "sessionViewer.detail.reasoning": "Reasoning",
   "sessionViewer.detail.rawJson": "Raw JSON",
   "sessionViewer.detail.openSubagent": "Open sub-agent trace",
 

--- a/src/kohakuterrarium/core/agent_handlers.py
+++ b/src/kohakuterrarium/core/agent_handlers.py
@@ -700,6 +700,32 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
                 },
             )
 
+        # Publish ordered reasoning before processing_end so live chat and the
+        # trace log can attach it to this turn's assistant message.
+        fields = (
+            getattr(getattr(controller, "llm", None), "last_assistant_extra_fields", {})
+            or {}
+        )
+        reasoning_metadata = {}
+        for key in (
+            "reasoning_content",
+            "reasoning_summary",
+            "reasoning_details",
+            "reasoning",
+            "_kt_assistant_segments",
+        ):
+            value = fields.get(key)
+            if value not in (None, "", [], {}):
+                reasoning_metadata[key] = value
+        if reasoning_metadata:
+            reasoning_metadata["turn_index"] = self._turn_index
+            reasoning_metadata["branch_id"] = self._branch_id
+            self.output_router.notify_activity(
+                "assistant_reasoning",
+                f"turn {self._turn_index} assistant reasoning",
+                metadata=reasoning_metadata,
+            )
+
         await self.output_router.emit(OutputEvent(type="processing_end"))
         self.output_router.clear_all()
 

--- a/src/kohakuterrarium/core/agent_handlers.py
+++ b/src/kohakuterrarium/core/agent_handlers.py
@@ -231,6 +231,9 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
 
             # Emit token usage after each LLM turn (real-time update)
             self._emit_token_usage(controller)
+            # Publish reasoning after each round, not just the final one:
+            # tool-selection rounds have their own assistant messages.
+            self._emit_assistant_reasoning(controller)
 
             # Check interrupt after LLM turn (before waiting for tools)
             if self._interrupt_requested:
@@ -656,6 +659,32 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
 
         return True
 
+    def _emit_assistant_reasoning(self, controller: Controller) -> None:
+        """Publish the latest LLM round's reasoning to output consumers."""
+        fields = (
+            getattr(getattr(controller, "llm", None), "last_assistant_extra_fields", {})
+            or {}
+        )
+        reasoning_metadata = {}
+        for key in (
+            "reasoning_content",
+            "reasoning_summary",
+            "reasoning_details",
+            "reasoning",
+            "_kt_assistant_segments",
+        ):
+            value = fields.get(key)
+            if value not in (None, "", [], {}):
+                reasoning_metadata[key] = value
+        if reasoning_metadata:
+            reasoning_metadata["turn_index"] = self._turn_index
+            reasoning_metadata["branch_id"] = self._branch_id
+            self.output_router.notify_activity(
+                "assistant_reasoning",
+                f"turn {self._turn_index} assistant reasoning",
+                metadata=reasoning_metadata,
+            )
+
     async def _finalize_processing(
         self,
         event: TriggerEvent,
@@ -698,32 +727,6 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
                     "cached_tokens": accum.get("cached_tokens", 0),
                     "total_tokens": accum.get("total_tokens", 0),
                 },
-            )
-
-        # Publish ordered reasoning before processing_end so live chat and the
-        # trace log can attach it to this turn's assistant message.
-        fields = (
-            getattr(getattr(controller, "llm", None), "last_assistant_extra_fields", {})
-            or {}
-        )
-        reasoning_metadata = {}
-        for key in (
-            "reasoning_content",
-            "reasoning_summary",
-            "reasoning_details",
-            "reasoning",
-            "_kt_assistant_segments",
-        ):
-            value = fields.get(key)
-            if value not in (None, "", [], {}):
-                reasoning_metadata[key] = value
-        if reasoning_metadata:
-            reasoning_metadata["turn_index"] = self._turn_index
-            reasoning_metadata["branch_id"] = self._branch_id
-            self.output_router.notify_activity(
-                "assistant_reasoning",
-                f"turn {self._turn_index} assistant reasoning",
-                metadata=reasoning_metadata,
             )
 
         await self.output_router.emit(OutputEvent(type="processing_end"))

--- a/src/kohakuterrarium/core/agent_message_history.py
+++ b/src/kohakuterrarium/core/agent_message_history.py
@@ -253,6 +253,21 @@ def reload_conversation_under_branch_view(
         for key in ("tool_calls", "tool_call_id", "name", "metadata"):
             if message.get(key):
                 extra[key] = message[key]
+        extra_fields = {
+            key: value
+            for key, value in message.items()
+            if key
+            not in {
+                "role",
+                "content",
+                "tool_calls",
+                "tool_call_id",
+                "name",
+                "metadata",
+            }
+        }
+        if extra_fields:
+            extra["extra_fields"] = extra_fields
         conversation.append(role, message.get("content", ""), **extra)
 
     # Rebuilds restore tool outputs elided during live turns; re-apply

--- a/src/kohakuterrarium/llm/README.md
+++ b/src/kohakuterrarium/llm/README.md
@@ -14,6 +14,7 @@ provides typed message structures compatible with the OpenAI API format.
 | `__init__.py`           | Re-exports all provider classes, message types, and tool schema utilities                                                 |
 | `base.py`               | `LLMProvider` protocol, `BaseLLMProvider` ABC, `LLMConfig`, `ChatChunk`, `ChatResponse`, `ToolSchema`, `NativeToolCall`   |
 | `openai.py`             | `OpenAIProvider`: OpenAI/OpenRouter/compatible API provider (+ `openai_helpers.py`, `openai_sanitize.py`, `openai_ws.py`) |
+| `responses_reasoning.py` | Shared Responses-API reasoning-event collector (used by the Codex provider and OpenAI WebSocket path)                |
 | `responses_ws.py`       | `ResponsesWSSession`: persistent Responses-API WebSocket transport with `previous_response_id` incremental continuation (shared by the openai + codex providers; enabled via `extra_body.websocket_mode`) |
 | `anthropic_provider.py` | Native Anthropic Messages API provider using the official SDK (+ `anthropic_format.py`, `anthropic_pairing.py`, `anthropic_cache.py`) |
 | `codex_provider.py`     | `CodexOAuthProvider`: ChatGPT subscription provider (+ `codex_format.py`, `codex_image_gen.py`, `codex_rate_limits.py`)   |

--- a/src/kohakuterrarium/llm/README.md
+++ b/src/kohakuterrarium/llm/README.md
@@ -15,6 +15,7 @@ provides typed message structures compatible with the OpenAI API format.
 | `base.py`               | `LLMProvider` protocol, `BaseLLMProvider` ABC, `LLMConfig`, `ChatChunk`, `ChatResponse`, `ToolSchema`, `NativeToolCall`   |
 | `openai.py`             | `OpenAIProvider`: OpenAI/OpenRouter/compatible API provider (+ `openai_helpers.py`, `openai_sanitize.py`, `openai_ws.py`) |
 | `responses_reasoning.py` | Shared Responses-API reasoning-event collector (used by the Codex provider and OpenAI WebSocket path)                |
+| `turn_segments.py`     | Ordered reasoning/text/tool-call segment builder stored as `_kt_assistant_segments`                                      |
 | `responses_ws.py`       | `ResponsesWSSession`: persistent Responses-API WebSocket transport with `previous_response_id` incremental continuation (shared by the openai + codex providers; enabled via `extra_body.websocket_mode`) |
 | `anthropic_provider.py` | Native Anthropic Messages API provider using the official SDK (+ `anthropic_format.py`, `anthropic_pairing.py`, `anthropic_cache.py`) |
 | `codex_provider.py`     | `CodexOAuthProvider`: ChatGPT subscription provider (+ `codex_format.py`, `codex_image_gen.py`, `codex_rate_limits.py`)   |

--- a/src/kohakuterrarium/llm/anthropic_provider.py
+++ b/src/kohakuterrarium/llm/anthropic_provider.py
@@ -49,6 +49,7 @@ from kohakuterrarium.llm.recovery import (
     backoff_delay,
     classify_openai_error,
 )
+from kohakuterrarium.llm.turn_segments import inject_anthropic_segments
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -315,7 +316,9 @@ class AnthropicProvider(BaseLLMProvider):
         content_blocks = ordered_blocks(blocks)
         self._last_tool_calls = tool_calls_from_blocks(content_blocks)
         if content_blocks:
-            self._last_assistant_extra_fields = {KT_CONTENT_KEY: content_blocks}
+            self._last_assistant_extra_fields = inject_anthropic_segments(
+                {KT_CONTENT_KEY: content_blocks}, content_blocks
+            )
         self._log_token_usage()
         if stop_reason:
             logger.debug("Anthropic stream completed", stop_reason=stop_reason)
@@ -383,7 +386,9 @@ class AnthropicProvider(BaseLLMProvider):
         ]
         self._last_tool_calls = tool_calls_from_blocks(content_blocks)
         if content_blocks:
-            self._last_assistant_extra_fields = {KT_CONTENT_KEY: content_blocks}
+            self._last_assistant_extra_fields = inject_anthropic_segments(
+                {KT_CONTENT_KEY: content_blocks}, content_blocks
+            )
         self._last_usage = usage_to_dict(getattr(response, "usage", None))
         self._log_token_usage()
         text = "".join(

--- a/src/kohakuterrarium/llm/codex_provider.py
+++ b/src/kohakuterrarium/llm/codex_provider.py
@@ -42,6 +42,7 @@ from kohakuterrarium.llm.codex_rate_limits import (
     set_cached,
 )
 from kohakuterrarium.llm.openai_sanitize import strip_surrogates
+from kohakuterrarium.llm.responses_reasoning import ResponsesReasoningCollector
 from kohakuterrarium.llm.recovery import (
     ErrorClass,
     RetryPolicy,
@@ -67,27 +68,6 @@ async def _capture_rate_limit_headers(response: Any) -> None:
             error=str(exc),
             exc_info=True,
         )
-
-
-def _reasoning_parts_text(parts: Any) -> str:
-    """Join Responses reasoning content/summary parts into plain text."""
-    if parts is None:
-        return ""
-    if isinstance(parts, str):
-        return parts
-    if isinstance(parts, dict):
-        parts = [parts]
-    if not isinstance(parts, list):
-        return ""
-    pieces: list[str] = []
-    for part in parts:
-        if isinstance(part, dict):
-            value = part.get("text") or part.get("content") or ""
-        else:
-            value = getattr(part, "text", None) or getattr(part, "content", None) or ""
-        if isinstance(value, str) and value:
-            pieces.append(value)
-    return "\n".join(pieces)
 
 
 class CodexOAuthProvider(BaseLLMProvider):
@@ -133,8 +113,7 @@ class CodexOAuthProvider(BaseLLMProvider):
         self._last_usage: dict[str, int] = {}
         self._last_assistant_parts: list[Any] = []
         self._last_assistant_extra_fields: dict[str, Any] = {}
-        self._reasoning_text = ""
-        self._reasoning_summary = ""
+        self._reasoning = ResponsesReasoningCollector()
         self.prompt_cache_key: str | None = None
 
     async def ensure_authenticated(self) -> None:
@@ -293,8 +272,7 @@ class CodexOAuthProvider(BaseLLMProvider):
         self._last_usage = {}
         self._last_assistant_parts = []
         self._last_assistant_extra_fields = {}
-        self._reasoning_text = ""
-        self._reasoning_summary = ""
+        self._reasoning = ResponsesReasoningCollector()
         await self._ensure_valid_token()
 
         if not self._client:
@@ -381,7 +359,7 @@ class CodexOAuthProvider(BaseLLMProvider):
                         piece = self._process_stream_event(event, collected_tool_calls)
                         if piece is not None:
                             yield piece
-                    self._pack_reasoning_extra_fields()
+                    self._last_assistant_extra_fields = self._reasoning.fields()
                     self._last_tool_calls = collected_tool_calls
                     return
                 except ResponsesWSError as exc:
@@ -421,7 +399,7 @@ class CodexOAuthProvider(BaseLLMProvider):
             if piece is not None:
                 yield piece
 
-        self._pack_reasoning_extra_fields()
+        self._last_assistant_extra_fields = self._reasoning.fields()
         self._last_tool_calls = collected_tool_calls
 
     async def _complete_chat(
@@ -474,28 +452,6 @@ class CodexOAuthProvider(BaseLLMProvider):
             return None
         return self._ws_session
 
-    def _pack_reasoning_extra_fields(self) -> None:
-        """Store captured Responses reasoning text for the conversation snapshot."""
-        packed: dict[str, Any] = {}
-        if self._reasoning_text:
-            packed["reasoning_content"] = self._reasoning_text
-        if self._reasoning_summary:
-            packed["reasoning_summary"] = self._reasoning_summary
-        self._last_assistant_extra_fields = packed
-
-    def _capture_reasoning_item(self, item: Any) -> None:
-        """Fold a completed ``reasoning`` output item into provider state."""
-        summary = _reasoning_parts_text(getattr(item, "summary", None))
-        content = _reasoning_parts_text(getattr(item, "content", None))
-        if summary:
-            self._reasoning_summary = "\n".join(
-                part for part in (self._reasoning_summary, summary) if part
-            )
-        if content:
-            self._reasoning_text = "\n".join(
-                part for part in (self._reasoning_text, content) if part
-            )
-
     def _process_stream_event(
         self, event: Any, collected_tool_calls: list[NativeToolCall]
     ) -> str | None:
@@ -504,26 +460,11 @@ class CodexOAuthProvider(BaseLLMProvider):
         maybe_capture_stream_rate_limit(
             event, parse_rate_limit_event, UsageSnapshot, set_cached
         )
+        self._reasoning.consume(event)
 
         match getattr(event, "type", ""):
             case "response.output_text.delta":
                 return strip_surrogates(event.delta)
-            case "response.reasoning_text.delta":
-                piece = getattr(event, "delta", None)
-                if isinstance(piece, str):
-                    self._reasoning_text += piece
-            case "response.reasoning_summary_text.delta":
-                piece = getattr(event, "delta", None)
-                if isinstance(piece, str):
-                    self._reasoning_summary += piece
-            case "response.reasoning_text.done":
-                piece = getattr(event, "text", None)
-                if isinstance(piece, str) and piece:
-                    self._reasoning_text = piece
-            case "response.reasoning_summary_text.done":
-                piece = getattr(event, "text", None)
-                if isinstance(piece, str) and piece:
-                    self._reasoning_summary = piece
             case "response.output_item.done":
                 item = event.item
                 itype = getattr(item, "type", "")
@@ -538,8 +479,6 @@ class CodexOAuthProvider(BaseLLMProvider):
                 elif itype == "image_generation_call":
                     # Image bytes are available before the item status completes.
                     self._handle_image_generation_call(item)
-                elif itype == "reasoning":
-                    self._capture_reasoning_item(item)
             case "response.completed":
                 resp = getattr(event, "response", None)
                 if resp:

--- a/src/kohakuterrarium/llm/codex_provider.py
+++ b/src/kohakuterrarium/llm/codex_provider.py
@@ -464,14 +464,18 @@ class CodexOAuthProvider(BaseLLMProvider):
 
         match getattr(event, "type", ""):
             case "response.output_text.delta":
-                return strip_surrogates(event.delta)
+                piece = strip_surrogates(event.delta)
+                self._reasoning.consume_output_text(piece)
+                return piece
             case "response.output_item.done":
                 item = event.item
                 itype = getattr(item, "type", "")
                 if itype == "function_call":
+                    call_id = getattr(item, "call_id", "")
+                    self._reasoning.consume_function_call(call_id)
                     collected_tool_calls.append(
                         NativeToolCall(
-                            id=getattr(item, "call_id", ""),
+                            id=call_id,
                             name=getattr(item, "name", "") or "",
                             arguments=getattr(item, "arguments", ""),
                         )

--- a/src/kohakuterrarium/llm/codex_provider.py
+++ b/src/kohakuterrarium/llm/codex_provider.py
@@ -69,6 +69,27 @@ async def _capture_rate_limit_headers(response: Any) -> None:
         )
 
 
+def _reasoning_parts_text(parts: Any) -> str:
+    """Join Responses reasoning content/summary parts into plain text."""
+    if parts is None:
+        return ""
+    if isinstance(parts, str):
+        return parts
+    if isinstance(parts, dict):
+        parts = [parts]
+    if not isinstance(parts, list):
+        return ""
+    pieces: list[str] = []
+    for part in parts:
+        if isinstance(part, dict):
+            value = part.get("text") or part.get("content") or ""
+        else:
+            value = getattr(part, "text", None) or getattr(part, "content", None) or ""
+        if isinstance(value, str) and value:
+            pieces.append(value)
+    return "\n".join(pieces)
+
+
 class CodexOAuthProvider(BaseLLMProvider):
     """Stream Codex Responses API output with tools, retries, and token refresh."""
 
@@ -111,6 +132,9 @@ class CodexOAuthProvider(BaseLLMProvider):
         self._last_tool_calls: list[NativeToolCall] = []
         self._last_usage: dict[str, int] = {}
         self._last_assistant_parts: list[Any] = []
+        self._last_assistant_extra_fields: dict[str, Any] = {}
+        self._reasoning_text = ""
+        self._reasoning_summary = ""
         self.prompt_cache_key: str | None = None
 
     async def ensure_authenticated(self) -> None:
@@ -268,6 +292,9 @@ class CodexOAuthProvider(BaseLLMProvider):
         self._last_tool_calls = []
         self._last_usage = {}
         self._last_assistant_parts = []
+        self._last_assistant_extra_fields = {}
+        self._reasoning_text = ""
+        self._reasoning_summary = ""
         await self._ensure_valid_token()
 
         if not self._client:
@@ -354,6 +381,7 @@ class CodexOAuthProvider(BaseLLMProvider):
                         piece = self._process_stream_event(event, collected_tool_calls)
                         if piece is not None:
                             yield piece
+                    self._pack_reasoning_extra_fields()
                     self._last_tool_calls = collected_tool_calls
                     return
                 except ResponsesWSError as exc:
@@ -393,6 +421,7 @@ class CodexOAuthProvider(BaseLLMProvider):
             if piece is not None:
                 yield piece
 
+        self._pack_reasoning_extra_fields()
         self._last_tool_calls = collected_tool_calls
 
     async def _complete_chat(
@@ -445,6 +474,28 @@ class CodexOAuthProvider(BaseLLMProvider):
             return None
         return self._ws_session
 
+    def _pack_reasoning_extra_fields(self) -> None:
+        """Store captured Responses reasoning text for the conversation snapshot."""
+        packed: dict[str, Any] = {}
+        if self._reasoning_text:
+            packed["reasoning_content"] = self._reasoning_text
+        if self._reasoning_summary:
+            packed["reasoning_summary"] = self._reasoning_summary
+        self._last_assistant_extra_fields = packed
+
+    def _capture_reasoning_item(self, item: Any) -> None:
+        """Fold a completed ``reasoning`` output item into provider state."""
+        summary = _reasoning_parts_text(getattr(item, "summary", None))
+        content = _reasoning_parts_text(getattr(item, "content", None))
+        if summary:
+            self._reasoning_summary = "\n".join(
+                part for part in (self._reasoning_summary, summary) if part
+            )
+        if content:
+            self._reasoning_text = "\n".join(
+                part for part in (self._reasoning_text, content) if part
+            )
+
     def _process_stream_event(
         self, event: Any, collected_tool_calls: list[NativeToolCall]
     ) -> str | None:
@@ -457,6 +508,22 @@ class CodexOAuthProvider(BaseLLMProvider):
         match getattr(event, "type", ""):
             case "response.output_text.delta":
                 return strip_surrogates(event.delta)
+            case "response.reasoning_text.delta":
+                piece = getattr(event, "delta", None)
+                if isinstance(piece, str):
+                    self._reasoning_text += piece
+            case "response.reasoning_summary_text.delta":
+                piece = getattr(event, "delta", None)
+                if isinstance(piece, str):
+                    self._reasoning_summary += piece
+            case "response.reasoning_text.done":
+                piece = getattr(event, "text", None)
+                if isinstance(piece, str) and piece:
+                    self._reasoning_text = piece
+            case "response.reasoning_summary_text.done":
+                piece = getattr(event, "text", None)
+                if isinstance(piece, str) and piece:
+                    self._reasoning_summary = piece
             case "response.output_item.done":
                 item = event.item
                 itype = getattr(item, "type", "")
@@ -471,6 +538,8 @@ class CodexOAuthProvider(BaseLLMProvider):
                 elif itype == "image_generation_call":
                     # Image bytes are available before the item status completes.
                     self._handle_image_generation_call(item)
+                elif itype == "reasoning":
+                    self._capture_reasoning_item(item)
             case "response.completed":
                 resp = getattr(event, "response", None)
                 if resp:

--- a/src/kohakuterrarium/llm/litellm_provider.py
+++ b/src/kohakuterrarium/llm/litellm_provider.py
@@ -13,6 +13,12 @@ from kohakuterrarium.llm.base import (
     NativeToolCall,
     ToolSchema,
 )
+from kohakuterrarium.llm.openai_helpers import (
+    delta_field,
+    delta_field_present,
+    merge_reasoning_detail_stream,
+    pack_reasoning_fields,
+)
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -36,6 +42,7 @@ class LiteLLMProvider(BaseLLMProvider):
         super().__init__(effective_config)
         self._api_key = api_key
         self._extra_kwargs = kwargs
+        self._last_assistant_extra_fields: dict[str, Any] = {}
 
     def with_model(self, name: str) -> "LiteLLMProvider":
         if not name or name == self.config.model:
@@ -65,6 +72,12 @@ class LiteLLMProvider(BaseLLMProvider):
         **kwargs: Any,
     ) -> AsyncIterator[str]:
         params = self._build_params(messages, tools=tools, stream=True, **kwargs)
+        self._last_assistant_extra_fields = {}
+        reasoning_text = ""
+        reasoning_details: list[Any] = []
+        reasoning_extra: dict[str, Any] = {}
+        reasoning_text_seen = False
+        reasoning_details_seen = False
 
         try:
             response = await litellm.acompletion(**params)
@@ -75,6 +88,25 @@ class LiteLLMProvider(BaseLLMProvider):
                 delta = chunk.choices[0].delta if chunk.choices else None
                 if delta is None:
                     continue
+
+                if delta_field_present(delta, "reasoning_content"):
+                    reasoning_text_seen = True
+                rc_piece = delta_field(delta, "reasoning_content")
+                if isinstance(rc_piece, str):
+                    reasoning_text += rc_piece
+                if delta_field_present(delta, "reasoning_details"):
+                    reasoning_details_seen = True
+                rd_piece = delta_field(delta, "reasoning_details")
+                if isinstance(rd_piece, list):
+                    for entry in rd_piece:
+                        if isinstance(entry, dict):
+                            merge_reasoning_detail_stream(reasoning_details, entry)
+                if delta_field_present(delta, "reasoning"):
+                    r_piece = delta_field(delta, "reasoning")
+                    if isinstance(r_piece, str):
+                        reasoning_extra["reasoning"] = (
+                            reasoning_extra.get("reasoning", "") + r_piece
+                        )
 
                 if delta.content:
                     yield delta.content
@@ -92,6 +124,21 @@ class LiteLLMProvider(BaseLLMProvider):
                                 entry["name"] = tc.function.name
                             if tc.function.arguments:
                                 entry["arguments"] += tc.function.arguments
+
+            if (
+                reasoning_text_seen
+                or reasoning_details_seen
+                or reasoning_text
+                or reasoning_details
+                or reasoning_extra
+            ):
+                self._last_assistant_extra_fields = pack_reasoning_fields(
+                    reasoning_text,
+                    reasoning_details,
+                    reasoning_extra,
+                    include_text=reasoning_text_seen,
+                    include_details=reasoning_details_seen,
+                )
 
             self._last_tool_calls = [
                 NativeToolCall(
@@ -113,6 +160,8 @@ class LiteLLMProvider(BaseLLMProvider):
         **kwargs: Any,
     ) -> ChatResponse:
         params = self._build_params(messages, stream=False, **kwargs)
+        self._last_tool_calls = []
+        self._last_assistant_extra_fields = {}
 
         try:
             response = await litellm.acompletion(**params)
@@ -128,6 +177,22 @@ class LiteLLMProvider(BaseLLMProvider):
                     "completion_tokens": response.usage.completion_tokens or 0,
                     "total_tokens": response.usage.total_tokens or 0,
                 }
+            self._last_usage = usage
+
+            extras = {}
+            if delta_field_present(message, "reasoning_content"):
+                rc = delta_field(message, "reasoning_content")
+                if isinstance(rc, str):
+                    extras["reasoning_content"] = rc
+            if delta_field_present(message, "reasoning_details"):
+                rd = delta_field(message, "reasoning_details")
+                if isinstance(rd, list):
+                    extras["reasoning_details"] = rd
+            if delta_field_present(message, "reasoning"):
+                reasoning = delta_field(message, "reasoning")
+                if isinstance(reasoning, str):
+                    extras["reasoning"] = reasoning
+            self._last_assistant_extra_fields = extras
 
             if hasattr(message, "tool_calls") and message.tool_calls:
                 self._last_tool_calls = [

--- a/src/kohakuterrarium/llm/litellm_provider.py
+++ b/src/kohakuterrarium/llm/litellm_provider.py
@@ -19,6 +19,8 @@ from kohakuterrarium.llm.openai_helpers import (
     merge_reasoning_detail_stream,
     pack_reasoning_fields,
 )
+from kohakuterrarium.llm.openai_sanitize import strip_internal_message_fields
+from kohakuterrarium.llm.turn_segments import TurnSegmentsBuilder
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -73,6 +75,7 @@ class LiteLLMProvider(BaseLLMProvider):
     ) -> AsyncIterator[str]:
         params = self._build_params(messages, tools=tools, stream=True, **kwargs)
         self._last_assistant_extra_fields = {}
+        segments = TurnSegmentsBuilder()
         reasoning_text = ""
         reasoning_details: list[Any] = []
         reasoning_extra: dict[str, Any] = {}
@@ -94,6 +97,7 @@ class LiteLLMProvider(BaseLLMProvider):
                 rc_piece = delta_field(delta, "reasoning_content")
                 if isinstance(rc_piece, str):
                     reasoning_text += rc_piece
+                    segments.append_reasoning(rc_piece, source="reasoning_content")
                 if delta_field_present(delta, "reasoning_details"):
                     reasoning_details_seen = True
                 rd_piece = delta_field(delta, "reasoning_details")
@@ -101,19 +105,28 @@ class LiteLLMProvider(BaseLLMProvider):
                     for entry in rd_piece:
                         if isinstance(entry, dict):
                             merge_reasoning_detail_stream(reasoning_details, entry)
+                            segments.append_reasoning(
+                                entry.get("text") or entry.get("thinking") or "",
+                                source="reasoning_details",
+                                key=f"{entry.get('index')}:{entry.get('type')}",
+                                signature=entry.get("signature"),
+                            )
                 if delta_field_present(delta, "reasoning"):
                     r_piece = delta_field(delta, "reasoning")
                     if isinstance(r_piece, str):
                         reasoning_extra["reasoning"] = (
                             reasoning_extra.get("reasoning", "") + r_piece
                         )
+                        segments.append_reasoning(r_piece, source="reasoning")
 
                 if delta.content:
+                    segments.append_text(delta.content)
                     yield delta.content
 
                 if delta.tool_calls:
                     for tc in delta.tool_calls:
                         idx = tc.index if hasattr(tc, "index") else 0
+                        segments.append_tool_call_ref(tc.id or "", idx)
                         entry = pending_tool_calls.setdefault(
                             idx, {"id": "", "name": "", "arguments": ""}
                         )
@@ -138,6 +151,10 @@ class LiteLLMProvider(BaseLLMProvider):
                     reasoning_extra,
                     include_text=reasoning_text_seen,
                     include_details=reasoning_details_seen,
+                )
+                segments.finalize_tool_call_refs(pending_tool_calls)
+                self._last_assistant_extra_fields = segments.inject_into(
+                    self._last_assistant_extra_fields
                 )
 
             self._last_tool_calls = [
@@ -194,6 +211,24 @@ class LiteLLMProvider(BaseLLMProvider):
                     extras["reasoning"] = reasoning
             self._last_assistant_extra_fields = extras
 
+            segments = TurnSegmentsBuilder()
+            if "reasoning_content" in extras:
+                segments.append_reasoning(
+                    extras["reasoning_content"], source="reasoning_content"
+                )
+            for entry in extras.get("reasoning_details") or []:
+                if isinstance(entry, dict):
+                    segments.append_reasoning(
+                        entry.get("text") or entry.get("thinking") or "",
+                        source="reasoning_details",
+                        key=f"{entry.get('index')}:{entry.get('type')}",
+                        signature=entry.get("signature"),
+                    )
+            if "reasoning" in extras:
+                segments.append_reasoning(extras["reasoning"], source="reasoning")
+            if message.content:
+                segments.append_text(message.content)
+
             if hasattr(message, "tool_calls") and message.tool_calls:
                 self._last_tool_calls = [
                     NativeToolCall(
@@ -203,6 +238,11 @@ class LiteLLMProvider(BaseLLMProvider):
                     )
                     for tc in message.tool_calls
                 ]
+                for tc in self._last_tool_calls:
+                    segments.append_tool_call_ref(tc.id)
+            self._last_assistant_extra_fields = segments.inject_into(
+                self._last_assistant_extra_fields
+            )
 
             return ChatResponse(
                 content=content,
@@ -225,7 +265,7 @@ class LiteLLMProvider(BaseLLMProvider):
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
             "model": self.config.model,
-            "messages": messages,
+            "messages": strip_internal_message_fields(messages),
             "temperature": kwargs.get("temperature", self.config.temperature),
             "stream": stream,
             "drop_params": True,

--- a/src/kohakuterrarium/llm/openai.py
+++ b/src/kohakuterrarium/llm/openai.py
@@ -33,9 +33,11 @@ from kohakuterrarium.llm.openai_helpers import (
 )
 from kohakuterrarium.llm.openai_sanitize import (
     log_request_shape,
+    strip_internal_message_fields,
     strip_kt_extras,
     strip_surrogates,
 )
+from kohakuterrarium.llm.turn_segments import TurnSegmentsBuilder
 from kohakuterrarium.llm.openai_ws import stream_ws_turn
 from kohakuterrarium.llm.recovery import (
     ErrorClass,
@@ -233,6 +235,7 @@ class OpenAIProvider(BaseLLMProvider):
     def _prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Resolve local images, strip internal fields, and add eligible cache markers."""
         messages = resolve_message_image_urls(messages)
+        messages = strip_internal_message_fields(messages)
         messages = strip_kt_extras(messages)
         messages = normalize_stateful_assistant_fields(messages)
         if not is_anthropic_endpoint(self.base_url, None):
@@ -366,6 +369,7 @@ class OpenAIProvider(BaseLLMProvider):
 
         self._last_usage = {}
         pending_calls: dict[int, dict[str, str]] = {}
+        segments = TurnSegmentsBuilder()
         reasoning_text = ""
         reasoning_details: list[Any] = []
         reasoning_extra: dict[str, Any] = {}
@@ -386,6 +390,7 @@ class OpenAIProvider(BaseLLMProvider):
             if delta.tool_calls:
                 for tc_delta in delta.tool_calls:
                     idx = tc_delta.index
+                    segments.append_tool_call_ref(tc_delta.id or "", idx)
                     if idx not in pending_calls:
                         pending_calls[idx] = {"id": "", "name": "", "arguments": ""}
                     if tc_delta.id:
@@ -405,6 +410,7 @@ class OpenAIProvider(BaseLLMProvider):
                 rc_piece = delta_field(delta, "reasoning_content")
                 if isinstance(rc_piece, str):
                     reasoning_text += rc_piece
+                    segments.append_reasoning(rc_piece, source="reasoning_content")
                 if delta_field_present(delta, "reasoning_details"):
                     reasoning_details_seen = True
                 rd_piece = delta_field(delta, "reasoning_details")
@@ -413,6 +419,12 @@ class OpenAIProvider(BaseLLMProvider):
                     for entry in rd_piece:
                         if isinstance(entry, dict):
                             merge_reasoning_detail_stream(reasoning_details, entry)
+                            segments.append_reasoning(
+                                entry.get("text") or entry.get("thinking") or "",
+                                source="reasoning_details",
+                                key=f"{entry.get('index')}:{entry.get('type')}",
+                                signature=entry.get("signature"),
+                            )
                 # Preserve the plain reasoning field independently of structured details.
                 if delta_field_present(delta, "reasoning"):
                     r_piece = delta_field(delta, "reasoning")
@@ -420,11 +432,15 @@ class OpenAIProvider(BaseLLMProvider):
                         reasoning_extra["reasoning"] = (
                             reasoning_extra.get("reasoning", "") + r_piece
                         )
+                        segments.append_reasoning(r_piece, source="reasoning")
 
             if delta.content:
-                yield strip_surrogates(delta.content)
+                piece = strip_surrogates(delta.content)
+                segments.append_text(piece)
+                yield piece
 
         if pending_calls:
+            segments.finalize_tool_call_refs(pending_calls)
             self._last_tool_calls = [
                 tool_call_from_pending(call)
                 for _, call in sorted(pending_calls.items())
@@ -448,6 +464,9 @@ class OpenAIProvider(BaseLLMProvider):
                 reasoning_extra,
                 include_text=reasoning_text_seen,
                 include_details=reasoning_details_seen,
+            )
+            self._last_assistant_extra_fields = segments.inject_into(
+                self._last_assistant_extra_fields
             )
             logger.debug(
                 "Reasoning fields captured",
@@ -566,6 +585,26 @@ class OpenAIProvider(BaseLLMProvider):
                 extras["reasoning"] = r
             if extras:
                 self._last_assistant_extra_fields = extras
+            segments = TurnSegmentsBuilder()
+            if isinstance(rc, str) and rc:
+                segments.append_reasoning(rc, source="reasoning_content")
+            for entry in rd or []:
+                if isinstance(entry, dict):
+                    segments.append_reasoning(
+                        entry.get("text") or entry.get("thinking") or "",
+                        source="reasoning_details",
+                        key=f"{entry.get('index')}:{entry.get('type')}",
+                        signature=entry.get("signature"),
+                    )
+            if isinstance(r, str) and r:
+                segments.append_reasoning(r, source="reasoning")
+            if message.content:
+                segments.append_text(message.content)
+            for tc in self._last_tool_calls:
+                segments.append_tool_call_ref(tc.id)
+            self._last_assistant_extra_fields = segments.inject_into(
+                self._last_assistant_extra_fields
+            )
 
         if response.usage:
             self._last_usage = extract_usage(response.usage)

--- a/src/kohakuterrarium/llm/openai_sanitize.py
+++ b/src/kohakuterrarium/llm/openai_sanitize.py
@@ -21,6 +21,30 @@ _OAI_PART_ALLOWED_KEYS: dict[str, frozenset[str]] = {
 # Nested image data likewise permits only the documented URL and detail fields.
 _OAI_IMAGE_URL_ALLOWED_KEYS: frozenset[str] = frozenset({"url", "detail"})
 
+# Provider-owned assistant fields that only matter for local persistence and
+# must never reach a Chat Completions-compatible endpoint.
+_INTERNAL_MESSAGE_KEYS = frozenset({"_kt_assistant_segments", "_kt_anthropic_content"})
+
+
+def strip_internal_message_fields(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Remove message-level internal fields while preserving identity when unchanged."""
+    out: list[dict[str, Any]] = []
+    any_changed = False
+    for msg in messages:
+        if not any(key in msg for key in _INTERNAL_MESSAGE_KEYS):
+            out.append(msg)
+            continue
+        cleaned = {
+            key: value
+            for key, value in msg.items()
+            if key not in _INTERNAL_MESSAGE_KEYS
+        }
+        out.append(cleaned)
+        any_changed = True
+    return out if any_changed else messages
+
 
 def strip_kt_extras(
     messages: list[dict[str, Any]],

--- a/src/kohakuterrarium/llm/openai_ws.py
+++ b/src/kohakuterrarium/llm/openai_ws.py
@@ -87,13 +87,17 @@ async def stream_ws_turn(
         reasoning.consume(event)
         etype = getattr(event, "type", "")
         if etype == "response.output_text.delta":
-            yield strip_surrogates(event.delta)
+            piece = strip_surrogates(event.delta)
+            reasoning.consume_output_text(piece)
+            yield piece
         elif etype == "response.output_item.done":
             item = event.item
             if getattr(item, "type", "") == "function_call":
+                call_id = getattr(item, "call_id", "")
+                reasoning.consume_function_call(call_id)
                 collected.append(
                     NativeToolCall(
-                        id=getattr(item, "call_id", ""),
+                        id=call_id,
                         name=getattr(item, "name", "") or "",
                         arguments=getattr(item, "arguments", ""),
                     )

--- a/src/kohakuterrarium/llm/openai_ws.py
+++ b/src/kohakuterrarium/llm/openai_ws.py
@@ -10,6 +10,7 @@ from typing import Any, AsyncIterator
 from kohakuterrarium.llm.base import NativeToolCall, ToolSchema
 from kohakuterrarium.llm.codex_format import fix_tool_call_pairing, to_responses_input
 from kohakuterrarium.llm.openai_sanitize import strip_kt_extras, strip_surrogates
+from kohakuterrarium.llm.responses_reasoning import ResponsesReasoningCollector
 from kohakuterrarium.llm.responses_ws import ResponsesWSSession
 
 # Request knobs consumed by the framework, never sent on the wire.
@@ -81,7 +82,9 @@ async def stream_ws_turn(
     """Run one WebSocket turn, folding results into the provider state."""
     base_event, items = build_ws_request(provider, messages, tools, kwargs)
     collected: list[NativeToolCall] = []
+    reasoning = ResponsesReasoningCollector()
     async for event in session.stream_turn(base_event, items, fix_tool_call_pairing):
+        reasoning.consume(event)
         etype = getattr(event, "type", "")
         if etype == "response.output_text.delta":
             yield strip_surrogates(event.delta)
@@ -107,3 +110,4 @@ async def stream_ws_turn(
                     "cached_tokens": cached,
                 }
     provider._last_tool_calls = collected
+    provider._last_assistant_extra_fields = reasoning.fields()

--- a/src/kohakuterrarium/llm/responses_reasoning.py
+++ b/src/kohakuterrarium/llm/responses_reasoning.py
@@ -41,6 +41,7 @@ class ResponsesReasoningCollector:
         self.text = ""
         self.summary = ""
         self.segments = TurnSegmentsBuilder()
+        self._seen_reasoning_item_ids: set[str] = set()
 
     def consume(self, event: Any) -> None:
         """Fold one Responses stream event into the collector."""
@@ -72,6 +73,9 @@ class ResponsesReasoningCollector:
                         source="responses_text",
                         key=getattr(event, "item_id", None),
                     )
+                    item_id = getattr(event, "item_id", None)
+                    if isinstance(item_id, str) and item_id:
+                        self._seen_reasoning_item_ids.add(item_id)
             case "response.reasoning_summary_text.done":
                 piece = getattr(event, "text", None) or getattr(event, "delta", None)
                 if isinstance(piece, str) and piece:
@@ -81,6 +85,9 @@ class ResponsesReasoningCollector:
                         source="responses_summary",
                         key=getattr(event, "item_id", None),
                     )
+                    item_id = getattr(event, "item_id", None)
+                    if isinstance(item_id, str) and item_id:
+                        self._seen_reasoning_item_ids.add(item_id)
             case "response.output_item.done":
                 item = getattr(event, "item", None)
                 if getattr(item, "type", "") == "reasoning":
@@ -88,6 +95,11 @@ class ResponsesReasoningCollector:
 
     def consume_item(self, item: Any) -> None:
         """Fold a completed ``reasoning`` output item into the collector."""
+        item_id = getattr(item, "id", None)
+        if isinstance(item_id, str) and item_id:
+            if item_id in self._seen_reasoning_item_ids:
+                return
+            self._seen_reasoning_item_ids.add(item_id)
         summary = _parts_text(getattr(item, "summary", None))
         content = _parts_text(getattr(item, "content", None))
         if summary:

--- a/src/kohakuterrarium/llm/responses_reasoning.py
+++ b/src/kohakuterrarium/llm/responses_reasoning.py
@@ -6,6 +6,8 @@ API; keep their reasoning stream handling in one place.
 
 from typing import Any
 
+from kohakuterrarium.llm.turn_segments import TurnSegmentsBuilder
+
 
 def _parts_text(parts: Any) -> str:
     """Join Responses reasoning content/summary parts into plain text."""
@@ -38,6 +40,7 @@ class ResponsesReasoningCollector:
     def __init__(self) -> None:
         self.text = ""
         self.summary = ""
+        self.segments = TurnSegmentsBuilder()
 
     def consume(self, event: Any) -> None:
         """Fold one Responses stream event into the collector."""
@@ -46,19 +49,39 @@ class ResponsesReasoningCollector:
                 piece = getattr(event, "delta", None)
                 if isinstance(piece, str):
                     self.text += piece
+                    self.segments.append_reasoning(
+                        piece,
+                        source="responses_text",
+                        key=getattr(event, "item_id", None),
+                    )
             case "response.reasoning_summary_text.delta":
                 piece = getattr(event, "delta", None)
                 if isinstance(piece, str):
                     self.summary += piece
+                    self.segments.append_reasoning(
+                        piece,
+                        source="responses_summary",
+                        key=getattr(event, "item_id", None),
+                    )
             case "response.reasoning_text.done":
                 piece = getattr(event, "text", None) or getattr(event, "delta", None)
                 if isinstance(piece, str) and piece:
                     self.text = piece
+                    self.segments.replace_reasoning(
+                        piece,
+                        source="responses_text",
+                        key=getattr(event, "item_id", None),
+                    )
             case "response.reasoning_summary_text.done":
                 piece = getattr(event, "text", None) or getattr(event, "delta", None)
                 if isinstance(piece, str) and piece:
                     self.summary = piece
-            case "response.output_item.added" | "response.output_item.done":
+                    self.segments.replace_reasoning(
+                        piece,
+                        source="responses_summary",
+                        key=getattr(event, "item_id", None),
+                    )
+            case "response.output_item.done":
                 item = getattr(event, "item", None)
                 if getattr(item, "type", "") == "reasoning":
                     self.consume_item(item)
@@ -69,8 +92,24 @@ class ResponsesReasoningCollector:
         content = _parts_text(getattr(item, "content", None))
         if summary:
             self.summary = _join(self.summary, summary)
+            self.segments.append_reasoning(
+                summary, source="responses_summary", key=getattr(item, "id", None)
+            )
         if content:
             self.text = _join(self.text, content)
+            self.segments.append_reasoning(
+                content, source="responses_text", key=getattr(item, "id", None)
+            )
+
+    def consume_output_text(self, piece: str) -> None:
+        """Record visible output text in its arrival position."""
+        if isinstance(piece, str) and piece:
+            self.segments.append_text(piece)
+
+    def consume_function_call(self, call_id: str) -> None:
+        """Record a tool-call reference in its arrival position."""
+        if call_id:
+            self.segments.append_tool_call_ref(call_id)
 
     def fields(self) -> dict[str, Any]:
         """Return non-empty extra fields for conversation persistence."""
@@ -79,4 +118,4 @@ class ResponsesReasoningCollector:
             packed["reasoning_content"] = self.text
         if self.summary:
             packed["reasoning_summary"] = self.summary
-        return packed
+        return self.segments.inject_into(packed)

--- a/src/kohakuterrarium/llm/responses_reasoning.py
+++ b/src/kohakuterrarium/llm/responses_reasoning.py
@@ -1,0 +1,82 @@
+"""Shared Responses-API reasoning event collection.
+
+Both Codex and the OpenAI-compatible WebSocket path speak the Responses
+API; keep their reasoning stream handling in one place.
+"""
+
+from typing import Any
+
+
+def _parts_text(parts: Any) -> str:
+    """Join Responses reasoning content/summary parts into plain text."""
+    if parts is None:
+        return ""
+    if isinstance(parts, str):
+        return parts
+    if isinstance(parts, dict):
+        parts = [parts]
+    if not isinstance(parts, list):
+        return ""
+    pieces: list[str] = []
+    for part in parts:
+        if isinstance(part, dict):
+            value = part.get("text") or part.get("content") or ""
+        else:
+            value = getattr(part, "text", None) or getattr(part, "content", None) or ""
+        if isinstance(value, str) and value:
+            pieces.append(value)
+    return "\n".join(pieces)
+
+
+def _join(existing: str, addition: str) -> str:
+    return "\n".join(part for part in (existing, addition) if part)
+
+
+class ResponsesReasoningCollector:
+    """Accumulate Responses-API reasoning text and summary fragments."""
+
+    def __init__(self) -> None:
+        self.text = ""
+        self.summary = ""
+
+    def consume(self, event: Any) -> None:
+        """Fold one Responses stream event into the collector."""
+        match getattr(event, "type", ""):
+            case "response.reasoning_text.delta":
+                piece = getattr(event, "delta", None)
+                if isinstance(piece, str):
+                    self.text += piece
+            case "response.reasoning_summary_text.delta":
+                piece = getattr(event, "delta", None)
+                if isinstance(piece, str):
+                    self.summary += piece
+            case "response.reasoning_text.done":
+                piece = getattr(event, "text", None) or getattr(event, "delta", None)
+                if isinstance(piece, str) and piece:
+                    self.text = piece
+            case "response.reasoning_summary_text.done":
+                piece = getattr(event, "text", None) or getattr(event, "delta", None)
+                if isinstance(piece, str) and piece:
+                    self.summary = piece
+            case "response.output_item.added" | "response.output_item.done":
+                item = getattr(event, "item", None)
+                if getattr(item, "type", "") == "reasoning":
+                    self.consume_item(item)
+
+    def consume_item(self, item: Any) -> None:
+        """Fold a completed ``reasoning`` output item into the collector."""
+        summary = _parts_text(getattr(item, "summary", None))
+        content = _parts_text(getattr(item, "content", None))
+        if summary:
+            self.summary = _join(self.summary, summary)
+        if content:
+            self.text = _join(self.text, content)
+
+    def fields(self) -> dict[str, Any]:
+        """Return non-empty extra fields for conversation persistence."""
+        packed: dict[str, Any] = {}
+        if self.text:
+            packed["reasoning_content"] = self.text
+        if self.summary:
+            packed["reasoning_summary"] = self.summary
+        return packed

--- a/src/kohakuterrarium/llm/turn_segments.py
+++ b/src/kohakuterrarium/llm/turn_segments.py
@@ -1,0 +1,168 @@
+"""Ordered assistant-turn segment helpers.
+
+Providers see reasoning, visible text, and tool calls as separate streams.
+This module records their arrival order in a compact segment list stored
+under ``extra_fields[_kt_assistant_segments]`` so UIs can render thinking
+in place instead of as one disconnected blob.
+"""
+
+from typing import Any
+
+KT_ASSISTANT_SEGMENTS = "_kt_assistant_segments"
+
+
+def _coerce_text(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+class TurnSegmentsBuilder:
+    """Accumulate reasoning/text/tool-call segments in arrival order."""
+
+    def __init__(self) -> None:
+        self._segments: list[dict[str, Any]] = []
+
+    def append_reasoning(
+        self,
+        text: Any,
+        *,
+        source: str,
+        key: str | None = None,
+        signature: str | None = None,
+    ) -> None:
+        piece = _coerce_text(text)
+        if not piece and not signature:
+            return
+        last = self._segments[-1] if self._segments else None
+        if (
+            last is not None
+            and last.get("type") == "reasoning"
+            and last.get("source") == source
+            and last.get("key") == key
+        ):
+            if piece:
+                last["text"] = f"{last.get('text', '')}{piece}"
+            if signature:
+                last["signature"] = signature
+            return
+        segment: dict[str, Any] = {"type": "reasoning", "source": source}
+        if key is not None:
+            segment["key"] = key
+        if piece:
+            segment["text"] = piece
+        else:
+            segment["text"] = ""
+        if signature:
+            segment["signature"] = signature
+        self._segments.append(segment)
+
+    def append_text(self, text: Any) -> None:
+        piece = _coerce_text(text)
+        if not piece:
+            return
+        last = self._segments[-1] if self._segments else None
+        if last is not None and last.get("type") == "text":
+            last["text"] = f"{last.get('text', '')}{piece}"
+            return
+        self._segments.append({"type": "text", "text": piece})
+
+    def replace_reasoning(
+        self, text: Any, *, source: str, key: str | None = None
+    ) -> None:
+        """Replace matching reasoning segments with one complete segment."""
+        self._segments = [
+            segment
+            for segment in self._segments
+            if not (
+                segment.get("type") == "reasoning"
+                and segment.get("source") == source
+                and segment.get("key") == key
+            )
+        ]
+        self.append_reasoning(text, source=source, key=key)
+
+    def append_tool_call_ref(self, call_id: str, index: int | None = None) -> None:
+        if index is not None:
+            for segment in reversed(self._segments):
+                if (
+                    segment.get("type") == "tool_call_ref"
+                    and segment.get("index") == index
+                ):
+                    if call_id:
+                        segment["call_id"] = call_id
+                    return
+        segment: dict[str, Any] = {"type": "tool_call_ref", "call_id": call_id}
+        if index is not None:
+            segment["index"] = index
+        self._segments.append(segment)
+
+    def finalize_tool_call_refs(self, pending_calls: dict[int, dict[str, Any]]) -> None:
+        for segment in self._segments:
+            if segment.get("type") != "tool_call_ref":
+                continue
+            index = segment.get("index")
+            call = pending_calls.get(index) if isinstance(index, int) else None
+            if call is not None:
+                segment["call_id"] = call.get("id", "") or segment.get("call_id", "")
+
+    def as_list(self) -> list[dict[str, Any]]:
+        segments: list[dict[str, Any]] = []
+        for segment in self._segments:
+            if segment.get("type") == "tool_call_ref":
+                call_id = segment.get("call_id")
+                if not call_id:
+                    continue
+                segments.append({"type": "tool_call_ref", "call_id": call_id})
+                continue
+            segments.append(dict(segment))
+        return segments
+
+    def inject_into(self, fields: dict[str, Any]) -> dict[str, Any]:
+        segments = self.as_list()
+        if not segments:
+            return fields
+        # A plain text/tool exchange without reasoning already has a stable
+        # representation; only emit segments when they add ordering value.
+        if not any(segment.get("type") == "reasoning" for segment in segments):
+            return fields
+        merged = dict(fields)
+        merged[KT_ASSISTANT_SEGMENTS] = segments
+        return merged
+
+
+def segments_from_anthropic_blocks(blocks: Any) -> list[dict[str, Any]]:
+    """Translate native Anthropic content blocks into ordered segments."""
+    segments: list[dict[str, Any]] = []
+    for block in blocks or []:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype in {"thinking", "redacted_thinking"}:
+            text = block.get("thinking") or block.get("data") or ""
+            signature = block.get("signature") or ""
+            segment: dict[str, Any] = {
+                "type": "reasoning",
+                "source": f"anthropic_{btype}",
+                "text": text,
+            }
+            if signature:
+                segment["signature"] = signature
+            segments.append(segment)
+        elif btype == "text":
+            text = block.get("text") or ""
+            if text:
+                segments.append({"type": "text", "text": text})
+        elif btype == "tool_use":
+            call_id = block.get("id") or ""
+            if call_id:
+                segments.append({"type": "tool_call_ref", "call_id": call_id})
+    return segments
+
+
+def inject_anthropic_segments(fields: dict[str, Any], blocks: Any) -> dict[str, Any]:
+    """Add ordered Anthropic segments to extra fields when thinking exists."""
+    segments = segments_from_anthropic_blocks(blocks)
+    if not any(segment.get("type") == "reasoning" for segment in segments):
+        return fields
+    merged = dict(fields)
+    merged[KT_ASSISTANT_SEGMENTS] = segments
+    return merged

--- a/src/kohakuterrarium/modules/subagent/base.py
+++ b/src/kohakuterrarium/modules/subagent/base.py
@@ -391,9 +391,14 @@ class SubAgent:
                 "assistant",
                 assistant_content or "",
                 tool_calls=tool_calls_data,
+                extra_fields=getattr(self.llm, "last_assistant_extra_fields", {}) or {},
             )
         else:
-            self.conversation.append("assistant", assistant_content)
+            self.conversation.append(
+                "assistant",
+                assistant_content,
+                extra_fields=getattr(self.llm, "last_assistant_extra_fields", {}) or {},
+            )
 
         self._log_turn_preview(assistant_content)
         self._accumulate_tokens()
@@ -424,7 +429,11 @@ class SubAgent:
             elif isinstance(event, TextEvent):
                 output_parts.append(event.text)
 
-        self.conversation.append("assistant", assistant_content)
+        self.conversation.append(
+            "assistant",
+            assistant_content,
+            extra_fields=getattr(self.llm, "last_assistant_extra_fields", {}) or {},
+        )
         self._log_turn_preview(assistant_content)
         self._accumulate_tokens()
         return tool_calls, output_parts

--- a/src/kohakuterrarium/session/history.py
+++ b/src/kohakuterrarium/session/history.py
@@ -760,6 +760,26 @@ def replay_conversation(
             )
         elif etype == "system_prompt_set":
             messages.append({"role": "system", "content": evt.get("content", "")})
+        elif etype == "assistant_reasoning":
+            target = next(
+                (
+                    message
+                    for message in reversed(messages)
+                    if message.get("role") == "assistant"
+                ),
+                None,
+            )
+            if target is not None:
+                for key in (
+                    "reasoning_content",
+                    "reasoning_summary",
+                    "reasoning_details",
+                    "reasoning",
+                    "_kt_assistant_segments",
+                ):
+                    value = evt.get(key)
+                    if value not in (None, "", [], {}):
+                        target[key] = value
 
     _flush_text()
     return messages

--- a/src/kohakuterrarium/session/output.py
+++ b/src/kohakuterrarium/session/output.py
@@ -398,6 +398,7 @@ class SessionOutput(OutputModule):
         "turn_token_usage": "_handle_turn_token_usage",
         "plugin_hook_timing": "_handle_plugin_hook_timing",
         "cache_stats": "_handle_cache_stats",
+        "assistant_reasoning": "_handle_assistant_reasoning",
         "scratchpad_write": "_handle_scratchpad_write",
         # Suppress duplicate activity rows for input already persisted by the agent.
         "user_input_injected": "_handle_user_input_injected",
@@ -416,6 +417,23 @@ class SessionOutput(OutputModule):
                 f"activity:{activity_type}",
                 {"name": name, "detail": detail, **metadata},
             )
+
+    def _handle_assistant_reasoning(
+        self, name: str, detail: str, metadata: dict
+    ) -> None:
+        payload = {}
+        for key in (
+            "reasoning_content",
+            "reasoning_summary",
+            "reasoning_details",
+            "reasoning",
+            "_kt_assistant_segments",
+        ):
+            value = metadata.get(key)
+            if value not in (None, "", [], {}):
+                payload[key] = value
+        if payload:
+            self._record("assistant_reasoning", payload)
 
     def _handle_trigger_fired(self, name: str, detail: str, metadata: dict) -> None:
         self._record(

--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -9,7 +9,6 @@ from kohakuterrarium.builtins.outputs import create_builtin_output
 from kohakuterrarium.core.agent import Agent
 from kohakuterrarium.core.agent_selection import restore_selections
 from kohakuterrarium.core.config_serde import unpack_agent_config
-from kohakuterrarium.core.conversation import Conversation
 from kohakuterrarium.core.conversation_elide import (
     elide_stale_tool_results,
     estimate_tokens,
@@ -34,6 +33,9 @@ from kohakuterrarium.session.resume_branch import (
     replayed_messages_for,
     snapshot_has_turn_metadata,
     snapshot_mismatches_branch,
+)
+from kohakuterrarium.session.resume_build import (
+    build_conversation as _build_conversation,
 )
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.utils.logging import get_logger
@@ -69,51 +71,6 @@ def _create_io_modules(
                 "(``cli`` mode must be constructed by the caller and "
                 "passed via ``input_module`` / ``output_module``)."
             )
-
-
-def _build_conversation(messages: list[dict]) -> Conversation:
-    """Build a conversation from persisted message dictionaries.
-
-    Tool-call identifiers, names, metadata, and provider-owned extra fields
-    (reasoning_content / reasoning_details / _kt_anthropic_content) are
-    retained when present.
-    """
-    conv = Conversation()
-    for msg in messages:
-        if not isinstance(msg, dict):
-            # Malformed persisted entry (corrupt snapshot): skip it rather
-            # than crashing on msg.get(...).
-            continue
-        role = msg.get("role", "user")
-        content = msg.get("content", "")
-        kwargs = {}
-        if msg.get("tool_calls"):
-            kwargs["tool_calls"] = msg["tool_calls"]
-        if msg.get("tool_call_id"):
-            kwargs["tool_call_id"] = msg["tool_call_id"]
-        if msg.get("name"):
-            kwargs["name"] = msg["name"]
-        if msg.get("metadata"):
-            kwargs["metadata"] = msg["metadata"]
-        extra_fields = {
-            key: value
-            for key, value in msg.items()
-            if key
-            not in {
-                "role",
-                "content",
-                "tool_calls",
-                "tool_call_id",
-                "name",
-                "metadata",
-            }
-        }
-        if extra_fields:
-            kwargs["extra_fields"] = extra_fields
-        conv.append(role, content, **kwargs)
-    # Preserve a trailing in-flight call while removing stale orphaned fragments.
-    conv.prune_orphan_tool_pairs(preserve_pending_tail=True)
-    return conv
 
 
 def _load_conversation_with_replay_fallback(

--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -74,7 +74,9 @@ def _create_io_modules(
 def _build_conversation(messages: list[dict]) -> Conversation:
     """Build a conversation from persisted message dictionaries.
 
-    Tool-call identifiers, names, and metadata are retained when present.
+    Tool-call identifiers, names, metadata, and provider-owned extra fields
+    (reasoning_content / reasoning_details / _kt_anthropic_content) are
+    retained when present.
     """
     conv = Conversation()
     for msg in messages:
@@ -93,6 +95,21 @@ def _build_conversation(messages: list[dict]) -> Conversation:
             kwargs["name"] = msg["name"]
         if msg.get("metadata"):
             kwargs["metadata"] = msg["metadata"]
+        extra_fields = {
+            key: value
+            for key, value in msg.items()
+            if key
+            not in {
+                "role",
+                "content",
+                "tool_calls",
+                "tool_call_id",
+                "name",
+                "metadata",
+            }
+        }
+        if extra_fields:
+            kwargs["extra_fields"] = extra_fields
         conv.append(role, content, **kwargs)
     # Preserve a trailing in-flight call while removing stale orphaned fragments.
     conv.prune_orphan_tool_pairs(preserve_pending_tail=True)

--- a/src/kohakuterrarium/session/resume_build.py
+++ b/src/kohakuterrarium/session/resume_build.py
@@ -1,0 +1,52 @@
+"""Rebuild persisted conversation messages into a runtime Conversation.
+
+Kept separate from :mod:`kohakuterrarium.session.resume` so the resume
+facade stays under the source-file size guard.
+"""
+
+from kohakuterrarium.core.conversation import Conversation
+
+
+def build_conversation(messages: list[dict]) -> Conversation:
+    """Build a conversation from persisted message dictionaries.
+
+    Tool-call identifiers, names, metadata, and provider-owned extra fields
+    (reasoning_content / reasoning_details / _kt_anthropic_content) are
+    retained when present.
+    """
+    conv = Conversation()
+    for msg in messages:
+        if not isinstance(msg, dict):
+            # Malformed persisted entry (corrupt snapshot): skip it rather
+            # than crashing on msg.get(...).
+            continue
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        kwargs = {}
+        if msg.get("tool_calls"):
+            kwargs["tool_calls"] = msg["tool_calls"]
+        if msg.get("tool_call_id"):
+            kwargs["tool_call_id"] = msg["tool_call_id"]
+        if msg.get("name"):
+            kwargs["name"] = msg["name"]
+        if msg.get("metadata"):
+            kwargs["metadata"] = msg["metadata"]
+        extra_fields = {
+            key: value
+            for key, value in msg.items()
+            if key
+            not in {
+                "role",
+                "content",
+                "tool_calls",
+                "tool_call_id",
+                "name",
+                "metadata",
+            }
+        }
+        if extra_fields:
+            kwargs["extra_fields"] = extra_fields
+        conv.append(role, content, **kwargs)
+    # Preserve a trailing in-flight call while removing stale orphaned fragments.
+    conv.prune_orphan_tool_pairs(preserve_pending_tail=True)
+    return conv

--- a/src/kohakuterrarium/studio/attach/_event_stream.py
+++ b/src/kohakuterrarium/studio/attach/_event_stream.py
@@ -328,4 +328,10 @@ _STREAM_METADATA_KEYS = (
     "final_state",
     # File-mutating tools may include a preview for immediate canvas rendering.
     "canvas_preview",
+    # Ordered assistant reasoning segments from the final LLM turn.
+    "reasoning_content",
+    "reasoning_summary",
+    "reasoning_details",
+    "reasoning",
+    "_kt_assistant_segments",
 )

--- a/tests/unit/core/test_agent_messages.py
+++ b/tests/unit/core/test_agent_messages.py
@@ -4,6 +4,8 @@ import asyncio
 
 import pytest
 
+import kohakuterrarium.core.agent_messages as agent_messages_module
+
 from kohakuterrarium.core.agent_messages import AgentMessagesMixin
 from kohakuterrarium.core.conversation import Conversation
 from kohakuterrarium.errors import ConflictError
@@ -498,6 +500,30 @@ class TestReloadConversationUnderBranchView:
         agent._parent_branch_path = [(1, 1)]
         with pytest.raises(InvalidBranchViewError):
             agent._reload_conversation_under_branch_view({99: 99})
+
+    async def test_provider_extra_fields_survive_reload(self, agent, monkeypatch):
+        agent._apply_user_input("u1")
+        agent._emit_assistant("a1")
+        monkeypatch.setattr(
+            agent_messages_module,
+            "replay_conversation",
+            lambda events, branch_view=None: [
+                {"role": "user", "content": "u1"},
+                {
+                    "role": "assistant",
+                    "content": "a1",
+                    "reasoning_content": "private thought",
+                    "_kt_anthropic_content": [{"type": "thinking", "thinking": "hmm"}],
+                },
+            ],
+        )
+        agent._reload_conversation_under_branch_view({1: 1})
+        assistant = next(
+            m
+            for m in agent.controller.conversation.get_messages()
+            if m.role == "assistant"
+        )
+        assert assistant.extra_fields["reasoning_content"] == "private thought"
 
     async def test_events_read_failure_no_op(self, agent, monkeypatch):
         def boom(name):

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -2573,7 +2573,7 @@ class TestTurnTokenUsageEmission:
 
 
 class TestAssistantReasoningEmission:
-    async def test_reasoning_activity_emitted_before_processing_end(
+    async def test_reasoning_activity_emitted_from_latest_round_fields(
         self, make_agent, monkeypatch
     ):
         agent = make_agent(script=["resp"])
@@ -2596,10 +2596,7 @@ class TestAssistantReasoningEmission:
                 calls.append((activity_type, detail, metadata))
 
             monkeypatch.setattr(agent.output_router, "notify_activity", capture)
-            from kohakuterrarium.core.events import TriggerEvent
-
-            evt = TriggerEvent(type="user_input", content="x")
-            await agent._finalize_processing(evt, agent.controller, ["resp"])
+            agent._emit_assistant_reasoning(agent.controller)
             assert (
                 "assistant_reasoning",
                 "turn 0 assistant reasoning",
@@ -2617,6 +2614,59 @@ class TestAssistantReasoningEmission:
                     "branch_id": 0,
                 },
             ) in calls
+        finally:
+            await agent.stop()
+
+    async def test_reasoning_emitted_after_each_controller_round(
+        self, make_agent, monkeypatch
+    ):
+        from kohakuterrarium.core.agent_tools import _TurnResult
+
+        agent = make_agent(script=["resp"])
+        await agent.start()
+        try:
+            rounds = 0
+
+            async def fake_turn(controller):
+                nonlocal rounds
+                rounds += 1
+                if rounds == 1:
+                    controller.llm.last_assistant_extra_fields = {
+                        "reasoning_content": "think A"
+                    }
+                else:
+                    controller.llm.last_assistant_extra_fields = {
+                        "reasoning_content": "think B"
+                    }
+                return _TurnResult(
+                    handles={},
+                    handle_order=[],
+                    text_output=["text"],
+                    native_mode=False,
+                    native_tool_call_ids={},
+                )
+
+            async def fake_feedback(*args, **kwargs):
+                return rounds < 2
+
+            monkeypatch.setattr(agent, "_run_single_turn", fake_turn)
+            monkeypatch.setattr(agent, "_collect_and_push_feedback", fake_feedback)
+            monkeypatch.setattr(agent, "_emit_token_usage", lambda controller: None)
+
+            calls = []
+
+            def capture(activity_type, detail, metadata=None):
+                calls.append((activity_type, detail, metadata))
+
+            monkeypatch.setattr(agent.output_router, "notify_activity", capture)
+            await agent._run_controller_loop(agent.controller, [])
+
+            reasoning = [
+                metadata["reasoning_content"]
+                for _, _, metadata in calls
+                if metadata and metadata.get("reasoning_content")
+            ]
+            assert reasoning == ["think A", "think B"]
         finally:
             await agent.stop()
 

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -2572,6 +2572,55 @@ class TestTurnTokenUsageEmission:
             await agent.stop()
 
 
+class TestAssistantReasoningEmission:
+    async def test_reasoning_activity_emitted_before_processing_end(
+        self, make_agent, monkeypatch
+    ):
+        agent = make_agent(script=["resp"])
+        await agent.start()
+        try:
+            agent.controller.llm.last_assistant_extra_fields = {
+                "reasoning_content": "think",
+                "_kt_assistant_segments": [
+                    {
+                        "type": "reasoning",
+                        "source": "reasoning_content",
+                        "text": "think",
+                    },
+                    {"type": "text", "text": "resp"},
+                ],
+            }
+            calls = []
+
+            def capture(activity_type, detail, metadata=None):
+                calls.append((activity_type, detail, metadata))
+
+            monkeypatch.setattr(agent.output_router, "notify_activity", capture)
+            from kohakuterrarium.core.events import TriggerEvent
+
+            evt = TriggerEvent(type="user_input", content="x")
+            await agent._finalize_processing(evt, agent.controller, ["resp"])
+            assert (
+                "assistant_reasoning",
+                "turn 0 assistant reasoning",
+                {
+                    "reasoning_content": "think",
+                    "_kt_assistant_segments": [
+                        {
+                            "type": "reasoning",
+                            "source": "reasoning_content",
+                            "text": "think",
+                        },
+                        {"type": "text", "text": "resp"},
+                    ],
+                    "turn_index": 0,
+                    "branch_id": 0,
+                },
+            ) in calls
+        finally:
+            await agent.stop()
+
+
 # ── _check_termination budget exhausted + force_terminate ───────
 
 

--- a/tests/unit/llm/test_codex_provider.py
+++ b/tests/unit/llm/test_codex_provider.py
@@ -149,6 +149,10 @@ class TestReasoningCapture:
         assert p._reasoning.fields() == {
             "reasoning_content": "think hard",
             "reasoning_summary": "summary",
+            "_kt_assistant_segments": [
+                {"type": "reasoning", "source": "responses_text", "text": "think hard"},
+                {"type": "reasoning", "source": "responses_summary", "text": "summary"},
+            ],
         }
 
     def test_reasoning_done_event_replaces_accumulator(self):
@@ -172,6 +176,10 @@ class TestReasoningCapture:
         assert p._reasoning.fields() == {
             "reasoning_content": "private",
             "reasoning_summary": "brief",
+            "_kt_assistant_segments": [
+                {"type": "reasoning", "source": "responses_summary", "text": "brief"},
+                {"type": "reasoning", "source": "responses_text", "text": "private"},
+            ],
         }
 
 

--- a/tests/unit/llm/test_codex_provider.py
+++ b/tests/unit/llm/test_codex_provider.py
@@ -129,6 +129,55 @@ class _Ev:
         self.__dict__.update(kwargs)
 
 
+class TestReasoningCapture:
+    """Codex must retain Responses reasoning text for snapshot persistence."""
+
+    def _provider(self) -> CodexOAuthProvider:
+        return CodexOAuthProvider(model="m", api_key="sk", base_url="https://h/v1")
+
+    def test_reasoning_delta_events_are_packed(self):
+        p = self._provider()
+        p._process_stream_event(
+            _Ev(type="response.reasoning_text.delta", delta="think "), []
+        )
+        p._process_stream_event(
+            _Ev(type="response.reasoning_text.delta", delta="hard"), []
+        )
+        p._process_stream_event(
+            _Ev(type="response.reasoning_summary_text.delta", delta="summary"), []
+        )
+        p._pack_reasoning_extra_fields()
+        assert p._last_assistant_extra_fields == {
+            "reasoning_content": "think hard",
+            "reasoning_summary": "summary",
+        }
+
+    def test_reasoning_done_event_replaces_accumulator(self):
+        p = self._provider()
+        p._process_stream_event(
+            _Ev(type="response.reasoning_text.delta", delta="partial"), []
+        )
+        p._process_stream_event(
+            _Ev(type="response.reasoning_text.done", text="complete"), []
+        )
+        p._pack_reasoning_extra_fields()
+        assert p._last_assistant_extra_fields["reasoning_content"] == "complete"
+
+    def test_reasoning_output_item_is_captured(self):
+        p = self._provider()
+        item = _Ev(
+            type="reasoning",
+            summary=[{"type": "summary_text", "text": "brief"}],
+            content=[{"type": "text", "text": "private"}],
+        )
+        p._process_stream_event(_Ev(type="response.output_item.done", item=item), [])
+        p._pack_reasoning_extra_fields()
+        assert p._last_assistant_extra_fields == {
+            "reasoning_content": "private",
+            "reasoning_summary": "brief",
+        }
+
+
 class _FakeWSConnection:
     def __init__(self):
         self.sent = []

--- a/tests/unit/llm/test_codex_provider.py
+++ b/tests/unit/llm/test_codex_provider.py
@@ -146,8 +146,7 @@ class TestReasoningCapture:
         p._process_stream_event(
             _Ev(type="response.reasoning_summary_text.delta", delta="summary"), []
         )
-        p._pack_reasoning_extra_fields()
-        assert p._last_assistant_extra_fields == {
+        assert p._reasoning.fields() == {
             "reasoning_content": "think hard",
             "reasoning_summary": "summary",
         }
@@ -160,8 +159,7 @@ class TestReasoningCapture:
         p._process_stream_event(
             _Ev(type="response.reasoning_text.done", text="complete"), []
         )
-        p._pack_reasoning_extra_fields()
-        assert p._last_assistant_extra_fields["reasoning_content"] == "complete"
+        assert p._reasoning.fields()["reasoning_content"] == "complete"
 
     def test_reasoning_output_item_is_captured(self):
         p = self._provider()
@@ -171,8 +169,7 @@ class TestReasoningCapture:
             content=[{"type": "text", "text": "private"}],
         )
         p._process_stream_event(_Ev(type="response.output_item.done", item=item), [])
-        p._pack_reasoning_extra_fields()
-        assert p._last_assistant_extra_fields == {
+        assert p._reasoning.fields() == {
             "reasoning_content": "private",
             "reasoning_summary": "brief",
         }

--- a/tests/unit/llm/test_codex_provider.py
+++ b/tests/unit/llm/test_codex_provider.py
@@ -165,6 +165,35 @@ class TestReasoningCapture:
         )
         assert p._reasoning.fields()["reasoning_content"] == "complete"
 
+    def test_segments_preserve_reasoning_text_tool_order(self):
+        p = self._provider()
+        collected = []
+        p._process_stream_event(
+            _Ev(type="response.reasoning_text.delta", delta="think 1"), collected
+        )
+        p._process_stream_event(
+            _Ev(type="response.output_text.delta", delta="answer 1"), collected
+        )
+        p._process_stream_event(
+            _Ev(
+                type="response.output_item.done",
+                item=_Ev(
+                    type="function_call", call_id="call_1", name="t", arguments="{}"
+                ),
+            ),
+            collected,
+        )
+        p._process_stream_event(
+            _Ev(type="response.reasoning_text.delta", delta="think 2"), collected
+        )
+
+        assert p._reasoning.fields()["_kt_assistant_segments"] == [
+            {"type": "reasoning", "source": "responses_text", "text": "think 1"},
+            {"type": "text", "text": "answer 1"},
+            {"type": "tool_call_ref", "call_id": "call_1"},
+            {"type": "reasoning", "source": "responses_text", "text": "think 2"},
+        ]
+
     def test_reasoning_output_item_is_captured(self):
         p = self._provider()
         item = _Ev(

--- a/tests/unit/llm/test_litellm_provider.py
+++ b/tests/unit/llm/test_litellm_provider.py
@@ -1,0 +1,141 @@
+"""Unit tests for ``llm/litellm_provider.py`` reasoning-field capture.
+
+LiteLLM is an optional dependency, so the SDK module is replaced with a small
+fake that exposes the same ``acompletion`` surface used by the provider.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+
+class _FakeLitellm:
+    acompletion = None
+
+
+class _ModelExtra:
+    def __init__(self, model_extra=None, model_fields_set=None, **attrs):
+        self.model_extra = model_extra
+        self.model_fields_set = model_fields_set
+        self.__dict__.update(attrs)
+
+
+class _Delta(_ModelExtra):
+    def __init__(self, content=None, tool_calls=None, **kwargs):
+        super().__init__(**kwargs)
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class _Choice:
+    def __init__(self, delta):
+        self.delta = delta
+
+
+class _Chunk:
+    def __init__(self, delta):
+        self.choices = [_Choice(delta)]
+
+
+class _Message(_ModelExtra):
+    def __init__(self, content, **kwargs):
+        super().__init__(**kwargs)
+        self.content = content
+        self.tool_calls = None
+
+
+class _Usage:
+    prompt_tokens = 10
+    completion_tokens = 5
+    total_tokens = 15
+
+
+class _Response:
+    def __init__(self, message):
+        self.choices = [
+            type("Choice", (), {"message": message, "finish_reason": "stop"})()
+        ]
+        self.usage = _Usage()
+        self.model = "fake"
+
+
+_fake_litellm = _FakeLitellm()
+
+
+@pytest.fixture
+def lpm(monkeypatch):
+    monkeypatch.setitem(sys.modules, "litellm", _fake_litellm)
+    module = importlib.import_module("kohakuterrarium.llm.litellm_provider")
+    return module, _fake_litellm
+
+
+class TestStreamingReasoningCapture:
+    async def test_reasoning_fields_packed(self, lpm, monkeypatch):
+        module, fake = lpm
+
+        async def _stream():
+            yield _Chunk(
+                _Delta(
+                    model_extra={"reasoning_content": "think "},
+                    model_fields_set={"reasoning_content"},
+                )
+            )
+            yield _Chunk(
+                _Delta(
+                    content="answer",
+                    model_extra={"reasoning_content": "hard"},
+                    model_fields_set={"reasoning_content"},
+                )
+            )
+
+        async def acompletion(**params):
+            return _stream()
+
+        monkeypatch.setattr(fake, "acompletion", acompletion)
+        provider = module.LiteLLMProvider(model="openai/gpt-4o", api_key="k")
+        chunks = []
+        async for chunk in provider._stream_chat([{"role": "user", "content": "q"}]):
+            chunks.append(chunk)
+
+        assert chunks == ["answer"]
+        assert provider._last_assistant_extra_fields == {
+            "reasoning_content": "think hard"
+        }
+
+    async def test_empty_reasoning_not_packed(self, lpm, monkeypatch):
+        module, fake = lpm
+
+        async def _stream():
+            yield _Chunk(_Delta(content="answer"))
+
+        async def acompletion(**params):
+            return _stream()
+
+        monkeypatch.setattr(fake, "acompletion", acompletion)
+        provider = module.LiteLLMProvider(model="openai/gpt-4o", api_key="k")
+        async for _ in provider._stream_chat([{"role": "user", "content": "q"}]):
+            pass
+
+        assert provider._last_assistant_extra_fields == {}
+
+
+class TestCompleteReasoningCapture:
+    async def test_reasoning_fields_packed(self, lpm, monkeypatch):
+        module, fake = lpm
+        message = _Message(
+            content="answer",
+            model_extra={"reasoning_content": "private"},
+            model_fields_set={"reasoning_content"},
+        )
+
+        async def acompletion(**params):
+            return _Response(message)
+
+        monkeypatch.setattr(fake, "acompletion", acompletion)
+        provider = module.LiteLLMProvider(model="openai/gpt-4o", api_key="k")
+        response = await provider._complete_chat([{"role": "user", "content": "q"}])
+
+        assert response.content == "answer"
+        assert provider._last_assistant_extra_fields == {"reasoning_content": "private"}
+        assert provider._last_usage["prompt_tokens"] == 10

--- a/tests/unit/llm/test_litellm_provider.py
+++ b/tests/unit/llm/test_litellm_provider.py
@@ -100,7 +100,15 @@ class TestStreamingReasoningCapture:
 
         assert chunks == ["answer"]
         assert provider._last_assistant_extra_fields == {
-            "reasoning_content": "think hard"
+            "reasoning_content": "think hard",
+            "_kt_assistant_segments": [
+                {
+                    "type": "reasoning",
+                    "source": "reasoning_content",
+                    "text": "think hard",
+                },
+                {"type": "text", "text": "answer"},
+            ],
         }
 
     async def test_empty_reasoning_not_packed(self, lpm, monkeypatch):
@@ -137,5 +145,11 @@ class TestCompleteReasoningCapture:
         response = await provider._complete_chat([{"role": "user", "content": "q"}])
 
         assert response.content == "answer"
-        assert provider._last_assistant_extra_fields == {"reasoning_content": "private"}
+        assert provider._last_assistant_extra_fields == {
+            "reasoning_content": "private",
+            "_kt_assistant_segments": [
+                {"type": "reasoning", "source": "reasoning_content", "text": "private"},
+                {"type": "text", "text": "answer"},
+            ],
+        }
         assert provider._last_usage["prompt_tokens"] == 10

--- a/tests/unit/llm/test_openai_sanitize.py
+++ b/tests/unit/llm/test_openai_sanitize.py
@@ -10,6 +10,7 @@ import logging
 
 from kohakuterrarium.llm.openai_sanitize import (
     log_request_shape,
+    strip_internal_message_fields,
     strip_kt_extras,
     strip_surrogates,
 )
@@ -109,6 +110,24 @@ class TestStripKtExtras:
         assert out[0] is clean_msg
         assert out[1] is not dirty_msg
         assert out[1]["content"][0] == {"type": "text", "text": "t"}
+
+
+class TestStripInternalMessageFields:
+    def test_clean_messages_return_identical_object(self):
+        messages = [{"role": "assistant", "content": "hi"}]
+        assert strip_internal_message_fields(messages) is messages
+
+    def test_internal_assistant_fields_stripped(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "hi",
+                "_kt_assistant_segments": [{"type": "reasoning", "text": "hmm"}],
+                "_kt_anthropic_content": [{"type": "thinking", "thinking": "hmm"}],
+            }
+        ]
+        out = strip_internal_message_fields(messages)
+        assert out[0] == {"role": "assistant", "content": "hi"}
 
 
 class TestStripSurrogates:

--- a/tests/unit/llm/test_openai_segments.py
+++ b/tests/unit/llm/test_openai_segments.py
@@ -1,0 +1,81 @@
+"""Unit tests for OpenAIProvider ordered reasoning segments."""
+
+import pytest
+
+from kohakuterrarium.llm.openai import OpenAIProvider
+
+
+class _Delta:
+    def __init__(self, content=None, tool_calls=None, model_extra=None):
+        self.content = content
+        self.tool_calls = tool_calls
+        self.model_extra = model_extra or {}
+
+
+class _ToolDelta:
+    def __init__(self, index, id=None, name=None, arguments=None):
+        self.index = index
+        self.id = id
+        self.function = type(
+            "Function",
+            (),
+            {"name": name, "arguments": arguments},
+        )()
+
+
+class _Chunk:
+    def __init__(self, delta):
+        self.choices = [type("Choice", (), {"delta": delta})()]
+        self.usage = None
+
+
+class _Completions:
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.kwargs = None
+
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+
+        async def _stream():
+            for chunk in self.chunks:
+                yield chunk
+
+        return _stream()
+
+
+class _Client:
+    def __init__(self, chunks):
+        self.chat = type("Chat", (), {"completions": _Completions(chunks)})()
+
+
+@pytest.mark.asyncio
+async def test_stream_builds_interleaved_reasoning_segments():
+    chunks = [
+        _Chunk(_Delta(model_extra={"reasoning_content": "think 1"})),
+        _Chunk(_Delta(content="answer 1")),
+        _Chunk(_Delta(tool_calls=[_ToolDelta(0, id="call_1")])),
+        _Chunk(_Delta(tool_calls=[_ToolDelta(0, name="read", arguments='{"path"')])),
+        _Chunk(_Delta(tool_calls=[_ToolDelta(0, arguments=': "a.md"}')])),
+        _Chunk(_Delta(model_extra={"reasoning_content": "think 2"})),
+        _Chunk(_Delta(content="answer 2")),
+    ]
+    provider = OpenAIProvider(api_key="sk-test", model="gpt-x")
+    provider._client = _Client(chunks)
+
+    text = []
+    async for piece in provider._raw_stream_chat([{"role": "user", "content": "q"}]):
+        text.append(piece)
+
+    assert "".join(text) == "answer 1answer 2"
+    assert [tc.id for tc in provider.last_tool_calls] == ["call_1"]
+    assert provider._last_assistant_extra_fields == {
+        "reasoning_content": "think 1think 2",
+        "_kt_assistant_segments": [
+            {"type": "reasoning", "source": "reasoning_content", "text": "think 1"},
+            {"type": "text", "text": "answer 1"},
+            {"type": "tool_call_ref", "call_id": "call_1"},
+            {"type": "reasoning", "source": "reasoning_content", "text": "think 2"},
+            {"type": "text", "text": "answer 2"},
+        ],
+    }

--- a/tests/unit/llm/test_openai_ws.py
+++ b/tests/unit/llm/test_openai_ws.py
@@ -183,6 +183,35 @@ class TestProviderWebsocketMode:
         }
         assert provider._last_tool_calls == []
 
+    async def test_ws_segments_preserve_reasoning_text_tool_order(self):
+        provider = make_provider(extra_body={"websocket_mode": True})
+        provider._client.responses.connection.scripts = [
+            [
+                Ev(type="response.reasoning_text.delta", delta="think 1"),
+                Ev(type="response.output_text.delta", delta="answer 1"),
+                Ev(
+                    type="response.output_item.done",
+                    item=Ev(
+                        type="function_call",
+                        call_id="call_1",
+                        name="fn",
+                        arguments="{}",
+                    ),
+                ),
+                Ev(type="response.reasoning_text.delta", delta="think 2"),
+                completed(),
+            ]
+        ]
+
+        await self._drive(provider)
+
+        assert provider._last_assistant_extra_fields["_kt_assistant_segments"] == [
+            {"type": "reasoning", "source": "responses_text", "text": "think 1"},
+            {"type": "text", "text": "answer 1"},
+            {"type": "tool_call_ref", "call_id": "call_1"},
+            {"type": "reasoning", "source": "responses_text", "text": "think 2"},
+        ]
+
     async def test_connect_failure_falls_back_to_chat_completions(self):
         provider = make_provider(extra_body={"websocket_mode": True})
         provider._client.responses.connect_exc = ConnectionError("no upgrade")

--- a/tests/unit/llm/test_openai_ws.py
+++ b/tests/unit/llm/test_openai_ws.py
@@ -176,6 +176,10 @@ class TestProviderWebsocketMode:
         assert provider._last_assistant_extra_fields == {
             "reasoning_content": "think hard",
             "reasoning_summary": "summary",
+            "_kt_assistant_segments": [
+                {"type": "reasoning", "source": "responses_text", "text": "think hard"},
+                {"type": "reasoning", "source": "responses_summary", "text": "summary"},
+            ],
         }
         assert provider._last_tool_calls == []
 

--- a/tests/unit/llm/test_openai_ws.py
+++ b/tests/unit/llm/test_openai_ws.py
@@ -160,6 +160,25 @@ class TestProviderWebsocketMode:
         assert provider._last_usage["prompt_tokens"] == 7
         assert provider._client.chat.completions.kwargs is None
 
+    async def test_ws_turn_captures_reasoning_fields(self):
+        provider = make_provider(extra_body={"websocket_mode": True})
+        provider._client.responses.connection.scripts = [
+            [
+                Ev(type="response.reasoning_text.delta", delta="think "),
+                Ev(type="response.reasoning_text.delta", delta="hard"),
+                Ev(type="response.reasoning_summary_text.delta", delta="summary"),
+                completed(),
+            ]
+        ]
+
+        await self._drive(provider)
+
+        assert provider._last_assistant_extra_fields == {
+            "reasoning_content": "think hard",
+            "reasoning_summary": "summary",
+        }
+        assert provider._last_tool_calls == []
+
     async def test_connect_failure_falls_back_to_chat_completions(self):
         provider = make_provider(extra_body={"websocket_mode": True})
         provider._client.responses.connect_exc = ConnectionError("no upgrade")

--- a/tests/unit/llm/test_responses_reasoning.py
+++ b/tests/unit/llm/test_responses_reasoning.py
@@ -19,6 +19,10 @@ class TestResponsesReasoningCollector:
         assert collector.fields() == {
             "reasoning_content": "think hard",
             "reasoning_summary": "summary",
+            "_kt_assistant_segments": [
+                {"type": "reasoning", "source": "responses_text", "text": "think hard"},
+                {"type": "reasoning", "source": "responses_summary", "text": "summary"},
+            ],
         }
 
     def test_done_event_replaces_accumulator(self):
@@ -38,6 +42,10 @@ class TestResponsesReasoningCollector:
         assert collector.fields() == {
             "reasoning_content": "private",
             "reasoning_summary": "brief",
+            "_kt_assistant_segments": [
+                {"type": "reasoning", "source": "responses_summary", "text": "brief"},
+                {"type": "reasoning", "source": "responses_text", "text": "private"},
+            ],
         }
 
     def test_empty_collector_returns_empty_fields(self):

--- a/tests/unit/llm/test_responses_reasoning.py
+++ b/tests/unit/llm/test_responses_reasoning.py
@@ -1,0 +1,44 @@
+"""Unit tests for ``llm/responses_reasoning.py``."""
+
+from kohakuterrarium.llm.responses_reasoning import ResponsesReasoningCollector
+
+
+class Ev:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class TestResponsesReasoningCollector:
+    def test_delta_events_are_accumulated(self):
+        collector = ResponsesReasoningCollector()
+        collector.consume(Ev(type="response.reasoning_text.delta", delta="think "))
+        collector.consume(Ev(type="response.reasoning_text.delta", delta="hard"))
+        collector.consume(
+            Ev(type="response.reasoning_summary_text.delta", delta="summary")
+        )
+        assert collector.fields() == {
+            "reasoning_content": "think hard",
+            "reasoning_summary": "summary",
+        }
+
+    def test_done_event_replaces_accumulator(self):
+        collector = ResponsesReasoningCollector()
+        collector.consume(Ev(type="response.reasoning_text.delta", delta="partial"))
+        collector.consume(Ev(type="response.reasoning_text.done", text="complete"))
+        assert collector.fields()["reasoning_content"] == "complete"
+
+    def test_reasoning_item_summary_and_content_are_captured(self):
+        collector = ResponsesReasoningCollector()
+        item = Ev(
+            type="reasoning",
+            summary=[{"type": "summary_text", "text": "brief"}],
+            content=[{"type": "text", "text": "private"}],
+        )
+        collector.consume(Ev(type="response.output_item.done", item=item))
+        assert collector.fields() == {
+            "reasoning_content": "private",
+            "reasoning_summary": "brief",
+        }
+
+    def test_empty_collector_returns_empty_fields(self):
+        assert ResponsesReasoningCollector().fields() == {}

--- a/tests/unit/llm/test_responses_reasoning.py
+++ b/tests/unit/llm/test_responses_reasoning.py
@@ -48,5 +48,45 @@ class TestResponsesReasoningCollector:
             ],
         }
 
+    def test_completed_output_item_is_deduplicated_after_done_events(self):
+        collector = ResponsesReasoningCollector()
+        collector.consume(
+            Ev(
+                type="response.reasoning_text.delta",
+                delta="partial",
+                item_id="reasoning_1",
+            )
+        )
+        collector.consume(
+            Ev(
+                type="response.reasoning_text.done",
+                text="complete",
+                item_id="reasoning_1",
+            )
+        )
+        collector.consume(
+            Ev(
+                type="response.output_item.done",
+                item=Ev(
+                    type="reasoning",
+                    id="reasoning_1",
+                    summary=[{"type": "summary_text", "text": "brief"}],
+                    content=[{"type": "text", "text": "complete"}],
+                ),
+            )
+        )
+
+        assert collector.fields() == {
+            "reasoning_content": "complete",
+            "_kt_assistant_segments": [
+                {
+                    "type": "reasoning",
+                    "source": "responses_text",
+                    "key": "reasoning_1",
+                    "text": "complete",
+                }
+            ],
+        }
+
     def test_empty_collector_returns_empty_fields(self):
         assert ResponsesReasoningCollector().fields() == {}

--- a/tests/unit/llm/test_turn_segments.py
+++ b/tests/unit/llm/test_turn_segments.py
@@ -1,0 +1,108 @@
+"""Unit tests for ``llm/turn_segments.py``."""
+
+from kohakuterrarium.llm.turn_segments import (
+    KT_ASSISTANT_SEGMENTS,
+    TurnSegmentsBuilder,
+    inject_anthropic_segments,
+    segments_from_anthropic_blocks,
+)
+
+
+class TestTurnSegmentsBuilder:
+    def test_records_reasoning_text_tool_order(self):
+        builder = TurnSegmentsBuilder()
+        builder.append_reasoning("think 1", source="reasoning_content")
+        builder.append_text("answer 1")
+        builder.append_tool_call_ref("call_1")
+        builder.append_reasoning("think 2", source="responses_text")
+        builder.append_tool_call_ref("call_2")
+        builder.append_text("answer 2")
+
+        fields = builder.inject_into({"reasoning_content": "think 1"})
+        assert fields[KT_ASSISTANT_SEGMENTS] == [
+            {"type": "reasoning", "source": "reasoning_content", "text": "think 1"},
+            {"type": "text", "text": "answer 1"},
+            {"type": "tool_call_ref", "call_id": "call_1"},
+            {"type": "reasoning", "source": "responses_text", "text": "think 2"},
+            {"type": "tool_call_ref", "call_id": "call_2"},
+            {"type": "text", "text": "answer 2"},
+        ]
+
+    def test_adjacent_same_source_reasoning_is_merged(self):
+        builder = TurnSegmentsBuilder()
+        builder.append_reasoning("think ", source="reasoning_content")
+        builder.append_reasoning("hard", source="reasoning_content")
+
+        assert builder.as_list() == [
+            {"type": "reasoning", "source": "reasoning_content", "text": "think hard"}
+        ]
+
+    def test_text_only_turn_does_not_emit_segments(self):
+        builder = TurnSegmentsBuilder()
+        builder.append_text("answer")
+        assert builder.inject_into({}) == {}
+
+    def test_tool_refs_are_finalized_by_index(self):
+        builder = TurnSegmentsBuilder()
+        builder.append_tool_call_ref("", index=0)
+        builder.finalize_tool_call_refs(
+            {0: {"id": "call_1", "name": "", "arguments": ""}}
+        )
+        builder.append_reasoning("think", source="reasoning_content")
+        assert builder.as_list()[0] == {"type": "tool_call_ref", "call_id": "call_1"}
+
+    def test_replace_reasoning_drops_partial_segments(self):
+        builder = TurnSegmentsBuilder()
+        builder.append_reasoning("partial", source="responses_text", key="item_1")
+        builder.append_text("answer")
+        builder.replace_reasoning("complete", source="responses_text", key="item_1")
+
+        assert builder.as_list() == [
+            {"type": "text", "text": "answer"},
+            {
+                "type": "reasoning",
+                "source": "responses_text",
+                "key": "item_1",
+                "text": "complete",
+            },
+        ]
+
+
+class TestAnthropicSegments:
+    def test_blocks_preserve_thinking_text_tool_order(self):
+        blocks = [
+            {"type": "thinking", "thinking": "think 1", "signature": "sig1"},
+            {"type": "text", "text": "answer 1"},
+            {"type": "tool_use", "id": "call_1"},
+            {"type": "thinking", "thinking": "think 2"},
+        ]
+
+        assert segments_from_anthropic_blocks(blocks) == [
+            {
+                "type": "reasoning",
+                "source": "anthropic_thinking",
+                "text": "think 1",
+                "signature": "sig1",
+            },
+            {"type": "text", "text": "answer 1"},
+            {"type": "tool_call_ref", "call_id": "call_1"},
+            {
+                "type": "reasoning",
+                "source": "anthropic_thinking",
+                "text": "think 2",
+            },
+        ]
+
+    def test_inject_only_when_thinking_exists(self):
+        assert inject_anthropic_segments({}, [{"type": "text", "text": "hi"}]) == {}
+        fields = inject_anthropic_segments(
+            {"_kt_anthropic_content": []},
+            [{"type": "thinking", "thinking": "hmm"}],
+        )
+        assert fields[KT_ASSISTANT_SEGMENTS] == [
+            {
+                "type": "reasoning",
+                "source": "anthropic_thinking",
+                "text": "hmm",
+            }
+        ]

--- a/tests/unit/modules/subagent/test_base.py
+++ b/tests/unit/modules/subagent/test_base.py
@@ -460,6 +460,45 @@ class TestSessionStorePersistence:
         assert saved[0]["name"] == "explore"
         assert saved[0]["run"] == 2
 
+    async def test_conversation_preserves_reasoning_extra_fields(self):
+        saved: list[dict] = []
+
+        class _FakeStore:
+            def save_subagent(self, **kwargs):
+                saved.append(kwargs)
+
+        class _ReasoningLLM:
+            model = "reasoning"
+            last_tool_calls: list = []
+            last_usage = {}
+            last_assistant_extra_fields = {
+                "reasoning_content": "think",
+                "_kt_assistant_segments": [
+                    {
+                        "type": "reasoning",
+                        "source": "reasoning_content",
+                        "text": "think",
+                    },
+                    {"type": "text", "text": "found it"},
+                ],
+            }
+
+            async def chat(self, messages, *, stream=True, **kwargs):
+                yield "found it"
+
+        sa = SubAgent(
+            SubAgentConfig(name="explore", max_turns=1),
+            _registry(),
+            _ReasoningLLM(),
+        )
+        sa._session_store = _FakeStore()
+        sa._parent_name = "controller"
+        sa._run_index = 2
+        await sa.run("find the bug")
+        conv_json = saved[0]["conv_json"]
+        assert '"reasoning_content"' in conv_json
+        assert '"_kt_assistant_segments"' in conv_json
+
     async def test_session_store_save_failure_does_not_fail_run(self):
         class _BadStore:
             def save_subagent(self, **kwargs):

--- a/tests/unit/scripts/test_inspect_session.py
+++ b/tests/unit/scripts/test_inspect_session.py
@@ -1,0 +1,72 @@
+"""Unit tests for ``scripts/inspect_session.py`` reasoning helpers."""
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "inspect_session.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("inspect_session", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_inspect_session = _load_script()
+
+
+class TestBoundedText:
+    def test_short_text_unchanged(self):
+        assert _inspect_session._bounded_text("short", 10) == "short"
+
+    def test_long_text_gets_marker(self):
+        out = _inspect_session._bounded_text("abcdef", 3)
+        assert out.startswith("abc")
+        assert "3 more chars" in out
+
+
+class TestReasoningEntries:
+    def test_flat_fields(self):
+        out = _inspect_session._reasoning_entries(
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_content": "private",
+                "reasoning": "plain",
+            }
+        )
+        assert out == [
+            ("reasoning_content", "private"),
+            ("reasoning", "plain"),
+        ]
+
+    def test_reasoning_details_with_signature(self):
+        out = _inspect_session._reasoning_entries(
+            {
+                "role": "assistant",
+                "reasoning_details": [
+                    {"type": "reasoning.text", "text": "think", "signature": "sig"}
+                ],
+            }
+        )
+        assert out == [
+            ("reasoning_details[0]:reasoning.text", "think\n[signature: sig]")
+        ]
+
+    def test_anthropic_thinking_blocks(self):
+        out = _inspect_session._reasoning_entries(
+            {
+                "role": "assistant",
+                "_kt_anthropic_content": [
+                    {"type": "text", "text": "answer"},
+                    {"type": "thinking", "thinking": "hmm", "signature": "sig2"},
+                ],
+            }
+        )
+        assert out == [("anthropic:thinking[1]", "hmm\n[signature: sig2]")]
+
+    def test_non_assistant_ignored_by_print_path(self):
+        assert _inspect_session._reasoning_entries({"role": "user"}) == []

--- a/tests/unit/scripts/test_inspect_session.py
+++ b/tests/unit/scripts/test_inspect_session.py
@@ -68,5 +68,27 @@ class TestReasoningEntries:
         )
         assert out == [("anthropic:thinking[1]", "hmm\n[signature: sig2]")]
 
+    def test_ordered_segments_preferred_over_flat_fields(self):
+        out = _inspect_session._reasoning_entries(
+            {
+                "role": "assistant",
+                "reasoning_content": "flat",
+                "_kt_assistant_segments": [
+                    {
+                        "type": "reasoning",
+                        "source": "reasoning_content",
+                        "text": "think 1",
+                    },
+                    {"type": "text", "text": "answer 1"},
+                    {"type": "tool_call_ref", "call_id": "call_1"},
+                ],
+            }
+        )
+        assert out == [
+            ("segments[0] reasoning:reasoning_content", "think 1"),
+            ("segments[1] text", "answer 1"),
+            ("segments[2] tool_call_ref", "call_1"),
+        ]
+
     def test_non_assistant_ignored_by_print_path(self):
         assert _inspect_session._reasoning_entries({"role": "user"}) == []

--- a/tests/unit/session/test_history.py
+++ b/tests/unit/session/test_history.py
@@ -67,6 +67,37 @@ class TestReplayConversation:
     def test_empty_events(self):
         assert replay_conversation([]) == []
 
+    def test_assistant_reasoning_attaches_to_previous_assistant(self):
+        events = [
+            {"type": "user_message", "content": "q", "event_id": 1},
+            {
+                "type": "text_chunk",
+                "content": "answer",
+                "event_id": 2,
+                "turn_index": 1,
+                "branch_id": 1,
+            },
+            {
+                "type": "assistant_reasoning",
+                "event_id": 3,
+                "turn_index": 1,
+                "branch_id": 1,
+                "reasoning_content": "think",
+                "_kt_assistant_segments": [
+                    {
+                        "type": "reasoning",
+                        "source": "reasoning_content",
+                        "text": "think",
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+            },
+        ]
+        out = replay_conversation(events)
+        assistant = next(m for m in out if m["role"] == "assistant")
+        assert assistant["reasoning_content"] == "think"
+        assert assistant["_kt_assistant_segments"][0]["text"] == "think"
+
     def test_user_message(self):
         events = [{"type": "user_message", "content": "hi", "event_id": 0}]
         out = replay_conversation(events)

--- a/tests/unit/session/test_output.py
+++ b/tests/unit/session/test_output.py
@@ -768,6 +768,37 @@ class TestActivityHandlers:
         finally:
             store.close()
 
+    def test_assistant_reasoning_recorded_as_clean_event(self, tmp_path):
+        store, out = _make(tmp_path, _FakeAgent(turn=2, branch=1))
+        try:
+            out.on_activity_with_metadata(
+                "assistant_reasoning",
+                "turn 2 assistant reasoning",
+                {
+                    "reasoning_content": "think",
+                    "_kt_assistant_segments": [
+                        {
+                            "type": "reasoning",
+                            "source": "reasoning_content",
+                            "text": "think",
+                        },
+                        {"type": "text", "text": "answer"},
+                    ],
+                },
+            )
+            store.flush()
+            evt = next(
+                e
+                for e in store.get_events("alice")
+                if e["type"] == "assistant_reasoning"
+            )
+            assert evt["reasoning_content"] == "think"
+            assert evt["_kt_assistant_segments"][0]["text"] == "think"
+            assert evt["turn_index"] == 2
+            assert evt["branch_id"] == 1
+        finally:
+            store.close()
+
     def test_context_cleared(self, tmp_path):
         store, out = _make(tmp_path)
         try:

--- a/tests/unit/session/test_resume.py
+++ b/tests/unit/session/test_resume.py
@@ -133,6 +133,24 @@ class TestBuildConversation:
         rebuilt = conv.get_messages()
         assert rebuilt[0].metadata == {"source": "test"}
 
+    def test_provider_extra_fields_preserved(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_content": "private thought",
+                "_kt_anthropic_content": [{"type": "thinking", "thinking": "hmm"}],
+            },
+        ]
+        conv = _build_conversation(msgs)
+        rebuilt = conv.get_messages()
+        assert rebuilt[0].extra_fields == {
+            "reasoning_content": "private thought",
+            "_kt_anthropic_content": [{"type": "thinking", "thinking": "hmm"}],
+        }
+        wire = conv.to_messages()
+        assert wire[0]["reasoning_content"] == "private thought"
+
     def test_tool_calls_preserved(self):
         msgs = [
             {

--- a/tests/unit/studio/test_event_stream.py
+++ b/tests/unit/studio/test_event_stream.py
@@ -118,6 +118,28 @@ class TestStreamOutputSync:
         # Unknown keys are filtered.
         assert "unknown_key" not in msg
 
+    def test_assistant_reasoning_metadata_streams_segments(self, _stream):
+        so, q, _log = _stream
+        so.on_activity_with_metadata(
+            "assistant_reasoning",
+            "turn 2 assistant reasoning",
+            metadata={
+                "reasoning_content": "think",
+                "_kt_assistant_segments": [
+                    {
+                        "type": "reasoning",
+                        "source": "reasoning_content",
+                        "text": "think",
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+            },
+        )
+        msg = q.get_nowait()
+        assert msg["activity_type"] == "assistant_reasoning"
+        assert msg["reasoning_content"] == "think"
+        assert msg["_kt_assistant_segments"][0]["text"] == "think"
+
     def test_tool_done_streams_preview_not_full_output(self, _stream):
         so, q, _log = _stream
         full = "x" * 200_000


### PR DESCRIPTION
## Summary

Expose ordered chain-of-thought from LLM providers in conversation history, live chat, trace, and the CLI session inspector. Reasoning is now attached to the correct assistant message and preserves `reasoning -> text -> tool_call -> reasoning` order instead of living only in a detached field bag.

## PR Type

- [ ] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Reasoning fields were already captured by some providers into `extra_fields`, but:

- the session viewer could only show them in a detached panel, making association with a specific message hard in long sessions;
- flat fields could not express interleaving between thinking, visible text, and tool calls;
- LiteLLM, Codex Responses, and OpenAI Responses WebSocket dropped reasoning entirely;
- resume and sub-agent turns dropped provider `extra_fields`.

## Changes

- Add `_kt_assistant_segments` ordered segment model (`reasoning`, `text`, `tool_call_ref`).
- Capture segments in OpenAI, LiteLLM, Anthropic, Codex, and OpenAI Responses WebSocket.
- Emit and persist an `assistant_reasoning` event at turn end, including turn/branch stamps.
- Stream `assistant_reasoning` to live chat through the attach WebSocket metadata whitelist.
- Replay `assistant_reasoning` in Python `replay_conversation()` and frontend `_replayEvents()`.
- Render reasoning inline as a collapsible assistant part in `ChatMessage`, shared by normal chat and the session-viewer Conversation tab.
- Show reasoning in the trace event list, filters, and event detail drawer.
- Preserve provider `extra_fields` when resume rebuilds conversations and when sub-agents save their conversations.
- Extend `scripts/inspect_session.py --reasoning` to print ordered segments.
- Strip internal segment fields before OpenAI-compatible provider requests.

### Screenshots

Conversation:

<img width="1594" height="1242" alt="Snipaste_2026-08-16_15-17-53" src="https://github.com/user-attachments/assets/572df8bf-f048-45d9-b847-d9fb1a890acd" />

Inspector:

<img width="2560" height="1369" alt="Snipaste_2026-08-16_15-18-34" src="https://github.com/user-attachments/assets/f51e650f-99c8-400a-843d-c17b5d78851d" />

## Validation

```bash
# Python lint / format
ruff check src/ tests/
black --check src/ tests/

# Affected unit suites after the final changes
pytest tests/unit/modules/subagent \
  tests/unit/scripts/test_inspect_session.py \
  tests/unit/llm/test_codex_provider.py \
  tests/unit/llm/test_openai_ws.py -q
# -> 183 passed

# Broader affected Python suites run during development
pytest tests/unit/llm tests/unit/session \
  tests/unit/studio/test_event_stream.py \
  tests/unit/core/test_agent_real.py -q
# -> 1694 passed

# Integration tier
pytest tests/integration/ -q
# -> 173 passed

# File-size and dependency guards
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
# -> 1700 passed
```

Frontend:

```bash
cd src/kohakuterrarium-frontend
npx eslint <changed files>
npx vitest run \
  src/stores/chat.reasoning.test.js \
  src/components/chat/ChatMessage.test.js \
  src/utils/chatReasoning.test.js
# -> 12 passed
npx prettier --check <changed files>
npm run build
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #165
- Follows the maintainer direction in #32 (opened 2026-04-20; @KohakuBlueleaf approved the thinking-event/display direction)
- Addresses #62

Approval was additionally obtained through the project community before implementation. Exact QQ/Discord permalink can be provided on request.

## Notes for Reviewers

- `_kt_assistant_segments` is deliberately stored in `extra_fields` rather than changing the public `Message` schema. It is stripped before provider wire requests by `strip_internal_message_fields()`.
- Existing sessions without segments keep the previous detached fallback panel.
- Sub-agents now persist reasoning in their saved conversation JSON, but do not yet emit `assistant_reasoning` events into the parent trace stream.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- Full `pytest tests/unit/` was run during development: 11975 passed, 6 pre-existing failures in `tests/unit/packages/test_git_backend_dulwich_integration.py` caused by the local environment defaulting to `refs/heads/master`, and 9 skipped.
- Full `npm test` locally reports 20 unrelated environment failures (`localStorage` unavailable in Node 26 and one StudioHomePage timeout); 977 tests pass.
- Fork CI is not green before opening because the fork CI will only run once this branch/PR is submitted; upstream CI is expected to run on the PR.
- Real-time streaming of reasoning deltas and exact parser-level tool positions inside text-mode output are intentionally not included in this PR.
