### PR TITLE
fix(prompt): clarify background task continuation

### DIFF
--- a/src/kohakuterrarium/builtin_skills/tools/bash.md
+++ b/src/kohakuterrarium/builtin_skills/tools/bash.md
@@ -76,6 +76,19 @@ Shell executable overrides are checked in this order:
 - Running build/test commands
 - Package management operations
 
+## Long-Running Processes
+
+A server, watcher, or daemon may keep running indefinitely. Do not start one as
+ordinary background work if you expect its completion result to let you continue
+with later requests—the process may never finish.
+
+When later steps need to interact with the process, start it so the startup
+command can finish while the child process keeps running. Detach and redirect the
+process appropriately for the selected shell and platform, and return identifiers
+such as its PID and log path. Continue with follow-up commands in a later turn.
+The startup result alone does not prove that the service is ready; use an explicit
+health, port, or log check before relying on it.
+
 ## Output
 
 Returns combined stdout/stderr. Exit code is included in the result metadata.

--- a/src/kohakuterrarium/core/agent_handlers.py
+++ b/src/kohakuterrarium/core/agent_handlers.py
@@ -37,10 +37,10 @@ from kohakuterrarium.utils.logging import get_logger
 
 _BG_PLACEHOLDER = (
     "Running in background — task delegated. "
-    "Do NOT do this same task yourself — it is already being done. "
-    "Do NOT use bash echo/sleep to wait — just end your response. "
-    "Work on a DIFFERENT task or STOP your response now. "
-    "Result arrives automatically in the next turn."
+    "No final result is available yet. Do NOT restart, duplicate, poll, or "
+    "sleep to wait for this task. Continue only with work that does not depend "
+    "on its result; otherwise, end your response and wait for the result to be "
+    "delivered."
 )
 
 logger = get_logger(__name__)
@@ -637,8 +637,8 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
             else:
                 # Text mode: add feedback text about promoted tasks
                 feedback_parts.append(
-                    "[Tasks promoted to background — results arrive later. "
-                    "Continue with other work.]"
+                    "[Tasks are still running in the background. No final results "
+                    "are available yet. Continue only with independent work.]"
                 )
 
         # Drain mid-turn buffered user_input/trigger events AFTER tool

--- a/src/kohakuterrarium/llm/tools.py
+++ b/src/kohakuterrarium/llm/tools.py
@@ -63,7 +63,11 @@ def build_tool_schemas(
             props = dict(params.get("properties", {}))
             props["run_in_background"] = {
                 "type": "boolean",
-                "description": "If true, run in background. Results delivered later, not immediately.",
+                "description": (
+                    "If true, run without waiting for it to finish. No result is "
+                    "available immediately, and starting it does not give you "
+                    "another turn to act."
+                ),
             }
             params["properties"] = props
 
@@ -100,9 +104,10 @@ def build_tool_schemas(
                         "run_in_background": {
                             "type": "boolean",
                             "description": (
-                                "If true (default), run in background — result "
-                                "delivered later. If false, block and wait for "
-                                "the sub-agent to finish before continuing."
+                                "If true (default), run without waiting for it to "
+                                "finish. No result is available immediately, and "
+                                "starting it does not give you another turn to act. "
+                                "If false, wait for the result before continuing."
                             ),
                         },
                     },

--- a/src/kohakuterrarium/prompt/aggregator.py
+++ b/src/kohakuterrarium/prompt/aggregator.py
@@ -73,8 +73,9 @@ def _build_command_hints(tool_format: str) -> str:
         f"- Read docs: `{info_ex}`\n"
         f"- List jobs: `{jobs_ex}`\n"
         f"- Wait for job: `{wait_ex}`\n\n"
-        "Sub-agents run in background by default. Results arrive automatically.\n"
-        "Use wait only if you must block until a specific job finishes."
+        "Starting background work does not immediately return a result or give "
+        "you another turn to act. Results are normally delivered after the work "
+        "finishes. Use wait only if you must block until a specific job finishes."
     )
 
 

--- a/src/kohakuterrarium/prompt/framework_hints.py
+++ b/src/kohakuterrarium/prompt/framework_hints.py
@@ -36,23 +36,30 @@ _DEFAULT_EXECUTION_MODEL_DYNAMIC = """
 ### Background Tasks
 
 Sub-agents run in background by default. Tools can also run in background
-with `run_in_background=true`. Background results arrive automatically in a later turn.
+with `run_in_background=true`.
 
-**Critical rule**: Once you delegate a task to background, do NOT do the same work yourself.
-The work is already being done — doing it again wastes tokens and produces duplicates.
+Starting a background task does not immediately return a result or give you
+another turn to act. You are normally invoked again after the task finishes or
+fails. Before ending your response, start every independent background task you
+already know is needed.
+
+Do not poll, sleep, restart, or duplicate background work. If you know before
+starting that your next step requires the result, use `run_in_background=false`
+and wait for it.
+
+A server, watcher, or daemon may run indefinitely and never produce a completion
+result. If you need to interact with a long-running process afterward, use a
+startup action that can finish while the process keeps running. This gives you a
+result to continue from without waiting for the long-running process to exit.
 
 **Workflow example**:
-1. Dispatch `explore` to investigate the project structure (background)
-2. Dispatch `research` to look up API documentation (background)
-3. **Stop your response and wait** — both are working in parallel
-4. Results arrive automatically → synthesize and continue
-
-**Direct sub-agents** (set `run_in_background=false`):
-Use when you need the result before continuing and the task is short.
+1. Start all independent background investigations in the same response
+2. End your response if no other independent work can be done now
+3. Continue after their results are delivered
 
 **WRONG** (duplicate work):
-1. Dispatch `explore` to investigate the codebase ← background
-2. Start reading the same codebase yourself ← WRONG, same task!
+1. Dispatch `explore` to investigate the codebase in the background
+2. Start the same investigation yourself
 
 IMPORTANT: When calling a function, output ONLY the function call block. Do not output any extra text, markers, or filler characters (like dashes, dots, etc.) before or after the function call. If you need results before continuing, end with the function call and nothing else.
 IMPORTANT: You may ONLY call functions listed in the "Available Functions" section above. Do NOT call functions that are not listed.
@@ -66,17 +73,21 @@ _DEFAULT_EXECUTION_MODEL_STATIC = """
 
 ### Background Tasks
 
-Sub-agents run in background by default. Background results arrive automatically
-in a later turn.
+Sub-agents run in background by default.
 
-**Critical rule**: Once you delegate a task to background, do NOT do the same
-work yourself. The work is already being done.
+Starting a background task does not immediately return a result or give you
+another turn to act. You are normally invoked again after the task finishes or
+fails. Before ending your response, start every independent background task you
+already know is needed.
 
-**Workflow**: dispatch sub-agents → do DIFFERENT direct work or stop and wait →
-results arrive automatically → continue.
+Do not poll, sleep, restart, or duplicate background work. If you know before
+starting that your next step requires the result, set `run_in_background=false`
+and wait for it.
 
-**Direct sub-agents**: Set `run_in_background=false` when you need the result
-before continuing and the task is short.
+A server, watcher, or daemon may run indefinitely and never produce a completion
+result. If you need to interact with a long-running process afterward, use a
+startup action that can finish while the process keeps running. This gives you a
+result to continue from without waiting for the long-running process to exit.
 
 IMPORTANT: When calling a function, output ONLY the function call block. Do not output any extra text, markers, or filler characters before or after. If you need results before continuing, end with the function call and nothing else.
 IMPORTANT: You may ONLY call functions listed in the "Available Functions" section above. Do NOT call functions that are not listed.
@@ -96,16 +107,24 @@ Sub-agents run in background by default. Set `run_in_background=false`
 to wait for a sub-agent's result before continuing (use for short tasks).
 Tools can also run in background with `run_in_background=true`.
 
-When a task runs in background, the result arrives automatically in
-a later turn. You do NOT need to poll or wait.
+Starting a background task does not immediately return a result or give you
+another turn to act. You are normally invoked again after the task finishes or
+fails. Before ending your response, start every independent background task you
+already know is needed.
 
-**Critical**: Once you delegate work to background, do NOT do the same
-work yourself. The task is already being done.
+Do not poll, sleep, restart, or duplicate background work. If you know before
+starting that your next step requires the result, set `run_in_background=false`
+and wait for it.
+
+A server, watcher, or daemon may run indefinitely and never produce a completion
+result. If you need to interact with a long-running process afterward, use a
+startup action that can finish while the process keeps running. This gives you a
+result to continue from without waiting for the long-running process to exit.
 
 **Example workflow**:
-1. Dispatch `explore` sub-agent to investigate module A (background)
-2. Use `read` on a DIFFERENT file (module B) yourself (direct)
-3. Stop — explore result for module A arrives in next turn
+1. Start all independent background investigations in the same response
+2. End your response if no other independent work can be done now
+3. Continue after their results are delivered
 
 You may ONLY call tools listed in the "Available Functions" section above.
 """

--- a/tests/integration/test_llm.py
+++ b/tests/integration/test_llm.py
@@ -861,8 +861,9 @@ class TestLlmIntegration:
                 "run_in_background": {
                     "type": "boolean",
                     "description": (
-                        "If true, run in background. Results delivered "
-                        "later, not immediately."
+                        "If true, run without waiting for it to finish. No result is "
+                        "available immediately, and starting it does not give you "
+                        "another turn to act."
                     ),
                 },
             },
@@ -893,8 +894,9 @@ class TestLlmIntegration:
                 "run_in_background": {
                     "type": "boolean",
                     "description": (
-                        "If true, run in background. Results delivered "
-                        "later, not immediately."
+                        "If true, run without waiting for it to finish. No result is "
+                        "available immediately, and starting it does not give you "
+                        "another turn to act."
                     ),
                 },
             },
@@ -923,9 +925,10 @@ class TestLlmIntegration:
                 "run_in_background": {
                     "type": "boolean",
                     "description": (
-                        "If true (default), run in background — result "
-                        "delivered later. If false, block and wait for "
-                        "the sub-agent to finish before continuing."
+                        "If true (default), run without waiting for it to finish. No "
+                        "result is available immediately, and starting it does not "
+                        "give you another turn to act. If false, wait for the result "
+                        "before continuing."
                     ),
                 },
             },
@@ -952,8 +955,9 @@ class TestLlmIntegration:
                 "run_in_background": {
                     "type": "boolean",
                     "description": (
-                        "If true, run in background. Results delivered "
-                        "later, not immediately."
+                        "If true, run without waiting for it to finish. No result is "
+                        "available immediately, and starting it does not give you "
+                        "another turn to act."
                     ),
                 },
             },
@@ -980,8 +984,9 @@ class TestLlmIntegration:
                 "run_in_background": {
                     "type": "boolean",
                     "description": (
-                        "If true, run in background. Results delivered "
-                        "later, not immediately."
+                        "If true, run without waiting for it to finish. No result is "
+                        "available immediately, and starting it does not give you "
+                        "another turn to act."
                     ),
                 },
             },

--- a/tests/integration/test_prompt.py
+++ b/tests/integration/test_prompt.py
@@ -290,6 +290,10 @@ class TestPromptIntegration:
             assert "## Calling Functions" in system_prompt
             assert "[/function_name" in system_prompt
             assert "[/info]" in system_prompt
+            assert "does not immediately return a result" in system_prompt
+            assert "another turn to act" in system_prompt
+            assert "server, watcher, or daemon" in system_prompt
+            assert "controller round" not in system_prompt
 
             # 1d. The custom plugin's contribution is present, and placed
             # after the tool list (runtime plugin prose sits between tool

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -5963,6 +5963,9 @@ class TestMidTurnBatchDrain:
                 if getattr(m, "role", None) == "user"
             )
             assert "Running in background" in all_user
+            assert "No final result is available yet" in all_user
+            assert "another turn to act" not in all_user
+            assert "controller" not in all_user
             assert "hangbg" in all_user
         finally:
             release.set()

--- a/tests/unit/llm/test_tools.py
+++ b/tests/unit/llm/test_tools.py
@@ -142,13 +142,13 @@ class TestBuildToolSchemas:
         }
         assert schema.parameters["required"] == ["command"]
         # run_in_background always injected
-        assert schema.parameters["properties"]["run_in_background"] == {
-            "type": "boolean",
-            "description": (
-                "If true, run in background. Results delivered later, "
-                "not immediately."
-            ),
-        }
+        background = schema.parameters["properties"]["run_in_background"]
+        assert background["type"] == "boolean"
+        assert "without waiting for it to finish" in background["description"]
+        assert "No result is available immediately" in background["description"]
+        assert "another turn to act" in background["description"]
+        assert "long-running process" not in background["description"]
+        assert "controller" not in background["description"]
 
     def test_builtin_schema_dict_not_mutated(self):
         # docstring: "don't mutate builtin schemas"
@@ -215,7 +215,11 @@ class TestBuildToolSchemas:
             in task_schema["description"]
         )
         assert schema.parameters["required"] == ["task"]
-        assert "run_in_background" in schema.parameters["properties"]
+        background = schema.parameters["properties"]["run_in_background"]
+        assert "without waiting for it to finish" in background["description"]
+        assert "No result is available immediately" in background["description"]
+        assert "another turn to act" in background["description"]
+        assert "controller" not in background["description"]
 
     def test_subagent_guidance_can_be_omitted_for_prompt_opt_out(self):
         reg = Registry()

--- a/tests/unit/prompt/test_aggregator.py
+++ b/tests/unit/prompt/test_aggregator.py
@@ -170,6 +170,14 @@ class TestToolListInvariants:
         out = aggregate_system_prompt("base", reg, skill_mode="static")
         assert "## Function Documentation" in out
 
+    def test_static_bash_doc_explains_long_running_processes(self):
+        reg = _registry_with(_make_tool("bash", "Execute shell commands"))
+        out = aggregate_system_prompt("base", reg, skill_mode="static")
+        assert "## Long-Running Processes" in out
+        assert "server, watcher, or daemon" in out
+        assert "command can finish while the child process keeps running" in out
+        assert "health, port, or log check" in out
+
     def test_tools_placeholder_suppresses_auto_appended_list(self):
         # The literal token ``{{ tools }}`` in the base prompt signals the
         # author placed the inventory themselves -> no auto-appended list.
@@ -226,6 +234,14 @@ class TestFrameworkHintInvariants:
         list_section = out.split("## Available Functions")[1].split("##")[0]
         # The tool list section itself must not contain call-syntax markers.
         assert "[/function_name]" not in list_section
+
+    def test_dynamic_command_hints_do_not_promise_immediate_continuation(self):
+        reg = _registry_with(_make_tool("bash", "Execute shell commands"))
+        out = aggregate_system_prompt("base", reg, tool_format="bracket")
+        commands = out.split("## Commands", 1)[1]
+        assert "does not immediately return a result" in commands
+        assert "another turn to act" in commands
+        assert "controller" not in commands
 
 
 class TestOutputHints:

--- a/tests/unit/prompt/test_framework_hints.py
+++ b/tests/unit/prompt/test_framework_hints.py
@@ -51,11 +51,34 @@ class TestGetFrameworkHint:
         hint = get_framework_hint(HINT_EXECUTION_MODEL_DYNAMIC)
         assert "## Execution Model" in hint
         assert "Background Tasks" in hint
+        assert "does not immediately return a result" in hint
+        assert "another turn to act" in hint
+        assert "server, watcher, or daemon" in hint
+
+    def test_default_static_execution_block(self):
+        hint = get_framework_hint(HINT_EXECUTION_MODEL_STATIC)
+        assert "does not immediately return a result" in hint
+        assert "another turn to act" in hint
+        assert "server, watcher, or daemon" in hint
 
     def test_default_native_execution_block(self):
         hint = get_framework_hint(HINT_EXECUTION_MODEL_NATIVE)
         assert "native function calling" in hint
         assert "## Tool Usage" in hint
+        assert "does not immediately return a result" in hint
+        assert "another turn to act" in hint
+        assert "server, watcher, or daemon" in hint
+
+    def test_execution_hints_avoid_internal_runtime_terms(self):
+        for key in (
+            HINT_EXECUTION_MODEL_DYNAMIC,
+            HINT_EXECUTION_MODEL_STATIC,
+            HINT_EXECUTION_MODEL_NATIVE,
+        ):
+            hint = get_framework_hint(key)
+            assert "controller round" not in hint
+            assert "completion event" not in hint
+            assert "controller re-entry" not in hint
 
     def test_non_canonical_key_returns_none(self):
         assert get_framework_hint("framework.not_a_real_key") is None


### PR DESCRIPTION
## Summary

Clarifies the model-facing semantics of background task submission so models do not assume that starting background work immediately returns a result or creates another opportunity to act. It also documents a safe planning pattern for persistent servers, watchers, and daemons without changing runtime scheduling or adding LLM calls.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The previous wording said results arrive automatically in a later turn, which could be interpreted as background submission itself causing that later turn. A persistent process may never finish, so a model that starts a server in the background and postpones follow-up requests can stall indefinitely.

This PR fixes the misleading guidance while preserving the existing background execution contract.

## Changes

- Clarify dynamic, static, and native execution hints using model-observable concepts rather than internal runtime terminology.
- Keep `run_in_background` tool and sub-agent schema descriptions concise and explicit about the lack of an immediate result or model turn.
- Align runtime background placeholders and dynamic command hints with the same semantics.
- Document finite startup actions and explicit readiness checks for long-running Bash processes.
- Update unit and integration assertions for the final aggregated prompts and native tool schemas.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -v --tb=short
pytest tests/unit/ -q --tb=short \
  --ignore=tests/unit/test_file_sizes.py \
  --ignore=tests/unit/test_dep_graph_lint.py \
  --ignore=tests/unit/packages/test_git_backend_dulwich_integration.py \
  --ignore=tests/unit/test_no_real_config_pollution.py
# 12077 passed, 9 skipped

# CI-compatible reruns for environment-sensitive tests:
GIT_CONFIG_GLOBAL=<temporary-config-with-defaultBranch-master> \
  pytest tests/unit/packages/test_git_backend_dulwich_integration.py -q --tb=short
# 6 passed

HOME=<temporary-home> USERPROFILE=<temporary-home> \
  pytest tests/unit/test_no_real_config_pollution.py -q --tb=short
# 1 passed

pytest tests/integration/ -q --tb=short
# 173 passed

# From a clean Git archive, matching CI checkout line endings:
cd src/kohakuterrarium-frontend
npm ci
npm run format:check
npm run build

uvx --from build pyproject-build
uvx twine check dist/*
uvx --from dist/kohakuterrarium-2.1.0-py3-none-any.whl kt --help
uvx --from dist/kohakuterrarium-2.1.0-py3-none-any.whl kt app --help
uvx --from dist/kohakuterrarium-2.1.0-py3-none-any.whl kt-cli --help
uvx --from dist/kohakuterrarium-2.1.0-py3-none-any.whl kt-tui --help
uvx --from dist/kohakuterrarium-2.1.0-py3-none-any.whl kt shims status
```

The built wheel was also inspected to confirm that `kohakuterrarium/builtin_skills/tools/bash.md` contains the new long-running-process guidance.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Closes #184

## Notes for Reviewers

This intentionally does not change background dispatch, completion delivery, UI promotion, timeout behavior, or the number of LLM calls. The scope is limited to prompt text, tool schema descriptions, runtime placeholder wording, Bash guidance, and their tests.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- E2E was not run because this change does not touch multi-node, Studio, serving, or frontend behavior; the repository CI also intentionally excludes E2E.
- The complete OS/Python matrix is left to the upstream PR CI. The local environment is Windows with Python 3.14.2, a combination excluded by the repository CI because pythonnet has no 3.14 Windows wheel.
- A push to a fork feature branch does not trigger this repository's `ci.yml`, which only runs on pushes to `main` and pull requests targeting `main`. Equivalent local checks above passed; the upstream PR CI will provide the required matrix result.
- Frontend format/build were run from a clean `git archive` export because the Windows working tree's line-ending conversion conflicts with Prettier's enforced LF setting. The clean-checkout-equivalent validation passed.
