### PR TITLE
fix(tui): settle modal waits during shutdown

### DIFF
--- a/src/kohakuterrarium/builtins/tui/session.py
+++ b/src/kohakuterrarium/builtins/tui/session.py
@@ -1,7 +1,7 @@
 """Share Textual UI state between input and output modules."""
 
 import asyncio
-from typing import Any
+from typing import Any, TypeVar
 
 from textual.containers import VerticalScroll
 from textual.widgets import Markdown, Static
@@ -40,6 +40,7 @@ DEFAULT_CULL_KEEP = 50
 DEFAULT_LOAD_BATCH = 30
 # Shared with output history restore so live and resumed chats keep the same window.
 CULL_KEEP = DEFAULT_CULL_KEEP
+_T = TypeVar("_T")
 
 
 class TUISession(TabModelRegistryMixin):
@@ -88,6 +89,7 @@ class TUISession(TabModelRegistryMixin):
         self.command_hint_fallback: dict[str, Any] = {}
         # Buffer mutations until Textual mounts so startup events are not lost.
         self._pending_safe_calls: list[tuple[Any, tuple[Any, ...]]] = []
+        self._pending_modal_defaults: dict[asyncio.Future[Any], Any] = {}
 
     def set_terrarium_tabs(self, tabs: list[str]) -> None:
         """Configure terrarium tabs and reconcile a running application."""
@@ -805,6 +807,7 @@ class TUISession(TabModelRegistryMixin):
 
     def _signal_input_shutdown(self) -> None:
         """Discard pending submissions and wake the runner with shutdown."""
+        self._settle_pending_modals()
         if not self._app:
             return
         while True:
@@ -819,6 +822,26 @@ class TUISession(TabModelRegistryMixin):
             return ""
         return await self._app._input_queue.get()
 
+    def _register_modal(self, default: _T) -> asyncio.Future[_T]:
+        """Track a modal waiter so application shutdown can settle it."""
+        future: asyncio.Future[_T] = asyncio.get_running_loop().create_future()
+        self._pending_modal_defaults[future] = default
+        return future
+
+    def _resolve_modal(self, future: asyncio.Future[_T], value: _T) -> None:
+        """Resolve a modal exactly once and remove its shutdown fallback."""
+        self._pending_modal_defaults.pop(future, None)
+        if not future.done():
+            future.set_result(value)
+
+    def _settle_pending_modals(self) -> None:
+        """Resolve every open modal with its cancellation default."""
+        pending = tuple(self._pending_modal_defaults.items())
+        self._pending_modal_defaults.clear()
+        for future, default in pending:
+            if not future.done():
+                future.set_result(default)
+
     async def show_selection_modal(
         self, title: str, options: list[dict], current: str = ""
     ) -> str | None:
@@ -826,31 +849,35 @@ class TUISession(TabModelRegistryMixin):
         if not self._app or not self._app.is_running:
             return None
 
-        result_future: asyncio.Future[str | None] = asyncio.Future()
+        result_future = self._register_modal(None)
         modal = SelectionModal(title=title, options=options, current=current)
 
         def _on_dismiss(value: str | None) -> None:
-            if not result_future.done():
-                result_future.set_result(value)
+            self._resolve_modal(result_future, value)
 
         # Modal screens must be pushed from Textual's application context.
         self._app.call_later(lambda: self._app.push_screen(modal, callback=_on_dismiss))
-        return await result_future
+        try:
+            return await result_future
+        finally:
+            self._pending_modal_defaults.pop(result_future, None)
 
     async def show_confirm_modal(self, message: str) -> bool:
         """Show a confirmation modal and return its result."""
         if not self._app or not self._app.is_running:
             return False
 
-        result_future: asyncio.Future[bool] = asyncio.Future()
+        result_future = self._register_modal(False)
         modal = ConfirmModal(message)
 
         def _on_dismiss(value: bool) -> None:
-            if not result_future.done():
-                result_future.set_result(value)
+            self._resolve_modal(result_future, value)
 
         self._app.call_later(lambda: self._app.push_screen(modal, callback=_on_dismiss))
-        return await result_future
+        try:
+            return await result_future
+        finally:
+            self._pending_modal_defaults.pop(result_future, None)
 
     async def show_model_picker_modal(self, agent: Any) -> None:
         """Open the model picker for an agent."""

--- a/tests/unit/builtins/tui/test_session.py
+++ b/tests/unit/builtins/tui/test_session.py
@@ -1,5 +1,6 @@
 """Tests for shared TUI session state."""
 
+import asyncio
 from collections.abc import Callable
 from typing import Any
 
@@ -44,6 +45,24 @@ class _CommandInput:
 class _Command:
     def __init__(self, *aliases: str) -> None:
         self.aliases = list(aliases)
+
+
+class _ModalApp:
+    is_running = True
+
+    def __init__(self) -> None:
+        self._input_queue: asyncio.Queue[str] = asyncio.Queue()
+        self.dismiss_callbacks: list[Callable[[Any], None]] = []
+
+    def call_later(self, callback: Callable[[], None]) -> bool:
+        callback()
+        return True
+
+    def push_screen(self, _modal: Any, callback: Callable[[Any], None]) -> None:
+        self.dismiss_callbacks.append(callback)
+
+    def exit(self) -> None:
+        self.is_running = False
 
 
 class _CommandAgent:
@@ -126,3 +145,32 @@ async def test_background_tab_culling_keeps_target_history_count() -> None:
         bob_chat = session._app.query_one(f"#chat-{_safe_id('bob')}", VerticalScroll)
         assert len(bob_chat.children) == 2
         assert session._culled_count == {"bob": 2}
+
+
+class TestModalShutdown:
+    async def test_stop_settles_pending_modal_defaults(self) -> None:
+        session = TUISession()
+        app = _ModalApp()
+        session._app = app  # type: ignore[assignment]
+
+        selection = asyncio.create_task(session.show_selection_modal("Pick", []))
+        confirmation = asyncio.create_task(session.show_confirm_modal("Continue?"))
+        await asyncio.sleep(0)
+
+        session.stop()
+
+        assert await asyncio.wait_for(selection, 0.1) is None
+        assert await asyncio.wait_for(confirmation, 0.1) is False
+        assert session._pending_modal_defaults == {}
+
+    async def test_dismiss_result_wins_before_shutdown(self) -> None:
+        session = TUISession()
+        app = _ModalApp()
+        session._app = app  # type: ignore[assignment]
+
+        selection = asyncio.create_task(session.show_selection_modal("Pick", []))
+        await asyncio.sleep(0)
+        app.dismiss_callbacks[0]("chosen")
+
+        assert await selection == "chosen"
+        session.stop()


### PR DESCRIPTION
## Summary

Settle pending TUI selection and confirmation futures when input shuts down. App exit now returns deterministic cancellation defaults instead of leaving modal waiters pending indefinitely.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

When the TUI stopped while a modal was open, `_signal_input_shutdown` only released the main input queue. Selection and confirmation futures could remain pending and keep their callers blocked.

## Changes

- Register pending modal futures with their shutdown defaults.
- Resolve selection waits to `None` and confirmation waits to `False` during shutdown.
- Remove futures from the registry after every completion path.
- Preserve a normal dismiss result when it wins the race with shutdown.
- Add negative shutdown and race regression tests.

## Validation

```bash
python -m pytest tests/unit/builtins/tui/test_session.py tests/unit/builtins/tui/test_app.py -q
python -m ruff check src/kohakuterrarium/builtins/tui/session.py tests/unit/builtins/tui/test_session.py
python -m black --check src/kohakuterrarium/builtins/tui/session.py tests/unit/builtins/tui/test_session.py
```

- Targeted tests: 7 passed.
- Fork CI: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577102444
- Fork Android workflow: https://github.com/WilliamQin7/KohakuTerrarium/actions/runs/32577102446

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #204

## Notes for Reviewers

Shutdown defaults mirror the existing modal cancellation behavior. Future resolution remains first-writer-wins, so a user dismissal completed before shutdown is retained.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- No documentation update is needed because this only releases blocked shutdown paths.
- No frontend files changed, so frontend commands are not applicable.
- Local full-unit run: 13,800 passed and 14 skipped, with 10 unrelated failures caused by missing optional `dulwich`, Windows default decoding in an existing test, one pre-existing timing-sensitive session-index test, and two existing logging-capture expectations. The targeted suite passed; the fork workflow runs the complete matrix.
- The first fork CI attempt had one unrelated Windows 3.12 failure in `TestSessionIndexHook.test_event_flush_debounced_by_time`; all other CI jobs and the Android workflow passed. A failed-job rerun was still in progress when this Draft PR was opened, so upstream PR CI is also being used for confirmation.
