### PR TITLE
fix(tui): target running jobs by content row

### DIFF
--- a/src/kohakuterrarium/builtins/tui/widgets/panels.py
+++ b/src/kohakuterrarium/builtins/tui/widgets/panels.py
@@ -76,18 +76,18 @@ class RunningPanel(Static):
         if not self._items:
             return
 
-        idx = 0
-        if len(self._items) == 1:
-            idx = 0
-        else:
-            idx = min(event.y, len(self._ordered_ids) - 1)
-            idx = max(idx, 0)
+        content_offset = event.get_content_offset(self)
+        if content_offset is None:
+            return
+        idx = content_offset.y
+        if idx < 0 or idx >= len(self._ordered_ids):
+            return
 
         job_id = self._ordered_ids[idx]
         label, start, promotable = self._items[job_id]
         elapsed = time.monotonic() - start
 
-        if promotable and elapsed >= self.PROMOTE_THRESHOLD and event.x > 35:
+        if promotable and elapsed >= self.PROMOTE_THRESHOLD and content_offset.x > 35:
             self.post_message(self.PromoteRequested(job_id))
         else:
             self.post_message(self.CancelRequested(job_id, label))

--- a/tests/unit/builtins/tui/test_widgets_panels.py
+++ b/tests/unit/builtins/tui/test_widgets_panels.py
@@ -1,0 +1,36 @@
+"""Tests for TUI status panels."""
+
+from textual.geometry import Offset
+
+from kohakuterrarium.builtins.tui.widgets.panels import RunningPanel
+
+
+class _Click:
+    def __init__(self, content_offset: Offset | None) -> None:
+        self._content_offset = content_offset
+
+    def get_content_offset(self, _widget: RunningPanel) -> Offset | None:
+        return self._content_offset
+
+
+class TestRunningPanel:
+    def test_click_targets_content_row_and_ignores_non_content(self) -> None:
+        panel = RunningPanel()
+        panel._items = {
+            "first": ("First", 0.0, False),
+            "second": ("Second", 0.0, False),
+        }
+        panel._ordered_ids = ["first", "second"]
+        posted = []
+        panel.post_message = posted.append  # type: ignore[method-assign]
+
+        panel.on_click(_Click(None))
+        panel.on_click(_Click(Offset(0, 2)))
+
+        assert posted == []
+
+        panel.on_click(_Click(Offset(0, 0)))
+
+        assert len(posted) == 1
+        assert isinstance(posted[0], RunningPanel.CancelRequested)
+        assert posted[0].job_id == "first"


### PR DESCRIPTION
## Summary

Fix RunningPanel mouse targeting so bordered widgets map clicks to their content rows instead of raw screen-relative rows. Border clicks and clicks outside the current job list are ignored.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The previous row calculation subtracted the widget region origin but not the border offset. In a bordered panel this selected or promoted the job above the one the user clicked.

## Changes

- Convert click coordinates with Textual's content-offset API.
- Reject border and out-of-range clicks.
- Add regression coverage for content-row selection, borders, and empty space.

## Validation

```bash
python -m pytest tests/unit/builtins/tui/test_widgets_panels.py tests/unit/builtins/tui/test_app.py tests/unit/builtins/tui/test_session.py -q
python -m ruff check src/kohakuterrarium/builtins/tui/widgets/panels.py tests/unit/builtins/tui/test_widgets_panels.py
python -m black --check src/kohakuterrarium/builtins/tui/widgets/panels.py tests/unit/builtins/tui/test_widgets_panels.py
```

- Targeted tests: 6 passed.
- Fork Android workflow: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577093370
- Fork CI workflow: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577093364

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #200

## Notes for Reviewers

The behavior change is limited to mouse-coordinate translation in `RunningPanel`; keyboard handling and job ordering are unchanged.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- No documentation update is needed because this restores the existing click behavior rather than changing a documented interface.
- No frontend files changed, so frontend commands are not applicable.
- A local full-unit attempt on the final batch branch reached 13,800 passed / 14 skipped but had 10 unrelated environment or baseline failures (missing optional `dulwich`, Windows default-encoding, one pre-existing timing-sensitive session-index test, and two logging-capture tests). The branch-specific suite passed, and the fork workflow runs the complete matrix.
- The first fork CI attempt had one unrelated Windows 3.12 failure in `TestSessionIndexHook.test_event_flush_debounced_by_time`; the other 12 CI jobs and the Android workflow passed. A failed-job rerun was still in progress when this Draft PR was opened, so upstream PR CI is also being used for confirmation.
