### PR TITLE
fix(cli): preserve serve restart lifecycle

### DIFF
--- a/src/kohakuterrarium/cli/serve.py
+++ b/src/kohakuterrarium/cli/serve.py
@@ -172,7 +172,10 @@ def _spawn_server_process(
     else:
         kwargs["start_new_session"] = True
 
-    proc = subprocess.Popen(cmd, **kwargs)
+    try:
+        proc = subprocess.Popen(cmd, **kwargs)
+    finally:
+        log_file.close()
     return proc.pid
 
 
@@ -446,6 +449,7 @@ def serve_restart_cli(args: argparse.Namespace) -> int:
         mode=getattr(args, "mode", "standalone"),
         lab_bind=getattr(args, "lab_bind", ""),
         lab_token=getattr(args, "lab_token", ""),
+        home_dir=getattr(args, "home_dir", ""),
         foreground=getattr(args, "foreground", False),
     )
     return serve_start_cli(start_args)

--- a/tests/unit/cli/test_serve.py
+++ b/tests/unit/cli/test_serve.py
@@ -1,0 +1,61 @@
+"""Tests for managed web-daemon CLI lifecycle."""
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import mock_open
+
+import pytest
+
+from kohakuterrarium.cli import serve
+
+
+class TestServeLifecycle:
+    def test_restart_preserves_home_dir(self, monkeypatch) -> None:
+        started = []
+        monkeypatch.setattr(serve, "serve_stop_cli", lambda _args: 0)
+        monkeypatch.setattr(
+            serve, "serve_start_cli", lambda args: started.append(args) or 0
+        )
+        args = argparse.Namespace(
+            timeout=5.0,
+            host="127.0.0.1",
+            port=8001,
+            dev=False,
+            log_level="INFO",
+            mode="standalone",
+            lab_bind="",
+            lab_token="",
+            home_dir="C:/kt-home",
+            foreground=False,
+        )
+
+        assert serve.serve_restart_cli(args) == 0
+        assert started[0].home_dir == "C:/kt-home"
+
+    def test_spawn_closes_parent_log_handle_on_success_and_failure(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        monkeypatch.setattr(serve, "RUN_DIR", tmp_path)
+        monkeypatch.setattr(serve, "LOG_PATH", tmp_path / "daemon.log")
+
+        opened = mock_open()
+        monkeypatch.setattr("builtins.open", opened)
+        monkeypatch.setattr(
+            serve.subprocess,
+            "Popen",
+            lambda *_args, **_kwargs: SimpleNamespace(pid=123),
+        )
+
+        assert serve._spawn_server_process("127.0.0.1", 8001, False, "INFO") == 123
+        assert opened.return_value.close.call_count == 1
+
+        opened.reset_mock()
+
+        def _fail(*_args, **_kwargs):
+            raise OSError("spawn failed")
+
+        monkeypatch.setattr(serve.subprocess, "Popen", _fail)
+
+        with pytest.raises(OSError, match="spawn failed"):
+            serve._spawn_server_process("127.0.0.1", 8001, False, "INFO")
+        assert opened.return_value.close.call_count == 1


### PR DESCRIPTION
## Summary

Preserve the configured home directory when `kt serve restart` starts the replacement process, and close the parent's daemon log handle after spawning. This keeps restart behavior consistent with the original serve invocation and prevents a parent-side descriptor leak.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The restart path dropped `home_dir`, causing the new server to use a different default state directory. The daemon spawn path also retained the parent's open log file after `Popen` returned.

## Changes

- Forward `home_dir` through `serve_restart_cli`.
- Close the parent log stream in a `finally` block after process creation.
- Add negative regression tests for both lifecycle defects.

## Validation

```bash
python -m pytest tests/unit/cli/test_serve.py tests/unit/cli/test_cli_parser.py -q
python -m ruff check src/kohakuterrarium/cli/serve.py tests/unit/cli/test_serve.py
python -m black --check src/kohakuterrarium/cli/serve.py tests/unit/cli/test_serve.py
```

- Targeted tests: 4 passed.
- Fork CI: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577095566
- Fork Android workflow: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577095432

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #201

## Notes for Reviewers

The child process still owns its duplicated/inherited output handle. Only the no-longer-needed parent handle is closed.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- No documentation update is needed because this restores the existing restart contract.
- No frontend files changed, so frontend commands are not applicable.
- The local full-unit exception is the same batch-level environment/baseline result described in the validation PR set; the targeted tests and complete fork CI matrix passed.

