### PR TITLE
fix(cli): report resume outcomes accurately

### DIFF
--- a/src/kohakuterrarium/cli/resume.py
+++ b/src/kohakuterrarium/cli/resume.py
@@ -62,17 +62,17 @@ def resume_cli(
         return 0
 
     try:
-        return asyncio.run(_run(path, resolved_pwd, llm, io_mode))
+        result = asyncio.run(_run(path, resolved_pwd, llm, io_mode))
     except KeyboardInterrupt:
         print("\nInterrupted")
         return 0
     except Exception as exc:
         print(f"Error: {exc}")
         return 1
-    finally:
-        if path.exists():
-            print("\nSession saved. To resume:")
-            print(f"  kt resume {path.stem}")
+    if result == 0 and path.exists():
+        print("\nSession saved. To resume:")
+        print(f"  kt resume {path.stem}")
+    return result
 
 
 def _resolve_missing_pwd(path, pwd_override: str | None) -> str | None | Literal[False]:

--- a/src/kohakuterrarium/cli/run.py
+++ b/src/kohakuterrarium/cli/run.py
@@ -486,12 +486,12 @@ def _resolve_session(query: str | None, last: bool = False) -> Path | None:
 
 def _session_preview(path: Path) -> str:
     """Get a short preview of session metadata."""
+    store = None
     try:
         # Read-only: a plain open+close here used to bump last_active,
         # corrupting the recency ordering the resume picker sorts by.
         store = SessionStore.open_readonly(path)
         meta = store.load_meta()
-        store.close()
         config_type = meta.get("config_type", "?")
         config_path = meta.get("config_path", "")
         name = Path(config_path).name if config_path else "?"
@@ -499,3 +499,13 @@ def _session_preview(path: Path) -> str:
     except Exception as e:
         logger.warning("Failed to read session label", error=str(e), exc_info=True)
         return ""
+    finally:
+        if store is not None:
+            try:
+                store.close()
+            except Exception as e:
+                logger.warning(
+                    "Failed to close session preview store",
+                    error=str(e),
+                    exc_info=True,
+                )

--- a/tests/unit/cli/test_resume_pwd.py
+++ b/tests/unit/cli/test_resume_pwd.py
@@ -78,3 +78,45 @@ class TestResolveMissingPwd:
 
         assert resume_mod.resume_cli("saved", None, "INFO") == 0
         assert "Resume cancelled." in capsys.readouterr().out
+
+    def test_resume_failure_does_not_report_session_saved(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        path = _make_store(tmp_path, str(tmp_path))
+        monkeypatch.setattr(resume_mod, "configure_utf8_stdio", lambda **_k: None)
+        monkeypatch.setattr(resume_mod, "set_level", lambda *_a, **_k: None)
+        monkeypatch.setattr(resume_mod, "_resolve_session", lambda *_a, **_k: path)
+        monkeypatch.setattr(
+            resume_mod, "announce_migration_if_needed", lambda *_a, **_k: None
+        )
+        monkeypatch.setattr(resume_mod, "_resolve_missing_pwd", lambda *_a: None)
+
+        async def failed_run(*_args, **_kwargs):
+            raise RuntimeError("resume failed")
+
+        monkeypatch.setattr(resume_mod, "_run", failed_run)
+
+        assert resume_mod.resume_cli("saved", None, "INFO") == 1
+        output = capsys.readouterr().out
+        assert "Error: resume failed" in output
+        assert "Session saved" not in output
+
+    def test_resume_success_still_reports_session_saved(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        path = _make_store(tmp_path, str(tmp_path))
+        monkeypatch.setattr(resume_mod, "configure_utf8_stdio", lambda **_k: None)
+        monkeypatch.setattr(resume_mod, "set_level", lambda *_a, **_k: None)
+        monkeypatch.setattr(resume_mod, "_resolve_session", lambda *_a, **_k: path)
+        monkeypatch.setattr(
+            resume_mod, "announce_migration_if_needed", lambda *_a, **_k: None
+        )
+        monkeypatch.setattr(resume_mod, "_resolve_missing_pwd", lambda *_a: None)
+
+        async def successful_run(*_args, **_kwargs):
+            return 0
+
+        monkeypatch.setattr(resume_mod, "_run", successful_run)
+
+        assert resume_mod.resume_cli("saved", None, "INFO") == 0
+        assert "Session saved" in capsys.readouterr().out

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -1,0 +1,25 @@
+"""Tests for CLI run and session-selection helpers."""
+
+from kohakuterrarium.cli import run
+
+
+class _FailingPreviewStore:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def load_meta(self) -> dict:
+        raise RuntimeError("broken metadata")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestSessionPreview:
+    def test_store_closes_when_metadata_loading_fails(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        store = _FailingPreviewStore()
+        monkeypatch.setattr(run.SessionStore, "open_readonly", lambda _path: store)
+
+        assert run._session_preview(tmp_path / "broken.kohakutr") == ""
+        assert store.closed is True


### PR DESCRIPTION
## Summary

Report a saved session only when `kt resume` completes successfully, and always close temporary session stores opened for run-command previews. Errors and interrupts no longer produce a misleading success hint or leak a preview store.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The resume command printed its success message from an unconditional `finally` block. Separately, `_session_preview` could exit after `load_meta()` failed without closing the opened store.

## Changes

- Gate the resume success message on a successful return code.
- Preserve existing error and interrupt return behavior.
- Close preview stores from a `finally` block without masking the original failure.
- Add failure-path and success-path regression coverage.

## Validation

```bash
python -m pytest tests/unit/cli/test_resume_pwd.py tests/unit/cli/test_resume_mode.py tests/unit/cli/test_run.py -q
python -m ruff check src/kohakuterrarium/cli/resume.py src/kohakuterrarium/cli/run.py tests/unit/cli/test_resume_pwd.py tests/unit/cli/test_run.py
python -m black --check src/kohakuterrarium/cli/resume.py src/kohakuterrarium/cli/run.py tests/unit/cli/test_resume_pwd.py tests/unit/cli/test_run.py
```

- Targeted tests: 19 passed.
- Fork CI: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577097418
- Fork Android workflow: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577097416

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #202

## Notes for Reviewers

Store-close errors are logged and do not replace the preview operation's original result or exception.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- No documentation update is needed because user-facing output is corrected to match the existing success/failure contract.
- No frontend files changed, so frontend commands are not applicable.
- The local full-unit exception is the same batch-level environment/baseline result described in the validation PR set; the targeted tests and complete fork CI matrix passed.

