### PR TITLE
fix(trace): preserve and classify tool failures

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
@@ -49,6 +49,7 @@ import TraceEventDetail from "@/components/sessions/trace/TraceEventDetail.vue"
 import TraceTab_TraceFilters from "@/components/sessions/trace/TraceFilters.vue"
 import TraceTab_TraceTimeline from "@/components/sessions/trace/TraceTimeline.vue"
 import TraceTab_TraceTurnGroup from "@/components/sessions/trace/TraceTurnGroup.vue"
+import { isTraceErrorEvent } from "@/components/sessions/trace/traceErrors"
 import { parseSearchTerms } from "@/components/sessions/trace/traceSearch"
 import { deriveTraceTimeline, traceTimelineFocus } from "@/components/sessions/trace/traceTimeline"
 import { useSessionEventStream } from "@/composables/useSessionEventStream"
@@ -136,15 +137,22 @@ const liveStatus = computed(() => {
 
 // Convert {key, event} → event objects for the per-turn group rendering.
 const liveEventsObjects = computed(() => liveEvents.value.map((e) => e.event))
+const liveErrorTurns = computed(
+  () =>
+    new Set(
+      liveEventsObjects.value
+        .filter(isTraceErrorEvent)
+        .map((event) => event.turn_index)
+        .filter((turn) => Number.isInteger(turn)),
+    ),
+)
 
-// "Errors only" reflects in turn-level filter too: hide turns that have
-// no error events. Turn rollups don't carry has_error today; we infer
-// from the live events buffer + the rollup row presence in error_turns.
+// "Errors only" reflects in the turn list as well as the timeline.
+// Persisted rollups and current live events both contribute failures.
 const displayedTurns = computed(() => {
   let turns = rollup.turns
   if (filters.value.errorsOnly) {
-    const errSet = new Set(detail.summary?.error_turns || [])
-    turns = turns.filter((t2) => errSet.has(t2.turn_index))
+    turns = turns.filter((t2) => t2.has_error || liveErrorTurns.value.has(t2.turn_index))
   }
   const focus = timelineFocus.value
   if (focus) turns = turns.filter((t2) => focus.turns.has(t2.turn_index))

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTurnGroup.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceTurnGroup.vue
@@ -30,6 +30,7 @@
 import { computed, nextTick, onUnmounted, ref, watch } from "vue"
 
 import TraceEventRow from "@/components/sessions/trace/TraceEventRow.vue"
+import { isTraceErrorEvent } from "@/components/sessions/trace/traceErrors"
 import { matchesSearch, parseSearchTerms } from "@/components/sessions/trace/traceSearch"
 import { disposeEventStreamStore, useEphemeralEventStreamStore } from "@/stores/eventStream"
 import { useI18n } from "@/utils/i18n"
@@ -133,7 +134,7 @@ const TYPE_GROUPS = {
 function _passesFilter(ev) {
   const f = props.filters || {}
   if (f.errorsOnly) {
-    if (!String(ev.type || "").includes("error")) return false
+    if (!isTraceErrorEvent(ev)) return false
   }
   const terms = parseSearchTerms(f.search)
   if (terms.length && !matchesSearch(ev, terms)) return false

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/traceErrors.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/traceErrors.js
@@ -1,0 +1,21 @@
+const ERROR_TYPES = new Set(["tool_error", "subagent_error", "processing_error"])
+const FAILED_STATES = new Set(["error", "interrupted", "cancelled"])
+
+export function isTraceErrorEvent(event) {
+  if (!event) return false
+  if (ERROR_TYPES.has(event.type)) return true
+  if (
+    event.success === false ||
+    Boolean(event.error) ||
+    Boolean(event.interrupted) ||
+    Boolean(event.cancelled) ||
+    FAILED_STATES.has(String(event.final_state || "").toLowerCase())
+  ) {
+    return true
+  }
+  if (event.type !== "tool_result" || event.exit_code == null || event.exit_code === "") {
+    return false
+  }
+  const exitCode = Number(event.exit_code)
+  return Number.isFinite(exitCode) && exitCode !== 0
+}

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/traceErrors.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/traceErrors.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { isTraceErrorEvent } from "./traceErrors"
+
+describe("isTraceErrorEvent", () => {
+  it("recognizes persisted tool failures", () => {
+    expect(isTraceErrorEvent({ type: "tool_result", error: "boom" })).toBe(true)
+    expect(isTraceErrorEvent({ type: "tool_result", exit_code: 2 })).toBe(true)
+    expect(isTraceErrorEvent({ type: "tool_result", exit_code: "1" })).toBe(true)
+  })
+
+  it("keeps successful tool results out of the error filter", () => {
+    expect(isTraceErrorEvent({ type: "tool_result", exit_code: 0 })).toBe(false)
+    expect(isTraceErrorEvent({ type: "tool_result", exit_code: null })).toBe(false)
+    expect(isTraceErrorEvent({ type: "tool_result", error: "" })).toBe(false)
+  })
+
+  it("recognizes explicit and terminal failure states", () => {
+    expect(isTraceErrorEvent({ type: "processing_error" })).toBe(true)
+    expect(isTraceErrorEvent({ type: "subagent_result", success: false })).toBe(true)
+    expect(isTraceErrorEvent({ type: "tool_result", interrupted: true })).toBe(true)
+    expect(isTraceErrorEvent({ type: "tool_result", final_state: "cancelled" })).toBe(true)
+  })
+})

--- a/src/kohakuterrarium/core/agent_runtime_tools.py
+++ b/src/kohakuterrarium/core/agent_runtime_tools.py
@@ -137,7 +137,15 @@ class AgentRuntimeToolsMixin:
             return
         job_id = getattr(event, "job_id", "")
         is_subagent = job_id.startswith("agent_")
-        error = event.context.get("error") if event.context else None
+        context = event.context or {}
+        error = context.get("error")
+        exit_code = context.get("exit_code")
+        try:
+            failed_exit = exit_code is not None and int(exit_code) != 0
+        except (TypeError, ValueError):
+            failed_exit = False
+        if failed_exit and not error:
+            error = f"Tool exited with code {exit_code}"
         content = render_content_text(event.content)
         _, label = _make_job_label(job_id)
         activity_done, activity_error = (
@@ -168,6 +176,7 @@ class AgentRuntimeToolsMixin:
                     "llm_name": sa_meta.get("llm_name", ""),
                     "model": sa_meta.get("model", ""),
                     "error": error,
+                    "exit_code": exit_code,
                     "interrupted": interrupted,
                     "cancelled": cancelled,
                     "final_state": final_state,
@@ -205,7 +214,11 @@ class AgentRuntimeToolsMixin:
             self.output_router.notify_activity(
                 activity_done,
                 f"[{label}] DONE",
-                metadata={"job_id": job_id, "result": content},
+                metadata={
+                    "job_id": job_id,
+                    "result": content,
+                    "exit_code": exit_code,
+                },
             )
 
         logger.info("Background job completed", job_id=job_id)

--- a/src/kohakuterrarium/core/agent_tools.py
+++ b/src/kohakuterrarium/core/agent_tools.py
@@ -516,7 +516,11 @@ class AgentToolsMixin(AgentRuntimeToolsMixin):
             # preview stays for UI rendering.
             "output": output,
             "output_preview": preview,
+            "exit_code": exit_code,
         }
+        if not succeeded:
+            metadata["error"] = f"Tool exited with code {exit_code}"
+            metadata["final_state"] = "error"
         if is_subagent:
             result_metadata = getattr(result, "metadata", {})
             metadata["result"] = preview
@@ -541,7 +545,7 @@ class AgentToolsMixin(AgentRuntimeToolsMixin):
         if isinstance(session_metadata, dict):
             metadata["tool_metadata"] = dict(session_metadata)
         self.output_router.notify_activity(
-            done_activity,
+            done_activity if succeeded else error_activity,
             f"[{label}] {status}",
             metadata=metadata,
         )

--- a/src/kohakuterrarium/session/output.py
+++ b/src/kohakuterrarium/session/output.py
@@ -461,7 +461,7 @@ class SessionOutput(OutputModule):
             "name": name,
             "call_id": metadata.get("job_id", ""),
             "output": metadata.get("result", metadata.get("output", detail)),
-            "exit_code": 0,
+            "exit_code": metadata.get("exit_code", 0),
         }
         # Persist preview metadata so history reload need not read the file again.
         canvas_preview = metadata.get("canvas_preview")
@@ -478,8 +478,8 @@ class SessionOutput(OutputModule):
             {
                 "name": name,
                 "call_id": metadata.get("job_id", ""),
-                "output": metadata.get("result", detail),
-                "exit_code": 1,
+                "output": metadata.get("result", metadata.get("output", detail)),
+                "exit_code": metadata.get("exit_code", 1),
                 "error": metadata.get("error", detail),
                 "interrupted": bool(metadata.get("interrupted", False)),
                 "cancelled": bool(metadata.get("cancelled", False)),

--- a/src/kohakuterrarium/studio/persistence/viewer/rollups.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/rollups.py
@@ -153,6 +153,29 @@ def _subagent_failed(evt: dict) -> bool:
     )
 
 
+def _event_failed(evt: dict) -> bool:
+    """Return whether one persisted event represents failed work."""
+    if evt.get("type") in ERROR_EVENT_TYPES or _subagent_failed(evt):
+        return True
+    if (
+        evt.get("success") is False
+        or bool(evt.get("error"))
+        or bool(evt.get("interrupted"))
+        or bool(evt.get("cancelled"))
+        or str(evt.get("final_state") or "").lower() in _FAILED_FINAL_STATES
+    ):
+        return True
+    if evt.get("type") != "tool_result":
+        return False
+    exit_code = evt.get("exit_code")
+    if exit_code in (None, ""):
+        return False
+    try:
+        return int(exit_code) != 0
+    except (TypeError, ValueError):
+        return False
+
+
 def _add_usage_bucket(
     buckets: dict[int, dict[str, Any]], turn: int, usage: dict[str, Any]
 ) -> None:
@@ -194,7 +217,7 @@ def derive_own_turns_from_events(events: list[dict], agent: str) -> list[dict]:
                 _add_usage_bucket(token_usage, ti, usage)
         elif etype == "tool_call":
             row["tool_calls"] += 1
-        elif etype in ERROR_EVENT_TYPES or _subagent_failed(evt):
+        elif _event_failed(evt):
             row["has_error"] = True
         elif etype in ("compact_complete", "compact_replace"):
             row["compacted"] = True
@@ -352,20 +375,40 @@ def derive_turns_from_events(events: list[dict], agent: str) -> list[dict]:
     return _merge_subagents(own_rows, sub_rows, agent)
 
 
-def _own_rollups_or_derived(store: SessionStore, agent: str) -> list[dict]:
-    rows = store.list_turn_rollups(agent)
-    if rows:
-        return rows
-    events = dedupe_adjacent_duplicate_events(store.get_events(agent))
-    return derive_own_turns_from_events(events, agent)
+def _merge_own_rollups(stored: list[dict], derived: list[dict]) -> list[dict]:
+    """Keep stored usage while overlaying diagnostics derived from events."""
+    by_turn = {row.get("turn_index"): dict(row) for row in stored}
+    for diagnostic in derived:
+        turn = diagnostic.get("turn_index")
+        row = by_turn.get(turn)
+        if row is None:
+            by_turn[turn] = dict(diagnostic)
+            continue
+        row["tool_calls"] = max(
+            _as_int(row.get("tool_calls")), _as_int(diagnostic.get("tool_calls"))
+        )
+        row["has_error"] = bool(row.get("has_error") or diagnostic.get("has_error"))
+        row["compacted"] = bool(row.get("compacted") or diagnostic.get("compacted"))
+        for field in ("started_at", "ended_at"):
+            if row.get(field) is None and diagnostic.get(field) is not None:
+                row[field] = diagnostic[field]
+    return sorted(by_turn.values(), key=lambda row: _as_int(row.get("turn_index")))
+
+
+def _own_rollups_or_derived(
+    store: SessionStore, agent: str, events: list[dict] | None = None
+) -> list[dict]:
+    if events is None:
+        events = dedupe_adjacent_duplicate_events(store.get_events(agent))
+    derived = derive_own_turns_from_events(events, agent)
+    stored = store.list_turn_rollups(agent)
+    return _merge_own_rollups(stored, derived) if stored else derived
 
 
 def rollups_or_derived(store: SessionStore, agent: str) -> list[dict]:
     """Return full turn rows for ``agent`` including sub-agent tokens."""
     events = dedupe_adjacent_duplicate_events(store.get_events(agent))
-    own_rows = store.list_turn_rollups(agent)
-    if not own_rows:
-        own_rows = derive_own_turns_from_events(events, agent)
+    own_rows = _own_rollups_or_derived(store, agent, events)
     sub_rows = derive_subagent_turns_from_events(events, agent)
     return _merge_subagents(own_rows, sub_rows, agent)
 
@@ -414,7 +457,7 @@ def _empty_aggregate(turn_index: int) -> dict:
 
 def _iter_rollup_contributions(store: SessionStore, name: str, kind: str):
     events = dedupe_adjacent_duplicate_events(store.get_events(name))
-    for row in _own_rollups_or_derived(store, name):
+    for row in _own_rollups_or_derived(store, name, events):
         yield name, kind, row
     for row in derive_subagent_turns_from_events(events, name):
         yield row.get("agent") or name, "subagent", row

--- a/src/kohakuterrarium/studio/persistence/viewer/summary.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/summary.py
@@ -10,7 +10,7 @@ from typing import Any
 from kohakuterrarium.errors import NotFoundError
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio.persistence.viewer.rollups import (
-    ERROR_EVENT_TYPES,
+    _event_failed,
     aggregate_turn_rollups,
     graph_total_usage,
     rollups_or_derived,
@@ -116,7 +116,7 @@ def _scan_events_for_summary(events: list[dict]) -> dict[str, Any]:
             ti = e.get("spawned_in_turn")
         if etype == "tool_call":
             tool_calls += 1
-        elif etype in ERROR_EVENT_TYPES or _subagent_failed(e):
+        elif _event_failed(e):
             if isinstance(ti, int) and ti not in seen_error_turns:
                 seen_error_turns.add(ti)
                 errors.append(ti)

--- a/src/kohakuterrarium/studio/persistence/viewer/timeline.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/timeline.py
@@ -11,9 +11,8 @@ from kohakuterrarium.errors import NotFoundError
 from kohakuterrarium.session.history import dedupe_adjacent_duplicate_events
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio.persistence.viewer.rollups import (
-    ERROR_EVENT_TYPES,
+    _event_failed,
     _event_turn_index,
-    _subagent_failed,
 )
 
 #: Fields copied onto each span. Everything else (content, output, …) is
@@ -47,11 +46,7 @@ def _span_from_event(evt: dict) -> dict[str, Any]:
         # Ordinary tool failures keep type ``tool_result`` and encode the
         # failure in ``error``/``exit_code`` — honour that, not just the
         # dedicated error event types.
-        "err": (
-            evt.get("type") in ERROR_EVENT_TYPES
-            or _subagent_failed(evt)
-            or bool(evt.get("error"))
-        ),
+        "err": _event_failed(evt),
     }
     label = evt.get("tool") or evt.get("name") or evt.get("tool_name")
     if label:

--- a/tests/unit/core/test_agent_runtime_tools.py
+++ b/tests/unit/core/test_agent_runtime_tools.py
@@ -358,6 +358,21 @@ class TestOnBgComplete:
         kinds = [c[0] for c in a.output_router.activity_calls]
         assert "tool_error" in kinds
 
+    async def test_nonzero_exit_code_is_an_error(self):
+        a = _make_mixin()
+        evt = TriggerEvent(
+            type=EventType.TOOL_COMPLETE,
+            job_id="bash_x",
+            content="bad",
+            context={"exit_code": 2},
+        )
+
+        a._on_bg_complete(evt)
+
+        kind, _detail, metadata = a.output_router.activity_calls[0]
+        assert kind == "tool_error"
+        assert metadata["exit_code"] == 2
+
     async def test_interrupted_flag(self):
         a = _make_mixin()
         evt = TriggerEvent(

--- a/tests/unit/core/test_agent_tools.py
+++ b/tests/unit/core/test_agent_tools.py
@@ -211,6 +211,16 @@ class TestEmitDirectCompletion:
         kinds = [c[0] for c in agent.output_router.activity_calls]
         assert "tool_error" in kinds
 
+    def test_nonzero_exit_code_emits_tool_error(self, agent):
+        agent._register_direct_job("bash_x", kind="tool", name="bash")
+        result = JobResult(job_id="bash_x", output="bad", exit_code=2)
+
+        agent._emit_direct_completion_activity("bash_x", result)
+
+        kind, _detail, metadata = agent.output_router.activity_calls[-1]
+        assert kind == "tool_error"
+        assert metadata["exit_code"] == 2
+
     def test_exception_result(self, agent):
         agent._register_direct_job("bash_x", kind="tool", name="bash")
         agent._emit_direct_completion_activity("bash_x", RuntimeError("oops"))

--- a/tests/unit/session/test_output.py
+++ b/tests/unit/session/test_output.py
@@ -598,21 +598,44 @@ class TestActivityHandlers:
         finally:
             store.close()
 
+    def test_tool_done_preserves_explicit_exit_code(self, tmp_path):
+        store, out = _make(tmp_path)
+        try:
+            out.on_activity_with_metadata(
+                "tool_done",
+                "[bash] exit=2",
+                {"job_id": "j1", "result": "bad", "exit_code": 2},
+            )
+            store.flush()
+            evt = next(
+                e for e in store.get_events("alice") if e["type"] == "tool_result"
+            )
+            assert evt["exit_code"] == 2
+        finally:
+            store.close()
+
     def test_tool_error(self, tmp_path):
         store, out = _make(tmp_path)
         try:
             out.on_activity_with_metadata(
                 "tool_error",
                 "[bash] failed",
-                {"job_id": "j1", "error": "boom", "interrupted": True},
+                {
+                    "job_id": "j1",
+                    "error": "boom",
+                    "interrupted": True,
+                    "exit_code": 2,
+                    "output": "bad output",
+                },
             )
             store.flush()
             evt = next(
                 e for e in store.get_events("alice") if e["type"] == "tool_result"
             )
-            assert evt["exit_code"] == 1
+            assert evt["exit_code"] == 2
             assert evt["interrupted"] is True
             assert evt["error"] == "boom"
+            assert evt["output"] == "bad output"
         finally:
             store.close()
 

--- a/tests/unit/studio/test_viewer_rollups.py
+++ b/tests/unit/studio/test_viewer_rollups.py
@@ -9,6 +9,7 @@ from kohakuterrarium.studio.persistence.viewer.rollups import (
     _empty_aggregate,
     _empty_row,
     _event_turn_index,
+    _event_failed,
     _is_subagent_token_event,
     _subagent_failed,
     _subagent_label,
@@ -207,6 +208,25 @@ class TestErrorEventTypes:
         assert "processing_error" in ERROR_EVENT_TYPES
 
 
+class TestEventFailed:
+    def test_tool_result_error(self):
+        assert _event_failed({"type": "tool_result", "error": "boom"})
+
+    def test_nonzero_exit_codes(self):
+        assert _event_failed({"type": "tool_result", "exit_code": 2})
+        assert _event_failed({"type": "tool_result", "exit_code": "1"})
+
+    def test_successful_tool_results(self):
+        assert not _event_failed({"type": "tool_result", "exit_code": 0})
+        assert not _event_failed({"type": "tool_result", "exit_code": None})
+        assert not _event_failed({"type": "tool_result", "error": ""})
+
+    def test_terminal_failure_flags(self):
+        assert _event_failed({"type": "tool_result", "success": False})
+        assert _event_failed({"type": "tool_result", "interrupted": True})
+        assert _event_failed({"type": "tool_result", "final_state": "cancelled"})
+
+
 # ── _empty_aggregate ───────────────────────────────────────────
 
 
@@ -258,6 +278,13 @@ class TestDeriveOwnTurns:
 
     def test_error_event_marks_error(self):
         events = [{"type": "tool_error", "turn_index": 1}]
+        rows = derive_own_turns_from_events(events, "alice")
+        assert rows[0]["has_error"] is True
+
+    def test_failed_tool_result_marks_error(self):
+        events = [
+            {"type": "tool_result", "turn_index": 1, "error": "boom", "exit_code": 1}
+        ]
         rows = derive_own_turns_from_events(events, "alice")
         assert rows[0]["has_error"] is True
 
@@ -405,6 +432,29 @@ class TestRollupsOrDerived:
             assert rows[0]["turn_index"] == 1
             assert rows[0]["tokens_in"] == 100
             assert rows[0]["tokens_out"] == 50
+        finally:
+            s.close()
+
+    def test_stored_usage_keeps_event_derived_error_state(self, tmp_path):
+        s = SessionStore(str(tmp_path / "s.kohakutr"))
+        try:
+            s.save_turn_rollup(
+                "alice",
+                1,
+                {"tokens_in": 100, "tokens_out": 50},
+            )
+            s.append_event(
+                "alice",
+                "tool_result",
+                {"error": "boom", "exit_code": 1},
+                turn_index=1,
+            )
+            s.flush()
+
+            rows = rollups_or_derived(s, "alice")
+
+            assert rows[0]["tokens_in"] == 100
+            assert rows[0]["has_error"] is True
         finally:
             s.close()
 

--- a/tests/unit/studio/test_viewer_summary.py
+++ b/tests/unit/studio/test_viewer_summary.py
@@ -105,6 +105,14 @@ class TestScanEvents:
         out = _scan_events_for_summary(events)
         assert sorted(out["error_turns"]) == [1, 2]
 
+    def test_failed_tool_result_counts_as_error(self):
+        events = [
+            {"type": "tool_result", "turn_index": 3, "error": "boom"},
+            {"type": "tool_result", "turn_index": 4, "exit_code": 2},
+        ]
+        out = _scan_events_for_summary(events)
+        assert out["error_turns"] == [3, 4]
+
     def test_tracks_compact_turns(self):
         events = [
             {"type": "compact_complete", "turn_index": 1},

--- a/tests/unit/studio/test_viewer_timeline.py
+++ b/tests/unit/studio/test_viewer_timeline.py
@@ -123,6 +123,21 @@ class TestBuildTimelinePayload:
         finally:
             s.close()
 
+    def test_exit_code_only_tool_failure_marked_as_error(self, tmp_path):
+        s = _store(tmp_path)
+        try:
+            s.init_meta("sess", "agent", "/p", "/w", ["alice"])
+            s.append_event(
+                "alice",
+                "tool_result",
+                {"tool": "bash", "output": "bad", "exit_code": 2},
+            )
+            s.flush()
+            out = build_timeline_payload(s, "sess", agent=None, limit=100)
+            assert out["spans"][0]["err"] is True
+        finally:
+            s.close()
+
 
 class TestPairDurations:
     def test_tool_call_result_pairing(self, tmp_path):


### PR DESCRIPTION
## Summary

- preserve actual tool exit codes and outputs in persisted session events
- classify non-zero tool results and terminal failure metadata consistently in Trace rollups, summaries, timelines, and the Errors only filter
- merge event-derived diagnostics into stored turn rollups without replacing persisted usage data
- add negative-case coverage for direct/background tool completion, persistence, viewer derivation, and frontend filtering

Fixes #180

## Validation

- `300 passed` — focused Python unit tests
- `32 passed` — affected integration workflows
- `13,770 passed, 1 skipped` — full Python unit suite in the sandbox; 17 loopback-binding cases were blocked by sandbox permissions
- `26 passed` — all loopback-binding failures rerun outside the sandbox
- `1,700 passed` — file-size constraints
- `27 passed` — focused frontend Trace tests
- `1,035 passed`; one existing `MacroShell.test.js` suite cannot resolve installed `monaco-editor` in Vitest
- `npm run format:check`
- `npm run build`
- targeted Black and Ruff checks
- `git diff --check`