### PR TITLE
fix(cli): make run arguments unambiguous

### DIFF
--- a/src/kohakuterrarium/cli/__init__.py
+++ b/src/kohakuterrarium/cli/__init__.py
@@ -85,14 +85,15 @@ def _build_parser() -> argparse.ArgumentParser:
             "(custom, package, stdout, plain), off=never, on=always"
         ),
     )
-    run_parser.add_argument(
+    session_group = run_parser.add_mutually_exclusive_group()
+    session_group.add_argument(
         "--session",
         nargs="?",
         const="__auto__",
         default="__auto__",
         help="Session file path (default: auto in ~/.kohakuterrarium/sessions/). Use --no-session to disable.",
     )
-    run_parser.add_argument(
+    session_group.add_argument(
         "--no-session",
         action="store_true",
         help="Disable session persistence",

--- a/src/kohakuterrarium/cli/_config_layers.py
+++ b/src/kohakuterrarium/cli/_config_layers.py
@@ -90,7 +90,7 @@ _ENV_MAP: dict[str, dict[str, tuple[str, ...]]] = {
 }
 
 
-_INT_KEYS = {("http", "port"), ("heartbeat_interval",)}
+_INT_KEYS = {("http", "port")}
 _FLOAT_KEYS = {("heartbeat_interval",)}
 
 

--- a/src/kohakuterrarium/cli/select_args.py
+++ b/src/kohakuterrarium/cli/select_args.py
@@ -37,7 +37,8 @@ def add_run_like_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Override LLM profile (e.g., gpt-5.4, gemini, claude-sonnet-4.6)",
     )
-    parser.add_argument(
+    session_group = parser.add_mutually_exclusive_group()
+    session_group.add_argument(
         "--session",
         nargs="?",
         const="__auto__",
@@ -47,7 +48,7 @@ def add_run_like_args(parser: argparse.ArgumentParser) -> None:
             "Use --no-session to disable."
         ),
     )
-    parser.add_argument(
+    session_group.add_argument(
         "--no-session",
         action="store_true",
         help="Disable session persistence",

--- a/tests/unit/cli/test_cli_parser.py
+++ b/tests/unit/cli/test_cli_parser.py
@@ -1,0 +1,19 @@
+"""Unit tests for the top-level ``kt`` argument parser."""
+
+import pytest
+
+from kohakuterrarium.cli import _build_parser
+
+
+class TestRunParser:
+    def test_session_defaults_remain_automatic(self):
+        args = _build_parser().parse_args(["run", "agent"])
+        assert args.session == "__auto__"
+        assert args.no_session is False
+
+    def test_session_and_no_session_are_mutually_exclusive(self):
+        with pytest.raises(SystemExit) as exc_info:
+            _build_parser().parse_args(
+                ["run", "agent", "--session", "run.kohakutr", "--no-session"]
+            )
+        assert exc_info.value.code == 2

--- a/tests/unit/cli/test_config_layers.py
+++ b/tests/unit/cli/test_config_layers.py
@@ -91,6 +91,12 @@ class TestEnvLayer:
         assert cfg["http"]["port"] == 9999
         assert isinstance(cfg["http"]["port"], int)
 
+    def test_heartbeat_interval_always_coerces_to_float(self, monkeypatch):
+        monkeypatch.setenv("KT_HEARTBEAT_INTERVAL", "5")
+        cfg = load_layered_config("client")
+        assert cfg["heartbeat_interval"] == 5.0
+        assert isinstance(cfg["heartbeat_interval"], float)
+
 
 class TestCliLayer:
     def test_cli_overrides_env(self, monkeypatch):

--- a/tests/unit/cli/test_select_args.py
+++ b/tests/unit/cli/test_select_args.py
@@ -3,6 +3,8 @@
 import argparse
 import sys
 
+import pytest
+
 from kohakuterrarium.cli.select_args import (
     add_resume_like_args,
     add_run_like_args,
@@ -56,6 +58,11 @@ class TestAddRunLikeArgs:
         assert _parser().parse_args(["--session"]).session == "__auto__"
         ns = _parser().parse_args(["--session", "/tmp/x.kohakutr"])
         assert ns.session == "/tmp/x.kohakutr"
+
+    def test_session_and_no_session_are_mutually_exclusive(self):
+        with pytest.raises(SystemExit) as exc_info:
+            _parser().parse_args(["--no-session", "--session", "/tmp/x.kohakutr"])
+        assert exc_info.value.code == 2
 
 
 class TestParseStandaloneArgs:


### PR DESCRIPTION
Closes #192.

## Summary

- coerce `heartbeat_interval` through the float table only, including integer-shaped environment values
- make `--session` and `--no-session` mutually exclusive in both run parser surfaces
- preserve the existing `__auto__` default and dispatch representation
- add negative parser coverage and type-stability coverage

## Validation

- `.venv/bin/python -m pytest tests/unit/cli/test_cli_parser.py tests/unit/cli/test_select_args.py tests/unit/cli/test_config_layers.py` — 25 passed
- `.venv/bin/black --check --fast src/kohakuterrarium/cli/__init__.py src/kohakuterrarium/cli/select_args.py tests/unit/cli/test_cli_parser.py tests/unit/cli/test_select_args.py`
- `.venv/bin/ruff check src/kohakuterrarium/cli/__init__.py src/kohakuterrarium/cli/select_args.py tests/unit/cli/test_cli_parser.py tests/unit/cli/test_select_args.py`
- `git diff --check`