### PR TITLE
fix(frontend): ignore stale Trace store responses

### DIFF
--- a/src/kohakuterrarium-frontend/src/stores/traceTimeline.js
+++ b/src/kohakuterrarium-frontend/src/stores/traceTimeline.js
@@ -23,12 +23,16 @@ const _traceTimelineOptions = {
     records: [],
     truncated: false,
     loading: false,
+    loadGeneration: 0,
+    loadingGeneration: null,
     error: "",
   }),
 
   actions: {
     async load(sessionName, agent = null) {
       if (!sessionName) return
+      this.loadGeneration += 1
+      const generation = this.loadGeneration
       const isSwitch = sessionName !== this.sessionName || (agent || "") !== this.agent
       this.sessionName = sessionName
       this.agent = agent || ""
@@ -38,17 +42,23 @@ const _traceTimelineOptions = {
         this.error = ""
       }
       this.loading = true
+      this.loadingGeneration = generation
       try {
         const data = await sessionAPI.getTimeline(sessionName, { agent })
+        if (generation !== this.loadGeneration) return
         this.records = (data.spans || []).map(normalizeSpan).filter(Boolean)
         this.truncated = Boolean(data.truncated)
         this.agent = data.agent || agent || ""
       } catch (err) {
+        if (generation !== this.loadGeneration) return
         this.error = `Failed to load timeline: ${err.message || err}`
         this.records = []
         this.truncated = false
       } finally {
-        this.loading = false
+        if (this.loadingGeneration === generation) {
+          this.loading = false
+          this.loadingGeneration = null
+        }
       }
     },
 
@@ -61,10 +71,13 @@ const _traceTimelineOptions = {
     },
 
     clear() {
+      this.loadGeneration += 1
       this.sessionName = ""
       this.agent = ""
       this.records = []
       this.truncated = false
+      this.loading = false
+      this.loadingGeneration = null
       this.error = ""
     },
   },

--- a/src/kohakuterrarium-frontend/src/stores/traceTimeline.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/traceTimeline.test.js
@@ -1,0 +1,71 @@
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useTraceTimelineStore } from "@/stores/traceTimeline"
+import { sessionAPI } from "@/utils/api"
+
+vi.mock("@/utils/api", () => ({
+  sessionAPI: { getTimeline: vi.fn() },
+}))
+
+function deferred() {
+  let resolve
+  const promise = new Promise((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe("trace timeline store", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    sessionAPI.getTimeline.mockReset()
+  })
+
+  it("ignores a stale response after switching agents", async () => {
+    const oldRequest = deferred()
+    sessionAPI.getTimeline.mockReturnValueOnce(oldRequest.promise).mockResolvedValueOnce({
+      agent: "bob",
+      spans: [{ eid: 2, type: "text", ts: 2, turn: 2 }],
+      truncated: false,
+    })
+    const store = useTraceTimelineStore("trace-timeline-race")
+
+    const firstLoad = store.load("session", "alice")
+    await Promise.resolve()
+    await store.load("session", "bob")
+    oldRequest.resolve({
+      agent: "alice",
+      spans: [{ eid: 1, type: "text", ts: 1, turn: 1 }],
+      truncated: true,
+    })
+    await firstLoad
+
+    expect(store.agent).toBe("bob")
+    expect(store.records.map((record) => record.eid)).toEqual([2])
+    expect(store.truncated).toBe(false)
+    expect(store.error).toBe("")
+    expect(store.loading).toBe(false)
+  })
+
+  it("invalidates an in-flight response when cleared", async () => {
+    const request = deferred()
+    sessionAPI.getTimeline.mockReturnValueOnce(request.promise)
+    const store = useTraceTimelineStore("trace-timeline-clear")
+
+    const load = store.load("session", "alice")
+    await Promise.resolve()
+    store.clear()
+    request.resolve({
+      agent: "alice",
+      spans: [{ eid: 1, type: "text", ts: 1, turn: 1 }],
+      truncated: false,
+    })
+    await load
+
+    expect(store.sessionName).toBe("")
+    expect(store.agent).toBe("")
+    expect(store.records).toEqual([])
+    expect(store.loading).toBe(false)
+  })
+})

--- a/src/kohakuterrarium-frontend/src/stores/turnRollup.js
+++ b/src/kohakuterrarium-frontend/src/stores/turnRollup.js
@@ -25,6 +25,8 @@ const _turnRollupOptions = {
     turns: [],
     total: 0,
     loading: false,
+    loadGeneration: 0,
+    loadingGeneration: null,
     error: "",
   }),
 
@@ -55,6 +57,8 @@ const _turnRollupOptions = {
   actions: {
     async load(sessionName, agent = null, { aggregate = false } = {}) {
       if (!sessionName) return
+      this.loadGeneration += 1
+      const generation = this.loadGeneration
       const isSwitch =
         sessionName !== this.sessionName ||
         (agent || "") !== this.agent ||
@@ -68,29 +72,38 @@ const _turnRollupOptions = {
         this.error = ""
       }
       this.loading = true
+      this.loadingGeneration = generation
       try {
         const data = await sessionAPI.getTurns(sessionName, {
           agent,
           limit: 1000,
           aggregate,
         })
+        if (generation !== this.loadGeneration) return
         this.turns = data.turns || []
         this.total = data.total || 0
         this.agent = data.agent || agent || ""
       } catch (err) {
+        if (generation !== this.loadGeneration) return
         this.error = `Failed to load turns: ${err.message || err}`
         this.turns = []
         this.total = 0
       } finally {
-        this.loading = false
+        if (this.loadingGeneration === generation) {
+          this.loading = false
+          this.loadingGeneration = null
+        }
       }
     },
 
     clear() {
+      this.loadGeneration += 1
       this.sessionName = ""
       this.agent = ""
       this.turns = []
       this.total = 0
+      this.loading = false
+      this.loadingGeneration = null
       this.error = ""
     },
   },

--- a/src/kohakuterrarium-frontend/src/stores/turnRollup.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/turnRollup.test.js
@@ -1,0 +1,63 @@
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useTurnRollupStore } from "@/stores/turnRollup"
+import { sessionAPI } from "@/utils/api"
+
+vi.mock("@/utils/api", () => ({
+  sessionAPI: { getTurns: vi.fn() },
+}))
+
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+describe("turn rollup store", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    sessionAPI.getTurns.mockReset()
+  })
+
+  it("ignores a stale response after switching agents", async () => {
+    const oldRequest = deferred()
+    sessionAPI.getTurns
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockResolvedValueOnce({ agent: "bob", turns: [{ turn_index: 2 }], total: 1 })
+    const store = useTurnRollupStore("turn-rollup-race")
+
+    const firstLoad = store.load("session", "alice")
+    await Promise.resolve()
+    await store.load("session", "bob")
+    oldRequest.resolve({ agent: "alice", turns: [{ turn_index: 1 }], total: 1 })
+    await firstLoad
+
+    expect(store.agent).toBe("bob")
+    expect(store.turns).toEqual([{ turn_index: 2 }])
+    expect(store.total).toBe(1)
+    expect(store.error).toBe("")
+    expect(store.loading).toBe(false)
+  })
+
+  it("invalidates an in-flight response when cleared", async () => {
+    const request = deferred()
+    sessionAPI.getTurns.mockReturnValueOnce(request.promise)
+    const store = useTurnRollupStore("turn-rollup-clear")
+
+    const load = store.load("session", "alice")
+    await Promise.resolve()
+    store.clear()
+    request.resolve({ agent: "alice", turns: [{ turn_index: 1 }], total: 1 })
+    await load
+
+    expect(store.sessionName).toBe("")
+    expect(store.agent).toBe("")
+    expect(store.turns).toEqual([])
+    expect(store.loading).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Prevent delayed turn-rollup and trace-timeline requests from overwriting the currently selected agent or resurrecting cleared session state.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The two Trace stores committed every asynchronous response unconditionally. Rapid agent switching could let an older request arrive last and replace the active agent's data.

## Changes

- add request-generation guards to the turn-rollup store
- add the same guards to the trace-timeline store
- invalidate in-flight loads from `clear()`
- cover agent-switch and clear races with deferred-promise tests

## Validation

```bash
npm test -- --run src/stores/turnRollup.test.js src/stores/traceTimeline.test.js src/stores/eventStream.test.js
npm run format:check
env CHOKIDAR_USEPOLLING=true npm run build
npm run lint -- src/stores/turnRollup.js src/stores/traceTimeline.js src/stores/turnRollup.test.js src/stores/traceTimeline.test.js
```

Focused result: 6 tests passed. Production build and formatting passed. ESLint reported no errors and three pre-existing TraceTab attribute-order warnings.

The full Vitest run reached 1,036 passing tests, but the existing `MacroShell.test.js` suite failed while resolving the installed `monaco-editor` package under the local Vitest environment.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I added or updated tests when needed
- [x] `npm run format:check` passes
- [x] `npm run build` passes
- [ ] CI on my fork is green

## Related Issues / Discussions

Fixes #179

## Notes for Reviewers

The implementation deliberately mirrors the generation invariant already used by `eventStream`; it does not add request cancellation or change API behavior.

## Exceptions / Not Run

The full Vitest run has one environment-level failure described above. Python checks were not run because this PR changes only frontend stores and tests.