### PR TITLE
perf(frontend): keep trace timelines responsive at scale

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.component.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.component.test.js
@@ -108,6 +108,106 @@ describe("TraceTimeline hover", () => {
     wrapper.unmount()
   })
 
+  it("loads bucket tooltip metadata only when the bucket is pointed at", async () => {
+    let tooltipReads = 0
+    const tooltipModel = {
+      ...model,
+      spans: [
+        {
+          ...model.spans[0],
+          get turn() {
+            tooltipReads += 1
+            return 1
+          },
+          get type() {
+            tooltipReads += 1
+            return "tool_call"
+          },
+          get label() {
+            tooltipReads += 1
+            return "bash"
+          },
+        },
+      ],
+    }
+    const wrapper = mount(TraceTimeline, { props: { model: tooltipModel } })
+    const track = wrapper.find('[tabindex="0"]')
+    vi.spyOn(track.element, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 72,
+      right: 210,
+      bottom: 92,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+
+    const mountedReads = tooltipReads
+    const bucket = wrapper.find("[data-timeline-bucket]")
+    expect(tooltipReads).toBe(mountedReads)
+
+    bucket.element.dispatchEvent(
+      new MouseEvent("pointermove", { bubbles: true, clientX: 60, clientY: 60 }),
+    )
+    flushFrames()
+    await wrapper.vm.$nextTick()
+
+    expect(tooltipReads).toBeGreaterThan(mountedReads)
+    expect(bucket.attributes("title")).toContain("bash")
+    expect(bucket.attributes("title")).toContain("turn 1")
+
+    await wrapper.setProps({ mode: "time" })
+    expect(bucket.attributes("title")).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it("clamps tooltip lookup to a bucket widened by the minimum render width", async () => {
+    const pointModel = {
+      start: 0,
+      end: 10,
+      spans: [
+        {
+          start: 0,
+          end: 0,
+          index: 0,
+          turn: 1,
+          lane: 0,
+          type: "text",
+          label: "point",
+          isError: false,
+        },
+      ],
+      turnBoundaries: [],
+    }
+    const wrapper = mount(TraceTimeline, { props: { model: pointModel } })
+    const track = wrapper.find('[tabindex="0"]')
+    vi.spyOn(track.element, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 100,
+      height: 72,
+      right: 110,
+      bottom: 92,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+
+    const bucket = wrapper.find("[data-timeline-bucket]")
+    bucket.element.dispatchEvent(
+      new MouseEvent("pointermove", { bubbles: true, clientX: 11.5, clientY: 29 }),
+    )
+    flushFrames()
+    await wrapper.vm.$nextTick()
+
+    expect(bucket.attributes("title")).toContain("point")
+
+    wrapper.unmount()
+  })
+
   it("keeps the hover line hidden when the model is not rendered", async () => {
     const wrapper = mount(TraceTimeline)
     const track = wrapper.find('[tabindex="0"]')

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.component.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.component.test.js
@@ -25,7 +25,24 @@ const model = {
   turnBoundaries: [],
 }
 
+let frameCallbacks
+let frameId
+
+function flushFrames() {
+  const callbacks = [...frameCallbacks.values()]
+  frameCallbacks.clear()
+  for (const callback of callbacks) callback(frameId)
+}
+
 beforeEach(() => {
+  frameCallbacks = new Map()
+  frameId = 0
+  vi.stubGlobal("requestAnimationFrame", (callback) => {
+    frameId += 1
+    frameCallbacks.set(frameId, callback)
+    return frameId
+  })
+  vi.stubGlobal("cancelAnimationFrame", (id) => frameCallbacks.delete(id))
   vi.stubGlobal(
     "ResizeObserver",
     class {
@@ -40,6 +57,26 @@ afterEach(() => {
 })
 
 describe("TraceTimeline hover", () => {
+  it("starts with the selection overlay hidden", () => {
+    const wrapper = mount(TraceTimeline, { props: { model } })
+
+    expect(wrapper.find('[data-testid="timeline-selection"]').element.style.display).toBe("none")
+
+    wrapper.unmount()
+  })
+
+  it("renders an initial committed range after the selection ref mounts", async () => {
+    const wrapper = mount(TraceTimeline, {
+      props: { model, range: { start: 0.5, end: 1.5 } },
+    })
+    await wrapper.vm.$nextTick()
+
+    const selection = wrapper.find('[data-testid="timeline-selection"]')
+    expect(selection.element.style.display).toBe("")
+    expect(selection.element.style.transform).toBe("translate3d(25%, 0, 0) scaleX(0.5)")
+
+    wrapper.unmount()
+  })
   it("moves the hover line without invalidating the track subtree", async () => {
     const wrapper = mount(TraceTimeline, { props: { model } })
     const track = wrapper.find('[tabindex="0"]')
@@ -59,6 +96,7 @@ describe("TraceTimeline hover", () => {
     track.element.dispatchEvent(
       new MouseEvent("pointermove", { bubbles: true, clientX: 60, clientY: 40 }),
     )
+    flushFrames()
     await wrapper.vm.$nextTick()
 
     const hoverLine = wrapper.find('[data-testid="timeline-hover-line"]')
@@ -118,6 +156,78 @@ describe("TraceTimeline hover", () => {
 
     expect(wrapper.find('[data-testid="timeline-hover-line"]').isVisible()).toBe(false)
 
+    wrapper.unmount()
+  })
+
+  it("previews a drag selection without rerendering on pointermove", async () => {
+    const wrapper = mount(TraceTimeline, { props: { model } })
+    const track = wrapper.find('[tabindex="0"]')
+    vi.spyOn(track.element, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 72,
+      right: 210,
+      bottom: 92,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+
+    track.element.dispatchEvent(
+      new MouseEvent("pointerdown", { bubbles: true, button: 0, clientX: 30, clientY: 40 }),
+    )
+    track.element.dispatchEvent(
+      new MouseEvent("pointermove", { bubbles: true, buttons: 1, clientX: 110, clientY: 40 }),
+    )
+    flushFrames()
+    await wrapper.vm.$nextTick()
+
+    const selection = wrapper.find('[data-testid="timeline-selection"]')
+    expect(selection.element.style.transform).toBe("translate3d(10%, 0, 0) scaleX(0.4)")
+    expect(selection.element.style.display).toBe("")
+
+    track.element.dispatchEvent(
+      new MouseEvent("pointerup", { bubbles: true, button: 0, clientX: 110, clientY: 40 }),
+    )
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted("update:range")?.at(-1)).toEqual([{ start: 0.2, end: 1 }])
+    wrapper.unmount()
+  })
+
+  it("applies the final pending pan position on pointerup", async () => {
+    const wrapper = mount(TraceTimeline, { props: { model } })
+    const track = wrapper.find('[tabindex="0"]')
+    vi.spyOn(track.element, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 72,
+      right: 210,
+      bottom: 92,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+
+    track.element.dispatchEvent(
+      new WheelEvent("wheel", { bubbles: true, clientX: 110, deltaY: -500 }),
+    )
+    flushFrames()
+    await wrapper.vm.$nextTick()
+    track.element.dispatchEvent(
+      new MouseEvent("pointerdown", { bubbles: true, button: 2, clientX: 150, clientY: 40 }),
+    )
+    track.element.dispatchEvent(
+      new MouseEvent("pointermove", { bubbles: true, buttons: 2, clientX: 70, clientY: 40 }),
+    )
+    track.element.dispatchEvent(
+      new MouseEvent("pointerup", { bubbles: true, button: 2, clientX: 50, clientY: 40 }),
+    )
+    await wrapper.vm.$nextTick()
+
+    expect(frameCallbacks.size).toBe(0)
     wrapper.unmount()
   })
 })

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.component.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.component.test.js
@@ -1,0 +1,123 @@
+import { mount } from "@vue/test-utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/utils/i18n", () => ({
+  useI18n: () => ({ t: (key) => key }),
+}))
+
+import TraceTimeline from "./TraceTimeline.vue"
+
+const model = {
+  start: 0,
+  end: 2,
+  spans: [
+    {
+      start: 0,
+      end: 1,
+      index: 1,
+      turn: 1,
+      type: "tool_call",
+      label: "bash",
+      lane: 2,
+      isError: false,
+    },
+  ],
+  turnBoundaries: [],
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("TraceTimeline hover", () => {
+  it("moves the hover line without invalidating the track subtree", async () => {
+    const wrapper = mount(TraceTimeline, { props: { model } })
+    const track = wrapper.find('[tabindex="0"]')
+    const rect = {
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 72,
+      right: 210,
+      bottom: 92,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    }
+    const geometry = vi.spyOn(track.element, "getBoundingClientRect").mockReturnValue(rect)
+
+    track.element.dispatchEvent(
+      new MouseEvent("pointermove", { bubbles: true, clientX: 60, clientY: 40 }),
+    )
+    await wrapper.vm.$nextTick()
+
+    const hoverLine = wrapper.find('[data-testid="timeline-hover-line"]')
+    expect(hoverLine.exists()).toBe(true)
+    expect(hoverLine.element.style.transform).toBe("translate3d(50px, 0, 0)")
+    expect(track.element.style.getPropertyValue("--tl-hover-x")).toBe("")
+    expect(geometry).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it("keeps the hover line hidden when the model is not rendered", async () => {
+    const wrapper = mount(TraceTimeline)
+    const track = wrapper.find('[tabindex="0"]')
+    vi.spyOn(track.element, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 72,
+      right: 210,
+      bottom: 92,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+
+    track.element.dispatchEvent(
+      new MouseEvent("pointermove", { bubbles: true, clientX: 60, clientY: 40 }),
+    )
+    await wrapper.setProps({ model })
+
+    expect(wrapper.find('[data-testid="timeline-hover-line"]').isVisible()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it("clears the hover state when the model is replaced through an empty state", async () => {
+    const wrapper = mount(TraceTimeline, { props: { model } })
+    const track = wrapper.find('[tabindex="0"]')
+    vi.spyOn(track.element, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 72,
+      right: 210,
+      bottom: 92,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+
+    track.element.dispatchEvent(
+      new MouseEvent("pointermove", { bubbles: true, clientX: 60, clientY: 40 }),
+    )
+    await wrapper.setProps({ model: null })
+    await wrapper.setProps({ model })
+
+    expect(wrapper.find('[data-testid="timeline-hover-line"]').isVisible()).toBe(false)
+
+    wrapper.unmount()
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.vue
@@ -26,18 +26,18 @@
           <div v-for="i in TIMELINE_LANES.length - 1" :key="i" class="absolute inset-x-0 border-t border-warm-200/60 dark:border-warm-700/60 pointer-events-none" :style="{ top: `${i * 18}px` }" />
 
           <!-- Turn boundaries -->
-          <div v-for="b in visibleBoundaries" :key="b.turn" class="absolute top-0 bottom-0 border-l border-dashed border-warm-300 dark:border-warm-600 pointer-events-none" :style="{ left: `${b.x}%` }">
-            <span v-if="showBoundaryLabels" class="absolute top-0 left-0.5 text-[8px] font-mono text-warm-400">#{{ b.turn }}</span>
+          <div v-for="b in visibleBoundaries" :key="b.key" class="absolute top-0 bottom-0 border-l border-dashed border-warm-300 dark:border-warm-600 pointer-events-none" :style="{ left: `${b.x}%` }">
+            <span v-if="showBoundaryLabels" class="absolute top-0 left-0.5 text-[8px] font-mono text-warm-400">#{{ b.label }}</span>
           </div>
 
           <!-- Span buckets -->
           <div v-for="b in buckets" :key="b.key" class="absolute rounded-[1px] hover:opacity-100" :class="bucketClass(b)" :style="bucketStyle(b)" :title="bucketTitle(b)" />
 
           <!-- Hover line moves independently so the span subtree keeps its computed styles. -->
-          <div v-show="hovering && !draft" ref="hoverLineEl" data-testid="timeline-hover-line" class="absolute top-0 bottom-0 left-0 w-px bg-warm-400/60 pointer-events-none will-change-transform" />
+          <div v-show="hovering && !dragStateActive" ref="hoverLineEl" data-testid="timeline-hover-line" class="absolute top-0 bottom-0 left-0 w-px bg-warm-400/60 pointer-events-none will-change-transform" />
 
           <!-- Selection overlay -->
-          <div v-if="selectionFraction" class="absolute top-0 bottom-0 bg-iolite/15 border-x border-iolite/60 pointer-events-none" :class="draft ? 'opacity-70' : ''" :style="{ left: `${selectionFraction.start}%`, width: `${selectionFraction.end - selectionFraction.start}%` }" />
+          <div ref="selectionEl" data-testid="timeline-selection" class="absolute top-0 bottom-0 left-0 w-full origin-left bg-iolite/15 border-x border-iolite/60 pointer-events-none will-change-transform" style="display: none" />
         </template>
       </div>
     </div>
@@ -63,7 +63,7 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue"
 
-import { TIMELINE_LANES, TIMELINE_MODES, formatTimelineDuration } from "@/components/sessions/trace/traceTimeline"
+import { TIMELINE_LANES, TIMELINE_MODES, formatTimelineDuration, rasterizeTimelineSpans, rasterizeTurnBoundaries } from "@/components/sessions/trace/traceTimeline"
 import { useI18n } from "@/utils/i18n"
 
 const MIN_DRAG_PX = 3
@@ -81,17 +81,22 @@ const emit = defineEmits(["update:mode", "update:range", "select-span"])
 
 const trackEl = ref(null)
 const hoverLineEl = ref(null)
+const selectionEl = ref(null)
 const minimapEl = ref(null)
 const trackWidth = ref(0)
 const viewport = ref(null)
-const draft = ref(null)
 const hovering = ref(false)
+const dragStateActive = ref(false)
 const panning = ref(false)
 const minimapDragging = ref(false)
 
 let dragState = null
 let panState = null
 let resizeObserver = null
+let pointerFrame = 0
+let pendingPointer = null
+let wheelFrame = 0
+let pendingWheel = []
 
 onMounted(() => {
   if (!trackEl.value) return
@@ -101,17 +106,21 @@ onMounted(() => {
   resizeObserver.observe(trackEl.value)
   trackWidth.value = trackEl.value.getBoundingClientRect().width
   trackEl.value.addEventListener("wheel", onWheel, { passive: false })
+  updateSelectionPreview(props.range)
 })
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()
   trackEl.value?.removeEventListener("wheel", onWheel)
+  if (pointerFrame) cancelAnimationFrame(pointerFrame)
+  if (wheelFrame) cancelAnimationFrame(wheelFrame)
 })
 
 // The range belongs to the current projection's domain; switching the
 // projection would silently reinterpret it, so clear it instead.
 function setMode(m) {
   if (m === props.mode) return
+  cancelPendingWheel()
   emit("update:mode", m)
   emit("update:range", null)
   viewport.value = null
@@ -122,8 +131,11 @@ watch(
   () => props.model,
   (model, prev) => {
     if (!model) {
+      cancelPointerInteraction()
+      cancelPendingWheel()
       viewport.value = null
       hovering.value = false
+      clearSelectionPreview()
       return
     }
     if (viewport.value && (viewport.value.end < model.start || viewport.value.start > model.end)) {
@@ -159,38 +171,14 @@ const buckets = computed(() => {
   const model = props.model
   const d = domain.value
   if (!model || !d) return []
-  const cols = columns.value
-  const dur = domainDuration.value
-  const result = []
-  for (const span of model.spans) {
-    if (span.end < d.start || span.start > d.end) continue
-    const c0 = Math.max(0, Math.min(cols - 1, Math.floor(((span.start - d.start) / dur) * cols)))
-    // Half-open [start, end): a span ending exactly on a column boundary
-    // must not bleed into the next column (zero-width spans stay 1 col).
-    const c1 = Math.max(c0, Math.min(cols - 1, Math.ceil(((span.end - d.start) / dur) * cols) - 1))
-    result.push({
-      key: `${span.lane}:${c0}:${c1}:${span.index}`,
-      lane: span.lane,
-      col: c0,
-      spanCols: c1 - c0 + 1,
-      count: 1,
-      error: span.isError,
-      turns: span.turn !== null ? [span.turn] : [],
-      types: span.type ? [span.type] : [],
-      labels: span.label ? [span.label] : [],
-      minStart: span.start,
-      maxEnd: span.end,
-    })
-  }
-  return result
+  return rasterizeTimelineSpans(model.spans, d, columns.value)
 })
 
 const visibleBoundaries = computed(() => {
   const model = props.model
   const d = domain.value
   if (!model || !d) return []
-  const dur = domainDuration.value
-  return model.turnBoundaries.filter((b) => b.time > d.start && b.time <= d.end).map((b) => ({ turn: b.turn, x: ((b.time - d.start) / dur) * 100 }))
+  return rasterizeTurnBoundaries(model.turnBoundaries, d, columns.value)
 })
 
 // Minimap rasterizes the full domain at fixed low resolution, ignoring
@@ -200,14 +188,7 @@ const MINIMAP_COLUMNS = 240
 const minimapBuckets = computed(() => {
   const model = props.model
   if (!model) return []
-  const dur = Math.max(1, model.end - model.start)
-  const result = []
-  for (const span of model.spans) {
-    const c0 = Math.max(0, Math.min(MINIMAP_COLUMNS - 1, Math.floor(((span.start - model.start) / dur) * MINIMAP_COLUMNS)))
-    const c1 = Math.max(c0, Math.min(MINIMAP_COLUMNS - 1, Math.ceil(((span.end - model.start) / dur) * MINIMAP_COLUMNS) - 1))
-    result.push({ key: `${span.lane}:${c0}:${c1}:${span.index}`, lane: span.lane, col: c0, spanCols: c1 - c0 + 1, error: span.isError })
-  }
-  return result
+  return rasterizeTimelineSpans(model.spans, { start: model.start, end: model.end }, MINIMAP_COLUMNS)
 })
 
 function minimapBucketStyle(b) {
@@ -270,6 +251,36 @@ function onMinimapPointerUp() {
 
 const showBoundaryLabels = computed(() => visibleBoundaries.value.length <= 24)
 
+function updateSelectionPreview(range) {
+  const element = selectionEl.value
+  const d = domain.value
+  if (!element || !range || !d) {
+    clearSelectionPreview()
+    return
+  }
+  const duration = domainDuration.value
+  const start = Math.min(Math.max((Math.min(range.start, range.end) - d.start) / duration, 0), 1)
+  const end = Math.min(Math.max((Math.max(range.start, range.end) - d.start) / duration, 0), 1)
+  element.style.display = ""
+  element.style.opacity = dragStateActive.value ? "0.7" : ""
+  element.style.transform = `translate3d(${start * 100}%, 0, 0) scaleX(${end - start})`
+}
+
+function clearSelectionPreview() {
+  if (!selectionEl.value) return
+  selectionEl.value.style.display = "none"
+  selectionEl.value.style.transform = ""
+  selectionEl.value.style.opacity = ""
+}
+
+watch(
+  () => [props.range, domain.value],
+  ([range]) => {
+    if (!dragState) updateSelectionPreview(range)
+  },
+  { flush: "post", immediate: true },
+)
+
 const LANE_CLASSES = ["bg-sage/70", "bg-iolite/70", "bg-aquamarine/70", "bg-taaffeite/70"]
 
 function bucketClass(b) {
@@ -301,24 +312,15 @@ function bucketTitle(b) {
   if (props.mode === "sequence") {
     parts.push(`${b.count} event${b.count === 1 ? "" : "s"}`)
   } else {
+    parts.push(`${b.count} event${b.count === 1 ? "" : "s"}`)
     parts.push(`${formatClock(b.minStart)} → ${formatClock(b.maxEnd)}`)
-    parts.push(formatTimelineDuration(b.maxEnd - b.minStart))
+    if (b.count === 1) parts.push(formatTimelineDuration(b.maxEnd - b.minStart))
   }
   if (b.labels.length) parts.push(b.labels.slice(0, 5).join(", "))
   else if (b.types.length) parts.push(b.types.slice(0, 5).join(", "))
   if (b.turns.length) parts.push(`turn ${b.turns.slice(0, 5).join(", ")}`)
   return parts.join("\n")
 }
-
-const selectionFraction = computed(() => {
-  const r = draft.value || props.range
-  const d = domain.value
-  if (!r || !d) return null
-  const dur = domainDuration.value
-  const start = Math.min(Math.max(((Math.min(r.start, r.end) - d.start) / dur) * 100, 0), 100)
-  const end = Math.min(Math.max(((Math.max(r.start, r.end) - d.start) / dur) * 100, 0), 100)
-  return { start, end }
-})
 
 const selectionLabel = computed(() => {
   const r = props.range
@@ -371,11 +373,22 @@ function onPointerDown(event) {
   if (event.button !== 0) return
   const t2 = timeAt(fractionAt(event))
   dragState = { anchorTime: t2, anchorClientX: event.clientX }
-  draft.value = { start: t2, end: t2 }
+  dragStateActive.value = true
+  updateSelectionPreview({ start: t2, end: t2 })
   trackEl.value?.setPointerCapture?.(event.pointerId)
 }
 
 function onPointerMove(event) {
+  pendingPointer = { clientX: event.clientX, clientY: event.clientY }
+  if (!pointerFrame) pointerFrame = requestAnimationFrame(flushPointerMove)
+}
+
+function flushPointerMove() {
+  if (pointerFrame) cancelAnimationFrame(pointerFrame)
+  pointerFrame = 0
+  const event = pendingPointer
+  pendingPointer = null
+  if (!event) return
   const rect = trackEl.value?.getBoundingClientRect()
   if (rect && rect.width > 0 && hoverLineEl.value) {
     const x = Math.min(Math.max(event.clientX - rect.left, 0), rect.width)
@@ -393,14 +406,18 @@ function onPointerMove(event) {
     return
   }
   const t2 = timeAt(fractionAt(event, rect))
-  draft.value = { start: Math.min(dragState.anchorTime, t2), end: Math.max(dragState.anchorTime, t2) }
+  updateSelectionPreview({ start: dragState.anchorTime, end: t2 })
 }
 
 function onPointerEnd(event) {
   if (panState) {
+    if (pendingPointer) flushPointerMove()
     const moved = panState.moved || Math.abs(event.clientX - panState.anchorClientX) >= MIN_DRAG_PX
+    if (pointerFrame) cancelAnimationFrame(pointerFrame)
+    pointerFrame = 0
     panState = null
     panning.value = false
+    pendingPointer = null
     // Right-click without a drag clears the focus interval.
     if (!moved) emit("update:range", null)
     return
@@ -410,49 +427,89 @@ function onPointerEnd(event) {
   const range = { start: Math.min(dragState.anchorTime, t2), end: Math.max(dragState.anchorTime, t2) }
   const isClick = Math.abs(event.clientX - dragState.anchorClientX) < MIN_DRAG_PX
   dragState = null
-  draft.value = null
+  dragStateActive.value = false
+  pendingPointer = null
   if (isClick) {
     const span = spanAtPoint(event)
     if (span) {
+      clearSelectionPreview()
       emit("update:range", null)
       emit("select-span", span)
       return
     }
     // Click on empty track clears an existing focus.
     if (props.range) emit("update:range", null)
+    clearSelectionPreview()
     return
   }
   if (range.end > range.start) emit("update:range", range)
+  else clearSelectionPreview()
 }
 
-function onPointerCancel() {
+function cancelPointerInteraction() {
+  if (pointerFrame) cancelAnimationFrame(pointerFrame)
+  pointerFrame = 0
+  pendingPointer = null
   dragState = null
   panState = null
-  draft.value = null
+  dragStateActive.value = false
   panning.value = false
 }
 
+function onPointerCancel() {
+  cancelPointerInteraction()
+  updateSelectionPreview(props.range)
+}
+
 function onPointerLeave() {
-  if (!dragState && !panState) hovering.value = false
+  if (dragState || panState) return
+  if (pointerFrame) cancelAnimationFrame(pointerFrame)
+  pointerFrame = 0
+  pendingPointer = null
+  hovering.value = false
 }
 
 function onWheel(event) {
-  const model = props.model
-  if (!model) return
+  if (!props.model) return
   event.preventDefault()
-  const fraction = fractionAt(event)
+  pendingWheel.push({ clientX: event.clientX, deltaY: event.deltaY })
+  if (!wheelFrame) wheelFrame = requestAnimationFrame(flushWheel)
+}
+
+function flushWheel() {
+  if (wheelFrame) cancelAnimationFrame(wheelFrame)
+  wheelFrame = 0
+  const events = pendingWheel
+  pendingWheel = []
+  const model = props.model
+  if (!events.length || !model) return
+  const rect = trackEl.value?.getBoundingClientRect()
+  if (!rect || rect.width <= 0) return
   const minDuration = props.mode === "sequence" ? Math.min(4, fullDuration.value) : Math.min(20, fullDuration.value)
-  const nextDuration = Math.min(fullDuration.value, Math.max(minDuration, domainDuration.value * Math.exp(event.deltaY * 0.0015)))
-  if (nextDuration >= fullDuration.value * 0.999) {
-    viewport.value = null
-    return
+  let current = domain.value
+  for (const event of events) {
+    const fraction = fractionAt(event, rect)
+    const duration = Math.max(1, current.end - current.start)
+    const nextDuration = Math.min(fullDuration.value, Math.max(minDuration, duration * Math.exp(event.deltaY * 0.0015)))
+    if (nextDuration >= fullDuration.value * 0.999) {
+      current = { start: model.start, end: model.end }
+      continue
+    }
+    const anchor = current.start + fraction * duration
+    const nextStart = Math.min(Math.max(anchor - fraction * nextDuration, model.start), model.end - nextDuration)
+    current = { start: nextStart, end: nextStart + nextDuration }
   }
-  const anchor = timeAt(fraction)
-  const nextStart = Math.min(Math.max(anchor - fraction * nextDuration, model.start), model.end - nextDuration)
-  viewport.value = { start: nextStart, end: nextStart + nextDuration }
+  viewport.value = current.start === model.start && current.end === model.end ? null : current
+}
+
+function cancelPendingWheel() {
+  pendingWheel = []
+  if (wheelFrame) cancelAnimationFrame(wheelFrame)
+  wheelFrame = 0
 }
 
 function resetAll() {
+  cancelPendingWheel()
   viewport.value = null
   emit("update:range", null)
 }

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.vue
@@ -31,7 +31,7 @@
           </div>
 
           <!-- Span buckets -->
-          <div v-for="b in buckets" :key="b.key" class="absolute rounded-[1px] hover:opacity-100" :class="bucketClass(b)" :style="bucketStyle(b)" :title="bucketTitle(b)" />
+          <div v-for="b in buckets" :key="b.key" data-timeline-bucket :data-column="b.col" :data-columns="b.spanCols" :data-lane="b.lane" class="absolute rounded-[1px] hover:opacity-100" :class="bucketClass(b)" :style="bucketStyle(b)" />
 
           <!-- Hover line moves independently so the span subtree keeps its computed styles. -->
           <div v-show="hovering && !dragStateActive" ref="hoverLineEl" data-testid="timeline-hover-line" class="absolute top-0 bottom-0 left-0 w-px bg-warm-400/60 pointer-events-none will-change-transform" />
@@ -63,7 +63,7 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue"
 
-import { TIMELINE_LANES, TIMELINE_MODES, formatTimelineDuration, rasterizeTimelineSpans, rasterizeTurnBoundaries } from "@/components/sessions/trace/traceTimeline"
+import { TIMELINE_LANES, TIMELINE_MODES, formatTimelineDuration, rasterizeTimelineGeometry, rasterizeTurnBoundaries, summarizeTimelineColumn } from "@/components/sessions/trace/traceTimeline"
 import { useI18n } from "@/utils/i18n"
 
 const MIN_DRAG_PX = 3
@@ -171,7 +171,17 @@ const buckets = computed(() => {
   const model = props.model
   const d = domain.value
   if (!model || !d) return []
-  return rasterizeTimelineSpans(model.spans, d, columns.value)
+  return rasterizeTimelineGeometry(model.spans, d, columns.value)
+})
+
+function clearBucketTitles() {
+  trackEl.value?.querySelectorAll("[data-timeline-bucket][title]").forEach((bucket) => {
+    bucket.removeAttribute("title")
+  })
+}
+
+watch([() => props.model, () => props.mode, domain, columns], clearBucketTitles, {
+  flush: "post",
 })
 
 const visibleBoundaries = computed(() => {
@@ -188,7 +198,7 @@ const MINIMAP_COLUMNS = 240
 const minimapBuckets = computed(() => {
   const model = props.model
   if (!model) return []
-  return rasterizeTimelineSpans(model.spans, { start: model.start, end: model.end }, MINIMAP_COLUMNS)
+  return rasterizeTimelineGeometry(model.spans, { start: model.start, end: model.end }, MINIMAP_COLUMNS)
 })
 
 function minimapBucketStyle(b) {
@@ -307,19 +317,34 @@ function formatClock(ms) {
   }
 }
 
-function bucketTitle(b) {
-  const parts = []
-  if (props.mode === "sequence") {
-    parts.push(`${b.count} event${b.count === 1 ? "" : "s"}`)
-  } else {
-    parts.push(`${b.count} event${b.count === 1 ? "" : "s"}`)
-    parts.push(`${formatClock(b.minStart)} → ${formatClock(b.maxEnd)}`)
-    if (b.count === 1) parts.push(formatTimelineDuration(b.maxEnd - b.minStart))
+function bucketTitle(summary) {
+  if (!summary) return ""
+  const parts = [`${summary.count} event${summary.count === 1 ? "" : "s"}`]
+  if (props.mode !== "sequence") {
+    parts.push(`${formatClock(summary.minStart)} → ${formatClock(summary.maxEnd)}`)
+    if (summary.count === 1) {
+      parts.push(formatTimelineDuration(summary.maxEnd - summary.minStart))
+    }
   }
-  if (b.labels.length) parts.push(b.labels.slice(0, 5).join(", "))
-  else if (b.types.length) parts.push(b.types.slice(0, 5).join(", "))
-  if (b.turns.length) parts.push(`turn ${b.turns.slice(0, 5).join(", ")}`)
+  if (summary.labels.length) parts.push(summary.labels.join(", "))
+  else if (summary.types.length) parts.push(summary.types.join(", "))
+  if (summary.turns.length) parts.push(`turn ${summary.turns.join(", ")}`)
   return parts.join("\n")
+}
+
+function updateBucketTooltip(event, rect) {
+  const target = event.target
+  const model = props.model
+  const d = domain.value
+  if (!(target instanceof HTMLElement) || !target.hasAttribute("data-timeline-bucket")) return
+  if (!model || !d || !rect || rect.width <= 0) return
+  const bucketColumn = Number.parseInt(target.dataset.column ?? "", 10)
+  const bucketColumns = Number.parseInt(target.dataset.columns ?? "", 10)
+  const bucketLane = Number.parseInt(target.dataset.lane ?? "", 10)
+  if (![bucketColumn, bucketColumns, bucketLane].every(Number.isFinite)) return
+  const pointerColumn = Math.min(columns.value - 1, Math.floor(fractionAt(event, rect) * columns.value))
+  const column = Math.min(bucketColumn + bucketColumns - 1, Math.max(bucketColumn, pointerColumn))
+  target.title = bucketTitle(summarizeTimelineColumn(model.spans, d, columns.value, bucketLane, column))
 }
 
 const selectionLabel = computed(() => {
@@ -341,8 +366,7 @@ function timeAt(fraction) {
   return d.start + fraction * domainDuration.value
 }
 
-function laneAt(event) {
-  const rect = trackEl.value?.getBoundingClientRect()
+function laneAt(event, rect = trackEl.value?.getBoundingClientRect()) {
   if (!rect || rect.height <= 0) return null
   return Math.max(0, Math.min(TIMELINE_LANES.length - 1, Math.floor((event.clientY - rect.top) / LANE_HEIGHT_PX)))
 }
@@ -379,7 +403,7 @@ function onPointerDown(event) {
 }
 
 function onPointerMove(event) {
-  pendingPointer = { clientX: event.clientX, clientY: event.clientY }
+  pendingPointer = { clientX: event.clientX, clientY: event.clientY, target: event.target }
   if (!pointerFrame) pointerFrame = requestAnimationFrame(flushPointerMove)
 }
 
@@ -395,6 +419,7 @@ function flushPointerMove() {
     hoverLineEl.value.style.transform = `translate3d(${x}px, 0, 0)`
     if (!hovering.value) hovering.value = true
   }
+  updateBucketTooltip(event, rect)
   if (!panState && !dragState) return
   if (panState) {
     if (Math.abs(event.clientX - panState.anchorClientX) >= MIN_DRAG_PX) panState.moved = true
@@ -467,6 +492,7 @@ function onPointerLeave() {
   pointerFrame = 0
   pendingPointer = null
   hovering.value = false
+  clearBucketTitles()
 }
 
 function onWheel(event) {

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTimeline.vue
@@ -33,8 +33,8 @@
           <!-- Span buckets -->
           <div v-for="b in buckets" :key="b.key" class="absolute rounded-[1px] hover:opacity-100" :class="bucketClass(b)" :style="bucketStyle(b)" :title="bucketTitle(b)" />
 
-          <!-- Hover line (positioned via CSS var — no re-render on move) -->
-          <div v-show="hovering && !draft" class="absolute top-0 bottom-0 w-px bg-warm-400/60 pointer-events-none" :style="{ left: 'var(--tl-hover-x, -2px)' }" />
+          <!-- Hover line moves independently so the span subtree keeps its computed styles. -->
+          <div v-show="hovering && !draft" ref="hoverLineEl" data-testid="timeline-hover-line" class="absolute top-0 bottom-0 left-0 w-px bg-warm-400/60 pointer-events-none will-change-transform" />
 
           <!-- Selection overlay -->
           <div v-if="selectionFraction" class="absolute top-0 bottom-0 bg-iolite/15 border-x border-iolite/60 pointer-events-none" :class="draft ? 'opacity-70' : ''" :style="{ left: `${selectionFraction.start}%`, width: `${selectionFraction.end - selectionFraction.start}%` }" />
@@ -80,12 +80,11 @@ const props = defineProps({
 const emit = defineEmits(["update:mode", "update:range", "select-span"])
 
 const trackEl = ref(null)
+const hoverLineEl = ref(null)
 const minimapEl = ref(null)
 const trackWidth = ref(0)
 const viewport = ref(null)
 const draft = ref(null)
-// Hover position is a plain CSS custom property on the track element —
-// updating it on pointermove must NOT trigger a Vue re-render.
 const hovering = ref(false)
 const panning = ref(false)
 const minimapDragging = ref(false)
@@ -124,6 +123,7 @@ watch(
   (model, prev) => {
     if (!model) {
       viewport.value = null
+      hovering.value = false
       return
     }
     if (viewport.value && (viewport.value.end < model.start || viewport.value.start > model.end)) {
@@ -328,8 +328,7 @@ const selectionLabel = computed(() => {
   return formatTimelineDuration(width)
 })
 
-function fractionAt(event) {
-  const rect = trackEl.value?.getBoundingClientRect()
+function fractionAt(event, rect = trackEl.value?.getBoundingClientRect()) {
   if (!rect || rect.width <= 0) return 0
   return Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width))
 }
@@ -378,25 +377,22 @@ function onPointerDown(event) {
 
 function onPointerMove(event) {
   const rect = trackEl.value?.getBoundingClientRect()
-  if (rect && rect.width > 0) {
+  if (rect && rect.width > 0 && hoverLineEl.value) {
     const x = Math.min(Math.max(event.clientX - rect.left, 0), rect.width)
-    trackEl.value.style.setProperty("--tl-hover-x", `${x}px`)
+    hoverLineEl.value.style.transform = `translate3d(${x}px, 0, 0)`
     if (!hovering.value) hovering.value = true
   }
-  const fraction = fractionAt(event)
+  if (!panState && !dragState) return
   if (panState) {
     if (Math.abs(event.clientX - panState.anchorClientX) >= MIN_DRAG_PX) panState.moved = true
-    if (!viewport.value || !props.model) return
-    const rect = trackEl.value?.getBoundingClientRect()
-    if (!rect || rect.width <= 0) return
+    if (!viewport.value || !props.model || !rect || rect.width <= 0) return
     const delta = (event.clientX - panState.anchorClientX) / rect.width
     const dur = domainDuration.value
     const nextStart = Math.min(Math.max(panState.anchorStart - delta * dur, props.model.start), props.model.end - dur)
     viewport.value = { start: nextStart, end: nextStart + dur }
     return
   }
-  if (!dragState) return
-  const t2 = timeAt(fraction)
+  const t2 = timeAt(fractionAt(event, rect))
   draft.value = { start: Math.min(dragState.anchorTime, t2), end: Math.max(dragState.anchorTime, t2) }
 }
 

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/traceTimeline.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/traceTimeline.js
@@ -173,6 +173,134 @@ function deriveTimedTimeline(records, actualDuration, compressIdle) {
   }
 }
 
+function projectedColumns(start, end, domain, columns) {
+  const duration = Math.max(1, domain.end - domain.start)
+  const c0 = Math.max(
+    0,
+    Math.min(columns - 1, Math.floor(((start - domain.start) / duration) * columns)),
+  )
+  const c1 = Math.max(
+    c0,
+    Math.min(columns - 1, Math.ceil(((end - domain.start) / duration) * columns) - 1),
+  )
+  return { c0, c1 }
+}
+
+function appendUnique(values, value) {
+  if (value !== null && value !== "") values.add(value)
+}
+
+function sameSet(a, b) {
+  if (a.size !== b.size) return false
+  for (const value of a) if (!b.has(value)) return false
+  return true
+}
+
+function sameBucketContent(a, b) {
+  return (
+    a.count === b.count &&
+    a.error === b.error &&
+    a.minStart === b.minStart &&
+    a.maxEnd === b.maxEnd &&
+    sameSet(a.turns, b.turns) &&
+    sameSet(a.types, b.types) &&
+    sameSet(a.labels, b.labels)
+  )
+}
+
+export function rasterizeTimelineSpans(spans, domain, columns) {
+  if (!domain || columns <= 0) return []
+  const laneCells = new Map()
+  for (const span of spans) {
+    const isPoint = span.start === span.end
+    if (
+      isPoint
+        ? span.start < domain.start || span.start > domain.end
+        : span.end <= domain.start || span.start >= domain.end
+    )
+      continue
+    const { c0, c1 } = projectedColumns(span.start, span.end, domain, columns)
+    let cells = laneCells.get(span.lane)
+    if (!cells) {
+      cells = Array(columns)
+      laneCells.set(span.lane, cells)
+    }
+    for (let column = c0; column <= c1; column += 1) {
+      let cell = cells[column]
+      if (!cell) {
+        cell = {
+          lane: span.lane,
+          col: column,
+          spanCols: 1,
+          count: 0,
+          error: false,
+          turns: new Set(),
+          types: new Set(),
+          labels: new Set(),
+          minStart: span.start,
+          maxEnd: span.end,
+        }
+        cells[column] = cell
+      }
+      cell.count += 1
+      cell.error ||= span.isError
+      appendUnique(cell.turns, span.turn)
+      appendUnique(cell.types, span.type)
+      appendUnique(cell.labels, span.label)
+      cell.minStart = Math.min(cell.minStart, span.start)
+      cell.maxEnd = Math.max(cell.maxEnd, span.end)
+    }
+  }
+
+  const result = []
+  for (const [lane, cells] of laneCells) {
+    let active = null
+    for (const cell of cells) {
+      if (!cell) {
+        active = null
+        continue
+      }
+      if (active && active.col + active.spanCols === cell.col && sameBucketContent(active, cell)) {
+        active.spanCols += 1
+        active.key = `${lane}:${active.col}:${active.col + active.spanCols - 1}`
+        continue
+      }
+      active = { ...cell, key: `${lane}:${cell.col}:${cell.col}` }
+      result.push(active)
+    }
+  }
+  return result.map((bucket) => ({
+    ...bucket,
+    turns: [...bucket.turns],
+    types: [...bucket.types],
+    labels: [...bucket.labels],
+  }))
+}
+
+export function rasterizeTurnBoundaries(boundaries, domain, columns) {
+  if (!domain || columns <= 0) return []
+  const duration = Math.max(1, domain.end - domain.start)
+  const byColumn = new Map()
+  for (const boundary of boundaries) {
+    if (boundary.time <= domain.start || boundary.time > domain.end) continue
+    const column = Math.max(
+      0,
+      Math.min(columns - 1, Math.floor(((boundary.time - domain.start) / duration) * columns)),
+    )
+    const existing = byColumn.get(column)
+    if (existing) existing.lastTurn = boundary.turn
+    else byColumn.set(column, { firstTurn: boundary.turn, lastTurn: boundary.turn })
+  }
+  return [...byColumn.entries()].map(([column, turns]) => ({
+    key: column,
+    x: ((column + 0.5) * 100) / columns,
+    label:
+      turns.firstTurn === turns.lastTurn
+        ? String(turns.firstTurn)
+        : `${turns.firstTurn}–${turns.lastTurn}`,
+  }))
+}
+
 /**
  * Records active at any point inside an inclusive selected interval.
  * @returns {{turns: Set<number>, eventIds: Set<number>}}

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/traceTimeline.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/traceTimeline.js
@@ -186,31 +186,15 @@ function projectedColumns(start, end, domain, columns) {
   return { c0, c1 }
 }
 
-function appendUnique(values, value) {
-  if (value !== null && value !== "") values.add(value)
+function appendSummaryValue(values, seen, value) {
+  if (values.length >= 5 || value === null || value === "" || seen.has(value)) return
+  seen.add(value)
+  values.push(value)
 }
 
-function sameSet(a, b) {
-  if (a.size !== b.size) return false
-  for (const value of a) if (!b.has(value)) return false
-  return true
-}
-
-function sameBucketContent(a, b) {
-  return (
-    a.count === b.count &&
-    a.error === b.error &&
-    a.minStart === b.minStart &&
-    a.maxEnd === b.maxEnd &&
-    sameSet(a.turns, b.turns) &&
-    sameSet(a.types, b.types) &&
-    sameSet(a.labels, b.labels)
-  )
-}
-
-export function rasterizeTimelineSpans(spans, domain, columns) {
+export function rasterizeTimelineGeometry(spans, domain, columns) {
   if (!domain || columns <= 0) return []
-  const laneCells = new Map()
+  const laneDiffs = new Map()
   for (const span of spans) {
     const isPoint = span.start === span.end
     if (
@@ -220,61 +204,88 @@ export function rasterizeTimelineSpans(spans, domain, columns) {
     )
       continue
     const { c0, c1 } = projectedColumns(span.start, span.end, domain, columns)
-    let cells = laneCells.get(span.lane)
-    if (!cells) {
-      cells = Array(columns)
-      laneCells.set(span.lane, cells)
-    }
-    for (let column = c0; column <= c1; column += 1) {
-      let cell = cells[column]
-      if (!cell) {
-        cell = {
-          lane: span.lane,
-          col: column,
-          spanCols: 1,
-          count: 0,
-          error: false,
-          turns: new Set(),
-          types: new Set(),
-          labels: new Set(),
-          minStart: span.start,
-          maxEnd: span.end,
-        }
-        cells[column] = cell
+    let diffs = laneDiffs.get(span.lane)
+    if (!diffs) {
+      diffs = {
+        count: new Int32Array(columns + 1),
+        errors: new Int32Array(columns + 1),
       }
-      cell.count += 1
-      cell.error ||= span.isError
-      appendUnique(cell.turns, span.turn)
-      appendUnique(cell.types, span.type)
-      appendUnique(cell.labels, span.label)
-      cell.minStart = Math.min(cell.minStart, span.start)
-      cell.maxEnd = Math.max(cell.maxEnd, span.end)
+      laneDiffs.set(span.lane, diffs)
+    }
+    diffs.count[c0] += 1
+    diffs.count[c1 + 1] -= 1
+    if (span.isError) {
+      diffs.errors[c0] += 1
+      diffs.errors[c1 + 1] -= 1
     }
   }
 
   const result = []
-  for (const [lane, cells] of laneCells) {
+  for (const [lane, diffs] of laneDiffs) {
+    let count = 0
+    let errors = 0
     let active = null
-    for (const cell of cells) {
-      if (!cell) {
+    for (let column = 0; column < columns; column += 1) {
+      count += diffs.count[column]
+      errors += diffs.errors[column]
+      if (!count) {
         active = null
         continue
       }
-      if (active && active.col + active.spanCols === cell.col && sameBucketContent(active, cell)) {
+      const error = errors > 0
+      if (active && active.error === error && active.col + active.spanCols === column) {
         active.spanCols += 1
-        active.key = `${lane}:${active.col}:${active.col + active.spanCols - 1}`
+        active.key = `${lane}:${active.col}:${column}`
         continue
       }
-      active = { ...cell, key: `${lane}:${cell.col}:${cell.col}` }
+      active = {
+        key: `${lane}:${column}:${column}`,
+        lane,
+        col: column,
+        spanCols: 1,
+        error,
+      }
       result.push(active)
     }
   }
-  return result.map((bucket) => ({
-    ...bucket,
-    turns: [...bucket.turns],
-    types: [...bucket.types],
-    labels: [...bucket.labels],
-  }))
+  return result
+}
+
+export function summarizeTimelineColumn(spans, domain, columns, lane, column) {
+  if (!domain || columns <= 0 || column < 0 || column >= columns) return null
+  const duration = Math.max(1, domain.end - domain.start)
+  const columnStart = domain.start + (column / columns) * duration
+  const columnEnd = domain.start + ((column + 1) / columns) * duration
+  const turns = []
+  const types = []
+  const labels = []
+  const seenTurns = new Set()
+  const seenTypes = new Set()
+  const seenLabels = new Set()
+  let count = 0
+  let error = false
+  let minStart = Infinity
+  let maxEnd = -Infinity
+
+  for (const span of spans) {
+    if (span.lane !== lane) continue
+    const isPoint = span.start === span.end
+    const overlaps = isPoint
+      ? span.start >= columnStart &&
+        (span.start < columnEnd || (column === columns - 1 && span.start === columnEnd))
+      : span.end > columnStart && span.start < columnEnd
+    if (!overlaps) continue
+    count += 1
+    error ||= span.isError
+    minStart = Math.min(minStart, span.start)
+    maxEnd = Math.max(maxEnd, span.end)
+    appendSummaryValue(turns, seenTurns, span.turn)
+    appendSummaryValue(types, seenTypes, span.type)
+    appendSummaryValue(labels, seenLabels, span.label)
+  }
+
+  if (!count) return null
+  return { count, error, turns, types, labels, minStart, maxEnd }
 }
 
 export function rasterizeTurnBoundaries(boundaries, domain, columns) {

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/traceTimeline.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/traceTimeline.test.js
@@ -5,8 +5,9 @@ import {
   formatTimelineDuration,
   laneForType,
   normalizeSpan,
-  rasterizeTimelineSpans,
+  rasterizeTimelineGeometry,
   rasterizeTurnBoundaries,
+  summarizeTimelineColumn,
   traceTimelineFocus,
 } from "@/components/sessions/trace/traceTimeline"
 
@@ -132,14 +133,130 @@ describe("deriveTraceTimeline", () => {
   })
 })
 
-describe("rasterizeTimelineSpans", () => {
-  it("merges spans that occupy the same lane and pixel columns", () => {
-    const buckets = rasterizeTimelineSpans(
+describe("rasterizeTimelineGeometry", () => {
+  function referenceGeometry(spans, domain, columns) {
+    const cells = new Map()
+    const duration = domain.end - domain.start
+    for (const span of spans) {
+      let lane = cells.get(span.lane)
+      if (!lane) {
+        lane = Array(columns).fill(0)
+        cells.set(span.lane, lane)
+      }
+      for (let column = 0; column < columns; column += 1) {
+        const start = domain.start + (column / columns) * duration
+        const end = domain.start + ((column + 1) / columns) * duration
+        const point = span.start === span.end
+        const overlaps = point
+          ? span.start >= start &&
+            (span.start < end || (column === columns - 1 && span.start === end))
+          : span.end > start && span.start < end
+        if (overlaps) lane[column] = Math.max(lane[column], span.isError ? 2 : 1)
+      }
+    }
+    const runs = []
+    for (const [lane, states] of cells) {
+      let active = null
+      for (let column = 0; column < states.length; column += 1) {
+        const state = states[column]
+        if (!state) {
+          active = null
+          continue
+        }
+        const error = state === 2
+        if (active && active.error === error && active.col + active.spanCols === column) {
+          active.spanCols += 1
+          active.key = `${lane}:${active.col}:${column}`
+        } else {
+          active = { key: `${lane}:${column}:${column}`, lane, col: column, spanCols: 1, error }
+          runs.push(active)
+        }
+      }
+    }
+    return runs
+  }
+
+  it("matches a per-column geometry reference without carrying semantic metadata", () => {
+    const spans = [
+      { start: 0, end: 4, lane: 1, isError: false },
+      { start: 2, end: 6, lane: 1, isError: true },
+      { start: 5, end: 5, lane: 2, isError: false },
+      { start: 9, end: 10, lane: 3, isError: false },
+    ]
+    const domain = { start: 0, end: 10 }
+
+    expect(rasterizeTimelineGeometry(spans, domain, 10)).toEqual(
+      referenceGeometry(spans, domain, 10),
+    )
+  })
+
+  it("excludes spans that only touch the half-open domain boundary", () => {
+    const buckets = rasterizeTimelineGeometry(
+      [
+        { start: -1, end: 0, lane: 1, isError: true },
+        { start: 10, end: 11, lane: 1, isError: true },
+        { start: 0, end: 1, lane: 1, isError: false },
+      ],
+      { start: 0, end: 10 },
+      10,
+    )
+
+    expect(buckets).toEqual([{ key: "1:0:0", lane: 1, col: 0, spanCols: 1, error: false }])
+  })
+
+  it("keeps zero-width point spans on the domain endpoints", () => {
+    const buckets = rasterizeTimelineGeometry(
+      [
+        { start: 0, end: 0, lane: 1, isError: false },
+        { start: 10, end: 10, lane: 1, isError: false },
+      ],
+      { start: 0, end: 10 },
+      10,
+    )
+
+    expect(buckets.map((bucket) => bucket.col)).toEqual([0, 9])
+  })
+
+  it("never reads tooltip metadata while building geometry", () => {
+    const spans = Array.from({ length: 32 }, () => ({
+      start: 0,
+      end: 10,
+      lane: 1,
+      isError: false,
+      get turn() {
+        throw new Error("geometry read turn")
+      },
+      get type() {
+        throw new Error("geometry read type")
+      },
+      get label() {
+        throw new Error("geometry read label")
+      },
+    }))
+
+    expect(rasterizeTimelineGeometry(spans, { start: 0, end: 10 }, 256)).toEqual([
+      { key: "1:0:255", lane: 1, col: 0, spanCols: 256, error: false },
+    ])
+  })
+
+  it("keeps projected long spans as one multi-column bucket", () => {
+    expect(
+      rasterizeTimelineGeometry(
+        [{ start: 2, end: 7, lane: 1, isError: false }],
+        { start: 0, end: 10 },
+        10,
+      ),
+    ).toEqual([{ key: "1:2:6", lane: 1, col: 2, spanCols: 5, error: false }])
+  })
+})
+
+describe("summarizeTimelineColumn", () => {
+  it("summarizes only spans overlapping the requested lane and column", () => {
+    const summary = summarizeTimelineColumn(
       [
         {
           start: 1,
-          end: 2,
-          index: 1,
+          end: 4,
           turn: 1,
           lane: 2,
           type: "tool_call",
@@ -147,9 +264,8 @@ describe("rasterizeTimelineSpans", () => {
           isError: false,
         },
         {
-          start: 1.1,
-          end: 1.9,
-          index: 2,
+          start: 2,
+          end: 3,
           turn: 2,
           lane: 2,
           type: "tool_result",
@@ -157,10 +273,9 @@ describe("rasterizeTimelineSpans", () => {
           isError: true,
         },
         {
-          start: 1.1,
-          end: 1.9,
-          index: 3,
-          turn: 2,
+          start: 2,
+          end: 3,
+          turn: 3,
           lane: 3,
           type: "subagent_call",
           label: "explore",
@@ -169,140 +284,65 @@ describe("rasterizeTimelineSpans", () => {
       ],
       { start: 0, end: 10 },
       10,
+      2,
+      2,
     )
 
-    expect(buckets).toHaveLength(2)
-    expect(buckets[0]).toMatchObject({
-      key: "2:1:1",
-      lane: 2,
-      col: 1,
-      spanCols: 1,
+    expect(summary).toEqual({
       count: 2,
       error: true,
       turns: [1, 2],
       types: ["tool_call", "tool_result"],
       labels: ["bash", "read"],
       minStart: 1,
-      maxEnd: 2,
+      maxEnd: 4,
     })
-    expect(buckets[1]).toMatchObject({ key: "3:1:1", lane: 3, count: 1 })
   })
 
-  it("excludes spans that only touch the half-open domain boundary", () => {
-    const buckets = rasterizeTimelineSpans(
-      [
-        {
-          start: -1,
-          end: 0,
-          index: 1,
-          turn: 1,
-          lane: 1,
-          type: "text",
-          label: "before",
-          isError: true,
-        },
-        {
-          start: 10,
-          end: 11,
-          index: 2,
-          turn: 2,
-          lane: 1,
-          type: "text",
-          label: "after",
-          isError: true,
-        },
-        {
-          start: 0,
-          end: 1,
-          index: 3,
-          turn: 3,
-          lane: 1,
-          type: "text",
-          label: "inside",
-          isError: false,
-        },
-      ],
-      { start: 0, end: 10 },
-      10,
-    )
+  it("uses half-open columns while keeping point spans on the endpoints", () => {
+    const spans = [
+      { start: -1, end: 0, turn: 1, lane: 1, type: "before", label: "before", isError: true },
+      { start: 0, end: 0, turn: 2, lane: 1, type: "point", label: "first", isError: false },
+      { start: 1, end: 2, turn: 3, lane: 1, type: "inside", label: "inside", isError: false },
+      { start: 10, end: 10, turn: 4, lane: 1, type: "point", label: "last", isError: false },
+      { start: 10, end: 11, turn: 5, lane: 1, type: "after", label: "after", isError: true },
+    ]
+    const domain = { start: 0, end: 10 }
 
-    expect(buckets).toHaveLength(1)
-    expect(buckets[0]).toMatchObject({ count: 1, error: false, labels: ["inside"] })
+    expect(summarizeTimelineColumn(spans, domain, 10, 1, 0)).toMatchObject({
+      count: 1,
+      labels: ["first"],
+      error: false,
+    })
+    expect(summarizeTimelineColumn(spans, domain, 10, 1, 1)).toMatchObject({
+      count: 1,
+      labels: ["inside"],
+      error: false,
+    })
+    expect(summarizeTimelineColumn(spans, domain, 10, 1, 9)).toMatchObject({
+      count: 1,
+      labels: ["last"],
+      error: false,
+    })
   })
 
-  it("keeps zero-width point spans on the domain endpoints", () => {
-    const buckets = rasterizeTimelineSpans(
-      [
-        {
-          start: 0,
-          end: 0,
-          index: 1,
-          turn: 1,
-          lane: 1,
-          type: "text",
-          label: "first",
-          isError: false,
-        },
-        {
-          start: 10,
-          end: 10,
-          index: 2,
-          turn: 2,
-          lane: 1,
-          type: "text",
-          label: "last",
-          isError: false,
-        },
-      ],
-      { start: 0, end: 10 },
-      10,
-    )
-
-    expect(buckets).toHaveLength(2)
-    expect(buckets.map((bucket) => bucket.col)).toEqual([0, 9])
-  })
-
-  it("rasterizes thousands of overlapping spans without quadratic metadata scans", () => {
-    const spans = Array.from({ length: 2000 }, (_, index) => ({
+  it("keeps only the first five unique tooltip values in span order", () => {
+    const spans = Array.from({ length: 8 }, (_, index) => ({
       start: 0,
       end: 10,
-      index,
       turn: index + 1,
       lane: 1,
       type: `type-${index}`,
       label: `label-${index}`,
       isError: false,
     }))
-    const started = performance.now()
 
-    const buckets = rasterizeTimelineSpans(spans, { start: 0, end: 10 }, 400)
-
-    expect(performance.now() - started).toBeLessThan(1000)
-    expect(buckets).toHaveLength(1)
-    expect(buckets[0]).toMatchObject({ count: 2000, spanCols: 400 })
-  })
-
-  it("keeps projected long spans as one multi-column bucket", () => {
-    const buckets = rasterizeTimelineSpans(
-      [
-        {
-          start: 2,
-          end: 7,
-          index: 1,
-          turn: 1,
-          lane: 1,
-          type: "processing_start",
-          label: "",
-          isError: false,
-        },
-      ],
-      { start: 0, end: 10 },
-      10,
-    )
-
-    expect(buckets).toEqual([
-      expect.objectContaining({ key: "1:2:6", col: 2, spanCols: 5, count: 1 }),
-    ])
+    expect(summarizeTimelineColumn(spans, { start: 0, end: 10 }, 10, 1, 4)).toMatchObject({
+      count: 8,
+      turns: [1, 2, 3, 4, 5],
+      types: ["type-0", "type-1", "type-2", "type-3", "type-4"],
+      labels: ["label-0", "label-1", "label-2", "label-3", "label-4"],
+    })
   })
 })
 

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/traceTimeline.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/traceTimeline.test.js
@@ -5,6 +5,8 @@ import {
   formatTimelineDuration,
   laneForType,
   normalizeSpan,
+  rasterizeTimelineSpans,
+  rasterizeTurnBoundaries,
   traceTimelineFocus,
 } from "@/components/sessions/trace/traceTimeline"
 
@@ -127,6 +129,199 @@ describe("deriveTraceTimeline", () => {
   it("returns null for empty input", () => {
     expect(deriveTraceTimeline([], "sequence")).toBe(null)
     expect(deriveTraceTimeline([], "actual")).toBe(null)
+  })
+})
+
+describe("rasterizeTimelineSpans", () => {
+  it("merges spans that occupy the same lane and pixel columns", () => {
+    const buckets = rasterizeTimelineSpans(
+      [
+        {
+          start: 1,
+          end: 2,
+          index: 1,
+          turn: 1,
+          lane: 2,
+          type: "tool_call",
+          label: "bash",
+          isError: false,
+        },
+        {
+          start: 1.1,
+          end: 1.9,
+          index: 2,
+          turn: 2,
+          lane: 2,
+          type: "tool_result",
+          label: "read",
+          isError: true,
+        },
+        {
+          start: 1.1,
+          end: 1.9,
+          index: 3,
+          turn: 2,
+          lane: 3,
+          type: "subagent_call",
+          label: "explore",
+          isError: false,
+        },
+      ],
+      { start: 0, end: 10 },
+      10,
+    )
+
+    expect(buckets).toHaveLength(2)
+    expect(buckets[0]).toMatchObject({
+      key: "2:1:1",
+      lane: 2,
+      col: 1,
+      spanCols: 1,
+      count: 2,
+      error: true,
+      turns: [1, 2],
+      types: ["tool_call", "tool_result"],
+      labels: ["bash", "read"],
+      minStart: 1,
+      maxEnd: 2,
+    })
+    expect(buckets[1]).toMatchObject({ key: "3:1:1", lane: 3, count: 1 })
+  })
+
+  it("excludes spans that only touch the half-open domain boundary", () => {
+    const buckets = rasterizeTimelineSpans(
+      [
+        {
+          start: -1,
+          end: 0,
+          index: 1,
+          turn: 1,
+          lane: 1,
+          type: "text",
+          label: "before",
+          isError: true,
+        },
+        {
+          start: 10,
+          end: 11,
+          index: 2,
+          turn: 2,
+          lane: 1,
+          type: "text",
+          label: "after",
+          isError: true,
+        },
+        {
+          start: 0,
+          end: 1,
+          index: 3,
+          turn: 3,
+          lane: 1,
+          type: "text",
+          label: "inside",
+          isError: false,
+        },
+      ],
+      { start: 0, end: 10 },
+      10,
+    )
+
+    expect(buckets).toHaveLength(1)
+    expect(buckets[0]).toMatchObject({ count: 1, error: false, labels: ["inside"] })
+  })
+
+  it("keeps zero-width point spans on the domain endpoints", () => {
+    const buckets = rasterizeTimelineSpans(
+      [
+        {
+          start: 0,
+          end: 0,
+          index: 1,
+          turn: 1,
+          lane: 1,
+          type: "text",
+          label: "first",
+          isError: false,
+        },
+        {
+          start: 10,
+          end: 10,
+          index: 2,
+          turn: 2,
+          lane: 1,
+          type: "text",
+          label: "last",
+          isError: false,
+        },
+      ],
+      { start: 0, end: 10 },
+      10,
+    )
+
+    expect(buckets).toHaveLength(2)
+    expect(buckets.map((bucket) => bucket.col)).toEqual([0, 9])
+  })
+
+  it("rasterizes thousands of overlapping spans without quadratic metadata scans", () => {
+    const spans = Array.from({ length: 2000 }, (_, index) => ({
+      start: 0,
+      end: 10,
+      index,
+      turn: index + 1,
+      lane: 1,
+      type: `type-${index}`,
+      label: `label-${index}`,
+      isError: false,
+    }))
+    const started = performance.now()
+
+    const buckets = rasterizeTimelineSpans(spans, { start: 0, end: 10 }, 400)
+
+    expect(performance.now() - started).toBeLessThan(1000)
+    expect(buckets).toHaveLength(1)
+    expect(buckets[0]).toMatchObject({ count: 2000, spanCols: 400 })
+  })
+
+  it("keeps projected long spans as one multi-column bucket", () => {
+    const buckets = rasterizeTimelineSpans(
+      [
+        {
+          start: 2,
+          end: 7,
+          index: 1,
+          turn: 1,
+          lane: 1,
+          type: "processing_start",
+          label: "",
+          isError: false,
+        },
+      ],
+      { start: 0, end: 10 },
+      10,
+    )
+
+    expect(buckets).toEqual([
+      expect.objectContaining({ key: "1:2:6", col: 2, spanCols: 5, count: 1 }),
+    ])
+  })
+})
+
+describe("rasterizeTurnBoundaries", () => {
+  it("collapses boundaries that land in the same pixel column", () => {
+    expect(
+      rasterizeTurnBoundaries(
+        [
+          { turn: 1, time: 1.1 },
+          { turn: 2, time: 1.8 },
+          { turn: 3, time: 5 },
+        ],
+        { start: 0, end: 10 },
+        10,
+      ),
+    ).toEqual([
+      { key: 1, x: 15, label: "1–2" },
+      { key: 5, x: 55, label: "3" },
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes severe Trace timeline jank on large saved sessions. Hover now updates only the hover indicator, while timeline spans and turn boundaries are rasterized into bounded pixel columns and high-frequency interactions are batched per animation frame.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

A real 16.8 MB session with 3,439 timeline spans exposed two bottlenecks:

1. Ordinary hover updated an inherited CSS custom property on the timeline ancestor, invalidating styles for its entire descendant tree. Across 120 hover moves, `UpdateLayoutTree` accumulated about 6,059 ms.
2. The main timeline and minimap rendered one bucket per span, producing about 6,878 raw bucket elements before other overlays.

The implementation keeps the existing interaction behavior while bounding DOM size and responsive updates.

## Changes

- Move the hover line directly with `translate3d()` instead of mutating an ancestor CSS custom property.
- Avoid reactive viewport work during ordinary hover and reuse one geometry read for drag/pan paths.
- Rasterize timeline buckets by lane and pixel column for the main timeline and minimap.
- Aggregate turn boundaries by pixel column.
- Batch pointer-move and wheel updates with `requestAnimationFrame`.
- Preview selection overlays through direct DOM updates during drag, committing reactive state at the interaction boundary.
- Preserve zero-width point spans and use `Set` metadata deduplication to avoid quadratic scans for overlapping spans.
- Add component and rasterizer regression tests covering hover, geometry reads, RAF batching, selection, wheel ordering, lifecycle cleanup, point spans, overlap, and large inputs.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/test_file_sizes.py -v --tb=short
pytest tests/unit/test_dep_graph_lint.py -v --tb=short
pytest tests/unit/packaging/ -q
pytest tests/integration/ -v --tb=short

cd src/kohakuterrarium-frontend
npm run format:check
npm run lint
npm run build
npx vitest run \
  src/components/sessions/trace/TraceTimeline.component.test.js \
  src/components/sessions/trace/traceTimeline.test.js

python -m build --wheel
# install dist/*.whl in a clean venv, then:
kt --help
kt app --help
kt-cli --help
kt-tui --help
kt shims status
```

Results:

- Trace timeline Vitest: 30 passed.
- Python integration: 173 passed.
- File-size, dependency-graph, and packaging guards passed.
- Frontend Prettier check and production build passed.
- ESLint passed with 0 errors and 3 pre-existing attribute-order warnings in `TraceTab.vue`.
- Wheel build, isolated installation, and all CLI smoke checks passed.

Real-session benchmark after this change:

| Metric | Before | After |
|---|---:|---:|
| Timeline track direct children | 3,456 | 634 |
| Absolutely positioned page elements | 6,921 | 1,040 |
| Main-pan longest renderer task | — | 9.64 ms |
| Minimap-drag longest renderer task | — | 10.15 ms |
| Renderer tasks over 16.7 ms | frequent during baseline hover | 0 in pan/minimap retest |

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Closes #176

## Notes for Reviewers

The optimization deliberately stops at single-domain pixel-column rasterization and RAF batching. A more complex three-screen pre-rasterized pan layer was prototyped and rejected because it introduced separate logical and rendering coordinate systems without measurable need: the final real-session pan and minimap traces contain no renderer task over 16.7 ms.

Review focus is welcome around zero-width point-span projection, half-open bucket intervals, and interaction cleanup when the model changes mid-frame.

## Screenshots / Logs (if applicable)

Chrome DevTools traces on the real session measured:

- ordinary-hover `UpdateLayoutTree`: about 6,059 ms before, about 28 ms when moving the hover line directly;
- main-pan maximum renderer task after both commits: 9.64 ms;
- minimap-drag maximum renderer task after both commits: 10.15 ms.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The complete local Windows unit suite reported `12059 passed, 9 skipped, 7 failed`:

- six Dulwich real-repository tests assume Git's initial branch is named `master`, while this machine globally configures `main`; rerunning that module with an isolated CI-equivalent `init.defaultBranch=master` configuration produced `6 passed`;
- the config-pollution guard observed the already-running KohakuTerrarium process updating `~/.kohakuterrarium/app.log`; rerunning the guard independently produced `1 passed`.

No failing test imports or exercises the modified frontend files. The GitHub Actions Python/OS matrix and fork CI remain the authoritative cross-platform checks.
