### PR TITLE
fix(bash): clean complete raw output files

### DIFF
--- a/src/kohakuterrarium/builtins/tools/bash.py
+++ b/src/kohakuterrarium/builtins/tools/bash.py
@@ -138,6 +138,19 @@ def _read_output_file(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
 
 
+def _remove_output_file(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as e:
+        logger.warning(
+            "Failed to remove cancelled Bash output file",
+            file_path=str(path),
+            error=str(e),
+        )
+
+
 def _get_available_shells() -> list[str]:
     """Return shell types whose executable can be resolved (cached)."""
     global _AVAILABLE_SHELLS
@@ -480,6 +493,11 @@ class ShellTool(BaseTool):
         except PermissionError:
             return ToolResult(error="Permission denied")
         except asyncio.CancelledError:
+            if output_handle is not None:
+                output_handle.close()
+                output_handle = None
+            _remove_output_file(output_path)
+            output_path = None
             logger.info("Command cancelled", shell=shell_type, command=command[:100])
             raise
         except Exception as e:

--- a/src/kohakuterrarium/builtins/tools/bash.py
+++ b/src/kohakuterrarium/builtins/tools/bash.py
@@ -145,7 +145,7 @@ def _remove_output_file(path: Path | None) -> None:
         path.unlink(missing_ok=True)
     except OSError as e:
         logger.warning(
-            "Failed to remove cancelled Bash output file",
+            "Failed to remove unused Bash output file",
             file_path=str(path),
             error=str(e),
         )
@@ -488,9 +488,14 @@ class ShellTool(BaseTool):
                 ),
             )
 
-        except FileNotFoundError:
-            return ToolResult(error=f"Shell not found: {resolved_exe or spec_exe}")
-        except PermissionError:
+        except (FileNotFoundError, PermissionError) as e:
+            if output_handle is not None:
+                output_handle.close()
+                output_handle = None
+            _remove_output_file(output_path)
+            output_path = None
+            if isinstance(e, FileNotFoundError):
+                return ToolResult(error=f"Shell not found: {resolved_exe or spec_exe}")
             return ToolResult(error="Permission denied")
         except asyncio.CancelledError:
             if output_handle is not None:

--- a/src/kohakuterrarium/core/executor.py
+++ b/src/kohakuterrarium/core/executor.py
@@ -13,7 +13,10 @@ from kohakuterrarium.core.job import (
     JobType,
     generate_job_id,
 )
-from kohakuterrarium.core.tool_output import normalize_tool_output
+from kohakuterrarium.core.tool_output import (
+    discard_raw_output_file,
+    normalize_tool_output,
+)
 from kohakuterrarium.modules.tool.base import BaseTool, Tool, ToolContext, ToolResult
 from kohakuterrarium.parsing.events import ToolCallEvent
 from kohakuterrarium.utils.logging import get_logger
@@ -354,6 +357,8 @@ class Executor:
             )
             metadata = dict(result_metadata)
             metadata.update(normalized.metadata)
+            if tool.tool_name == "bash" and not normalized.metadata.get("truncated"):
+                discard_raw_output_file(metadata)
 
             job_result = JobResult(
                 job_id=job_id,

--- a/src/kohakuterrarium/core/tool_output.py
+++ b/src/kohakuterrarium/core/tool_output.py
@@ -8,6 +8,7 @@ import base64
 import re
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from kohakuterrarium.core.constants import TOOL_OUTPUT_PREVIEW_CHARS
@@ -49,6 +50,21 @@ class NormalizedToolOutput:
     @property
     def text(self) -> str:
         return self.stats.text
+
+
+def discard_raw_output_file(metadata: dict[str, Any]) -> None:
+    """Remove a complete raw-output file without changing the tool result."""
+    raw_output_path = metadata.pop("raw_output_path", None)
+    if not raw_output_path:
+        return
+    try:
+        Path(str(raw_output_path)).unlink(missing_ok=True)
+    except OSError as e:
+        logger.warning(
+            "Failed to remove complete raw tool output file",
+            file_path=str(raw_output_path),
+            error=str(e),
+        )
 
 
 def truncate_text_utf8(

--- a/tests/integration/test_laboratory_advanced.py
+++ b/tests/integration/test_laboratory_advanced.py
@@ -29,6 +29,7 @@ Modules targeted (gap-filling):
 
 import asyncio
 import base64
+from pathlib import Path
 
 import pytest
 
@@ -66,6 +67,7 @@ from kohakuterrarium.modules.plugin.base import BasePlugin, PluginBlockError
 from kohakuterrarium.modules.tool.base import (
     BaseTool,
     ExecutionMode,
+    ToolConfig,
     ToolResult,
 )
 from kohakuterrarium.parsing import ToolCallEvent
@@ -103,6 +105,28 @@ def _make_agent_cfg(name: str, tmp_path, **overrides) -> AgentConfig:
     for k, v in overrides.items():
         setattr(cfg, k, v)
     return cfg
+
+
+class _BashOutputTool(BaseTool):
+    """Expose a real raw-output file through Bash's executor contract."""
+
+    def __init__(self, raw_path: Path):
+        super().__init__(ToolConfig(max_output=1024))
+        self.raw_path = raw_path
+
+    @property
+    def tool_name(self) -> str:
+        return "bash"
+
+    @property
+    def description(self) -> str:
+        return "Return output captured in a raw Bash file."
+
+    async def _execute(self, args, **kwargs):
+        return ToolResult(
+            output="complete bash output",
+            metadata={"raw_output_path": str(self.raw_path)},
+        )
 
 
 # ── Tool fixtures used across workflows ──────────────────────────────
@@ -606,8 +630,6 @@ class TestLaboratoryToolOutputWorkflow:
         assert norm_big.metadata["omitted_text_bytes"] == 150
 
         # normalize_tool_output WITH artifact store → image materialized
-        from pathlib import Path
-
         class _ArtifactStore:
             def __init__(self, root: Path):
                 self.session_id = "sess-1"
@@ -664,6 +686,15 @@ class TestLaboratoryToolOutputWorkflow:
             assert png_b64 not in convo_text, "raw base64 leaked into model context!"
             # The snapshot text result IS visible
             assert "snapshot ready" in convo_text
+
+            raw_path = tmp_path / "complete-bash.log"
+            raw_path.write_text("complete bash output", encoding="utf-8")
+            agent.executor.register_tool(_BashOutputTool(raw_path))
+            job_id = await agent.executor.submit("bash", {}, is_direct=True)
+            bash_result = await agent.executor.wait_for(job_id)
+            assert bash_result.output == "complete bash output"
+            assert raw_path.exists() is False
+            assert "raw_output_path" not in bash_result.metadata
         finally:
             await agent.stop()
 

--- a/tests/unit/builtins/tools/test_bash.py
+++ b/tests/unit/builtins/tools/test_bash.py
@@ -138,3 +138,34 @@ class TestBashOutputFileLifecycle:
             await task
         assert process_terminated.is_set()
         assert output_path.exists() is False
+
+    @pytest.mark.parametrize(
+        ("spawn_error", "expected_error"),
+        [
+            (FileNotFoundError, "Shell not found: /fake/sh"),
+            (PermissionError, "Permission denied"),
+        ],
+    )
+    async def test_spawn_failure_removes_output_file(
+        self, tmp_path, monkeypatch, spawn_error, expected_error
+    ):
+        output_path = tmp_path / "bash.log"
+
+        async def _create_subprocess(*_args, **_kwargs):
+            raise spawn_error
+
+        def _create_output_file():
+            return output_path, output_path.open("w+b")
+
+        monkeypatch.setattr(
+            bash_module, "_resolve_shell_executable", lambda _shell: "/fake/sh"
+        )
+        monkeypatch.setattr(
+            bash_module.asyncio, "create_subprocess_exec", _create_subprocess
+        )
+        monkeypatch.setattr(bash_module, "_create_output_file", _create_output_file)
+
+        result = await ShellTool()._execute({"command": "echo", "type": "sh"})
+
+        assert result.error == expected_error
+        assert output_path.exists() is False

--- a/tests/unit/builtins/tools/test_bash.py
+++ b/tests/unit/builtins/tools/test_bash.py
@@ -1,0 +1,140 @@
+"""Unit tests for Bash output-file lifecycle behavior."""
+
+import asyncio
+
+import pytest
+
+from kohakuterrarium.builtins.tools import bash as bash_module
+from kohakuterrarium.builtins.tools.bash import ShellTool
+from kohakuterrarium.core.executor import Executor
+from kohakuterrarium.modules.tool.base import ToolConfig
+
+
+def _capture_output_files(monkeypatch, tmp_path):
+    paths = []
+
+    def _create_output_file():
+        path = tmp_path / f"bash_{len(paths)}.log"
+        paths.append(path)
+        return path, path.open("w+b")
+
+    monkeypatch.setattr(bash_module, "_create_output_file", _create_output_file)
+    return paths
+
+
+class TestBashOutputFileLifecycle:
+    @pytest.mark.skipif(
+        bash_module._resolve_shell_executable("sh") is None,
+        reason="POSIX shell is unavailable",
+    )
+    @pytest.mark.parametrize(
+        ("command", "expected_output", "expected_error"),
+        [
+            ("printf success", "success", None),
+            ("printf failure; exit 7", "failure", "Command exited with code 7"),
+        ],
+    )
+    async def test_complete_outputs_are_removed_after_normalization(
+        self, tmp_path, monkeypatch, command, expected_output, expected_error
+    ):
+        paths = _capture_output_files(monkeypatch, tmp_path)
+        executor = Executor()
+        executor._working_dir = tmp_path
+        executor.register_tool(ShellTool(ToolConfig(timeout=1, max_output=1024)))
+
+        result = await executor.wait_for(
+            await executor.submit("bash", {"command": command, "type": "sh"})
+        )
+
+        assert result.output == expected_output
+        assert result.error == expected_error
+        assert "raw_output_path" not in result.metadata
+        assert len(paths) == 1
+        assert paths[0].exists() is False
+
+    @pytest.mark.skipif(
+        bash_module._resolve_shell_executable("sh") is None,
+        reason="POSIX shell is unavailable",
+    )
+    async def test_complete_timeout_output_is_removed(self, tmp_path, monkeypatch):
+        paths = _capture_output_files(monkeypatch, tmp_path)
+        executor = Executor()
+        executor._working_dir = tmp_path
+        executor.register_tool(ShellTool(ToolConfig(timeout=0.05, max_output=1024)))
+
+        result = await executor.wait_for(
+            await executor.submit(
+                "bash", {"command": "printf waiting; sleep 5", "type": "sh"}
+            )
+        )
+
+        assert result.output == "waiting"
+        assert "timed out" in result.error
+        assert "raw_output_path" not in result.metadata
+        assert len(paths) == 1
+        assert paths[0].exists() is False
+
+    @pytest.mark.skipif(
+        bash_module._resolve_shell_executable("sh") is None,
+        reason="POSIX shell is unavailable",
+    )
+    async def test_truncated_output_file_is_retained(self, tmp_path, monkeypatch):
+        paths = _capture_output_files(monkeypatch, tmp_path)
+        executor = Executor()
+        executor._working_dir = tmp_path
+        executor.register_tool(ShellTool(ToolConfig(timeout=1, max_output=5)))
+
+        result = await executor.wait_for(
+            await executor.submit(
+                "bash", {"command": "printf 1234567890", "type": "sh"}
+            )
+        )
+
+        assert result.metadata["truncated"] is True
+        assert result.metadata["raw_output_path"] == str(paths[0])
+        assert paths[0].read_text(encoding="utf-8") == "1234567890"
+        paths[0].unlink()
+
+    async def test_cancellation_removes_output_file(self, tmp_path, monkeypatch):
+        output_path = tmp_path / "bash.log"
+        process_started = asyncio.Event()
+        process_terminated = asyncio.Event()
+
+        class _FakeProcess:
+            returncode = None
+
+            async def wait(self):
+                process_started.set()
+                await asyncio.Event().wait()
+
+        process = _FakeProcess()
+
+        async def _create_subprocess(*_args, **_kwargs):
+            return process
+
+        async def _terminate(candidate):
+            assert candidate is process
+            process_terminated.set()
+
+        def _create_output_file():
+            return output_path, output_path.open("w+b")
+
+        monkeypatch.setattr(
+            bash_module, "_resolve_shell_executable", lambda _shell: "/fake/sh"
+        )
+        monkeypatch.setattr(
+            bash_module.asyncio, "create_subprocess_exec", _create_subprocess
+        )
+        monkeypatch.setattr(bash_module, "terminate_process_tree", _terminate)
+        monkeypatch.setattr(bash_module, "_create_output_file", _create_output_file)
+
+        task = asyncio.create_task(
+            ShellTool()._execute({"command": "long-running", "type": "sh"})
+        )
+        await asyncio.wait_for(process_started.wait(), timeout=1.0)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert process_terminated.is_set()
+        assert output_path.exists() is False

--- a/tests/unit/core/test_executor.py
+++ b/tests/unit/core/test_executor.py
@@ -109,6 +109,31 @@ class _SlowTool(BaseTool):
         return ToolResult(output="done")
 
 
+class _BashFileTool(BaseTool):
+    """Return Bash-shaped output metadata without spawning a subprocess."""
+
+    def __init__(self, path: Path, output: str, *, max_output: int, **result_kwargs):
+        super().__init__(ToolConfig(max_output=max_output))
+        self.path = path
+        self.output = output
+        self.result_kwargs = result_kwargs
+
+    @property
+    def tool_name(self):
+        return "bash"
+
+    @property
+    def description(self):
+        return "bash-shaped test tool"
+
+    async def _execute(self, args, **kwargs):
+        return ToolResult(
+            output=self.output,
+            metadata={"raw_output_path": str(self.path)},
+            **self.result_kwargs,
+        )
+
+
 # ── basic submit / wait_for ──────────────────────────────────────
 
 
@@ -549,6 +574,89 @@ class TestOutputNormalisation:
             "Full output saved to /tmp/kohakuterrarium-bash/bash_1.log" in result.output
         )
         assert "use read to view it" in result.output
+
+    async def test_complete_bash_output_file_is_removed(self, tmp_path):
+        raw_path = tmp_path / "bash.log"
+        raw_path.write_text("complete output", encoding="utf-8")
+        ex = Executor()
+        ex.register_tool(
+            _BashFileTool(raw_path, "complete output", max_output=1024, exit_code=0)
+        )
+
+        result = await ex.wait_for(await ex.submit("bash", {}))
+
+        assert result.output == "complete output"
+        assert result.metadata["truncated"] is False
+        assert "raw_output_path" not in result.metadata
+        assert raw_path.exists() is False
+
+    @pytest.mark.parametrize(
+        ("exit_code", "error"),
+        [
+            (7, "Command exited with code 7"),
+            (-1, "Command timed out after 1s"),
+        ],
+    )
+    async def test_complete_failed_bash_output_file_is_removed(
+        self, tmp_path, exit_code, error
+    ):
+        raw_path = tmp_path / "bash.log"
+        raw_path.write_text("failure output", encoding="utf-8")
+        ex = Executor()
+        ex.register_tool(
+            _BashFileTool(
+                raw_path,
+                "failure output",
+                max_output=1024,
+                exit_code=exit_code,
+                error=error,
+            )
+        )
+
+        result = await ex.wait_for(await ex.submit("bash", {}))
+
+        assert result.error == error
+        assert result.exit_code == exit_code
+        assert "raw_output_path" not in result.metadata
+        assert raw_path.exists() is False
+
+    async def test_truncated_bash_output_file_is_retained(self, tmp_path):
+        raw_path = tmp_path / "bash.log"
+        full_output = "x" * 100
+        raw_path.write_text(full_output, encoding="utf-8")
+        ex = Executor()
+        ex.register_tool(_BashFileTool(raw_path, full_output, max_output=10))
+
+        result = await ex.wait_for(await ex.submit("bash", {}))
+
+        assert result.metadata["truncated"] is True
+        assert result.metadata["raw_output_path"] == str(raw_path)
+        assert raw_path.read_text(encoding="utf-8") == full_output
+
+    async def test_bash_cleanup_failure_does_not_change_result(
+        self, tmp_path, monkeypatch
+    ):
+        raw_path = tmp_path / "bash.log"
+        raw_path.write_text("complete output", encoding="utf-8")
+        original_unlink = Path.unlink
+
+        def _fail_raw_unlink(path, *args, **kwargs):
+            if path == raw_path:
+                raise OSError("busy")
+            return original_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", _fail_raw_unlink)
+        ex = Executor()
+        ex.register_tool(_BashFileTool(raw_path, "complete output", max_output=1024))
+
+        result = await ex.wait_for(await ex.submit("bash", {}))
+
+        assert result.output == "complete output"
+        assert result.error is None
+        assert result.exit_code is None
+        assert "raw_output_path" not in result.metadata
+        assert raw_path.exists() is True
+        original_unlink(raw_path)
 
 
 # ── pending / running / task accessors ───────────────────────────


### PR DESCRIPTION
Closes #194.

## Summary

- keep Bash's existing raw-file capture path
- remove the raw file after executor normalization when `truncated=False`
- remove `raw_output_path` from complete-result metadata
- retain the path and readable file when output is truncated
- remove the capture file when subprocess execution is cancelled before returning a result
- warn on unlink failure without changing the command result

## Scope

This PR only removes files that normalization proves are no longer needed. It does not add TTL cleanup, JobStore/session artifact ownership, streaming caps, shutdown hooks, or a general temporary-storage subsystem.

## Validation

- real local shell coverage: success, non-zero exit, timeout, and truncation
- deterministic coverage: cancellation and unlink failure
- `.venv/bin/python -m pytest tests/unit/test_file_sizes.py tests/unit/builtins/tools/test_bash.py tests/unit/core/test_executor.py tests/unit/core/test_tool_output.py tests/integration/test_laboratory_advanced.py::TestLaboratoryToolOutputWorkflow::test_tool_output_rendering_full_workflow` — 1810 passed
- `.venv/bin/black --check --fast` on all changed Python files
- `.venv/bin/ruff check` on all changed Python files
- `git diff --check`