### PR TITLE
fix(read): guard paths before type dispatch

### DIFF
--- a/src/kohakuterrarium/builtins/tools/read.py
+++ b/src/kohakuterrarium/builtins/tools/read.py
@@ -54,6 +54,11 @@ class ReadTool(BaseTool):
 
         file_path = resolve_tool_path(path, context)
 
+        if context and context.path_guard:
+            msg = context.path_guard.check(str(file_path))
+            if msg:
+                return ToolResult(error=msg)
+
         if _is_image_file(file_path):
             return await self._read_image(file_path, path)
 
@@ -68,11 +73,6 @@ class ReadTool(BaseTool):
                 error=f"Binary file detected ({file_path.suffix}). "
                 "Use bash with xxd, file, or other tools to inspect binary files."
             )
-
-        if context and context.path_guard:
-            msg = context.path_guard.check(str(file_path))
-            if msg:
-                return ToolResult(error=msg)
 
         if not file_path.exists():
             return ToolResult(error=f"File not found: {path}")

--- a/tests/unit/builtins/tools/test_read.py
+++ b/tests/unit/builtins/tools/test_read.py
@@ -1,11 +1,40 @@
 """Unit tests for :mod:`kohakuterrarium.builtins.tools.read`."""
 
+import pytest
+
 from kohakuterrarium.builtins.tools.read import MAX_DEFAULT_LINES, ReadTool
 from kohakuterrarium.modules.tool.base import ToolContext
+from kohakuterrarium.utils.file_guard import PathBoundaryGuard
 
 
 def _ctx(tmp_path):
     return ToolContext(agent_name="agent", session=None, working_dir=tmp_path)
+
+
+def _guarded_ctx(workspace):
+    return ToolContext(
+        agent_name="agent",
+        session=None,
+        working_dir=workspace,
+        path_guard=PathBoundaryGuard(cwd=workspace, mode="block"),
+    )
+
+
+class TestReadPathGuard:
+    @pytest.mark.parametrize("suffix", [".png", ".pdf"])
+    async def test_blocks_multimodal_files_before_type_dispatch(self, tmp_path, suffix):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / f"secret{suffix}"
+        outside.write_bytes(b"not real media")
+
+        result = await ReadTool().execute(
+            {"path": str(outside)}, context=_guarded_ctx(workspace)
+        )
+
+        assert result.success is False
+        assert "Access denied" in result.error
+        assert str(workspace) in result.error
 
 
 class TestReadDefaultLineGuard:


### PR DESCRIPTION
## Summary

Moves path-boundary enforcement immediately after path resolution so image, PDF, and binary dispatch cannot bypass the configured guard.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Moves path-boundary enforcement immediately after path resolution so image, PDF, and binary dispatch cannot bypass the configured guard.

## Changes

- Check `context.path_guard` before any file-type-specific handling.
- Add regression coverage for guarded image and PDF paths outside the workspace.

## Validation

```bash
python -m pytest tests/unit/builtins/tools/test_read.py tests/unit/builtins/tools/test_json_read.py tests/unit/utils/test_file_guard.py -q --basetemp .pytest-read-review -p no:cacheprovider
# 39 passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it (not applicable: scoped bug fix)
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (not applicable: restores intended behavior)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes for the affected scope
- [x] `black --check src/ tests/` passes for the affected scope
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` (not applicable: no frontend files)
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #212

## Notes for Reviewers

The regression test failed for both image and PDF paths before the source change. The guard's policy and error text are unchanged; only its ordering moves earlier.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The full repository-wide unit/integration matrix, cross-platform jobs, frontend build, wheel build, and fork CI were not run locally for this isolated bug fix. Targeted affected-tier tests and scoped lint/format checks passed. This Draft PR is opened so the actual upstream PR CI can run the authoritative matrix. Frontend and e2e checks are not applicable to this scope.