### PR TITLE
fix(android): guard release metadata and dependency policy

### DIFF
--- a/packaging/android/check_chaquopy_ceiling.py
+++ b/packaging/android/check_chaquopy_ceiling.py
@@ -222,7 +222,6 @@ URL_REF_PACKAGES: frozenset[str] = frozenset(
         "pydantic-core",
         "safetensors",
         "tokenizers",
-        "primp",
         # Recent OpenAI and Anthropic packages require this Rust extension.
         "jiter",
         # jsonschema pulls this Rust extension through referencing.
@@ -245,6 +244,10 @@ DROPPED_PACKAGES: frozenset[str] = frozenset(
         "uvloop",
         "httptools",
         "watchfiles",
+        # ddgs falls back to the framework's pure-httpx DDG scraper on Android;
+        # primp's Rust runtime hard-crashes the Android host process.
+        "ddgs",
+        "primp",
         # hf-xet: HuggingFace LFS transfer accelerator (Rust+PyO3).
         # huggingface_hub pulls it via a ``platform_machine ==
         # 'aarch64' ...`` marker which is ACTIVE on Android.  hf-xet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,8 +256,9 @@ min_os_version = "26"
 # targetSdk/compileSdk 35 (Android 15): the Briefcase template references an
 # API-35 attribute, and 35 is the Play Store baseline for new uploads.
 target_os_version = "35"
-# Version code encodes <major><MM><NN><PP>: 1.5.0 → 1_05_00_00.
-version_code = "10500000"
+# Version code encodes <major><minor:02><patch:02><build:03>:
+# 2.1.0 build 0 -> 2_01_00_000.
+version_code = "20100000"
 # arm64-v8a only — covers ~99% of physical devices; x86_64 also tripped a
 # Chaquopy cross-ABI URL-ref resolution quirk.
 android_abis = ["arm64-v8a"]

--- a/tests/unit/packaging/test_android_release_config.py
+++ b/tests/unit/packaging/test_android_release_config.py
@@ -1,0 +1,48 @@
+"""Consistency tests for Android release metadata and policy tables."""
+
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestAndroidReleaseConfig:
+    def test_version_code_matches_project_version(self):
+        config = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+        major, minor, patch = map(int, config["project"]["version"].split("."))
+        expected = f"{major}{minor:02}{patch:02}000"
+
+        assert (
+            config["tool"]["briefcase"]["app"]["kohakuterrarium"]["android"][
+                "version_code"
+            ]
+            == expected
+        )
+
+    def test_dependency_policy_tables_stay_aligned(self):
+        postcreate = _load_module(
+            "android_postcreate",
+            _REPO_ROOT / "packaging" / "android" / "postcreate.py",
+        )
+        ceiling = _load_module(
+            "android_check_chaquopy_ceiling",
+            _REPO_ROOT / "packaging" / "android" / "check_chaquopy_ceiling.py",
+        )
+
+        assert set(postcreate._ANDROID_URL_REFS) == set(ceiling.URL_REF_PACKAGES)
+        postcreate_drops = {
+            name.replace("-", "_") for name in postcreate._ANDROID_DROP_PACKAGES
+        }
+        ceiling_drops = {name.replace("-", "_") for name in ceiling.DROPPED_PACKAGES}
+        assert postcreate_drops <= ceiling_drops


### PR DESCRIPTION
Closes #190.

## Summary

- align the Briefcase Android version code with project version 2.1.0
- document the `<major><minor:02><patch:02><build:03>` encoding
- remove `primp` from URL-reference packages and mark `ddgs`/`primp` as dropped
- add invariant tests for Android version metadata and duplicated dependency-policy tables

## Scope

The scripts remain independently executable. This PR adds a test-time consistency guard instead of introducing runtime imports between packaging scripts.

## Validation

- `.venv/bin/python -m pytest tests/unit/packaging/test_android_release_config.py tests/unit/packaging/test_postcreate.py tests/unit/packaging/test_chaquopy_ceiling.py` — 55 passed
- `.venv/bin/black --fast tests/unit/packaging/test_android_release_config.py packaging/android/check_chaquopy_ceiling.py`
- `.venv/bin/ruff check tests/unit/packaging/test_android_release_config.py packaging/android/check_chaquopy_ceiling.py`
- `git diff --check`