### PR TITLE
fix(android): ignore callbacks after activity destroy

### DIFF
--- a/packaging/android/template/app/src/main/java/org/kohaku/terrarium/MainActivity.java
+++ b/packaging/android/template/app/src/main/java/org/kohaku/terrarium/MainActivity.java
@@ -73,6 +73,7 @@ public class MainActivity extends Activity {
     private String pendingConnectUri;
     private int connectUriReplayCount = 0;
     private boolean webViewLoaded = false;
+    private volatile boolean destroyed = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -102,6 +103,11 @@ public class MainActivity extends Activity {
 
     @Override
     protected void onDestroy() {
+        destroyed = true;
+        mainHandler.removeCallbacksAndMessages(null);
+        if (probeHandler != null) {
+            probeHandler.removeCallbacksAndMessages(null);
+        }
         if (probeThread != null) {
             probeThread.quitSafely();
             probeThread = null;
@@ -111,6 +117,7 @@ public class MainActivity extends Activity {
             webView.destroy();
             webView = null;
         }
+        statusView = null;
         super.onDestroy();
     }
 
@@ -135,6 +142,7 @@ public class MainActivity extends Activity {
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
+                if (destroyed || webView == null) return;
                 webViewLoaded = true;
                 replayConnectUri();
             }
@@ -161,21 +169,34 @@ public class MainActivity extends Activity {
         Runnable check = new Runnable() {
             @Override
             public void run() {
+                if (destroyed) return;
                 int port = readBoundPort();
                 if (port > 0 && probeHost(port)) {
                     final int boundPort = port;
-                    mainHandler.post(() -> loadFrontend(boundPort));
+                    mainHandler.post(() -> {
+                        if (destroyed) return;
+                        loadFrontend(boundPort);
+                    });
                     return;
                 }
                 if (System.currentTimeMillis() > deadline) {
-                    mainHandler.post(() -> statusView.setText(
-                        "Host failed to start within 30s.  Check the log."));
+                    mainHandler.post(() -> {
+                        if (destroyed || statusView == null) return;
+                        statusView.setText(
+                            "Host failed to start within 30s.  Check the log.");
+                    });
                     return;
                 }
-                probeHandler.postDelayed(this, HOST_BOOT_POLL_MS);
+                Handler handler = probeHandler;
+                if (!destroyed && handler != null) {
+                    handler.postDelayed(this, HOST_BOOT_POLL_MS);
+                }
             }
         };
-        probeHandler.postDelayed(check, HOST_BOOT_POLL_MS);
+        Handler handler = probeHandler;
+        if (!destroyed && handler != null) {
+            handler.postDelayed(check, HOST_BOOT_POLL_MS);
+        }
     }
 
     private int readBoundPort() {
@@ -207,6 +228,7 @@ public class MainActivity extends Activity {
     }
 
     private void loadFrontend(int port) {
+        if (destroyed || isDestroyed() || webView == null || statusView == null) return;
         statusView.setVisibility(View.GONE);
         webView.setVisibility(View.VISIBLE);
         webView.loadUrl("http://127.0.0.1:" + port + "/");
@@ -223,7 +245,7 @@ public class MainActivity extends Activity {
     }
 
     private void replayConnectUri() {
-        if (pendingConnectUri == null || webView == null) return;
+        if (destroyed || pendingConnectUri == null || webView == null) return;
         if (!webViewLoaded) return;
         if (connectUriReplayCount >= CONNECT_URI_REPLAY_MAX_TRIES) {
             // Capped retries — Vue side never acked.  Most likely
@@ -264,6 +286,7 @@ public class MainActivity extends Activity {
         @JavascriptInterface
         public void ackConnectUri() {
             mainHandler.post(() -> {
+                if (destroyed) return;
                 pendingConnectUri = null;
                 Log.i(TAG, "JS acked connect URI; stopping replay");
             });

--- a/tests/unit/packaging/test_android_activity_lifecycle.py
+++ b/tests/unit/packaging/test_android_activity_lifecycle.py
@@ -1,0 +1,37 @@
+"""Regression contracts for the packaged Android Activity lifecycle."""
+
+from pathlib import Path
+
+_ACTIVITY = (
+    Path(__file__).resolve().parents[3]
+    / "packaging"
+    / "android"
+    / "template"
+    / "app"
+    / "src"
+    / "main"
+    / "java"
+    / "org"
+    / "kohaku"
+    / "terrarium"
+    / "MainActivity.java"
+)
+
+
+class TestAndroidActivityLifecycle:
+    def test_destroyed_activity_rejects_delayed_probe_callbacks(self) -> None:
+        source = _ACTIVITY.read_text(encoding="utf-8")
+        on_destroy = source.split("protected void onDestroy()", 1)[1].split(
+            "private void setupUi()", 1
+        )[0]
+        load_frontend = source.split("private void loadFrontend(int port)", 1)[1].split(
+            "private void handleConnectIntent", 1
+        )[0]
+
+        assert on_destroy.index("destroyed = true") < on_destroy.index(
+            "webView.destroy()"
+        )
+        assert "probeHandler.removeCallbacksAndMessages(null)" in on_destroy
+        assert "mainHandler.removeCallbacksAndMessages(null)" in on_destroy
+        assert "destroyed || isDestroyed() || webView == null" in load_frontend
+        assert "if (destroyed) return" in source


### PR DESCRIPTION
## Summary

Make Android Activity teardown invalidate pending callbacks before destroying the WebView. Delayed service probes, page callbacks, and JavaScript acknowledgements now return safely after `onDestroy` instead of touching cleared UI state.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Activity callbacks can race with teardown. The prior implementation could run posted work after `onDestroy` and access a destroyed WebView or stale status view.

## Changes

- Mark the Activity destroyed before cancelling callbacks and tearing down views.
- Remove pending main-thread and probe callbacks.
- Guard delayed UI, WebView, replay, and acknowledgement callbacks.
- Null view references after teardown.
- Add a template lifecycle contract regression test.

## Validation

```bash
python -m pytest tests/unit/packaging/test_android_activity_lifecycle.py tests/unit/packaging/test_postcreate.py -q
python -m ruff check tests/unit/packaging/test_android_activity_lifecycle.py
python -m black --check tests/unit/packaging/test_android_activity_lifecycle.py
```

- Targeted tests: 40 passed.
- Fork CI: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577099889
- Fork Android workflow: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577099912

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #203

## Notes for Reviewers

The repository does not include a directly runnable Gradle/Robolectric project for this generated template, so the new test verifies the teardown and callback-guard contract statically. The Android packaging workflow provides build-time coverage but is not real-device lifecycle proof.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- No physical-device or instrumented lifecycle test was available in this repository.
- No documentation or frontend update is needed; the change is internal lifecycle hardening.
- The local full-unit exception is the same batch-level environment/baseline result described in the validation PR set; the targeted tests and fork workflows provide the recorded validation.
- Fork CI had one unrelated Windows 3.12 failure in `TestBashOutputFileLifecycle.test_complete_timeout_output_is_removed`; all other CI jobs and the separate Android workflow passed. A failed-job rerun was still in progress when this Draft PR was opened, so upstream PR CI is also being used for confirmation.
