### PR TITLE
fix(subagents): require self-contained task context

### DIFF
--- a/src/kohakuterrarium/bootstrap/agent_init.py
+++ b/src/kohakuterrarium/bootstrap/agent_init.py
@@ -307,6 +307,7 @@ class AgentInitMixin:
             system_prompt=system_prompt,
             include_job_status=True,
             include_tools_list=False,  # The aggregated prompt already contains tools.
+            include_subagent_schema_guidance=self.config.include_tools_in_prompt,
             max_messages=self.config.max_messages,
             ephemeral=self.config.ephemeral,
             known_outputs=getattr(self, "_known_outputs", set()),

--- a/src/kohakuterrarium/core/controller.py
+++ b/src/kohakuterrarium/core/controller.py
@@ -101,6 +101,7 @@ class ControllerConfig:
     # Compaction can separate native calls from results; providers must not see
     # either half of such an orphaned exchange.
     sanitize_orphan_tool_calls: bool = True
+    include_subagent_schema_guidance: bool = True
 
 
 @dataclass
@@ -248,7 +249,10 @@ class Controller:
 
     def _get_native_tool_schemas(self) -> "list[ToolSchema]":
         """Build callable schemas, applying plugin tool-visibility restrictions."""
-        schemas = build_tool_schemas(self.registry)
+        schemas = build_tool_schemas(
+            self.registry,
+            include_subagent_guidance=self.config.include_subagent_schema_guidance,
+        )
         visibility = self._get_tool_visibility()
         if visibility is None:
             return schemas

--- a/src/kohakuterrarium/llm/tools.py
+++ b/src/kohakuterrarium/llm/tools.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from kohakuterrarium.core.registry import Registry
 from kohakuterrarium.llm.base import ToolSchema
+from kohakuterrarium.modules.subagent_guidance import TASK_SUBAGENT_CONTEXT_GUIDANCE
 
 # Built-in schemas remain centralized so registry dispatch stays provider-agnostic.
 from kohakuterrarium.llm.tool_schemas import _BUILTIN_SCHEMAS
@@ -14,7 +15,11 @@ from kohakuterrarium.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def build_tool_schemas(registry: Registry) -> list[ToolSchema]:
+def build_tool_schemas(
+    registry: Registry,
+    *,
+    include_subagent_guidance: bool = True,
+) -> list[ToolSchema]:
     """Build callable schemas, excluding tools translated natively by providers."""
     schemas: list[ToolSchema] = []
 
@@ -86,7 +91,11 @@ def build_tool_schemas(registry: Registry) -> list[ToolSchema]:
                     "properties": {
                         "task": {
                             "type": "string",
-                            "description": "Task description for the sub-agent",
+                            "description": (
+                                TASK_SUBAGENT_CONTEXT_GUIDANCE
+                                if include_subagent_guidance
+                                else "Task description for the sub-agent"
+                            ),
                         },
                         "run_in_background": {
                             "type": "boolean",

--- a/src/kohakuterrarium/modules/subagent/manager.py
+++ b/src/kohakuterrarium/modules/subagent/manager.py
@@ -12,6 +12,7 @@ from kohakuterrarium.core.registry import Registry
 from kohakuterrarium.llm.base import LLMProvider
 from kohakuterrarium.modules.subagent.base import SubAgent, SubAgentJob, SubAgentResult
 from kohakuterrarium.modules.subagent.config import SubAgentConfig, SubAgentInfo
+from kohakuterrarium.modules.subagent_guidance import TASK_SUBAGENT_CONTEXT_GUIDANCE
 from kohakuterrarium.modules.subagent.runtime_builders import (
     build_compact_manager,
     build_plugin_manager,
@@ -131,6 +132,7 @@ class SubAgentManager(InteractiveManagerMixin):
             lines.append("Sub-agents are called as tools via the API (param: `task`).")
         else:
             lines.append("Call sub-agents like tools with a task description.")
+        lines.append(TASK_SUBAGENT_CONTEXT_GUIDANCE)
 
         return "\n".join(lines)
 

--- a/src/kohakuterrarium/modules/subagent_guidance.py
+++ b/src/kohakuterrarium/modules/subagent_guidance.py
@@ -1,0 +1,9 @@
+"""Shared guidance for one-shot task-subagent invocations."""
+
+TASK_SUBAGENT_CONTEXT_GUIDANCE = (
+    "Each task-subagent call is a fresh, context-isolated invocation. It cannot "
+    "resume or inherit conversation history from previous calls. Provide a "
+    "complete, self-contained task that includes the original goal, current "
+    "state, work already completed, what remains, and any relevant paths, "
+    "errors, or findings. Never use shorthand such as 'continue the previous task'."
+)

--- a/tests/integration/test_llm.py
+++ b/tests/integration/test_llm.py
@@ -910,7 +910,15 @@ class TestLlmIntegration:
             "properties": {
                 "task": {
                     "type": "string",
-                    "description": "Task description for the sub-agent",
+                    "description": (
+                        "Each task-subagent call is a fresh, context-isolated "
+                        "invocation. It cannot resume or inherit conversation history "
+                        "from previous calls. Provide a complete, self-contained task "
+                        "that includes the original goal, current state, work already "
+                        "completed, what remains, and any relevant paths, errors, or "
+                        "findings. Never use shorthand such as 'continue the previous "
+                        "task'."
+                    ),
                 },
                 "run_in_background": {
                     "type": "boolean",

--- a/tests/unit/bootstrap/test_agent_init.py
+++ b/tests/unit/bootstrap/test_agent_init.py
@@ -681,6 +681,19 @@ class TestInitController:
         AgentInitMixin._init_controller(agent)
         assert "SUBAGENT-SECTION-MARKER" in agent._controller_config.system_prompt
 
+    def test_tools_prompt_opt_out_excludes_subagent_instructions(self):
+        agent = self._agent(
+            config=AgentConfig(name="ctrl-agent", include_tools_in_prompt=False),
+            subagent_manager=SimpleNamespace(
+                get_subagents_prompt=lambda: "SUBAGENT-SECTION-MARKER"
+            ),
+        )
+        AgentInitMixin._init_controller(agent)
+        prompt = agent._controller_config.system_prompt
+        assert "SUBAGENT-SECTION-MARKER" not in prompt
+        assert "## Available Functions" not in prompt
+        assert agent._controller_config.include_subagent_schema_guidance is False
+
     def test_create_controller_produces_independent_instance(self):
         agent = self._agent()
         AgentInitMixin._init_controller(agent)

--- a/tests/unit/core/test_controller.py
+++ b/tests/unit/core/test_controller.py
@@ -6,6 +6,7 @@ import types
 import pytest
 
 from kohakuterrarium.core.controller import (
+    Controller,
     ControllerConfig,
     ControllerContext,
     _merge_text_and_parts,
@@ -56,11 +57,31 @@ class TestControllerConfig:
         assert c.system_prompt.startswith("You are")
         assert c.include_job_status is True
         assert c.include_tools_list is True
+        assert c.include_subagent_schema_guidance is True
         assert c.max_messages == 50
         assert c.ephemeral is False
         assert c.known_outputs == set()
         assert c.tool_format is None
         assert c.sanitize_orphan_tool_calls is True
+
+    def test_native_schema_respects_subagent_guidance_opt_out(self):
+        from kohakuterrarium.core.registry import Registry
+
+        registry = Registry()
+        registry.register_subagent(
+            "explore", types.SimpleNamespace(description="finds")
+        )
+        controller = Controller(
+            ScriptedLLM([]),
+            ControllerConfig(
+                tool_format="native",
+                include_subagent_schema_guidance=False,
+            ),
+            registry=registry,
+        )
+        schemas = controller._get_native_tool_schemas()
+        task_description = schemas[0].parameters["properties"]["task"]["description"]
+        assert task_description == "Task description for the sub-agent"
 
 
 class TestControllerContext:

--- a/tests/unit/core/test_controller.py
+++ b/tests/unit/core/test_controller.py
@@ -21,6 +21,7 @@ from kohakuterrarium.core.events import (
     create_user_input_event,
 )
 from kohakuterrarium.core.job import JobResult
+from kohakuterrarium.core.registry import Registry
 from kohakuterrarium.llm.message import ImagePart
 from kohakuterrarium.parsing.events import (
     TextEvent,
@@ -65,8 +66,6 @@ class TestControllerConfig:
         assert c.sanitize_orphan_tool_calls is True
 
     def test_native_schema_respects_subagent_guidance_opt_out(self):
-        from kohakuterrarium.core.registry import Registry
-
         registry = Registry()
         registry.register_subagent(
             "explore", types.SimpleNamespace(description="finds")

--- a/tests/unit/llm/test_tools.py
+++ b/tests/unit/llm/test_tools.py
@@ -207,9 +207,22 @@ class TestBuildToolSchemas:
         assert schema.name == "explore"
         assert schema.description == "Explores the codebase"
         # sub-agent schema shape: task (required) + run_in_background
-        assert schema.parameters["properties"]["task"]["type"] == "string"
+        task_schema = schema.parameters["properties"]["task"]
+        assert task_schema["type"] == "string"
+        assert "fresh, context-isolated invocation" in task_schema["description"]
+        assert (
+            "cannot resume or inherit conversation history"
+            in task_schema["description"]
+        )
         assert schema.parameters["required"] == ["task"]
         assert "run_in_background" in schema.parameters["properties"]
+
+    def test_subagent_guidance_can_be_omitted_for_prompt_opt_out(self):
+        reg = Registry()
+        reg.register_subagent("explore", _FakeSubAgent())
+        schemas = build_tool_schemas(reg, include_subagent_guidance=False)
+        task_description = schemas[0].parameters["properties"]["task"]["description"]
+        assert task_description == "Task description for the sub-agent"
 
     def test_subagent_without_description_gets_default(self):
         reg = Registry()

--- a/tests/unit/modules/subagent/test_manager.py
+++ b/tests/unit/modules/subagent/test_manager.py
@@ -53,13 +53,19 @@ class TestRegistration:
     def test_subagents_prompt_empty_when_none_registered(self):
         assert _manager().get_subagents_prompt() == ""
 
-    def test_subagents_prompt_native_format_mentions_task_param(self):
+    def test_subagents_prompt_requires_self_contained_task_context(self):
         mgr = _manager(tool_format="native")
         mgr.register(SubAgentConfig(name="explore", description="finds"))
         prompt = mgr.get_subagents_prompt()
-        # Native mode hint references the API ``task`` param.
-        assert "task" in prompt
-        assert "API" in prompt
+        assert "fresh, context-isolated invocation" in prompt
+        assert "cannot resume or inherit conversation history" in prompt
+        assert "complete, self-contained task" in prompt
+        assert (
+            "original goal, current state, work already completed, what remains"
+            in prompt
+        )
+        assert "relevant paths, errors, or findings" in prompt
+        assert "continue the previous task" in prompt
 
     def test_register_warns_on_tools_missing_from_parent_registry(self):
         # A config referencing tools the parent doesn't have still


### PR DESCRIPTION
## Summary

Clarifies that every task-subagent call starts as a fresh, context-isolated invocation and requires a complete, self-contained task. The guidance is shared by the aggregated sub-agent prompt and native tool schema while preserving the complete `include_tools_in_prompt: false` opt-out for restricted creatures.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Controllers can currently send follow-up shorthand such as "continue the previous task" to a task sub-agent. Task sub-agents do not inherit earlier invocation history, so they must rediscover the missing goal, state, paths, and findings. This wastes turns and tokens and can produce incomplete work.

This is a focused bug fix rather than a new sub-agent execution model. The existing context-isolated behavior is unchanged; its calling contract is now exposed to the controller in both prompt-based and native-tool modes.

## Changes

- Add one shared task-subagent context guidance string.
- Include the guidance in the aggregated sub-agent prompt.
- Include the guidance in native sub-agent `task.description` schemas.
- Preserve the clean-prompt/tool-surface contract when `include_tools_in_prompt` is disabled.
- Add unit and integration regression coverage for default and opt-out behavior.

## Validation

```bash
# Current branch after rebasing onto upstream main
ruff check src/ tests/
# All checks passed

ruff check <10 changed Python files>
black --check --target-version py314 <10 changed Python files>
# All checks passed; 10 files left unchanged

pytest tests/unit/modules/subagent/test_manager.py \
  tests/unit/llm/test_tools.py \
  tests/unit/core/test_controller.py \
  tests/unit/bootstrap/test_agent_init.py \
  tests/integration/test_llm.py -q
# 228 passed

# Additional local CI-equivalent checks
pytest tests/integration/ -v --tb=short
# 173 passed

pytest tests/unit/test_file_sizes.py -v --tb=short
# 1702 passed

pytest tests/unit/test_dep_graph_lint.py -v --tb=short
# 2 passed

cd src/kohakuterrarium-frontend
npm ci
npm run build
# Passed; build output generated

uv run --with build python -m build --wheel
# Passed

# Installed the wheel into a clean venv, then ran:
kt --help
kt app --help
kt-cli --help
kt-tui --help
kt shims status
# Passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #174

Issue opened on 2026-08-19. This is a bug fix under the looser contribution path in `CONTRIBUTING.md`; it does not add a public API or alter the sub-agent execution architecture.

## Notes for Reviewers

The main review point is the opt-out boundary: `include_tools_in_prompt: false` suppresses both the aggregated sub-agent guidance and the additional native schema guidance, while leaving explicitly registered tools available to creature-defined prompt/tool management.

## Screenshots / Logs (if applicable)

Not applicable; this changes controller guidance and schema metadata.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- Full local unit run on Windows/Python 3.14.2 completed with `12062 passed, 9 skipped, 7 failed`. Six failures are in Dulwich real-ref checkout tests whose temporary repositories did not expose the expected `refs/heads/master`; one failure detected concurrent writes to the real `~/.kohakuterrarium/app.log`. None touch the files or behavior changed here. The supported CI matrix excludes Windows + Python 3.14.
- Full-repository `black --check src/ tests/` reports 107 pre-existing formatting differences locally. All 10 files changed by this PR pass Black.
- Frontend `npm run format:check` reports 443 pre-existing formatting differences locally. No frontend source file is changed by this PR; `npm ci` and the production build pass.
- GitHub Actions did not start for the fork branch because the workflow only triggers pushes to `main` and pull requests targeting `main`. The upstream PR checks are the first available GitHub-hosted matrix run for this branch.
- E2E was not run because this change does not touch the multi-node, Studio, or serving stack.
