### PR TITLE
feat(subagent): add user-level model defaults

### DIFF
--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -739,6 +739,11 @@ it while its Drive records stay per-user.
 version: 3
 default_model: <preset name>
 
+# Optional exact sub-agent name → default model selector mapping.
+subagent_models:
+  explore: openrouter/mimo-v2.5-pro
+  worker: codex/gpt-5.5
+
 backends:
   <provider-name>:
     backend_type: openai | anthropic | codex  # transport implementation
@@ -782,6 +787,15 @@ base URLs and `api_key_env` values are fixed via built-in defaults.
 Per-agent overrides via `controller.base_url` / `controller.api_key_env`
 still work.
 
+`subagent_models` supplies user-level defaults without editing packaged creature
+configs. Keys match the final `SubAgentConfig.name` exactly. A concrete `model`
+on the creature or sub-agent module still wins; `parent`, `inherit`, and `default`
+explicitly inherit the parent LLM. An absent model, `subagent-default`, or
+`subagent_default` uses the named entry when present, otherwise it inherits the
+parent. The mapping is read when a sub-agent is created, so edits affect future
+jobs only. Conversation and Inspector Trace rows record the model actually bound
+to each new job, preferring its canonical profile selector and falling back to
+the raw model id.
 
 ### Adding a custom LLM backend provider
 

--- a/docs/zh-CN/reference/configuration.md
+++ b/docs/zh-CN/reference/configuration.md
@@ -619,6 +619,11 @@ Drive 记录保持按用户隔离。
 version: 3
 default_model: <preset name>
 
+# 可选：按 subagent 最终名称精确匹配的默认模型 selector。
+subagent_models:
+  explore: openrouter/mimo-v2.5-pro
+  worker: codex/gpt-5.5
+
 backends:
   <provider-name>:
     backend_type: openai | anthropic | codex  # transport 实现
@@ -650,6 +655,8 @@ presets:
 旧值 `codex-oauth` 仍然接受并在读取时正规化为 `codex`。
 
 内置 provider 名称 (`codex`、`openai`、`openrouter`、`anthropic`、`gemini`、`mimo`、`kimi-code`、`glm-coding`) 无法删除；它们的 base URL 与 `api_key_env` 是内置默认固定的。每只代理仍可通过 `controller.base_url` / `controller.api_key_env` 覆盖。
+
+`subagent_models` 允许用户不修改上游 creature 包，直接设置各 subagent 的默认模型。键会与最终的 `SubAgentConfig.name` 精确匹配。creature 或 subagent 模块中具体的 `model` 仍然优先；`parent`、`inherit`、`default` 明确表示继承父 LLM。未设置模型、使用 `subagent-default` 或 `subagent_default` 时会优先采用同名配置，未命中则继承父模型。该映射在创建 subagent 时读取，因此修改只影响之后创建的 job。Conversation 与 Inspector Trace 会记录每个新 job 实际绑定的模型，优先显示规范化 profile selector，缺失时回退到 raw model id。
 
 ### 添加自定义 LLM backend provider
 

--- a/docs/zh-TW/reference/configuration.md
+++ b/docs/zh-TW/reference/configuration.md
@@ -620,6 +620,11 @@ Drive 記錄保持按使用者隔離。
 version: 3
 default_model: <preset name>
 
+# 選用：依 subagent 最終名稱精確匹配的預設模型 selector。
+subagent_models:
+  explore: openrouter/mimo-v2.5-pro
+  worker: codex/gpt-5.5
+
 backends:
   <provider-name>:
     backend_type: openai | anthropic | codex  # transport 實作
@@ -651,6 +656,8 @@ presets:
 舊值 `codex-oauth` 為了向後相容仍會被接受，讀取時會正規化為 `codex`。
 
 內建 provider 名稱 (`codex`、`openai`、`openrouter`、`anthropic`、`gemini`、`mimo`、`kimi-code`、`glm-coding`) 不能刪除；它們的 base URL 與 `api_key_env` 由內建預設值寫死。每隻代理仍然可以用 `controller.base_url` / `controller.api_key_env` 覆寫。
+
+`subagent_models` 讓使用者不用修改上游 creature 套件，就能設定各 subagent 的預設模型。鍵會與最終的 `SubAgentConfig.name` 精確匹配。creature 或 subagent 模組中的具體 `model` 仍然優先；`parent`、`inherit`、`default` 明確表示繼承父 LLM。未設定模型、使用 `subagent-default` 或 `subagent_default` 時會優先採用同名設定，未命中則繼承父模型。此映射在建立 subagent 時讀取，因此修改只影響之後建立的 job。Conversation 與 Inspector Trace 會記錄每個新 job 實際綁定的模型，優先顯示正規化 profile selector，缺少時 fallback 到 raw model id。
 
 ### 新增自訂 LLM backend provider
 

--- a/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.test.js
@@ -47,6 +47,21 @@ const subagentTc = () => ({
   children: [],
 })
 
+describe("ToolCallBlock — sub-agent model identity", () => {
+  it("shows the canonical selector and falls back to the actual model", () => {
+    const canonical = subagentTc()
+    canonical.llm_name = "anthropic/worker@reasoning=high"
+    canonical.model = "claude-actual"
+    expect(mountBlock(canonical).text()).toContain("anthropic/worker@reasoning=high")
+
+    const raw = subagentTc()
+    raw.model = "raw-worker-model"
+    expect(mountBlock(raw).text()).toContain("raw-worker-model")
+
+    expect(mountBlock(subagentTc()).text()).not.toContain("model:")
+  })
+})
+
 describe("ToolCallBlock — sub-agent conversation (UXI-05)", () => {
   it("shows the send box for ANY messageable sub-agent (gated on can_receive, not interactive) and targets by job_id", async () => {
     // ``interactive:false`` but ``can_receive:true`` — the box must still

--- a/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.vue
@@ -6,7 +6,10 @@
       <span class="font-semibold font-mono shrink-0" :class="tc.kind === 'subagent' ? 'text-taaffeite dark:text-taaffeite-light' : 'text-iolite dark:text-iolite-light'">
         {{ tc.kind === "subagent" ? `[sub] ${tc.name}` : tc.name }}
       </span>
-      <span class="text-warm-400 dark:text-warm-500 truncate flex-1 font-mono min-w-0">{{ formatArgs(tc.args) }}</span>
+      <span class="text-warm-400 dark:text-warm-500 truncate flex-1 font-mono min-w-0">
+        {{ formatArgs(tc.args) }}
+        <span v-if="tc.kind === 'subagent' && (tc.llm_name || tc.model)"> · model: {{ tc.llm_name || tc.model }}</span>
+      </span>
       <span v-if="elapsed" class="text-[10px] text-warm-400 font-mono shrink-0">{{ elapsed }}</span>
       <button v-if="canPromote" class="text-[10px] px-1.5 py-0.5 rounded bg-iolite/15 text-iolite hover:bg-iolite/25 shrink-0 font-mono" title="Move to background — agent continues working" aria-label="Move task to background" @click.stop="chat.promoteTask(tc.jobId || tc.id)">→ bg</button>
       <span v-if="tc.result || tc.tools_used?.length || tc.children?.length || tc.status === 'running'" class="i-carbon-chevron-down text-warm-400 transition-transform text-[10px] shrink-0" :class="{ 'rotate-180': expanded }" />

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventRow.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventRow.test.js
@@ -1,0 +1,28 @@
+import { mount } from "@vue/test-utils"
+import { describe, expect, it } from "vitest"
+
+import TraceEventRow from "./TraceEventRow.vue"
+
+function row(event) {
+  return mount(TraceEventRow, { props: { event } })
+}
+
+describe("TraceEventRow sub-agent model identity", () => {
+  it("shows the canonical selector before the effective model", () => {
+    const wrapper = row({
+      type: "subagent_call",
+      name: "explore",
+      llm_name: "anthropic/worker@reasoning=high",
+      model: "claude-actual",
+    })
+    expect(wrapper.text()).toContain("explore · anthropic/worker@reasoning=high")
+    expect(wrapper.text()).not.toContain("claude-actual")
+  })
+
+  it("falls back to the effective model and omits an empty identity", () => {
+    expect(row({ type: "subagent_call", name: "explore", model: "raw-worker" }).text()).toContain(
+      "explore · raw-worker",
+    )
+    expect(row({ type: "subagent_call", name: "explore" }).text()).toContain("explore")
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventRow.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventRow.vue
@@ -84,7 +84,10 @@ const summary = computed(() => {
   const fromOutput = extractTextPreview(e.output, 200)
   if (fromOutput) return fromOutput
   if (e.tool) return String(e.tool)
-  if (e.name) return String(e.name)
+  if (e.name) {
+    const modelIdentity = e.type === "subagent_call" ? e.llm_name || e.model : ""
+    return modelIdentity ? `${e.name} · ${modelIdentity}` : String(e.name)
+  }
   if (Array.isArray(e._kt_assistant_segments)) {
     const first = e._kt_assistant_segments.find((s) => s?.type === "reasoning")
     if (first?.text) return first.text

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -967,14 +967,21 @@ export function _replayEvents(messages, events, branchView = null) {
           timestamp: "",
         })
       } else if (at === "subagent_start") {
-        addTool(
+        const tool = addTool(
           evt.name,
           "subagent",
           evt.args || { info: evt.detail },
           evt.job_id,
           _evtStartedTs(evt),
         )
+        tool.llm_name = evt.llm_name || ""
+        tool.model = evt.model || ""
       } else if (at === "subagent_done") {
+        const tool =
+          findSubagent(evt.name, evt.job_id) ||
+          addTool(evt.name, "subagent", {}, evt.job_id, _evtStartedTs(evt))
+        tool.llm_name = evt.llm_name || tool.llm_name || ""
+        tool.model = evt.model || tool.model || ""
         updateTool(
           evt.name,
           evt.result || evt.detail,
@@ -989,6 +996,11 @@ export function _replayEvents(messages, events, branchView = null) {
           evt.job_id,
         )
       } else if (at === "subagent_error") {
+        const tool =
+          findSubagent(evt.name, evt.job_id) ||
+          addTool(evt.name, "subagent", {}, evt.job_id, _evtStartedTs(evt))
+        tool.llm_name = evt.llm_name || tool.llm_name || ""
+        tool.model = evt.model || tool.model || ""
         updateTool(
           evt.name,
           evt.result || evt.error || evt.detail,
@@ -1095,8 +1107,21 @@ export function _replayEvents(messages, events, branchView = null) {
         evt.call_id || evt.job_id,
       )
     } else if (t === "subagent_call") {
-      addTool(evt.name, "subagent", { task: evt.task || "" }, evt.job_id, _evtStartedTs(evt))
+      const tool = addTool(
+        evt.name,
+        "subagent",
+        { task: evt.task || "" },
+        evt.job_id,
+        _evtStartedTs(evt),
+      )
+      tool.llm_name = evt.llm_name || ""
+      tool.model = evt.model || ""
     } else if (t === "subagent_result") {
+      const tool =
+        findSubagent(evt.name, evt.job_id) ||
+        addTool(evt.name, "subagent", {}, evt.job_id, _evtStartedTs(evt))
+      tool.llm_name = evt.llm_name || tool.llm_name || ""
+      tool.model = evt.model || tool.model || ""
       updateTool(
         evt.name,
         evt.output || evt.error || "",
@@ -3243,6 +3268,8 @@ const _chatStoreOptions = {
           tools_used: data.tools_used || [],
           children: [],
           startedAt: Date.now(),
+          llm_name: at === "subagent_start" ? data.llm_name || "" : "",
+          model: at === "subagent_start" ? data.model || "" : "",
         }
         last.parts.push(startedPart)
         this._indexToolPart(source, startedPart, msgs)
@@ -3277,6 +3304,10 @@ const _chatStoreOptions = {
           this._indexToolPart(source, tc, msgs)
         }
         tc.status = "done"
+        if (at === "subagent_done") {
+          tc.llm_name = data.llm_name || tc.llm_name || ""
+          tc.model = data.model || tc.model || ""
+        }
         const payload = toolResultPayload(data.result || data.output || data.detail || "", data)
         tc.result = payload.result
         tc.resultParts = payload.resultParts
@@ -3310,6 +3341,10 @@ const _chatStoreOptions = {
           this._indexToolPart(source, tc, msgs)
         }
         tc.status = data.interrupted || data.final_state === "interrupted" ? "interrupted" : "error"
+        if (at === "subagent_error") {
+          tc.llm_name = data.llm_name || tc.llm_name || ""
+          tc.model = data.model || tc.model || ""
+        }
         const payload = toolResultPayload(data.result || data.error || data.detail || "", data)
         tc.result = payload.result
         tc.resultParts = payload.resultParts

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -1085,6 +1085,74 @@ describe("chat store — interrupted task handling", () => {
     expect(pendingJobs.agent_explore_1).toBeTruthy()
   })
 
+  it("maps persisted subagent model identity to its job part", () => {
+    const events = [
+      { type: "processing_start" },
+      {
+        type: "subagent_call",
+        name: "explore",
+        job_id: "agent_explore_1",
+        task: "find auth",
+        llm_name: "anthropic/worker@reasoning=high",
+        model: "claude-actual",
+      },
+    ]
+
+    const { messages: replayed } = _replayEvents([], events)
+    const tool = replayed[0].parts[0]
+    expect(tool.llm_name).toBe("anthropic/worker@reasoning=high")
+    expect(tool.model).toBe("claude-actual")
+  })
+
+  it("accepts model identity from a replay terminal when the start is missing", () => {
+    const { messages: replayed } = _replayEvents(
+      [],
+      [
+        { type: "processing_start" },
+        {
+          type: "subagent_result",
+          name: "explore",
+          job_id: "agent_explore_orphan",
+          output: "done",
+          llm_name: "openai/worker",
+          model: "gpt-worker",
+        },
+      ],
+    )
+    const tool = replayed[0].parts[0]
+    expect(tool.llm_name).toBe("openai/worker")
+    expect(tool.model).toBe("gpt-worker")
+  })
+
+  it("maps live subagent model identity on start and orphan terminal events", () => {
+    const chat = useChatStore()
+    chat.messagesByTab = { main: [{ id: "m1", role: "assistant", parts: [] }] }
+    chat.activeTab = "main"
+
+    chat._handleActivity("main", {
+      activity_type: "subagent_start",
+      name: "explore",
+      job_id: "job_start",
+      llm_name: "anthropic/worker@reasoning=high",
+      model: "claude-actual",
+    })
+    let part = chat._findToolPart("main", chat.messagesByTab.main, "explore", "job_start")
+    expect(part.llm_name).toBe("anthropic/worker@reasoning=high")
+    expect(part.model).toBe("claude-actual")
+
+    chat._handleActivity("main", {
+      activity_type: "subagent_error",
+      name: "reviewer",
+      job_id: "job_orphan",
+      error: "failed",
+      llm_name: "openai/reviewer",
+      model: "gpt-reviewer",
+    })
+    part = chat._findToolPart("main", chat.messagesByTab.main, "reviewer", "job_orphan")
+    expect(part.llm_name).toBe("openai/reviewer")
+    expect(part.model).toBe("gpt-reviewer")
+  })
+
   it("derives replay message/part ids from the originating event_id", () => {
     const events = [
       { type: "user_input", event_id: 1, content: "q1" },

--- a/src/kohakuterrarium/bootstrap/llm.py
+++ b/src/kohakuterrarium/bootstrap/llm.py
@@ -12,7 +12,12 @@ from kohakuterrarium.llm.base import LLMConfig, LLMProvider
 from kohakuterrarium.llm.codex_provider import CodexOAuthProvider
 from kohakuterrarium.llm.openai import OpenAIProvider
 from kohakuterrarium.llm import api_keys as _api_keys
-from kohakuterrarium.llm.profiles import LLMProfile, get_api_key, resolve_controller_llm
+from kohakuterrarium.llm.profiles import (
+    LLMProfile,
+    get_api_key,
+    profile_to_identifier,
+    resolve_controller_llm,
+)
 from kohakuterrarium.utils.env_interp import interpolate_env_vars
 from kohakuterrarium.utils.logging import get_logger
 
@@ -266,7 +271,9 @@ def _create_from_profile(profile: LLMProfile) -> LLMProvider:
 
 
 def _apply_backend_native_identity(provider: LLMProvider, profile: LLMProfile) -> None:
-    """Apply backend-native identity and tool capabilities to a provider."""
+    """Apply canonical selector, backend identity, and tool capabilities."""
+    if isinstance(profile, LLMProfile):
+        provider._llm_identifier = profile_to_identifier(profile)
     backend_name = getattr(profile, "backend_provider_name", "")
     if backend_name:
         provider.provider_name = backend_name

--- a/src/kohakuterrarium/core/agent_handlers.py
+++ b/src/kohakuterrarium/core/agent_handlers.py
@@ -46,6 +46,17 @@ _BG_PLACEHOLDER = (
 logger = get_logger(__name__)
 
 
+def _provider_model(provider: object | None) -> str:
+    """Read a provider's effective model across legacy and config-backed shapes."""
+    if provider is None:
+        return ""
+    model = getattr(provider, "model", "") or ""
+    if model:
+        return str(model)
+    config = getattr(provider, "config", None)
+    return str(getattr(config, "model", "") or "")
+
+
 class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMixin):
     """Mixin providing event handling and tool execution for the Agent class.
 
@@ -497,10 +508,19 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
 
         await self._flush_output()
         _, label = _make_job_label(job_id)
+        subagent = self.subagent_manager.get_live_subagent(job_id)
+        provider = getattr(subagent, "llm", None)
         self.output_router.notify_activity(
             "subagent_start",
             f"[{label}] {full_task[:60]}",
-            metadata={"job_id": job_id, "task": full_task, "background": is_bg},
+            metadata={
+                "job_id": job_id,
+                "task": full_task,
+                "background": is_bg,
+                "subagent": parse_event.name,
+                "llm_name": getattr(provider, "_llm_identifier", "") or "",
+                "model": _provider_model(provider),
+            },
         )
 
     def _check_termination(self, round_text: list[str]) -> bool:

--- a/src/kohakuterrarium/core/agent_runtime_tools.py
+++ b/src/kohakuterrarium/core/agent_runtime_tools.py
@@ -164,6 +164,9 @@ class AgentRuntimeToolsMixin:
                 f"[{label}] {state_label}: {error}",
                 metadata={
                     "job_id": job_id,
+                    "subagent": sa_meta.get("subagent", ""),
+                    "llm_name": sa_meta.get("llm_name", ""),
+                    "model": sa_meta.get("model", ""),
                     "error": error,
                     "interrupted": interrupted,
                     "cancelled": cancelled,
@@ -185,6 +188,9 @@ class AgentRuntimeToolsMixin:
                 f"[{label}] tools: {tools_summary}",
                 metadata={
                     "job_id": job_id,
+                    "subagent": sa_meta.get("subagent", ""),
+                    "llm_name": sa_meta.get("llm_name", ""),
+                    "model": sa_meta.get("model", ""),
                     "tools_used": tools_used,
                     "result": content,
                     "turns": sa_meta.get("turns", 0),

--- a/src/kohakuterrarium/core/agent_tools.py
+++ b/src/kohakuterrarium/core/agent_tools.py
@@ -371,8 +371,12 @@ class AgentToolsMixin(AgentRuntimeToolsMixin):
             if hasattr(result, "turns"):
                 if event.context is None:
                     event.context = {}
+                result_metadata = getattr(result, "metadata", {})
                 event.context["subagent_metadata"] = {
-                    "tools_used": getattr(result, "metadata", {}).get("tools_used", []),
+                    "tools_used": result_metadata.get("tools_used", []),
+                    "subagent": result_metadata.get("subagent", ""),
+                    "llm_name": result_metadata.get("llm_name", ""),
+                    "model": result_metadata.get("model", ""),
                     "turns": result.turns,
                     "duration": getattr(result, "duration", 0),
                     "total_tokens": getattr(result, "total_tokens", 0),
@@ -514,7 +518,11 @@ class AgentToolsMixin(AgentRuntimeToolsMixin):
             "output_preview": preview,
         }
         if is_subagent:
+            result_metadata = getattr(result, "metadata", {})
             metadata["result"] = preview
+            metadata["subagent"] = result_metadata.get("subagent", metric_name)
+            metadata["llm_name"] = result_metadata.get("llm_name", "")
+            metadata["model"] = result_metadata.get("model", "")
             metadata["turns"] = getattr(result, "turns", 0)
             metadata["duration"] = getattr(result, "duration", 0)
             metadata["total_tokens"] = getattr(result, "total_tokens", 0)

--- a/src/kohakuterrarium/llm/preset_store.py
+++ b/src/kohakuterrarium/llm/preset_store.py
@@ -84,6 +84,18 @@ def _looks_nested(stored: dict[str, Any]) -> bool:
     return True
 
 
+def get_subagent_models() -> dict[str, str]:
+    """Return exact sub-agent name to model-selector defaults."""
+    stored = _load_yaml().get("subagent_models", {})
+    if not isinstance(stored, dict):
+        return {}
+    return {
+        name: selector
+        for name, selector in stored.items()
+        if isinstance(name, str) and isinstance(selector, str) and selector.strip()
+    }
+
+
 def load_presets() -> dict[tuple[str, str], LLMPreset]:
     """Load nested or legacy presets, with host-resolved worker entries authoritative."""
     data = _load_yaml()
@@ -105,11 +117,14 @@ def serialize_user_data(
     presets: dict[tuple[str, str], LLMPreset],
     backends: dict[str, LLMBackend],
     default_model: str = "",
+    subagent_models: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Serialize user providers and presets in the current nested schema."""
     data: dict[str, Any] = {"version": _SCHEMA_VERSION}
     if default_model:
         data["default_model"] = default_model
+    if subagent_models:
+        data["subagent_models"] = dict(subagent_models)
     user_backends = {
         name: backend.to_dict()
         for name, backend in backends.items()

--- a/src/kohakuterrarium/llm/profiles.py
+++ b/src/kohakuterrarium/llm/profiles.py
@@ -35,7 +35,7 @@ from kohakuterrarium.llm.backends import (
     validate_backend_type,
 )
 from kohakuterrarium.llm.codex_auth import CodexTokens
-from kohakuterrarium.llm.preset_store import load_presets
+from kohakuterrarium.llm.preset_store import get_subagent_models, load_presets
 from kohakuterrarium.llm.preset_store import preset_from_data as _preset_from_data
 from kohakuterrarium.llm.preset_store import serialize_user_data as _serialize_user_data
 from kohakuterrarium.llm.presets import ALIASES as ALIASES
@@ -64,7 +64,14 @@ def save_backend(backend: LLMBackend) -> None:
     backends = load_backends()
     presets = load_presets()
     backends[backend.name] = backend
-    _save_yaml(_serialize_user_data(presets, backends, data.get("default_model", "")))
+    _save_yaml(
+        _serialize_user_data(
+            presets,
+            backends,
+            data.get("default_model", ""),
+            get_subagent_models(),
+        )
+    )
 
 
 def delete_backend(name: str) -> bool:
@@ -79,7 +86,14 @@ def delete_backend(name: str) -> bool:
         raise ValueError(f"Provider still in use by one or more presets: {name}")
     backends = load_backends()
     backends.pop(name, None)
-    _save_yaml(_serialize_user_data(presets, backends, data.get("default_model", "")))
+    _save_yaml(
+        _serialize_user_data(
+            presets,
+            backends,
+            data.get("default_model", ""),
+            get_subagent_models(),
+        )
+    )
     save_api_key(name, "")
     return True
 
@@ -181,7 +195,11 @@ def _upgrade_bare_default(bare: str) -> str:
 
 
 def set_default_model(model_name: str) -> None:
-    _save_yaml(_serialize_user_data(load_presets(), load_backends(), model_name))
+    _save_yaml(
+        _serialize_user_data(
+            load_presets(), load_backends(), model_name, get_subagent_models()
+        )
+    )
 
 
 def save_profile(profile: LLMProfile | LLMPreset) -> None:
@@ -215,7 +233,14 @@ def save_profile(profile: LLMProfile | LLMPreset) -> None:
         raise ValueError(f"Provider not found: {preset.provider}")
     presets = load_presets()
     presets[(preset.provider, preset.name)] = preset
-    _save_yaml(_serialize_user_data(presets, backends, data.get("default_model", "")))
+    _save_yaml(
+        _serialize_user_data(
+            presets,
+            backends,
+            data.get("default_model", ""),
+            get_subagent_models(),
+        )
+    )
 
 
 def delete_profile(name: str, provider: str = "") -> bool:
@@ -233,7 +258,12 @@ def delete_profile(name: str, provider: str = "") -> bool:
             return False
         presets.pop(hits[0])
     _save_yaml(
-        _serialize_user_data(presets, load_backends(), data.get("default_model", ""))
+        _serialize_user_data(
+            presets,
+            load_backends(),
+            data.get("default_model", ""),
+            get_subagent_models(),
+        )
     )
     return True
 

--- a/src/kohakuterrarium/modules/subagent/manager.py
+++ b/src/kohakuterrarium/modules/subagent/manager.py
@@ -252,6 +252,18 @@ class SubAgentManager(InteractiveManagerMixin):
         job_id = await self.spawn(event.name, task, background=True)
         return job_id, is_background
 
+    @staticmethod
+    def _stamp_model_metadata(result: SubAgentResult, subagent: SubAgent) -> None:
+        result.metadata.update(
+            {
+                "subagent": subagent.config.name,
+                "llm_name": getattr(subagent.llm, "_llm_identifier", "") or "",
+                "model": getattr(subagent.llm, "model", "")
+                or getattr(getattr(subagent.llm, "config", None), "model", "")
+                or "",
+            }
+        )
+
     async def _run_subagent(
         self,
         job_id: str,
@@ -280,6 +292,7 @@ class SubAgentManager(InteractiveManagerMixin):
                         error=str(exc),
                         exc_info=True,
                     )
+            self._stamp_model_metadata(result, job.subagent)
             self._results[job_id] = result
 
             if result.interrupted or result.cancelled:
@@ -317,6 +330,7 @@ class SubAgentManager(InteractiveManagerMixin):
                 result = current(error_msg, cancelled=True)
             else:
                 result = SubAgentResult(success=False, error=error_msg, cancelled=True)
+            self._stamp_model_metadata(result, job.subagent)
             self._results[job_id] = result
             self.job_store.update_status(
                 job_id,
@@ -332,6 +346,7 @@ class SubAgentManager(InteractiveManagerMixin):
                 result = current(str(e))
             else:
                 result = SubAgentResult(success=False, error=str(e))
+            self._stamp_model_metadata(result, job.subagent)
             self._results[job_id] = result
             self.job_store.update_status(
                 job_id,

--- a/src/kohakuterrarium/modules/subagent/model_resolve.py
+++ b/src/kohakuterrarium/modules/subagent/model_resolve.py
@@ -6,6 +6,7 @@ Selectors may name a full profile or a raw model ID on the parent provider.
 from kohakuterrarium.errors import LLMNotConfiguredError
 from kohakuterrarium.bootstrap.llm import _create_from_profile
 from kohakuterrarium.llm.base import LLMProvider
+from kohakuterrarium.llm.preset_store import get_subagent_models
 from kohakuterrarium.llm.profiles import get_profile
 from kohakuterrarium.utils.logging import get_logger
 from kohakuterrarium.modules.subagent.config import SubAgentConfig
@@ -13,9 +14,9 @@ from kohakuterrarium.modules.subagent.config import SubAgentConfig
 logger = get_logger(__name__)
 
 
-# These aliases bypass provider validation because they denote inheritance.
-_INHERIT_PARENT_SENTINELS: frozenset[str] = frozenset(
-    {"subagent-default", "subagent_default", "default", "inherit", "parent"}
+_INHERIT_PARENT_SENTINELS: frozenset[str] = frozenset({"default", "inherit", "parent"})
+_NAMED_DEFAULT_SENTINELS: frozenset[str] = frozenset(
+    {"subagent-default", "subagent_default"}
 )
 
 
@@ -24,8 +25,13 @@ def resolve_subagent_llm(
 ) -> LLMProvider:
     """Resolve a profile selector or apply a same-provider model override."""
     name = (config.model or "").strip()
-    if not name or name.lower() in _INHERIT_PARENT_SENTINELS:
+    lowered = name.lower()
+    if lowered in _INHERIT_PARENT_SENTINELS:
         return parent_llm
+    if not name or lowered in _NAMED_DEFAULT_SENTINELS:
+        name = get_subagent_models().get(config.name, "").strip()
+        if not name:
+            return parent_llm
 
     # Direct lookup avoids warning for valid raw model IDs that are not profiles.
     profile = get_profile(name)

--- a/src/kohakuterrarium/session/output.py
+++ b/src/kohakuterrarium/session/output.py
@@ -488,6 +488,7 @@ class SessionOutput(OutputModule):
         )
 
     def _handle_subagent_start(self, name: str, detail: str, metadata: dict) -> None:
+        name = _subagent_name(name, metadata)
         task = metadata.get("task", detail)
         job_id = metadata.get("job_id", "")
         if job_id:
@@ -495,6 +496,8 @@ class SessionOutput(OutputModule):
             self._subagent_tasks[job_id] = {
                 "name": name,
                 "task": task,
+                "llm_name": metadata.get("llm_name", ""),
+                "model": metadata.get("model", ""),
             }
         self._record(
             "subagent_call",
@@ -503,11 +506,14 @@ class SessionOutput(OutputModule):
                 "task": task,
                 "job_id": job_id,
                 "background": bool(metadata.get("background", False)),
+                "llm_name": metadata.get("llm_name", ""),
+                "model": metadata.get("model", ""),
             },
         )
 
     def _handle_subagent_done(self, name: str, detail: str, metadata: dict) -> None:
         job_id = metadata.get("job_id", "")
+        task_record = self._subagent_tasks.get(job_id) or {}
         name = _subagent_name(name, metadata)
         output_text = metadata.get("result", detail)
         self._record(
@@ -519,6 +525,9 @@ class SessionOutput(OutputModule):
                 "tools_used": metadata.get("tools_used", []),
                 "turns": metadata.get("turns", 0),
                 "duration": metadata.get("duration", 0),
+                "llm_name": metadata.get("llm_name", "")
+                or task_record.get("llm_name", ""),
+                "model": metadata.get("model", "") or task_record.get("model", ""),
                 **_token_metadata(metadata),
             },
         )
@@ -541,6 +550,7 @@ class SessionOutput(OutputModule):
 
     def _handle_subagent_error(self, name: str, detail: str, metadata: dict) -> None:
         job_id = metadata.get("job_id", "")
+        task_record = self._subagent_tasks.get(job_id) or {}
         name = _subagent_name(name, metadata)
         output_text = metadata.get("result", detail)
         self._record(
@@ -557,6 +567,9 @@ class SessionOutput(OutputModule):
                 "tools_used": metadata.get("tools_used", []),
                 "turns": metadata.get("turns", 0),
                 "duration": metadata.get("duration", 0),
+                "llm_name": metadata.get("llm_name", "")
+                or task_record.get("llm_name", ""),
+                "model": metadata.get("model", "") or task_record.get("model", ""),
                 **_token_metadata(metadata),
             },
         )
@@ -597,6 +610,10 @@ class SessionOutput(OutputModule):
                     "tools_used": metadata.get("tools_used", []),
                     "success": success,
                     "duration": metadata.get("duration", 0),
+                    "llm_name": metadata.get("llm_name", "")
+                    or (task_record or {}).get("llm_name", ""),
+                    "model": metadata.get("model", "")
+                    or (task_record or {}).get("model", ""),
                     "output_preview": (output_text or "")[:500],
                     "source": "session_output",
                 },

--- a/src/kohakuterrarium/studio/attach/_event_stream.py
+++ b/src/kohakuterrarium/studio/attach/_event_stream.py
@@ -163,6 +163,8 @@ class StreamOutput(OutputModule):
         self, activity_type: str, detail: str, metadata: dict
     ) -> None:
         name, info = _parse_detail(detail)
+        if activity_type.startswith("subagent_"):
+            name = metadata.get("subagent") or name
         frame_id = f"{activity_type}_{self._n}"
         msg: dict = {
             "type": "activity",
@@ -304,6 +306,7 @@ _STREAM_METADATA_KEYS = (
     "summary",
     "messages_compacted",
     "session_id",
+    "llm_name",
     "model",
     "agent_name",
     "max_context",

--- a/tests/unit/bootstrap/test_llm.py
+++ b/tests/unit/bootstrap/test_llm.py
@@ -230,6 +230,8 @@ class TestCreateFromProfile:
         assert isinstance(provider, OpenAIProvider)
         # max_context from the profile is stamped onto the provider.
         assert provider._profile_max_context == 123456
+        assert provider._llm_identifier == "openai/p"
+        assert provider.config.model == "gpt-4o"
 
     def test_anthropic_backend_builds_anthropic_provider(self, monkeypatch):
         monkeypatch.setattr(llm_mod, "get_api_key", lambda p: "k")

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -3607,6 +3607,43 @@ class TestDispatchSubAgentEventDirect:
         finally:
             await agent.stop()
 
+    async def test_real_dispatch_start_metadata_uses_resolved_child_provider(
+        self, make_agent, monkeypatch
+    ):
+        from kohakuterrarium.parsing import SubAgentCallEvent
+        from kohakuterrarium.modules.subagent.config import SubAgentConfig
+
+        agent = make_agent()
+        agent.llm.model = "gpt-child-actual"
+        agent.llm._llm_identifier = "openai/child-profile@reasoning=high"
+        agent.subagent_manager.llm = agent.llm
+        agent.subagent_manager._configs["explore"] = SubAgentConfig(
+            name="explore", model="parent"
+        )
+        calls = []
+        original = agent.output_router.notify_activity
+
+        def capture(activity_type, detail, metadata=None):
+            calls.append((activity_type, detail, metadata or {}))
+            return original(activity_type, detail, metadata)
+
+        monkeypatch.setattr(agent.output_router, "notify_activity", capture)
+        await agent.start()
+        try:
+            await agent._dispatch_subagent_event(
+                SubAgentCallEvent(name="explore", args={"task": "inspect"}, raw=""),
+                agent.controller,
+                {},
+                [],
+                {},
+                False,
+            )
+            start = next(call for call in calls if call[0] == "subagent_start")
+            assert start[2]["model"] == "gpt-child-actual"
+            assert start[2]["llm_name"] == "openai/child-profile@reasoning=high"
+        finally:
+            await agent.stop()
+
     async def test_dispatch_vetoed_by_plugin(self, make_agent):
         from kohakuterrarium.modules.plugin.base import (
             BasePlugin,

--- a/tests/unit/core/test_agent_runtime_tools.py
+++ b/tests/unit/core/test_agent_runtime_tools.py
@@ -329,6 +329,9 @@ class TestOnBgComplete:
                     "turns": 3,
                     "duration": 1.5,
                     "total_tokens": 100,
+                    "subagent": "explore",
+                    "llm_name": "openai/worker",
+                    "model": "gpt-worker",
                 }
             },
         )
@@ -339,6 +342,9 @@ class TestOnBgComplete:
             c[2] for c in a.output_router.activity_calls if c[0] == "subagent_done"
         )
         assert meta["turns"] == 3
+        assert meta["subagent"] == "explore"
+        assert meta["llm_name"] == "openai/worker"
+        assert meta["model"] == "gpt-worker"
 
     async def test_error_path(self):
         a = _make_mixin()

--- a/tests/unit/core/test_agent_tools.py
+++ b/tests/unit/core/test_agent_tools.py
@@ -250,11 +250,22 @@ class TestEmitDirectCompletion:
         result.prompt_tokens = 60
         result.completion_tokens = 40
         result.cached_tokens = 20
-        result.metadata = {"tools_used": ["bash"]}
+        result.metadata = {
+            "tools_used": ["bash"],
+            "subagent": "explore",
+            "llm_name": "openai/worker",
+            "model": "gpt-worker",
+        }
         result.get_text_output = lambda: "ok output"
         agent._emit_direct_completion_activity("agent_x", result)
         kinds = [c[0] for c in agent.output_router.activity_calls]
         assert "subagent_done" in kinds
+        meta = next(
+            c[2] for c in agent.output_router.activity_calls if c[0] == "subagent_done"
+        )
+        assert meta["subagent"] == "explore"
+        assert meta["llm_name"] == "openai/worker"
+        assert meta["model"] == "gpt-worker"
 
 
 # ── _emit_interrupted_activity ───────────────────────────────────

--- a/tests/unit/llm/test_preset_store.py
+++ b/tests/unit/llm/test_preset_store.py
@@ -204,3 +204,8 @@ class TestSerializeUserData:
         loaded = load_presets()
         assert loaded[("openai", "rt")].max_output == 999
         assert loaded[("openai", "rt")].model == "gpt-4o"
+
+    def test_named_subagent_models_are_serialised_without_normalisation(self):
+        mapping = {"researcher": "anthropic/claude-sonnet", "Reviewer": "raw-model"}
+        data = serialize_user_data({}, {}, subagent_models=mapping)
+        assert data["subagent_models"] == mapping

--- a/tests/unit/llm/test_profiles.py
+++ b/tests/unit/llm/test_profiles.py
@@ -498,6 +498,29 @@ class TestIsAvailable:
 
 
 class TestBackendCrud:
+    def test_all_yaml_rewrites_preserve_subagent_models_profiles_and_backends(self):
+        from kohakuterrarium.llm.backends import load_yaml_store, save_yaml_store
+
+        mapping = {
+            "explore": "anthropic/worker@reasoning=high",
+            "Reviewer": "raw-review-model",
+        }
+        save_yaml_store({"version": 3, "subagent_models": mapping})
+
+        save_backend(LLMBackend(name="proxy", backend_type="openai"))
+        save_profile(LLMPreset(name="worker", model="m1", provider="proxy"))
+        set_default_model("proxy/worker")
+        save_backend(LLMBackend(name="spare", backend_type="openai"))
+        assert delete_backend("spare") is True
+        save_profile(LLMPreset(name="temporary", model="m2", provider="proxy"))
+        assert delete_profile("temporary", provider="proxy") is True
+
+        stored = load_yaml_store()
+        assert stored["subagent_models"] == mapping
+        assert stored["default_model"] == "proxy/worker"
+        assert stored["backends"]["proxy"]["backend_type"] == "openai"
+        assert stored["presets"]["proxy"]["worker"]["model"] == "m1"
+
     def test_save_then_load_custom_backend(self):
         backend = LLMBackend(
             name="my-proxy",

--- a/tests/unit/modules/subagent/test_manager.py
+++ b/tests/unit/modules/subagent/test_manager.py
@@ -468,6 +468,20 @@ class TestRunSubagentOutcomes:
         assert result.interrupted is True
         assert mgr.get_status(job_id).state is JobState.CANCELLED
 
+    async def test_result_metadata_records_actual_model_identity(self):
+        llm = ScriptedLLM(["done"])
+        llm.model = "gpt-worker"
+        llm._llm_identifier = "openai/worker@reasoning=high"
+        mgr = SubAgentManager(Registry(), llm)
+        mgr.register(SubAgentConfig(name="explore", model="parent"))
+
+        job_id = await mgr.spawn("explore", "task", background=False)
+        result = mgr.get_result(job_id)
+
+        assert result.metadata["subagent"] == "explore"
+        assert result.metadata["llm_name"] == "openai/worker@reasoning=high"
+        assert result.metadata["model"] == "gpt-worker"
+
     async def test_cancel_all_cancels_running_tasks(self):
         import asyncio
 

--- a/tests/unit/modules/subagent/test_runtime_builders.py
+++ b/tests/unit/modules/subagent/test_runtime_builders.py
@@ -53,13 +53,36 @@ class TestResolveLLM:
         # canonical resolver so the two code paths never diverge.
         assert resolve_llm is resolve_subagent_llm
 
-    def test_empty_model_inherits_parent(self, monkeypatch):
+    def test_empty_model_uses_exact_named_global_selector(self, monkeypatch):
+        parent = _FakeLLM()
+        selected = object()
+        monkeypatch.setattr(
+            model_resolve, "get_subagent_models", lambda: {"x": "openai/worker"}
+        )
+        monkeypatch.setattr(model_resolve, "get_profile", lambda name: object())
+        monkeypatch.setattr(
+            model_resolve, "_create_from_profile", lambda profile: selected
+        )
+        cfg = SubAgentConfig(name="x", model=None)
+        assert resolve_llm(parent, cfg) is selected
+        assert parent.with_model_calls == []
+
+    def test_empty_model_inherits_when_named_global_missing(self, monkeypatch):
         _no_profiles(monkeypatch)
+        monkeypatch.setattr(model_resolve, "get_subagent_models", lambda: {})
         parent = _FakeLLM()
         cfg = SubAgentConfig(name="x", model=None)
         assert resolve_llm(parent, cfg) is parent
-        # No model switch attempted.
         assert parent.with_model_calls == []
+
+    def test_parent_sentinel_never_uses_named_global(self, monkeypatch):
+        _no_profiles(monkeypatch)
+        monkeypatch.setattr(
+            model_resolve, "get_subagent_models", lambda: {"x": "openai/worker"}
+        )
+        parent = _FakeLLM()
+        cfg = SubAgentConfig(name="x", model="parent")
+        assert resolve_llm(parent, cfg) is parent
 
     def test_sentinel_model_inherits_parent(self, monkeypatch):
         _no_profiles(monkeypatch)

--- a/tests/unit/session/test_output.py
+++ b/tests/unit/session/test_output.py
@@ -622,7 +622,12 @@ class TestActivityHandlers:
             out.on_activity_with_metadata(
                 "subagent_start",
                 "[explore] task",
-                {"job_id": "j1", "task": "find x"},
+                {
+                    "job_id": "j1",
+                    "task": "find x",
+                    "llm_name": "openai/worker",
+                    "model": "gpt-worker",
+                },
             )
             out.on_activity_with_metadata(
                 "subagent_done",
@@ -631,14 +636,35 @@ class TestActivityHandlers:
             )
             store.flush()
             evts = store.get_events("alice")
-            assert any(e["type"] == "subagent_call" for e in evts)
-            assert any(e["type"] == "subagent_result" for e in evts)
+            call = next(e for e in evts if e["type"] == "subagent_call")
+            assert call["name"] == "explore"
+            assert call["llm_name"] == "openai/worker"
+            assert call["model"] == "gpt-worker"
+            result = next(e for e in evts if e["type"] == "subagent_result")
+            assert result["llm_name"] == "openai/worker"
+            assert result["model"] == "gpt-worker"
             # SubAgent conversation persisted.
             convo = store.load_subagent_conversation("alice", "explore", 0)
             assert convo is not None
             parsed = json.loads(convo)
             assert parsed[0]["role"] == "user"
             assert parsed[1]["content"] == "found"
+        finally:
+            store.close()
+
+    def test_subagent_start_uses_metadata_name_over_job_label(self, tmp_path):
+        store, out = _make(tmp_path)
+        try:
+            out.on_activity_with_metadata(
+                "subagent_start",
+                "[agent_explore[abc12345]] task",
+                {"job_id": "agent_explore_abc12345", "subagent": "explore"},
+            )
+            store.flush()
+            call = next(
+                e for e in store.get_events("alice") if e["type"] == "subagent_call"
+            )
+            assert call["name"] == "explore"
         finally:
             store.close()
 

--- a/tests/unit/studio/test_event_stream.py
+++ b/tests/unit/studio/test_event_stream.py
@@ -118,6 +118,23 @@ class TestStreamOutputSync:
         # Unknown keys are filtered.
         assert "unknown_key" not in msg
 
+    def test_subagent_model_identity_is_streamed(self, _stream):
+        so, q, _log = _stream
+        so.on_activity_with_metadata(
+            "subagent_start",
+            "[explore] task",
+            metadata={
+                "job_id": "j1",
+                "subagent": "explore",
+                "llm_name": "openai/worker@reasoning=high",
+                "model": "gpt-worker",
+            },
+        )
+        msg = q.get_nowait()
+        assert msg["name"] == "explore"
+        assert msg["llm_name"] == "openai/worker@reasoning=high"
+        assert msg["model"] == "gpt-worker"
+
     def test_assistant_reasoning_metadata_streams_segments(self, _stream):
         so, q, _log = _stream
         so.on_activity_with_metadata(


### PR DESCRIPTION
Add user-level defaults for named subagent models and persist the model identity actually bound to each job. Conversation and Inspector Trace now show the canonical selector when available, with the actual model ID as fallback.

## PR Type

- [ ] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Packaged creatures can select subagent models, but end users should not need to edit or fork an upstream creature package to choose models for common subagents such as `explore` and `worker`.

Historical job displays also need to use persisted runtime facts rather than infer a model from the current configuration, which may have changed since the job ran.

## Changes

- Add an exact-name `subagent_models` mapping to the existing user-level `llm_profiles.yaml` store and preserve it across all profile/backend/default rewrites.
- Apply named defaults only when a subagent has no concrete override or uses `subagent-default`; keep explicit model selectors and parent-inheritance sentinels authoritative.
- Preserve the canonical profile selector on resolved providers and propagate each job's canonical selector plus actual model ID through live and persisted subagent events.
- Show the actual job model in Conversation and Inspector Trace, preferring the canonical selector and falling back to the model ID.
- Document the configuration and behavior in English, Simplified Chinese, and Traditional Chinese.

## Validation

```bash
python -m ruff check src/ tests/
python -m black --check --target-version py310 src/ tests/
python -m pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
python -m pytest tests/unit/test_file_sizes.py -q
python -m pytest tests/integration/ -q

cd src/kohakuterrarium-frontend
npm test -- --run src/stores/chat.test.js src/components/chat/ToolCallBlock.test.js src/components/sessions/trace/TraceEventRow.test.js
npx prettier --check src/stores/chat.js src/stores/chat.test.js src/components/chat/ToolCallBlock.vue src/components/chat/ToolCallBlock.test.js src/components/sessions/trace/TraceEventRow.vue src/components/sessions/trace/TraceEventRow.test.js
npx eslint src/stores/chat.js src/stores/chat.test.js src/components/chat/ToolCallBlock.vue src/components/chat/ToolCallBlock.test.js src/components/sessions/trace/TraceEventRow.vue src/components/sessions/trace/TraceEventRow.test.js
npm run build
```

Results:

- Ruff and Black passed.
- Full unit run: 12,062 passed, 9 skipped, with 6 unrelated Windows-local Dulwich failures described under Exceptions / Not Run.
- Focused affected Python unit/integration suite: 680 passed.
- File-size guard: 1,700 passed.
- Affected frontend tests: 176 passed.
- Prettier, ESLint, and the production frontend build passed for the changed frontend surface.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #171
- Community discussion opened and approved before this PR on **2026-08-19**.
- Approved by maintainer **KohakuBlueleaf** on **2026-08-19 01:55 UTC+8** with: **“可以做”** ("go ahead").
- The PR matches the approved scope: static, single-node, exact-name defaults for future subagent jobs, with persisted runtime model identity and Conversation/Inspector Trace display. It does not add runtime switching, session overrides, a dedicated configuration UI, or Laboratory/multi-node propagation.

## Notes for Reviewers

The key behavior boundaries are encoded in `modules/subagent/model_resolve.py`: concrete creature selectors win, explicit parent-inheritance sentinels inherit, and only unset/`subagent-default` selectors consult the user mapping. Runtime displays are derived from the provider bound to the actual job, not from the current config.

## Screenshots / Logs (if applicable)

The UI change is a compact model label in existing subagent job rows; no layout or configuration screen was added.

## Breaking Changes (if applicable)

None. Existing configurations without `subagent_models` retain their previous behavior, and older session events without model fields remain readable.

## Exceptions / Not Run

- The full local unit suite completed with **12,062 passed, 9 skipped, 6 failed**. All six failures are in `tests/unit/packages/test_git_backend_dulwich_integration.py` and fail while their fixture pushes hard-coded `refs/heads/master`; this machine creates the temporary repository on `main`, so Dulwich raises `KeyError: refs/heads/master` before the code changed by this PR is exercised. The affected feature tests and integration tests pass.
- Fork CI does not start on a plain feature-branch push because `.github/workflows/ci.yml` triggers pushes only on `main` and pull requests targeting `main`. GitHub Actions is enabled on the fork; opening this PR is what creates the pull-request CI run.
- The complete frontend Vitest suite has existing environment failures in unrelated Studio tests (`localStorage` unavailable in the current Node test process and one page import timeout). The affected frontend test files all pass, and the required format/build checks pass for the changed surface.
- E2E was not run because this change does not alter multi-node, Laboratory, Studio serving, or transport topology.
