### PR TITLE
fix(frontend): improve subagent input contrast

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.test.js
@@ -82,6 +82,14 @@ describe("ToolCallBlock — sub-agent conversation (UXI-05)", () => {
     expect(getConv).toHaveBeenCalledWith("g1", "root", { jobId: "job_x" })
     const textarea = wrapper.find("textarea")
     expect(textarea.exists()).toBe(true)
+    expect(textarea.classes()).toEqual(
+      expect.arrayContaining([
+        "text-warm-800",
+        "dark:text-warm-200",
+        "placeholder-warm-400",
+        "dark:placeholder-warm-500",
+      ]),
+    )
 
     await textarea.setValue("keep going")
     await wrapper

--- a/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.vue
@@ -112,7 +112,7 @@
                 <div v-if="!convBlocks.length" class="text-[11px] text-warm-400 italic">{{ t("chat.subagent.empty") }}</div>
               </div>
               <div v-if="canReceive" class="flex items-end gap-2 pt-1 border-t border-taaffeite/15 dark:border-taaffeite/20">
-                <textarea v-model="sendText" rows="1" :placeholder="t('chat.subagent.placeholder')" class="flex-1 min-w-0 resize-none rounded border border-warm-200 dark:border-warm-700 bg-warm-50 dark:bg-warm-950 px-2 py-1 text-[11px] focus:outline-none focus:border-taaffeite" @keydown.enter.exact.prevent="submitSend" />
+                <textarea v-model="sendText" rows="1" :placeholder="t('chat.subagent.placeholder')" class="flex-1 min-w-0 resize-none rounded border border-warm-200 dark:border-warm-700 bg-warm-50 dark:bg-warm-950 px-2 py-1 text-[11px] text-warm-800 dark:text-warm-200 placeholder-warm-400 dark:placeholder-warm-500 focus:outline-none focus:border-taaffeite" @keydown.enter.exact.prevent="submitSend" />
                 <button class="text-[11px] px-2 py-1 rounded bg-taaffeite/20 text-taaffeite-shadow dark:text-taaffeite-light hover:bg-taaffeite/30 disabled:opacity-50 shrink-0" :disabled="sending || !sendText.trim()" @click.stop="submitSend">
                   {{ t("chat.subagent.send") }}
                 </button>


### PR DESCRIPTION
## Summary

Set explicit theme-aware foreground and placeholder colors on the nested subagent Conversation textarea so entered text remains readable against its dark background. Add a regression test that pins the light and dark theme utility classes.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The textarea in the subagent Conversation panel used `dark:bg-warm-950` without explicit text or placeholder colors. Native form-control styling could therefore render dark text on the dark background, making messages almost unreadable in the default/dark theme.

## Changes

- Add explicit light and dark theme text colors to the subagent Conversation textarea.
- Add matching placeholder colors for both themes.
- Assert the theme utility classes in the existing `ToolCallBlock` regression test.

## Validation

```bash
cd src/kohakuterrarium-frontend
npx prettier --check src/components/chat/ToolCallBlock.vue src/components/chat/ToolCallBlock.test.js
npx eslint src/components/chat/ToolCallBlock.vue src/components/chat/ToolCallBlock.test.js
npx vitest run src/components/chat/ToolCallBlock.test.js
npm run build

git diff --check
```

Results:

- Prettier passed for both changed files.
- ESLint passed for both changed files.
- `ToolCallBlock.test.js`: 9/9 tests passed.
- The production frontend build passed and produced `src/kohakuterrarium/web_dist/index.html`.
- The UI was manually verified in the desktop app.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #186

## Notes for Reviewers

This is intentionally limited to the nested subagent textarea. It reuses the warm theme color semantics already used by the main chat input and does not alter layout or behavior.

## Screenshots / Logs (if applicable)

No screenshot is attached. The corrected input was manually verified in the desktop app.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- Python lint and test suites were not rerun because this PR only changes a Vue template class list and its colocated frontend unit test.
- Full local `npm run format:check` was attempted, but the Windows checkout reports repository-wide CRLF/LF differences across 442 unchanged files. The two changed files pass Prettier directly, and the clean Linux CI checkout will run the repository-wide check.
- The complete Vitest suite is not part of the repository's frontend CI job. It was additionally attempted locally: 105 test files and 1,047 tests passed, while pre-existing environment failures remained around unavailable `localStorage.clear`, unresolved `monaco-editor`, and one layout test timeout. The changed test file passes 9/9.
- The workflow only triggers for pushes to `main` and pull requests targeting `main`, so pushing this topic branch to the fork did not create a fork CI run. This PR's checks will provide the required clean-checkout CI validation.
