### PR TITLE
fix(cli): hide interactive API key input

### DIFF
--- a/src/kohakuterrarium/cli/identity_keys.py
+++ b/src/kohakuterrarium/cli/identity_keys.py
@@ -1,5 +1,7 @@
 """CLI API key management — list/set/delete + login passthrough."""
 
+import getpass
+
 from kohakuterrarium.cli.config_prompts import confirm as _confirm
 from kohakuterrarium.studio.identity.api_keys import (
     KEYS_FILE_PATH,
@@ -8,6 +10,15 @@ from kohakuterrarium.studio.identity.api_keys import (
     remove_key,
     set_key,
 )
+
+
+def _prompt_for_key(prompt: str) -> str | None:
+    """Read a secret without echoing it, returning ``None`` when cancelled."""
+    try:
+        return getpass.getpass(prompt).strip()
+    except (EOFError, KeyboardInterrupt):
+        print("\nCancelled")
+        return None
 
 
 def list_cli() -> int:
@@ -25,7 +36,9 @@ def list_cli() -> int:
 
 def set_cli(provider: str, value: str | None) -> int:
     """Store an API key for a configured provider."""
-    key = value or input(f"API key for {provider}: ").strip()
+    key = value or _prompt_for_key(f"API key for {provider}: ")
+    if key is None:
+        return 0
     if not key:
         print("Key is required.")
         return 1
@@ -70,10 +83,8 @@ def login_with_api_key(provider: str, env_var: str) -> int:
         print(f"Environment fallback: {env_var}")
     print()
 
-    try:
-        key = input("API key: ").strip()
-    except (EOFError, KeyboardInterrupt):
-        print("\nCancelled")
+    key = _prompt_for_key("API key: ")
+    if key is None:
         return 0
 
     if not key:

--- a/tests/unit/cli/test_identity_keys.py
+++ b/tests/unit/cli/test_identity_keys.py
@@ -1,0 +1,88 @@
+"""Tests for CLI API-key prompting and cancellation."""
+
+import builtins
+import getpass
+
+import pytest
+
+from kohakuterrarium.cli import identity_keys
+
+
+class TestSecretKeyPrompts:
+    def test_set_uses_hidden_prompt(self, monkeypatch, capsys) -> None:
+        saved = []
+        prompts = []
+        monkeypatch.setattr(
+            builtins,
+            "input",
+            lambda _prompt: pytest.fail("secret prompt must not use input()"),
+        )
+        monkeypatch.setattr(
+            getpass,
+            "getpass",
+            lambda prompt: prompts.append(prompt) or "secret-key",
+        )
+        monkeypatch.setattr(
+            identity_keys,
+            "set_key",
+            lambda provider, key: saved.append((provider, key)),
+        )
+
+        assert identity_keys.set_cli("openai", None) == 0
+
+        assert prompts == ["API key for openai: "]
+        assert saved == [("openai", "secret-key")]
+        assert "Saved key for: openai" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("exc_type", [EOFError, KeyboardInterrupt])
+    def test_set_cancels_cleanly_when_hidden_prompt_stops(
+        self, monkeypatch, capsys, exc_type
+    ) -> None:
+        def cancelled(_prompt):
+            raise exc_type
+
+        monkeypatch.setattr(getpass, "getpass", cancelled)
+        monkeypatch.setattr(
+            identity_keys,
+            "set_key",
+            lambda *_args: pytest.fail("cancelled prompt must not save a key"),
+        )
+
+        assert identity_keys.set_cli("openai", None) == 0
+        assert "Cancelled" in capsys.readouterr().out
+
+    def test_login_uses_hidden_prompt(self, monkeypatch) -> None:
+        saved = []
+        monkeypatch.setattr(identity_keys, "get_existing_key", lambda _provider: None)
+        monkeypatch.setattr(
+            builtins,
+            "input",
+            lambda _prompt: pytest.fail("secret prompt must not use input()"),
+        )
+        monkeypatch.setattr(getpass, "getpass", lambda _prompt: "login-secret")
+        monkeypatch.setattr(
+            identity_keys,
+            "set_key",
+            lambda provider, key: saved.append((provider, key)),
+        )
+
+        assert identity_keys.login_with_api_key("openai", "OPENAI_API_KEY") == 0
+        assert saved == [("openai", "login-secret")]
+
+    @pytest.mark.parametrize("exc_type", [EOFError, KeyboardInterrupt])
+    def test_login_cancels_cleanly_when_hidden_prompt_stops(
+        self, monkeypatch, capsys, exc_type
+    ) -> None:
+        def cancelled(_prompt):
+            raise exc_type
+
+        monkeypatch.setattr(identity_keys, "get_existing_key", lambda _provider: None)
+        monkeypatch.setattr(getpass, "getpass", cancelled)
+        monkeypatch.setattr(
+            identity_keys,
+            "set_key",
+            lambda *_args: pytest.fail("cancelled prompt must not save a key"),
+        )
+
+        assert identity_keys.login_with_api_key("openai", "OPENAI_API_KEY") == 0
+        assert "Cancelled" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Uses a non-echoing prompt for interactive API-key entry while preserving existing CLI return codes and cancellation behavior.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Uses a non-echoing prompt for interactive API-key entry while preserving existing CLI return codes and cancellation behavior.

## Changes

- Centralize secret input through `getpass.getpass()`.
- Handle EOF and Ctrl+C as clean cancellation without saving.
- Keep ordinary non-secret confirmation prompts unchanged.

## Validation

```bash
python -m pytest tests/unit/cli/test_identity_keys.py tests/unit/cli/test_cli_parser.py -q --basetemp .pytest-identity-review -p no:cacheprovider
# 8 passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it (not applicable: scoped bug fix)
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (not applicable: restores intended behavior)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes for the affected scope
- [x] `black --check src/ tests/` passes for the affected scope
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` (not applicable: no frontend files)
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #213

## Notes for Reviewers

Tests prove the secret paths never call `input()` and that cancellation never writes a key.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The full repository-wide unit/integration matrix, cross-platform jobs, frontend build, wheel build, and fork CI were not run locally for this isolated bug fix. Targeted affected-tier tests and scoped lint/format checks passed. This Draft PR is opened so the actual upstream PR CI can run the authoritative matrix. Frontend and e2e checks are not applicable to this scope.