### PR TITLE
fix(trace): page long-session turns

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.pagination.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.pagination.test.js
@@ -1,0 +1,122 @@
+import { flushPromises, shallowMount } from "@vue/test-utils"
+import { reactive } from "vue"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const state = vi.hoisted(() => ({
+  detail: null,
+  rollup: null,
+  timeline: null,
+  router: { replace: vi.fn() },
+}))
+
+vi.mock("@tanstack/vue-virtual", async () => {
+  const { ref } = await import("vue")
+  return {
+    useVirtualizer: () =>
+      ref({
+        getVirtualItems: () => [],
+        getTotalSize: () => 0,
+        measureElement: vi.fn(),
+        measure: vi.fn(),
+        scrollToIndex: vi.fn(),
+      }),
+  }
+})
+
+vi.mock("vue-router", () => ({
+  useRoute: () => reactive({ query: {} }),
+  useRouter: () => state.router,
+}))
+
+vi.mock("@/stores/sessionDetail", () => ({
+  useSessionDetailStore: () => state.detail,
+}))
+vi.mock("@/stores/turnRollup", () => ({
+  useTurnRollupStore: () => state.rollup,
+}))
+vi.mock("@/stores/traceTimeline", () => ({
+  useTraceTimelineStore: () => state.timeline,
+}))
+vi.mock("@/stores/eventStream", () => ({
+  useEventStreamStore: () => ({ appendLive: vi.fn() }),
+}))
+vi.mock("@/composables/useSessionEventStream", async () => {
+  const { ref } = await import("vue")
+  return {
+    useSessionEventStream: () => ({
+      events: ref([]),
+      newSinceLastClear: ref(0),
+      error: ref(""),
+      subscribed: ref(false),
+      attach: vi.fn(),
+      detach: vi.fn(),
+      clearNewCounter: vi.fn(),
+    }),
+  }
+})
+vi.mock("@/utils/i18n", () => ({
+  useI18n: () => ({ t: (key) => key }),
+}))
+
+import TraceTab from "./TraceTab.vue"
+import TraceTimeline from "@/components/sessions/trace/TraceTimeline.vue"
+
+beforeEach(() => {
+  state.detail = reactive({
+    name: "session-a",
+    agents: ["alice"],
+    reloadKey: 0,
+    summary: { error_turns: [] },
+  })
+  state.rollup = reactive({
+    sessionName: "session-a",
+    agent: "alice",
+    aggregate: false,
+    turns: [{ turn_index: 1001 }],
+    total: 1001,
+    loading: false,
+    loadingOlder: false,
+    hasOlder: true,
+    error: "",
+    pageError: "",
+    load: vi.fn().mockResolvedValue(),
+    loadOlder: vi.fn().mockResolvedValue(true),
+    ensureTurn: vi.fn().mockResolvedValue(true),
+  })
+  state.timeline = reactive({
+    records: [
+      {
+        eid: 42,
+        turn: 5,
+        member: null,
+        type: "tool_result",
+        label: "bash",
+        lane: "tools",
+        err: false,
+        durMs: 1,
+        ts: 1,
+      },
+    ],
+    truncated: false,
+    load: vi.fn().mockResolvedValue(),
+    appendLive: vi.fn(),
+  })
+  state.router.replace.mockReset()
+})
+
+describe("TraceTab long-session navigation", () => {
+  it("resolves a missing turn before routing to a selected timeline span", async () => {
+    const wrapper = shallowMount(TraceTab)
+    await flushPromises()
+
+    wrapper.findComponent(TraceTimeline).vm.$emit("select-span", {
+      turn: 5,
+      index: 42,
+      member: null,
+    })
+    await flushPromises()
+
+    expect(state.rollup.ensureTurn).toHaveBeenCalledWith(5)
+    expect(state.router.replace).toHaveBeenCalledWith({ query: { turn: 5 } })
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
@@ -12,10 +12,15 @@
         {{ t("sessionViewer.trace.timeline.focusTurns", { n: displayedTurns.length }) }}
         <button class="i-carbon-close hover:text-coral" :title="t('sessionViewer.trace.timeline.clearFocus')" @click="timelineRange = null" />
       </span>
+      <button v-if="rollup.hasOlder" class="text-iolite hover:underline disabled:opacity-50" :disabled="rollup.loadingOlder" @click="loadOlderTurns">
+        {{ rollup.loadingOlder ? "…" : t("sessionViewer.trace.turn.loadEarlier") }}
+      </button>
       <span class="flex-1" />
       <button class="text-warm-500 hover:text-warm-700 dark:hover:text-warm-300" @click="expandAll">{{ t("sessionViewer.trace.turn.expandAll") }}</button>
       <button class="text-warm-500 hover:text-warm-700 dark:hover:text-warm-300" @click="collapseAll">{{ t("sessionViewer.trace.turn.collapseAll") }}</button>
     </div>
+
+    <div v-if="rollup.pageError" class="text-[11px] text-coral">{{ rollup.pageError }}</div>
 
     <!-- Live "↓ N new" banner (V4) -->
     <button v-if="filters.live && newSinceLastClear > 0 && !atBottom" class="self-end px-3 py-1 rounded-full bg-aquamarine/15 text-aquamarine text-[11px] font-mono shadow-md hover:bg-aquamarine/25" @click="scrollToBottom">{{ t("sessionViewer.trace.live.newBanner", { n: newSinceLastClear }) }}</button>
@@ -213,18 +218,19 @@ function onToggle(turnIndex) {
   expandedTurns.value = new Set(expandedTurns.value)
 }
 
-function onSelectTurn(turnIndex) {
+async function onSelectTurn(turnIndex, { updateRoute = true } = {}) {
+  if (!(await rollup.ensureTurn(turnIndex))) return false
   // Selecting a turn outside the focused interval clears the focus, like
   // the reference trajectory UI — otherwise the target would stay hidden.
   if (timelineFocus.value && !timelineFocus.value.turns.has(turnIndex)) {
     timelineRange.value = null
   }
   expandedTurns.value = new Set([...expandedTurns.value, turnIndex])
-  router.replace({ query: { ...route.query, turn: turnIndex } })
-  nextTick(() => {
-    const index = displayedTurns.value.findIndex((t2) => t2.turn_index === turnIndex)
-    if (index >= 0) rowVirtualizer.value.scrollToIndex(index, { align: "center" })
-  })
+  if (updateRoute) router.replace({ query: { ...route.query, turn: turnIndex } })
+  await nextTick()
+  const index = displayedTurns.value.findIndex((t2) => t2.turn_index === turnIndex)
+  if (index >= 0) rowVirtualizer.value.scrollToIndex(index, { align: "center" })
+  return true
 }
 
 // Timeline span click: expand the span's turn, then hand the event id to
@@ -244,10 +250,10 @@ function jumpMemberFor(turnIndex) {
   return t2 && t2.turn === turnIndex ? t2.member : null
 }
 
-function onSelectSpan(span) {
+async function onSelectSpan(span) {
   if (!span || span.turn == null) return
   jumpTarget.value = typeof span.index === "number" ? { turn: span.turn, eid: span.index, member: span.member ?? null } : null
-  onSelectTurn(span.turn)
+  if (!(await onSelectTurn(span.turn))) jumpTarget.value = null
 }
 
 function onJumped({ event }) {
@@ -269,6 +275,13 @@ function scrollToBottom() {
   if (!el) return
   el.scrollTop = el.scrollHeight
   liveStream.clearNewCounter()
+}
+
+async function loadOlderTurns() {
+  if (await rollup.loadOlder()) {
+    await nextTick()
+    rowVirtualizer.value.measure()
+  }
 }
 
 // Forward live events into the active turn's stream-store so
@@ -321,12 +334,12 @@ watch(
 
 // Deep-link: ``?turn=N`` opens that turn group.
 watch(
-  () => route.query.turn,
-  (q) => {
-    if (q == null) return
+  () => [route.query.turn, rollup.loading, rollup.sessionName, rollup.agent],
+  async ([q, loading]) => {
+    if (q == null || loading) return
     const ti = Number(q)
     if (!Number.isFinite(ti)) return
-    expandedTurns.value = new Set([...expandedTurns.value, ti])
+    await onSelectTurn(ti, { updateRoute: false })
   },
   { immediate: true },
 )

--- a/src/kohakuterrarium-frontend/src/stores/turnRollup.js
+++ b/src/kohakuterrarium-frontend/src/stores/turnRollup.js
@@ -17,6 +17,40 @@ import { getCurrentInstance } from "vue"
 import { injectScope, registerScopeDisposer } from "@/composables/useScope"
 import { sessionAPI } from "@/utils/api"
 
+const TURN_PAGE_SIZE = 1000
+
+function _scopeOf(store) {
+  return {
+    sessionName: store.sessionName,
+    agent: store.agent,
+    aggregate: store.aggregate,
+  }
+}
+
+function _scopeIsActive(store, scope) {
+  return (
+    store.sessionName === scope.sessionName &&
+    store.agent === scope.agent &&
+    store.aggregate === scope.aggregate
+  )
+}
+
+function _turnKey(turn) {
+  return `${turn.member_sid || ""}\u0000${turn.agent || ""}\u0000${turn.turn_index}`
+}
+
+function _mergeTurns(...pages) {
+  const turns = new Map()
+  for (const page of pages) {
+    for (const turn of page || []) turns.set(_turnKey(turn), turn)
+  }
+  return [...turns.values()].sort(
+    (a, b) =>
+      Number(a.turn_index || 0) - Number(b.turn_index || 0) ||
+      String(a.agent || a.member_sid || "").localeCompare(String(b.agent || b.member_sid || "")),
+  )
+}
+
 const _turnRollupOptions = {
   state: () => ({
     sessionName: "",
@@ -24,10 +58,13 @@ const _turnRollupOptions = {
     aggregate: false,
     turns: [],
     total: 0,
+    windowOffset: 0,
     loading: false,
+    loadingOlder: false,
     loadGeneration: 0,
     loadingGeneration: null,
     error: "",
+    pageError: "",
   }),
 
   getters: {
@@ -52,6 +89,8 @@ const _turnRollupOptions = {
     },
 
     costAvailable: (state) => state.turns.some((t) => t.cost_usd != null),
+
+    hasOlder: (state) => state.windowOffset > 0,
   },
 
   actions: {
@@ -69,25 +108,46 @@ const _turnRollupOptions = {
       if (isSwitch) {
         this.turns = []
         this.total = 0
-        this.error = ""
+        this.windowOffset = 0
+        this.loadingOlder = false
       }
+      this.error = ""
+      this.pageError = ""
       this.loading = true
       this.loadingGeneration = generation
       try {
-        const data = await sessionAPI.getTurns(sessionName, {
+        const firstPage = await sessionAPI.getTurns(sessionName, {
           agent,
-          limit: 1000,
+          limit: TURN_PAGE_SIZE,
+          offset: 0,
           aggregate,
         })
         if (generation !== this.loadGeneration) return
+
+        let data = firstPage
+        const total = Number(firstPage.total || 0)
+        const latestOffset = Math.max(0, total - TURN_PAGE_SIZE)
+        const resolvedAgent = firstPage.agent || agent || ""
+        if (latestOffset > 0) {
+          data = await sessionAPI.getTurns(sessionName, {
+            agent: resolvedAgent || null,
+            limit: TURN_PAGE_SIZE,
+            offset: latestOffset,
+            aggregate,
+          })
+          if (generation !== this.loadGeneration) return
+        }
+
         this.turns = data.turns || []
-        this.total = data.total || 0
-        this.agent = data.agent || agent || ""
+        this.total = Number(data.total ?? total)
+        this.windowOffset = Number(data.offset ?? latestOffset)
+        this.agent = data.agent || resolvedAgent
       } catch (err) {
         if (generation !== this.loadGeneration) return
         this.error = `Failed to load turns: ${err.message || err}`
         this.turns = []
         this.total = 0
+        this.windowOffset = 0
       } finally {
         if (this.loadingGeneration === generation) {
           this.loading = false
@@ -96,15 +156,79 @@ const _turnRollupOptions = {
       }
     },
 
+    async loadOlder() {
+      if (!this.sessionName || !this.hasOlder || this.loadingOlder) return false
+      const scope = _scopeOf(this)
+      const generation = this.loadGeneration
+      const offset = Math.max(0, this.windowOffset - TURN_PAGE_SIZE)
+      const limit = this.windowOffset - offset
+      this.loadingOlder = true
+      this.pageError = ""
+      try {
+        const data = await sessionAPI.getTurns(scope.sessionName, {
+          agent: scope.agent || null,
+          limit,
+          offset,
+          aggregate: scope.aggregate,
+        })
+        if (generation !== this.loadGeneration || !_scopeIsActive(this, scope)) return false
+        this.turns = _mergeTurns(data.turns, this.turns)
+        this.total = Number(data.total ?? this.total)
+        this.windowOffset = Number(data.offset ?? offset)
+        return true
+      } catch (err) {
+        if (generation === this.loadGeneration && _scopeIsActive(this, scope)) {
+          this.pageError = `Failed to load earlier turns: ${err.message || err}`
+        }
+        return false
+      } finally {
+        if (_scopeIsActive(this, scope)) this.loadingOlder = false
+      }
+    },
+
+    async ensureTurn(turnIndex) {
+      const target = Number(turnIndex)
+      if (!Number.isFinite(target) || !this.sessionName) return false
+      if (this.turns.some((turn) => Number(turn.turn_index) === target)) return true
+
+      const scope = _scopeOf(this)
+      const generation = this.loadGeneration
+      this.pageError = ""
+      try {
+        const data = await sessionAPI.getTurns(scope.sessionName, {
+          agent: scope.agent || null,
+          fromTurn: target,
+          toTurn: target,
+          limit: TURN_PAGE_SIZE,
+          offset: 0,
+          aggregate: scope.aggregate,
+        })
+        if (generation !== this.loadGeneration || !_scopeIsActive(this, scope)) return false
+        const exact = (data.turns || []).filter((turn) => Number(turn.turn_index) === target)
+        if (!exact.length) return false
+        this.turns = _mergeTurns(this.turns, exact)
+        return true
+      } catch (err) {
+        if (generation === this.loadGeneration && _scopeIsActive(this, scope)) {
+          this.pageError = `Failed to load turn ${target}: ${err.message || err}`
+        }
+        return false
+      }
+    },
+
     clear() {
       this.loadGeneration += 1
       this.sessionName = ""
       this.agent = ""
+      this.aggregate = false
       this.turns = []
       this.total = 0
+      this.windowOffset = 0
       this.loading = false
+      this.loadingOlder = false
       this.loadingGeneration = null
       this.error = ""
+      this.pageError = ""
     },
   },
 }

--- a/src/kohakuterrarium-frontend/src/stores/turnRollup.pagination.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/turnRollup.pagination.test.js
@@ -1,0 +1,211 @@
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/utils/api", () => ({
+  sessionAPI: {
+    getTurns: vi.fn(),
+  },
+}))
+
+import { useTurnRollupStore } from "./turnRollup"
+import { sessionAPI } from "@/utils/api"
+
+function deferred() {
+  let resolve
+  const promise = new Promise((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe("turn rollup bounded pagination", () => {
+  it("loads the latest window when the session exceeds the page size", async () => {
+    sessionAPI.getTurns
+      .mockResolvedValueOnce({
+        agent: "alice",
+        turns: [{ turn_index: 1 }],
+        total: 1001,
+      })
+      .mockResolvedValueOnce({
+        agent: "alice",
+        turns: [{ turn_index: 2 }, { turn_index: 1001 }],
+        total: 1001,
+        offset: 1,
+      })
+
+    const store = useTurnRollupStore()
+    await store.load("session-a", "alice")
+
+    expect(sessionAPI.getTurns).toHaveBeenNthCalledWith(1, "session-a", {
+      agent: "alice",
+      limit: 1000,
+      offset: 0,
+      aggregate: false,
+    })
+    expect(sessionAPI.getTurns).toHaveBeenNthCalledWith(2, "session-a", {
+      agent: "alice",
+      limit: 1000,
+      offset: 1,
+      aggregate: false,
+    })
+    expect(store.turns.map((turn) => turn.turn_index)).toEqual([2, 1001])
+    expect(store.windowOffset).toBe(1)
+    expect(store.hasOlder).toBe(true)
+  })
+
+  it("settles loading after the server resolves the default agent", async () => {
+    sessionAPI.getTurns.mockResolvedValue({
+      agent: "alice",
+      turns: [{ turn_index: 1 }],
+      total: 1,
+      offset: 0,
+    })
+
+    const store = useTurnRollupStore()
+    await store.load("session-a")
+
+    expect(store.agent).toBe("alice")
+    expect(store.loading).toBe(false)
+  })
+
+  it("prepends the previous bounded page", async () => {
+    const store = useTurnRollupStore()
+    store.sessionName = "session-a"
+    store.agent = "alice"
+    store.total = 1500
+    store.windowOffset = 500
+    store.turns = [{ turn_index: 501 }, { turn_index: 1500 }]
+    sessionAPI.getTurns.mockResolvedValue({
+      agent: "alice",
+      turns: [{ turn_index: 1 }, { turn_index: 500 }],
+      total: 1500,
+      offset: 0,
+    })
+
+    await store.loadOlder()
+
+    expect(sessionAPI.getTurns).toHaveBeenCalledWith("session-a", {
+      agent: "alice",
+      limit: 500,
+      offset: 0,
+      aggregate: false,
+    })
+    expect(store.turns.map((turn) => turn.turn_index)).toEqual([1, 500, 501, 1500])
+    expect(store.windowOffset).toBe(0)
+    expect(store.hasOlder).toBe(false)
+  })
+
+  it("fetches and inserts a missing timeline turn exactly once", async () => {
+    const store = useTurnRollupStore()
+    store.sessionName = "session-a"
+    store.agent = "alice"
+    store.turns = [{ turn_index: 1001 }]
+    sessionAPI.getTurns.mockResolvedValue({
+      agent: "alice",
+      turns: [{ turn_index: 5 }],
+      total: 1,
+    })
+
+    await expect(store.ensureTurn(5)).resolves.toBe(true)
+    await expect(store.ensureTurn(5)).resolves.toBe(true)
+
+    expect(sessionAPI.getTurns).toHaveBeenCalledTimes(1)
+    expect(sessionAPI.getTurns).toHaveBeenCalledWith("session-a", {
+      agent: "alice",
+      fromTurn: 5,
+      toTurn: 5,
+      limit: 1000,
+      offset: 0,
+      aggregate: false,
+    })
+    expect(store.turns.map((turn) => turn.turn_index)).toEqual([5, 1001])
+  })
+
+  it("drops an exact-turn response after the active scope changes", async () => {
+    const pending = deferred()
+    const store = useTurnRollupStore()
+    store.sessionName = "session-a"
+    store.agent = "alice"
+    store.turns = [{ turn_index: 1001 }]
+    sessionAPI.getTurns.mockReturnValue(pending.promise)
+
+    const request = store.ensureTurn(5)
+    store.sessionName = "session-b"
+    store.agent = "bob"
+    store.turns = [{ turn_index: 8 }]
+    pending.resolve({ agent: "alice", turns: [{ turn_index: 5 }], total: 1 })
+
+    await expect(request).resolves.toBe(false)
+    expect(store.turns).toEqual([{ turn_index: 8 }])
+  })
+
+  it("drops an older-page response after the active scope changes", async () => {
+    const pending = deferred()
+    const store = useTurnRollupStore()
+    store.sessionName = "session-a"
+    store.agent = "alice"
+    store.total = 1500
+    store.windowOffset = 500
+    store.turns = [{ turn_index: 501 }]
+    sessionAPI.getTurns.mockReturnValue(pending.promise)
+
+    const request = store.loadOlder()
+    store.sessionName = "session-b"
+    store.agent = "bob"
+    store.turns = [{ turn_index: 8 }]
+    pending.resolve({ agent: "alice", turns: [{ turn_index: 1 }], total: 1500 })
+
+    await expect(request).resolves.toBe(false)
+    expect(store.turns).toEqual([{ turn_index: 8 }])
+  })
+
+  it("drops an older-page response after the same scope reloads", async () => {
+    const pending = deferred()
+    const store = useTurnRollupStore()
+    store.sessionName = "session-a"
+    store.agent = "alice"
+    store.total = 1500
+    store.windowOffset = 500
+    store.turns = [{ turn_index: 501 }]
+    sessionAPI.getTurns.mockReturnValueOnce(pending.promise).mockResolvedValueOnce({
+      agent: "alice",
+      turns: [{ turn_index: 700 }],
+      total: 1,
+      offset: 0,
+    })
+
+    const olderRequest = store.loadOlder()
+    await store.load("session-a", "alice")
+    pending.resolve({ agent: "alice", turns: [{ turn_index: 1 }], total: 1500 })
+
+    await expect(olderRequest).resolves.toBe(false)
+    expect(store.turns).toEqual([{ turn_index: 700 }])
+    expect(store.loadingOlder).toBe(false)
+  })
+
+  it("drops an exact-turn response after the same scope reloads", async () => {
+    const pending = deferred()
+    const store = useTurnRollupStore()
+    store.sessionName = "session-a"
+    store.agent = "alice"
+    store.turns = [{ turn_index: 1001 }]
+    sessionAPI.getTurns.mockReturnValueOnce(pending.promise).mockResolvedValueOnce({
+      agent: "alice",
+      turns: [{ turn_index: 700 }],
+      total: 1,
+      offset: 0,
+    })
+
+    const exactRequest = store.ensureTurn(5)
+    await store.load("session-a", "alice")
+    pending.resolve({ agent: "alice", turns: [{ turn_index: 5 }], total: 1 })
+
+    await expect(exactRequest).resolves.toBe(false)
+    expect(store.turns).toEqual([{ turn_index: 700 }])
+  })
+})

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -1090,6 +1090,7 @@ export default {
   "sessionViewer.trace.turn.expand": "Expand turn",
   "sessionViewer.trace.turn.collapse": "Collapse turn",
   "sessionViewer.trace.turn.loadMore": "Load more events",
+  "sessionViewer.trace.turn.loadEarlier": "Load earlier turns",
   "sessionViewer.trace.turn.empty": "No events for this turn.",
   "sessionViewer.trace.live.subscribed": "Live",
   "sessionViewer.trace.live.connecting": "Connecting…",

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
@@ -175,6 +175,7 @@ export default {
   "sessionViewer.trace.timeline.clearFocus": "清除区间聚焦",
   "sessionViewer.trace.turn.expandAll": "全部展开",
   "sessionViewer.trace.turn.collapseAll": "全部折叠",
+  "sessionViewer.trace.turn.loadEarlier": "加载更早的 turn",
   "sessionViewer.trace.filters.search": "搜索事件…",
 
   "memoryBuild.titleBuild": ({ name }) => `构建嵌入向量 — ${name}`,

--- a/src/kohakuterrarium/api/routes/persistence/viewer.py
+++ b/src/kohakuterrarium/api/routes/persistence/viewer.py
@@ -321,7 +321,10 @@ def _merge_turns(
             str(r.get("agent") or r.get("member_sid") or ""),
         )
     )
-    total = len(rows)
+    total = sum(
+        int(payload.get("total", len(payload.get("turns") or [])))
+        for _member_sid, payload in per_member
+    )
     page = rows[offset : offset + limit]
     return {
         "session_name": session_name,
@@ -435,6 +438,14 @@ async def get_session_turns(
     # outer merge restores one cross-cluster window.
     fanout_aggregate = aggregate or len(members) > 1
 
+    # Cluster pagination is applied after member rows are merged. Each member
+    # must therefore contribute enough of its prefix to cover the requested
+    # merged window; applying the offset here as well would skip rows twice.
+    member_offset = clamped_offset if len(members) == 1 else 0
+    member_limit = (
+        clamped_limit if len(members) == 1 else clamped_offset + clamped_limit
+    )
+
     def _build(store: SessionStore, canonical: str) -> dict[str, Any]:
         return build_turns_payload(
             store,
@@ -442,8 +453,8 @@ async def get_session_turns(
             agent=agent,
             from_turn=from_turn,
             to_turn=to_turn,
-            limit=clamped_limit,
-            offset=clamped_offset,
+            limit=member_limit,
+            offset=member_offset,
             aggregate=fanout_aggregate,
         )
 

--- a/tests/unit/api/test_persistence_viewer_routes.py
+++ b/tests/unit/api/test_persistence_viewer_routes.py
@@ -238,6 +238,33 @@ class TestTurns:
         assert captured["limit"] == 1000
         assert captured["offset"] == 0
 
+    def test_cluster_applies_offset_after_member_merge(self, monkeypatch):
+        async def _members(_session_name, _service):
+            return [("member-a", Path("/a")), ("member-b", Path("/b"))]
+
+        captured = []
+
+        def _fake_build(_store, canonical, **kw):
+            captured.append(kw)
+            rows = [{"turn_index": turn, "agent": canonical} for turn in range(1, 1201)]
+            page = rows[kw["offset"] : kw["offset"] + kw["limit"]]
+            return {"turns": page, "total": len(rows)}
+
+        def _per_member(members, builder):
+            return [(sid, builder(None, sid)) for sid, _path in members]
+
+        monkeypatch.setattr(viewer_mod, "_resolve_cluster_or_404", _members)
+        monkeypatch.setattr(viewer_mod, "build_turns_payload", _fake_build)
+        monkeypatch.setattr(viewer_mod, "_run_per_member", _per_member)
+
+        resp = TestClient(_app()).get("/sessions/cluster/turns?limit=1000&offset=1000")
+
+        assert resp.status_code == 200
+        assert len(resp.json()["turns"]) == 1000
+        assert resp.json()["offset"] == 1000
+        assert all(call["offset"] == 0 for call in captured)
+        assert all(call["limit"] == 2000 for call in captured)
+
 
 # ── export ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- load the latest bounded 1,000-turn window instead of leaving the Trace list at the oldest window
- allow users to prepend earlier turn pages without unbounded frontend loading
- fetch a specific missing turn before timeline-span or deep-link navigation
- discard older-page and exact-turn responses after the active session/agent scope changes
- apply cluster offsets only after member rows are merged, so pagination does not skip twice
- add store, component, and API regression coverage

Fixes #178

## Integration note

PR #181 also updates request lifecycle handling in `turnRollup.js`. Both PRs are independently based on `main`; whichever merges second should be rebased so both protections are retained.

## Validation

- `25 passed` — focused Trace/store/frontend tests
- `46 passed` — affected API, Studio, and integration workflows
- `13,760 passed, 1 skipped` — full Python unit suite in the sandbox; 17 loopback-binding cases were blocked by sandbox permissions
- `26 passed` — all loopback-binding failures rerun outside the sandbox
- `1,700 passed` — file-size constraints
- `1,039 passed`; one existing `MacroShell.test.js` suite cannot resolve installed `monaco-editor` in Vitest
- `npm run format:check`
- `npm run build`
- Black and Ruff checks
- `git diff --check`