### PR TITLE
fix(frontend): keep multi-round chain-of-thought in arrival order

### DIFF
--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -67,8 +67,9 @@ function normalizeMessageContent(content) {
 function _insertReasoningSegments(message, segments, idPrefix = "reasoning_") {
   if (!message || !Array.isArray(segments) || !segments.length) return
   const parts = Array.isArray(message.parts) ? message.parts : []
+  const start = Number.isInteger(message._reasoningCursor) ? message._reasoningCursor : 0
   const out = []
-  let cursor = 0
+  let cursor = Math.min(Math.max(start, 0), parts.length)
   let n = 0
 
   const nextText = (from) => parts.findIndex((part, idx) => idx >= from && part?.type === "text")
@@ -99,8 +100,15 @@ function _insertReasoningSegments(message, segments, idPrefix = "reasoning_") {
     out.push(parts[cursor++])
   }
   while (cursor < parts.length) out.push(parts[cursor++])
+  if (!out.length) return
 
-  if (out.length) message.parts = out
+  message.parts = [...parts.slice(0, start), ...out]
+  message._reasoningCursor = message.parts.length
+  const tail = message.parts[message.parts.length - 1]
+  if (tail?.type === "text") {
+    tail._roundEnd = true
+    tail._streaming = false
+  }
 }
 
 function contentSignature(content) {
@@ -304,6 +312,7 @@ export function _convertHistory(messages) {
           }
         }
         message.parts = parts
+        message._reasoningCursor = parts.length
       }
       result.push(message)
     }
@@ -583,7 +592,7 @@ export function _replayEvents(messages, events, branchView = null) {
   function appendText(content) {
     const c = ensureCur()
     const tail = c.parts.length ? c.parts[c.parts.length - 1] : null
-    if (tail && tail.type === "text") {
+    if (tail && tail.type === "text" && !tail._roundEnd) {
       tail.content += content
     } else {
       c.parts.push({ type: "text", content, id: stableId("txt_") })

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -589,8 +589,20 @@ export function _replayEvents(messages, events, branchView = null) {
     return cur
   }
 
+  function commitPendingReasoningRound(c) {
+    if (!Number.isInteger(c._pendingReasoningCursor)) return
+    c._reasoningCursor = c._pendingReasoningCursor
+    c._pendingReasoningCursor = undefined
+    const tail = c.parts.length ? c.parts[c.parts.length - 1] : null
+    if (tail?.type === "text") {
+      tail._roundEnd = true
+      tail._streaming = false
+    }
+  }
+
   function appendText(content) {
     const c = ensureCur()
+    commitPendingReasoningRound(c)
     const tail = c.parts.length ? c.parts[c.parts.length - 1] : null
     if (tail && tail.type === "text" && !tail._roundEnd) {
       tail.content += content
@@ -605,6 +617,7 @@ export function _replayEvents(messages, events, branchView = null) {
 
   function addTool(name, kind, args, jobId, startedTs) {
     const c = ensureCur()
+    commitPendingReasoningRound(c)
     const tail = c.parts.length ? c.parts[c.parts.length - 1] : null
     if (tail && tail.type === "text") tail._streaming = false
     // Sub-agents run asynchronously in the background — the assistant
@@ -932,7 +945,9 @@ export function _replayEvents(messages, events, branchView = null) {
           sender,
           timestamp: "",
         })
-      } else if (at === "token_usage" || at === "processing_complete") {
+      } else if (at === "token_usage") {
+        if (cur) cur._pendingReasoningCursor = cur.parts.length
+      } else if (at === "processing_complete") {
         // skip
       } else if (at === "context_cleared") {
         cur = null
@@ -1185,6 +1200,7 @@ export function _replayEvents(messages, events, branchView = null) {
       // sessions (and plain history reloads) show it in place. Mirrors
       // the live `_handleAssistantImage` path so shape + meta match.
       const c = ensureCur()
+      commitPendingReasoningRound(c)
       for (const p of c.parts || []) {
         if (p.type === "text") p._streaming = false
       }
@@ -1208,7 +1224,10 @@ export function _replayEvents(messages, events, branchView = null) {
         evt._kt_assistant_segments || [],
         typeof evt.event_id === "number" ? `h_${evt.event_id}_r` : "h_reasoning_",
       )
-    } else if (t === "token_usage" || t === "processing_complete") {
+      c._pendingReasoningCursor = undefined
+    } else if (t === "token_usage") {
+      if (cur) cur._pendingReasoningCursor = cur.parts.length
+    } else if (t === "processing_complete") {
       // skip
     }
   }
@@ -2952,6 +2971,7 @@ const _chatStoreOptions = {
             data._kt_assistant_segments || [],
             `live_${data.id || "reasoning"}_r`,
           )
+          target._pendingReasoningCursor = undefined
         }
         return
       }
@@ -3005,6 +3025,9 @@ const _chatStoreOptions = {
           cached: prev.cached + (data.cached_tokens || 0),
           lastPrompt: data.prompt_tokens || prev.lastPrompt,
         }
+        const list = this.messagesByTab[source] || []
+        const target = [...list].reverse().find((message) => message?.role === "assistant")
+        if (target?.parts) target._pendingReasoningCursor = target.parts.length
         return
       }
 
@@ -3201,6 +3224,7 @@ const _chatStoreOptions = {
           this.processingByTab[source] = true
         }
         const last = this._ensureAssistantMsg(msgs)
+        this._commitPendingReasoningRound(last)
         if (last.parts.length > 0) {
           const tail = last.parts[last.parts.length - 1]
           if (tail.type === "text") tail._streaming = false
@@ -4751,11 +4775,24 @@ const _chatStoreOptions = {
       return last
     },
 
+    _commitPendingReasoningRound(message) {
+      if (!message || !Array.isArray(message.parts)) return
+      if (!Number.isInteger(message._pendingReasoningCursor)) return
+      message._reasoningCursor = message._pendingReasoningCursor
+      message._pendingReasoningCursor = undefined
+      const tail = message.parts.length ? message.parts[message.parts.length - 1] : null
+      if (tail?.type === "text") {
+        tail._roundEnd = true
+        tail._streaming = false
+      }
+    },
+
     _appendStreamChunk(source, content) {
       const msgs = this.messagesByTab[source]
       if (!msgs) return
       this._historyMutationSeqByTab[source] = (this._historyMutationSeqByTab[source] || 0) + 1
       const last = this._ensureAssistantMsg(msgs)
+      this._commitPendingReasoningRound(last)
       const tail = last.parts.length > 0 ? last.parts[last.parts.length - 1] : null
       if (tail && tail.type === "text" && tail._streaming) {
         tail.content += content
@@ -4775,6 +4812,7 @@ const _chatStoreOptions = {
       const msgs = this.messagesByTab[source]
       if (!msgs) return
       const last = this._ensureAssistantMsg(msgs)
+      this._commitPendingReasoningRound(last)
       for (const p of last.parts || []) {
         if (p.type === "text") p._streaming = false
       }

--- a/src/kohakuterrarium-frontend/src/stores/chat.reasoning.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.reasoning.test.js
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest"
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it } from "vitest"
 
-import { _convertHistory, _replayEvents } from "./chat"
+import { _convertHistory, _replayEvents, useChatStore } from "./chat"
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
 
 function reasoningMessage() {
   return {
@@ -44,7 +49,7 @@ describe("_convertHistory reasoning segments", () => {
   })
 })
 
-describe("_replayEvents reasoning segments", () => {
+describe("reasoning segment ordering", () => {
   it("inserts persisted assistant_reasoning into the current message", () => {
     const events = [
       { type: "user_input", content: "q", event_id: 1, turn_index: 1, branch_id: 1 },
@@ -207,5 +212,222 @@ describe("_replayEvents reasoning segments", () => {
     const assistant = messages.find((message) => message.role === "assistant")
     expect(assistant.parts.map((part) => part.type)).toEqual(["reasoning", "text", "reasoning"])
     expect(assistant.parts.map((part) => part.text)).toEqual(["think 1", undefined, "think 2"])
+  })
+  it("keeps a reasoning round after an intervening round that emitted no reasoning", () => {
+    const events = [
+      { type: "user_input", content: "q", event_id: 1, turn_index: 1, branch_id: 1 },
+      { type: "processing_start", event_id: 2, turn_index: 1, branch_id: 1 },
+      { type: "text_chunk", content: "answer 1", event_id: 3, turn_index: 1, branch_id: 1 },
+      {
+        type: "tool_call",
+        name: "read",
+        args: {},
+        call_id: "call_1",
+        event_id: 4,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      {
+        type: "token_usage",
+        event_id: 5,
+        turn_index: 1,
+        branch_id: 1,
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      },
+      {
+        type: "assistant_reasoning",
+        event_id: 6,
+        turn_index: 1,
+        branch_id: 1,
+        _kt_assistant_segments: [
+          { type: "reasoning", source: "reasoning_content", text: "think 1" },
+          { type: "text", text: "answer 1" },
+          { type: "tool_call_ref", call_id: "call_1" },
+        ],
+      },
+      {
+        type: "tool_result",
+        name: "read",
+        output: "ok",
+        call_id: "call_1",
+        event_id: 7,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      { type: "text_chunk", content: "answer 2", event_id: 8, turn_index: 1, branch_id: 1 },
+      {
+        type: "tool_call",
+        name: "bash",
+        args: {},
+        call_id: "call_2",
+        event_id: 9,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      {
+        type: "token_usage",
+        event_id: 10,
+        turn_index: 1,
+        branch_id: 1,
+        prompt_tokens: 20,
+        completion_tokens: 10,
+        total_tokens: 30,
+      },
+      {
+        type: "tool_result",
+        name: "bash",
+        output: "done",
+        call_id: "call_2",
+        event_id: 11,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      { type: "text_chunk", content: "answer 3", event_id: 12, turn_index: 1, branch_id: 1 },
+      {
+        type: "tool_call",
+        name: "grep",
+        args: {},
+        call_id: "call_3",
+        event_id: 13,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      {
+        type: "token_usage",
+        event_id: 14,
+        turn_index: 1,
+        branch_id: 1,
+        prompt_tokens: 30,
+        completion_tokens: 15,
+        total_tokens: 45,
+      },
+      {
+        type: "assistant_reasoning",
+        event_id: 15,
+        turn_index: 1,
+        branch_id: 1,
+        _kt_assistant_segments: [
+          { type: "reasoning", source: "reasoning_content", text: "think 3" },
+          { type: "text", text: "answer 3" },
+          { type: "tool_call_ref", call_id: "call_3" },
+        ],
+      },
+      {
+        type: "tool_result",
+        name: "grep",
+        output: "hit",
+        call_id: "call_3",
+        event_id: 16,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      { type: "processing_end", event_id: 17, turn_index: 1, branch_id: 1 },
+    ]
+    const { messages } = _replayEvents([], events)
+    const assistant = messages.find((message) => message.role === "assistant")
+    expect(assistant.parts.map((part) => part.type)).toEqual([
+      "reasoning",
+      "text",
+      "tool",
+      "text",
+      "tool",
+      "reasoning",
+      "text",
+      "tool",
+    ])
+    expect(assistant.parts.map((part) => part.text || part.jobId)).toEqual([
+      "think 1",
+      undefined,
+      "call_1",
+      undefined,
+      "call_2",
+      "think 3",
+      undefined,
+      "call_3",
+    ])
+  })
+
+  it("keeps live reasoning after a no-reasoning round", () => {
+    const chat = useChatStore()
+    chat.messagesByTab = { main: [] }
+    chat.activeTab = "main"
+
+    const toolStart = (name, jobId, id) =>
+      chat._handleActivity("main", {
+        activity_type: "tool_start",
+        name,
+        job_id: jobId,
+        id,
+        args: {},
+        background: false,
+      })
+    const tokenUsage = (tokens) =>
+      chat._handleActivity("main", {
+        activity_type: "token_usage",
+        prompt_tokens: tokens,
+        completion_tokens: tokens / 2,
+        total_tokens: tokens * 1.5,
+      })
+    const reasoning = (id, text, segments) =>
+      chat._handleActivity("main", {
+        activity_type: "assistant_reasoning",
+        id,
+        _kt_assistant_segments: segments,
+      })
+    const toolDone = (name, jobId, output) =>
+      chat._handleActivity("main", {
+        activity_type: "tool_done",
+        name,
+        job_id: jobId,
+        output,
+      })
+
+    chat._appendStreamChunk("main", "answer 1")
+    toolStart("read", "call_1", "tc_1")
+    tokenUsage(10)
+    reasoning("reasoning_1", "", [
+      { type: "reasoning", source: "reasoning_content", text: "think 1" },
+      { type: "text", text: "answer 1" },
+      { type: "tool_call_ref", call_id: "call_1" },
+    ])
+    toolDone("read", "call_1", "ok")
+
+    chat._appendStreamChunk("main", "answer 2")
+    toolStart("bash", "call_2", "tc_2")
+    tokenUsage(20)
+    toolDone("bash", "call_2", "done")
+
+    chat._appendStreamChunk("main", "answer 3")
+    toolStart("grep", "call_3", "tc_3")
+    tokenUsage(30)
+    reasoning("reasoning_3", "", [
+      { type: "reasoning", source: "reasoning_content", text: "think 3" },
+      { type: "text", text: "answer 3" },
+      { type: "tool_call_ref", call_id: "call_3" },
+    ])
+
+    const assistant = chat.messagesByTab.main.find((message) => message.role === "assistant")
+    expect(assistant.parts.map((part) => part.type)).toEqual([
+      "reasoning",
+      "text",
+      "tool",
+      "text",
+      "tool",
+      "reasoning",
+      "text",
+      "tool",
+    ])
+    expect(assistant.parts.map((part) => part.text || part.jobId)).toEqual([
+      "think 1",
+      undefined,
+      "call_1",
+      undefined,
+      "call_2",
+      "think 3",
+      undefined,
+      "call_3",
+    ])
   })
 })

--- a/src/kohakuterrarium-frontend/src/stores/chat.reasoning.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.reasoning.test.js
@@ -88,4 +88,124 @@ describe("_replayEvents reasoning segments", () => {
     expect(assistant.parts[0].text).toBe("think 1")
     expect(assistant.parts[2].jobId).toBe("call_1")
   })
+
+  it("keeps multi-round reasoning interleaved with text and tools in arrival order", () => {
+    const events = [
+      { type: "user_input", content: "q", event_id: 1, turn_index: 1, branch_id: 1 },
+      { type: "processing_start", event_id: 2, turn_index: 1, branch_id: 1 },
+      { type: "text_chunk", content: "answer 1", event_id: 3, turn_index: 1, branch_id: 1 },
+      {
+        type: "tool_call",
+        name: "read",
+        args: {},
+        call_id: "call_1",
+        event_id: 4,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      {
+        type: "assistant_reasoning",
+        event_id: 5,
+        turn_index: 1,
+        branch_id: 1,
+        _kt_assistant_segments: [
+          { type: "reasoning", source: "reasoning_content", text: "think 1" },
+          { type: "text", text: "answer 1" },
+          { type: "tool_call_ref", call_id: "call_1" },
+        ],
+      },
+      {
+        type: "tool_result",
+        name: "read",
+        output: "ok",
+        call_id: "call_1",
+        event_id: 6,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      { type: "text_chunk", content: "answer 2", event_id: 7, turn_index: 1, branch_id: 1 },
+      {
+        type: "tool_call",
+        name: "bash",
+        args: {},
+        call_id: "call_2",
+        event_id: 8,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      {
+        type: "assistant_reasoning",
+        event_id: 9,
+        turn_index: 1,
+        branch_id: 1,
+        _kt_assistant_segments: [
+          { type: "reasoning", source: "reasoning_content", text: "think 2" },
+          { type: "text", text: "answer 2" },
+          { type: "tool_call_ref", call_id: "call_2" },
+        ],
+      },
+      {
+        type: "tool_result",
+        name: "bash",
+        output: "done",
+        call_id: "call_2",
+        event_id: 10,
+        turn_index: 1,
+        branch_id: 1,
+      },
+      { type: "processing_end", event_id: 11, turn_index: 1, branch_id: 1 },
+    ]
+    const { messages } = _replayEvents([], events)
+    const assistant = messages.find((message) => message.role === "assistant")
+    expect(assistant.parts.map((part) => part.type)).toEqual([
+      "reasoning",
+      "text",
+      "tool",
+      "reasoning",
+      "text",
+      "tool",
+    ])
+    expect(assistant.parts.map((part) => part.text || part.jobId)).toEqual([
+      "think 1",
+      undefined,
+      "call_1",
+      "think 2",
+      undefined,
+      "call_2",
+    ])
+    expect(assistant.parts[2].result).toBe("ok")
+    expect(assistant.parts[5].result).toBe("done")
+  })
+
+  it("appends a trailing reasoning-only round after prior round parts", () => {
+    const events = [
+      { type: "user_input", content: "q", event_id: 1, turn_index: 1, branch_id: 1 },
+      { type: "processing_start", event_id: 2, turn_index: 1, branch_id: 1 },
+      { type: "text_chunk", content: "answer 1", event_id: 3, turn_index: 1, branch_id: 1 },
+      {
+        type: "assistant_reasoning",
+        event_id: 4,
+        turn_index: 1,
+        branch_id: 1,
+        _kt_assistant_segments: [
+          { type: "reasoning", source: "reasoning_content", text: "think 1" },
+          { type: "text", text: "answer 1" },
+        ],
+      },
+      {
+        type: "assistant_reasoning",
+        event_id: 5,
+        turn_index: 1,
+        branch_id: 1,
+        _kt_assistant_segments: [
+          { type: "reasoning", source: "reasoning_content", text: "think 2" },
+        ],
+      },
+      { type: "processing_end", event_id: 6, turn_index: 1, branch_id: 1 },
+    ]
+    const { messages } = _replayEvents([], events)
+    const assistant = messages.find((message) => message.role === "assistant")
+    expect(assistant.parts.map((part) => part.type)).toEqual(["reasoning", "text", "reasoning"])
+    expect(assistant.parts.map((part) => part.text)).toEqual(["think 1", undefined, "think 2"])
+  })
 })


### PR DESCRIPTION
## Problem

After #166, a turn with multiple controller rounds renders each round's chain-of-thought into the same assistant bubble. Two ordering bugs surfaced:

1. `_insertReasoningSegments` was called once per `assistant_reasoning` event but always scanned from `parts[0]`, so each new round's reasoning was prepended:

   ```text
   R2, R1, text1, tool1, text2, tool2
   ```

2. A controller round can emit no `assistant_reasoning` event (providers reset reasoning metadata per call and the backend only emits the event for non-empty reasoning). The cursor then stayed at the previous reasoning round, so a later reasoning round anchored its text to the intervening round's parts.

## Fix

- Track `_reasoningCursor` on assistant messages. Each `assistant_reasoning` event only reorders/anchor-searches the parts after the previous reasoning insertion, and the cursor advances to the new end.
- Use the existing per-round `token_usage` event as a pending round boundary in both replay and live paths. If reasoning follows, it is inserted normally and the pending boundary is cleared; if no reasoning follows, the next new text/tool/image part commits the boundary first. This keeps the cursor advancing across rounds that emit no reasoning.
- Mark the tail text part as round-closed so replay/live text chunks do not merge across controller-round boundaries.
- Initialize the cursor when `_convertHistory` builds ordered parts from `_kt_assistant_segments`, so snapshot messages stay correct if live reasoning arrives later.

## Tests

Added regressions that fail before this change:

- two reasoning rounds with realistic event order (`tool_result` after `assistant_reasoning`) render as `R1, text1, tool1, R2, text2, tool2`
- a trailing reasoning-only round is appended after its previous round instead of prepended
- an intervening no-reasoning round (`R1 -> text2/tool2 without reasoning -> R3`) renders as `R1, text1, tool1, text2, tool2, R3, text3, tool3`
- the same no-reasoning gap stays correct in the live activity path

Verification:

- `npx vitest run src/stores/chat*.test.js`: 242 passed
- `npx eslint src/stores/chat.js src/stores/chat.reasoning.test.js`
- `npm run format:check`
- `npm run build`