### PR TITLE
fix(write): replace files atomically

### DIFF
--- a/src/kohakuterrarium/builtins/tools/write.py
+++ b/src/kohakuterrarium/builtins/tools/write.py
@@ -1,7 +1,10 @@
 """Guarded file creation and replacement."""
 
 import os
+import secrets
+import stat
 import time
+from pathlib import Path
 from typing import Any
 
 import aiofiles
@@ -63,13 +66,21 @@ class WriteTool(BaseTool):
         if msg:
             return ToolResult(error=msg)
 
+        temp_path: Path | None = None
         try:
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
             exists = file_path.exists()
+            existing_mode = stat.S_IMODE(file_path.stat().st_mode) if exists else None
 
-            async with aiofiles.open(file_path, "w", encoding="utf-8") as f:
+            temp_path = file_path.parent / f".kt-write-{secrets.token_hex(12)}.tmp"
+            async with aiofiles.open(temp_path, "x", encoding="utf-8") as f:
                 await f.write(content)
+
+            if existing_mode is not None:
+                os.chmod(temp_path, existing_mode)
+            os.replace(temp_path, file_path)
+            temp_path = None
 
             action = "Updated" if exists else "Created"
             lines = content.count("\n") + 1 if content else 0
@@ -107,3 +118,15 @@ class WriteTool(BaseTool):
         except Exception as e:
             logger.error("Write failed", error=str(e))
             return ToolResult(error=str(e))
+        finally:
+            if temp_path is not None:
+                try:
+                    temp_path.unlink()
+                except FileNotFoundError:
+                    pass
+                except OSError as e:
+                    logger.warning(
+                        "Failed to remove temporary write file",
+                        file_path=str(temp_path),
+                        error=str(e),
+                    )

--- a/tests/integration/test_laboratory.py
+++ b/tests/integration/test_laboratory.py
@@ -875,6 +875,7 @@ class TestLaboratoryDeepWorkflows:
                 artifact.exists()
             ), f"write tool didn't create file; chunks={chunks_t2!r}"
             assert artifact.read_text(encoding="utf-8").strip() == ("body-from-tool")
+            assert list(tmp_path.glob(".kt-write-*.tmp")) == []
 
             # Turn 3: continue conversation — exercises conversation
             # state across multiple turns.

--- a/tests/unit/builtins/tools/test_write.py
+++ b/tests/unit/builtins/tools/test_write.py
@@ -1,0 +1,76 @@
+"""Unit tests for atomic file replacement in ``WriteTool``."""
+
+import os
+import stat
+import time
+from pathlib import Path
+
+from kohakuterrarium.builtins.tools import write as write_module
+from kohakuterrarium.builtins.tools.write import WriteTool
+from kohakuterrarium.modules.tool.base import ToolContext
+from kohakuterrarium.utils.file_guard import FileReadState
+
+
+def _context(tmp_path: Path, existing: Path | None = None) -> ToolContext:
+    read_state = FileReadState()
+    if existing is not None:
+        read_state.record_read(
+            str(existing), os.stat(existing).st_mtime_ns, False, time.time()
+        )
+    return ToolContext(
+        agent_name="test",
+        session=None,
+        working_dir=tmp_path,
+        file_read_state=read_state,
+    )
+
+
+class TestWriteToolAtomicReplace:
+    async def test_success_replaces_content_and_removes_temp_file(self, tmp_path):
+        path = tmp_path / "target.txt"
+        reference = tmp_path / "reference.txt"
+        reference.write_text("reference", encoding="utf-8")
+
+        result = await WriteTool()._execute(
+            {"path": str(path), "content": "complete"},
+            context=_context(tmp_path),
+        )
+
+        assert result.exit_code == 0
+        assert path.read_text(encoding="utf-8") == "complete"
+        assert stat.S_IMODE(path.stat().st_mode) == stat.S_IMODE(
+            reference.stat().st_mode
+        )
+        assert list(tmp_path.glob(".kt-write-*.tmp")) == []
+
+    async def test_replace_failure_keeps_original_and_removes_temp_file(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "target.txt"
+        path.write_text("original", encoding="utf-8")
+
+        def _fail_replace(_source, _target):
+            raise OSError("replace failed")
+
+        monkeypatch.setattr(write_module.os, "replace", _fail_replace)
+        result = await WriteTool()._execute(
+            {"path": str(path), "content": "replacement"},
+            context=_context(tmp_path, path),
+        )
+
+        assert result.error == "replace failed"
+        assert path.read_text(encoding="utf-8") == "original"
+        assert list(tmp_path.glob(".kt-write-*.tmp")) == []
+
+    async def test_existing_permission_mode_is_preserved(self, tmp_path):
+        path = tmp_path / "target.txt"
+        path.write_text("original", encoding="utf-8")
+        path.chmod(0o640)
+
+        result = await WriteTool()._execute(
+            {"path": str(path), "content": "replacement"},
+            context=_context(tmp_path, path),
+        )
+
+        assert result.exit_code == 0
+        assert stat.S_IMODE(path.stat().st_mode) == 0o640

--- a/tests/unit/builtins/tools/test_write.py
+++ b/tests/unit/builtins/tools/test_write.py
@@ -5,6 +5,8 @@ import stat
 import time
 from pathlib import Path
 
+import pytest
+
 from kohakuterrarium.builtins.tools import write as write_module
 from kohakuterrarium.builtins.tools.write import WriteTool
 from kohakuterrarium.modules.tool.base import ToolContext
@@ -62,6 +64,9 @@ class TestWriteToolAtomicReplace:
         assert path.read_text(encoding="utf-8") == "original"
         assert list(tmp_path.glob(".kt-write-*.tmp")) == []
 
+    @pytest.mark.skipif(
+        os.name == "nt", reason="Windows does not preserve POSIX permission bits"
+    )
     async def test_existing_permission_mode_is_preserved(self, tmp_path):
         path = tmp_path / "target.txt"
         path.write_text("original", encoding="utf-8")


### PR DESCRIPTION
Closes #193.

## Summary

- write complete content to an exclusive temporary sibling first
- preserve normal creation permissions for new files and the existing mode for replacements
- replace the destination with `os.replace` only after the temporary file is closed
- remove the temporary file on failure without masking the original error
- extend the existing laboratory workflow to assert that successful writes leave no temporary artifacts

## Scope

This is intentionally a minimal atomic-replacement change. It does not add file or directory `fsync`, a shared atomic-write framework, or broader durability semantics.

## Validation

- `.venv/bin/python -m pytest tests/unit/builtins/tools/test_write.py tests/unit/builtins/tools/test_canvas_preview.py tests/integration/test_laboratory.py::TestLaboratoryDeepWorkflows::test_chat_with_tools_and_resume` — 16 passed
- `.venv/bin/black --check --fast src/kohakuterrarium/builtins/tools/write.py tests/unit/builtins/tools/test_write.py tests/integration/test_laboratory.py`
- `.venv/bin/ruff check src/kohakuterrarium/builtins/tools/write.py tests/unit/builtins/tools/test_write.py tests/integration/test_laboratory.py`
- `git diff --check`