### PR TITLE
fix(frontend): cache model inventory across tab switches

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chrome/ModelSwitcher.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chrome/ModelSwitcher.test.js
@@ -1,0 +1,192 @@
+import { createPinia, setActivePinia } from "pinia"
+import { flushPromises, mount } from "@vue/test-utils"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/composables/useModelInventory", async () => {
+  const { ref } = await import("vue")
+  const state = {
+    models: ref([]),
+    initialLoading: ref(false),
+    refreshing: ref(false),
+    ensureLoaded: vi.fn(),
+    revalidateIfStale: vi.fn(),
+    refresh: vi.fn(),
+  }
+  return {
+    __modelInventoryTest: state,
+    useModelInventory: () => state,
+  }
+})
+
+vi.mock("@/components/chrome/instanceContext", async () => {
+  const { ref } = await import("vue")
+  const currentInstance = ref(null)
+  return {
+    __instanceContextTest: { currentInstance },
+    useInstanceContext: () => ({ instance: currentInstance }),
+  }
+})
+
+vi.mock("@/composables/useDensity", () => ({
+  useDensity: () => ({ isCompact: { value: false } }),
+}))
+
+vi.mock("@/stores/chat", () => {
+  const chat = {
+    tabs: ["agent"],
+    terrariumTarget: "agent",
+    modelByTab: {},
+    sessionInfo: { llmName: "codex/current", model: "codex/current" },
+    setActiveTab: vi.fn(),
+    openTab: vi.fn(),
+  }
+  return { __chatTest: chat, useChatStore: () => chat }
+})
+
+vi.mock("@/stores/hosts", async () => {
+  const { reactive } = await import("vue")
+  const hosts = reactive({ activeHostId: null })
+  return { __hostsTest: hosts, useHostsStore: () => hosts }
+})
+
+vi.mock("@/stores/instances", () => {
+  const instances = { current: null, list: [], fetchOne: vi.fn() }
+  return { __instancesTest: instances, useInstancesStore: () => instances }
+})
+
+vi.mock("@/utils/api", () => {
+  const switchCreatureModel = vi.fn()
+  return {
+    __apiTest: { switchCreatureModel },
+    terrariumAPI: { switchCreatureModel },
+  }
+})
+
+vi.mock("@/utils/layoutEvents", () => ({
+  LAYOUT_EVENTS: { MODEL_CONFIG_OPEN: "model:config-open" },
+  onLayoutEvent: () => () => {},
+}))
+vi.mock("vue-router", () => ({ useRoute: () => ({ params: {}, query: {} }) }))
+
+import ModelSwitcher from "./ModelSwitcher.vue"
+import { __instanceContextTest } from "@/components/chrome/instanceContext"
+import { __modelInventoryTest } from "@/composables/useModelInventory"
+import { __chatTest } from "@/stores/chat"
+import { __hostsTest } from "@/stores/hosts"
+import { __instancesTest } from "@/stores/instances"
+import { __apiTest } from "@/utils/api"
+
+function deferred() {
+  let resolve
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function mountSwitcher() {
+  return mount(ModelSwitcher, {
+    props: { instanceId: "session-1" },
+    global: {
+      stubs: {
+        ElDrawer: { template: '<div><slot v-if="$attrs.modelValue" /></div>' },
+        ElInput: { template: "<div />" },
+        ElButton: {
+          emits: ["click"],
+          template: "<button @click=\"$emit('click')\"><slot /></button>",
+        },
+        ElOption: true,
+        ElSelect: true,
+        ElIcon: { template: "<span><slot /></span>" },
+        ArrowDown: true,
+      },
+    },
+  })
+}
+
+function buttonByText(wrapper, text) {
+  return wrapper.findAll("button").find((button) => button.text().trim() === text)
+}
+
+beforeEach(() => {
+  vi.stubGlobal("useRoute", () => ({ params: {}, query: {} }))
+  setActivePinia(createPinia())
+  __modelInventoryTest.models.value = [
+    { provider: "codex", name: "current", model: "current", available: true },
+    { provider: "codex", name: "other", model: "other", available: true },
+  ]
+  __instanceContextTest.currentInstance.value = {
+    id: "session-1",
+    graph_id: "session-1",
+    type: "creature",
+    creatures: [{ name: "agent", llm_name: "codex/current", model: "current" }],
+  }
+  __chatTest.modelByTab = {}
+  __chatTest.sessionInfo = { llmName: "codex/current", model: "codex/current" }
+  __hostsTest.activeHostId = null
+  vi.resetAllMocks()
+  __modelInventoryTest.ensureLoaded.mockResolvedValue(__modelInventoryTest.models.value)
+  __modelInventoryTest.revalidateIfStale.mockResolvedValue(__modelInventoryTest.models.value)
+  __modelInventoryTest.refresh.mockResolvedValue(__modelInventoryTest.models.value)
+  __instancesTest.fetchOne.mockResolvedValue(__instanceContextTest.currentInstance.value)
+  __apiTest.switchCreatureModel.mockResolvedValue({ model: "codex/other" })
+})
+
+describe("ModelSwitcher inventory refresh", () => {
+  it("preserves an in-progress valid selection when background revalidation finishes", async () => {
+    const request = deferred()
+    __modelInventoryTest.revalidateIfStale.mockReturnValueOnce(request.promise)
+    const wrapper = mountSwitcher()
+    await flushPromises()
+
+    await wrapper.find(".model-pill").trigger("click")
+    await flushPromises()
+    expect(wrapper.text()).toContain("other")
+    await wrapper
+      .findAll(".model-row")
+      .find((button) => button.text().includes("other"))
+      .trigger("click")
+    request.resolve(__modelInventoryTest.models.value)
+    await flushPromises()
+    await buttonByText(wrapper, "Switch").trigger("click")
+    await flushPromises()
+
+    expect(__apiTest.switchCreatureModel).toHaveBeenCalledWith("session-1", "agent", "codex/other")
+  })
+
+  it("closes the open drawer when the active host changes", async () => {
+    const wrapper = mountSwitcher()
+    await flushPromises()
+
+    await wrapper.find(".model-pill").trigger("click")
+    await flushPromises()
+    expect(wrapper.text()).toContain("Refresh")
+    __hostsTest.activeHostId = "host-a"
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain("Refresh")
+  })
+
+  it("falls back to the current model when explicit refresh removes the draft selection", async () => {
+    __modelInventoryTest.refresh.mockImplementationOnce(async () => {
+      __modelInventoryTest.models.value = [
+        { provider: "codex", name: "current", model: "current", available: true },
+      ]
+      return __modelInventoryTest.models.value
+    })
+    const wrapper = mountSwitcher()
+    await flushPromises()
+
+    await wrapper.find(".model-pill").trigger("click")
+    await flushPromises()
+    expect(wrapper.text()).toContain("other")
+    await wrapper
+      .findAll(".model-row")
+      .find((button) => button.text().includes("other"))
+      .trigger("click")
+    await buttonByText(wrapper, "Refresh").trigger("click")
+    await flushPromises()
+
+    expect(buttonByText(wrapper, "Switch").attributes("disabled")).toBeDefined()
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/chrome/ModelSwitcher.vue
+++ b/src/kohakuterrarium-frontend/src/components/chrome/ModelSwitcher.vue
@@ -26,7 +26,7 @@
         <!-- Search -->
         <div class="flex items-center gap-2">
           <el-input v-model="searchQuery" size="small" placeholder="Search model or provider…" clearable @keydown.esc="popoverVisible = false" />
-          <el-button size="small" :loading="loading" @click="loadModels">Refresh</el-button>
+          <el-button size="small" :loading="refreshing" @click="refreshInventory">Refresh</el-button>
         </div>
 
         <!-- Three-pane on desktop (provider rail | model list |
@@ -96,9 +96,11 @@ import { ArrowDown } from "@element-plus/icons-vue"
 
 import { useInstanceContext } from "@/components/chrome/instanceContext"
 import { useDensity } from "@/composables/useDensity"
+import { useModelInventory } from "@/composables/useModelInventory"
 import { useChatStore } from "@/stores/chat"
+import { useHostsStore } from "@/stores/hosts"
 import { useInstancesStore } from "@/stores/instances"
-import { agentAPI, terrariumAPI, configAPI } from "@/utils/api"
+import { terrariumAPI } from "@/utils/api"
 import { onLayoutEvent, LAYOUT_EVENTS } from "@/utils/layoutEvents"
 
 const props = defineProps({
@@ -107,10 +109,10 @@ const props = defineProps({
 
 const route = useRoute()
 const chat = useChatStore()
+const hosts = useHostsStore()
 const instances = useInstancesStore()
 
-const models = ref([])
-const loading = ref(false)
+const { models, initialLoading: loading, refreshing, ensureLoaded: loadModels, revalidateIfStale, refresh: refreshModels } = useModelInventory()
 const applying = ref(false)
 const popoverVisible = ref(false)
 const searchQuery = ref("")
@@ -332,17 +334,25 @@ function toggleVariation(group, option) {
   }
 }
 
-async function loadModels() {
-  loading.value = true
-  try {
-    const data = await configAPI.getModels()
-    models.value = Array.isArray(data) ? data : []
+function reconcileDraft() {
+  if (!draftPreset.value) {
     resetDraftFromCurrent()
-  } catch {
-    models.value = []
-  } finally {
-    loading.value = false
+    return
   }
+  const preset = models.value.find((model) => model.name === draftPreset.value && (model.provider || model.login_provider || "") === draftProvider.value)
+  if (!preset) {
+    resetDraftFromCurrent()
+    return
+  }
+  const groups = preset.variation_groups || {}
+  for (const [group, option] of Object.entries(draftSelections)) {
+    if (!groups[group]?.[option]) delete draftSelections[group]
+  }
+}
+
+async function refreshInventory() {
+  await refreshModels()
+  reconcileDraft()
 }
 
 function onPickTarget(target) {
@@ -402,19 +412,26 @@ async function applySelection() {
 }
 
 watch(popoverVisible, (open) => {
-  if (open) {
-    if (models.value.length === 0) loadModels()
-    else resetDraftFromCurrent()
-  }
+  if (!open) return
+  resetDraftFromCurrent()
+  revalidateIfStale().then(() => reconcileDraft())
 })
 
 watch(currentModel, () => {
   if (!popoverVisible.value) resetDraftFromCurrent()
 })
 
+watch(
+  () => hosts.activeHostId,
+  () => {
+    popoverVisible.value = false
+    resetDraftFromCurrent()
+  },
+)
+
 let _cleanup = null
 onMounted(() => {
-  loadModels()
+  loadModels().then(() => reconcileDraft())
   _cleanup = onLayoutEvent(LAYOUT_EVENTS.MODEL_CONFIG_OPEN, () => (popoverVisible.value = true))
 })
 onUnmounted(() => {

--- a/src/kohakuterrarium-frontend/src/composables/useModelInventory.js
+++ b/src/kohakuterrarium-frontend/src/composables/useModelInventory.js
@@ -1,0 +1,106 @@
+import { computed, readonly, ref, watch } from "vue"
+
+import { useHostsStore } from "@/stores/hosts"
+import { configAPI } from "@/utils/api"
+
+export const MODEL_INVENTORY_FRESH_MS = 60_000
+
+const buckets = new Map()
+
+function createBucket() {
+  return {
+    models: ref([]),
+    hasLoaded: ref(false),
+    initialLoading: ref(false),
+    refreshing: ref(false),
+    error: ref(""),
+    fetchedAt: 0,
+    inFlight: null,
+    requestId: 0,
+  }
+}
+
+function bucketFor(key) {
+  let bucket = buckets.get(key)
+  if (!bucket) {
+    bucket = createBucket()
+    buckets.set(key, bucket)
+  }
+  return bucket
+}
+
+async function load(key) {
+  const bucket = bucketFor(key)
+  if (bucket.inFlight) return bucket.inFlight
+  bucket.initialLoading.value = !bucket.hasLoaded.value
+  bucket.refreshing.value = bucket.hasLoaded.value
+  bucket.error.value = ""
+  const requestId = ++bucket.requestId
+  bucket.inFlight = configAPI
+    .getModels()
+    .then((data) => {
+      if (requestId !== bucket.requestId) return bucket.models.value
+      bucket.models.value = Array.isArray(data) ? data : []
+      bucket.hasLoaded.value = true
+      bucket.fetchedAt = Date.now()
+      return bucket.models.value
+    })
+    .catch((err) => {
+      if (requestId === bucket.requestId) bucket.error.value = err?.message || String(err)
+      return bucket.models.value
+    })
+    .finally(() => {
+      if (requestId !== bucket.requestId) return
+      bucket.initialLoading.value = false
+      bucket.refreshing.value = false
+      bucket.inFlight = null
+    })
+  return bucket.inFlight
+}
+
+export function useModelInventory() {
+  const hosts = useHostsStore()
+  const key = computed(() => hosts.activeHostId || "_same_origin")
+  const current = () => bucketFor(key.value)
+  const models = computed(() => current().models.value)
+  const hasLoaded = computed(() => current().hasLoaded.value)
+  const initialLoading = computed(() => current().initialLoading.value)
+  const refreshing = computed(() => current().refreshing.value)
+  const error = computed(() => current().error.value)
+
+  watch(key, (nextKey, previousKey) => {
+    const previous = bucketFor(previousKey)
+    if (previous.inFlight) {
+      previous.requestId++
+      previous.inFlight = null
+      previous.initialLoading.value = false
+      previous.refreshing.value = false
+    }
+    if (!bucketFor(nextKey).hasLoaded.value) load(nextKey)
+  })
+
+  return {
+    models: readonly(models),
+    hasLoaded: readonly(hasLoaded),
+    initialLoading: readonly(initialLoading),
+    refreshing: readonly(refreshing),
+    error: readonly(error),
+    ensureLoaded() {
+      const bucket = current()
+      return bucket.hasLoaded.value ? Promise.resolve(bucket.models.value) : load(key.value)
+    },
+    revalidateIfStale() {
+      const bucket = current()
+      const isFresh =
+        bucket.hasLoaded.value && Date.now() - bucket.fetchedAt < MODEL_INVENTORY_FRESH_MS
+      return isFresh ? Promise.resolve(bucket.models.value) : load(key.value)
+    },
+    refresh() {
+      return load(key.value)
+    },
+  }
+}
+
+export function _resetModelInventoryForTests() {
+  buckets.clear()
+}

--- a/src/kohakuterrarium-frontend/src/composables/useModelInventory.test.js
+++ b/src/kohakuterrarium-frontend/src/composables/useModelInventory.test.js
@@ -1,0 +1,243 @@
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  MODEL_INVENTORY_FRESH_MS,
+  _resetModelInventoryForTests,
+  useModelInventory,
+} from "@/composables/useModelInventory"
+import { useHostsStore } from "@/stores/hosts"
+import { configAPI } from "@/utils/api"
+
+vi.mock("@/utils/api", () => ({
+  configAPI: {
+    getModels: vi.fn(),
+  },
+}))
+
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.useRealTimers()
+  vi.resetAllMocks()
+  _resetModelInventoryForTests()
+})
+
+describe("useModelInventory", () => {
+  it("loads the model inventory once and exposes the result to later consumers", async () => {
+    const models = [{ name: "fast", provider: "codex", available: true }]
+    configAPI.getModels.mockResolvedValueOnce(models)
+
+    const first = useModelInventory()
+    await first.ensureLoaded()
+    const second = useModelInventory()
+    await second.ensureLoaded()
+
+    expect(configAPI.getModels).toHaveBeenCalledOnce()
+    expect(first.models.value).toEqual(models)
+    expect(second.models.value).toEqual(models)
+    expect(second.initialLoading.value).toBe(false)
+  })
+
+  it("keeps separate app-lifetime inventories for different hosts", async () => {
+    const hosts = useHostsStore()
+    hosts.hosts = [
+      { id: "host-a", name: "A", url: "http://a.test" },
+      { id: "host-b", name: "B", url: "http://b.test" },
+    ]
+    configAPI.getModels.mockResolvedValueOnce([{ name: "same-origin" }])
+    const sameOrigin = useModelInventory()
+    await sameOrigin.ensureLoaded()
+
+    hosts.activeHostId = "host-a"
+    configAPI.getModels.mockResolvedValueOnce([{ name: "remote-a" }])
+    const remoteA = useModelInventory()
+    await remoteA.ensureLoaded()
+
+    hosts.activeHostId = null
+    expect(useModelInventory().models.value).toEqual([{ name: "same-origin" }])
+    hosts.activeHostId = "host-a"
+    expect(useModelInventory().models.value).toEqual([{ name: "remote-a" }])
+    expect(configAPI.getModels).toHaveBeenCalledTimes(2)
+  })
+
+  it("loads the newly active host for an existing consumer", async () => {
+    const hosts = useHostsStore()
+    hosts.hosts = [{ id: "host-a", name: "A", url: "http://a.test" }]
+    configAPI.getModels
+      .mockResolvedValueOnce([{ name: "same-origin" }])
+      .mockResolvedValueOnce([{ name: "remote-a" }])
+
+    const inventory = useModelInventory()
+    await inventory.ensureLoaded()
+    hosts.activeHostId = "host-a"
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(configAPI.getModels).toHaveBeenCalledTimes(2)
+    expect(inventory.models.value).toEqual([{ name: "remote-a" }])
+  })
+
+  it("discards an in-flight response after switching hosts", async () => {
+    const hosts = useHostsStore()
+    hosts.hosts = [{ id: "host-a", name: "A", url: "http://a.test" }]
+    const oldRequest = deferred()
+    configAPI.getModels
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockResolvedValueOnce([{ name: "remote-a" }])
+
+    const inventory = useModelInventory()
+    const initialLoad = inventory.ensureLoaded()
+    hosts.activeHostId = "host-a"
+    await Promise.resolve()
+    await Promise.resolve()
+    oldRequest.resolve([{ name: "wrong-host" }])
+    await initialLoad
+
+    hosts.activeHostId = null
+    expect(inventory.models.value).toEqual([])
+    expect(inventory.hasLoaded.value).toBe(false)
+    hosts.activeHostId = "host-a"
+    expect(inventory.models.value).toEqual([{ name: "remote-a" }])
+  })
+
+  it("shares an in-flight initial request between concurrent consumers", async () => {
+    const request = deferred()
+    configAPI.getModels.mockReturnValueOnce(request.promise)
+
+    const first = useModelInventory()
+    const second = useModelInventory()
+    const firstLoad = first.ensureLoaded()
+    const secondLoad = second.ensureLoaded()
+
+    expect(configAPI.getModels).toHaveBeenCalledOnce()
+    expect(first.initialLoading.value).toBe(true)
+    request.resolve([{ name: "shared" }])
+    await Promise.all([firstLoad, secondLoad])
+
+    expect(second.models.value).toEqual([{ name: "shared" }])
+    expect(first.initialLoading.value).toBe(false)
+  })
+
+  it("treats an empty response as a successfully loaded inventory", async () => {
+    configAPI.getModels.mockResolvedValueOnce([])
+
+    const inventory = useModelInventory()
+    await inventory.ensureLoaded()
+    await inventory.ensureLoaded()
+
+    expect(inventory.hasLoaded.value).toBe(true)
+    expect(inventory.models.value).toEqual([])
+    expect(configAPI.getModels).toHaveBeenCalledOnce()
+  })
+
+  it("allows a failed initial load to be retried", async () => {
+    configAPI.getModels
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce([{ name: "retry" }])
+
+    const inventory = useModelInventory()
+    await inventory.ensureLoaded()
+    await inventory.ensureLoaded()
+
+    expect(configAPI.getModels).toHaveBeenCalledTimes(2)
+    expect(inventory.hasLoaded.value).toBe(true)
+    expect(inventory.models.value).toEqual([{ name: "retry" }])
+  })
+
+  it("keeps cached models visible while a stale inventory revalidates", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+    configAPI.getModels.mockResolvedValueOnce([{ name: "old" }])
+
+    const inventory = useModelInventory()
+    await inventory.ensureLoaded()
+    vi.advanceTimersByTime(MODEL_INVENTORY_FRESH_MS + 1)
+    const request = deferred()
+    configAPI.getModels.mockReturnValueOnce(request.promise)
+
+    const refresh = inventory.revalidateIfStale()
+
+    expect(inventory.models.value).toEqual([{ name: "old" }])
+    expect(inventory.initialLoading.value).toBe(false)
+    expect(inventory.refreshing.value).toBe(true)
+    request.resolve([{ name: "new" }])
+    await refresh
+    expect(inventory.models.value).toEqual([{ name: "new" }])
+  })
+
+  it("revalidates after an inventory that was previously fresh becomes stale", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+    configAPI.getModels
+      .mockResolvedValueOnce([{ name: "old" }])
+      .mockResolvedValueOnce([{ name: "new" }])
+
+    const inventory = useModelInventory()
+    await inventory.ensureLoaded()
+    await inventory.revalidateIfStale()
+    vi.advanceTimersByTime(MODEL_INVENTORY_FRESH_MS + 1)
+    await inventory.revalidateIfStale()
+
+    expect(configAPI.getModels).toHaveBeenCalledTimes(2)
+    expect(inventory.models.value).toEqual([{ name: "new" }])
+  })
+
+  it("does not revalidate a fresh inventory", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+    configAPI.getModels.mockResolvedValueOnce([{ name: "fresh" }])
+
+    const inventory = useModelInventory()
+    await inventory.ensureLoaded()
+    vi.advanceTimersByTime(MODEL_INVENTORY_FRESH_MS - 1)
+    await inventory.revalidateIfStale()
+
+    expect(configAPI.getModels).toHaveBeenCalledOnce()
+  })
+
+  it("forces a refresh while retaining stale models if the request fails", async () => {
+    configAPI.getModels
+      .mockResolvedValueOnce([{ name: "old" }])
+      .mockRejectedValueOnce(new Error("failed"))
+
+    const inventory = useModelInventory()
+    await inventory.ensureLoaded()
+    await inventory.refresh()
+
+    expect(configAPI.getModels).toHaveBeenCalledTimes(2)
+    expect(inventory.models.value).toEqual([{ name: "old" }])
+    expect(inventory.hasLoaded.value).toBe(true)
+    expect(inventory.refreshing.value).toBe(false)
+    expect(inventory.error.value).toBe("failed")
+  })
+
+  it("deduplicates an explicit refresh against an in-flight revalidation", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+    configAPI.getModels.mockResolvedValueOnce([{ name: "old" }])
+
+    const inventory = useModelInventory()
+    await inventory.ensureLoaded()
+    vi.advanceTimersByTime(MODEL_INVENTORY_FRESH_MS + 1)
+    const request = deferred()
+    configAPI.getModels.mockReturnValueOnce(request.promise)
+
+    const staleRefresh = inventory.revalidateIfStale()
+    const forcedRefresh = inventory.refresh()
+
+    expect(configAPI.getModels).toHaveBeenCalledTimes(2)
+    request.resolve([{ name: "new" }])
+    await Promise.all([staleRefresh, forcedRefresh])
+    expect(inventory.models.value).toEqual([{ name: "new" }])
+  })
+})


### PR DESCRIPTION
Cache the model inventory for the current frontend app lifecycle so remounting `ModelSwitcher` after a macro-tab switch does not return to `Loading models...` or immediately duplicate `/configs/models` requests. Stale data is revalidated in the background, with per-host isolation and race-safe draft handling.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

`ModelSwitcher` previously owned its inventory request state inside the component. Macro-tab changes remount the active view even though the scoped Chat store, WebSocket, and background turn remain alive, so returning to a tab discarded the inventory and showed a loading state again.

This is a focused UI bug fix. It does not change the model-switch API, Chat WebSocket lifecycle, background task lifecycle, public APIs, or tab mounting architecture.

## Changes

- add an app-lifecycle `useModelInventory` composable with per-host cache buckets
- deduplicate concurrent inventory requests and revalidate stale data after 60 seconds
- preserve stale inventory on refresh errors and retain still-valid user drafts
- discard responses from an obsolete host generation and close the drawer on host changes
- add composable and component regression tests for caching, refresh, host isolation, and race behavior

## Validation

```bash
cd src/kohakuterrarium-frontend
npm ci
npx prettier --check src/components/chrome/ModelSwitcher.vue src/components/chrome/ModelSwitcher.test.js src/composables/useModelInventory.js src/composables/useModelInventory.test.js
npx eslint src/components/chrome/ModelSwitcher.vue src/components/chrome/ModelSwitcher.test.js src/composables/useModelInventory.js src/composables/useModelInventory.test.js
npm test -- --run src/components/chrome/ModelSwitcher.test.js src/composables/useModelInventory.test.js src/stores/tabs.attach.test.js src/stores/chat.test.js
npm run build
node -e "const fs=require('fs'); const p='../kohakuterrarium/web_dist/index.html'; if(!fs.existsSync(p)) throw new Error('missing '+p); console.log('verified '+p)"
```

Results:

- targeted Prettier check passed for all four changed files
- targeted ESLint passed
- 4 Vitest files passed, 183 tests total
- production build passed
- `src/kohakuterrarium/web_dist/index.html` was generated and verified
- the project wheel also built with `python -m build --wheel --no-isolation`, installed into a clean Python 3.14 virtual environment, and passed `kt --help`, `kt app --help`, `kt-cli --help`, and `kt-tui --help` smoke tests

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #210

## Notes for Reviewers

The cache intentionally lasts only for the current frontend app lifecycle. A browser reload clears it. The inventory is keyed by `activeHostId || "_same_origin"`; it is not treated as live runtime model state.

The focused review areas are stale-while-revalidate draft reconciliation and the host-generation guard in `useModelInventory`.

## Screenshots / Logs (if applicable)

No screenshot is included. The regression is pinned by component tests that remount and refresh `ModelSwitcher`, plus composable tests covering single-flight requests and host-switch races.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- `ruff`, `black`, and Python unit/integration suites were not rerun because this PR changes only Vue/JavaScript frontend files. A clean-wheel install and CLI smoke test were run as an additional package check.
- Full `npm run format:check` was executed on Windows but reported CRLF-related Prettier failures across 438 pre-existing frontend files. The four changed files pass an explicit Prettier check, and the Linux PR CI checkout is the authoritative full-tree format check.
- Full Vitest is not part of the repository CI workflow. On local Node 26 it is not green because unrelated existing suites depend on a global `localStorage`, one layout test times out, and one MacroShell suite cannot resolve Monaco during collection. The four directly relevant suites pass all 183 tests.
- Fork Actions are enabled, but this workflow listens only to pushes to `main` and pull requests targeting `main`; pushing this feature branch therefore created no fork check run. This upstream PR triggers the same CI workflow and its result should be used before review/merge.
- Local environment was Node 26.7.0, npm 11.17.0, Windows 11, and Python 3.14.2; repository frontend CI uses Node 24.