### PR TITLE
fix(cli): reject empty host token files

### DIFF
--- a/src/kohakuterrarium/cli/_aio_entrypoint.py
+++ b/src/kohakuterrarium/cli/_aio_entrypoint.py
@@ -45,7 +45,14 @@ def _resolve_token(config_dir: Path) -> str:
     """
     token_file = os.environ.get("KT_HOST_TOKEN_FILE", "")
     if token_file and Path(token_file).is_file():
-        return Path(token_file).read_text(encoding="utf-8").strip()
+        file_token = Path(token_file).read_text(encoding="utf-8").strip()
+        if file_token:
+            return file_token
+        print(
+            f"[kt-aio] Ignoring empty KT_HOST_TOKEN_FILE: {token_file}",
+            file=sys.stderr,
+            flush=True,
+        )
 
     env_token = os.environ.get("KT_HOST_TOKEN", "")
     if env_token:

--- a/tests/unit/cli/test_aio_entrypoint.py
+++ b/tests/unit/cli/test_aio_entrypoint.py
@@ -19,8 +19,31 @@ class TestResolveToken:
         token_file = tmp_path / "tok"
         token_file.write_text("filetoken\n", encoding="utf-8")
         monkeypatch.setenv("KT_HOST_TOKEN_FILE", str(token_file))
-        monkeypatch.delenv("KT_HOST_TOKEN", raising=False)
+        monkeypatch.setenv("KT_HOST_TOKEN", "envtoken")
         assert aio._resolve_token(tmp_path) == "filetoken"
+
+    def test_empty_token_file_falls_back_to_env(self, tmp_path, monkeypatch, capsys):
+        token_file = tmp_path / "tok"
+        token_file.write_text("", encoding="utf-8")
+        monkeypatch.setenv("KT_HOST_TOKEN_FILE", str(token_file))
+        monkeypatch.setenv("KT_HOST_TOKEN", "envtoken")
+
+        assert aio._resolve_token(tmp_path) == "envtoken"
+        assert "Ignoring empty KT_HOST_TOKEN_FILE" in capsys.readouterr().err
+
+    def test_whitespace_token_file_falls_back_to_generated(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        token_file = tmp_path / "tok"
+        token_file.write_text(" \n\t", encoding="utf-8")
+        monkeypatch.setenv("KT_HOST_TOKEN_FILE", str(token_file))
+        monkeypatch.delenv("KT_HOST_TOKEN", raising=False)
+        monkeypatch.setattr(aio.secrets, "token_hex", lambda _size: "generated")
+
+        assert aio._resolve_token(tmp_path) == "generated"
+        err = capsys.readouterr().err
+        assert "Ignoring empty KT_HOST_TOKEN_FILE" in err
+        assert "generated one" in err
 
     def test_token_from_env_when_file_missing(self, tmp_path, monkeypatch):
         monkeypatch.delenv("KT_HOST_TOKEN_FILE", raising=False)


### PR DESCRIPTION
Closes #191.

## Summary

- treat empty and whitespace-only `KT_HOST_TOKEN_FILE` content as invalid
- emit a concise stderr warning
- continue through the existing environment-token and generated-token fallback
- preserve valid token-file precedence over `KT_HOST_TOKEN`

## Validation

- `.venv/bin/python -m pytest tests/unit/cli/test_aio_entrypoint.py` — 10 passed
- `.venv/bin/black --check --fast src/kohakuterrarium/cli/_aio_entrypoint.py tests/unit/cli/test_aio_entrypoint.py`
- `.venv/bin/ruff check src/kohakuterrarium/cli/_aio_entrypoint.py tests/unit/cli/test_aio_entrypoint.py`
- `git diff --check`