### PR TITLE
fix(cli): configure UTF-8 at startup

### DIFF
--- a/src/kohakuterrarium/cli/__init__.py
+++ b/src/kohakuterrarium/cli/__init__.py
@@ -45,6 +45,7 @@ from kohakuterrarium.cli.serve import add_serve_subparser, serve_cli
 from kohakuterrarium.cli.service import add_service_subparser, service_cli
 from kohakuterrarium.cli.version import format_version_report
 from kohakuterrarium.serving.web import run_desktop_app, run_web_server
+from kohakuterrarium.utils.logging import configure_utf8_stdio
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -620,6 +621,7 @@ COMMANDS: dict[str, callable] = {
 
 def main() -> int:
     """Main CLI entry point."""
+    configure_utf8_stdio(log=False)
     parser = _build_parser()
     args = parser.parse_args()
 

--- a/tests/unit/cli/test_cli_parser.py
+++ b/tests/unit/cli/test_cli_parser.py
@@ -1,19 +1,47 @@
 """Unit tests for the top-level ``kt`` argument parser."""
 
+import argparse
+
 import pytest
 
-from kohakuterrarium.cli import _build_parser
+from kohakuterrarium import cli
 
 
 class TestRunParser:
     def test_session_defaults_remain_automatic(self):
-        args = _build_parser().parse_args(["run", "agent"])
+        args = cli._build_parser().parse_args(["run", "agent"])
         assert args.session == "__auto__"
         assert args.no_session is False
 
     def test_session_and_no_session_are_mutually_exclusive(self):
         with pytest.raises(SystemExit) as exc_info:
-            _build_parser().parse_args(
+            cli._build_parser().parse_args(
                 ["run", "agent", "--session", "run.kohakutr", "--no-session"]
             )
         assert exc_info.value.code == 2
+
+
+class TestMainStartup:
+    def test_configures_utf8_before_building_parser(self, monkeypatch, capsys):
+        events = []
+
+        class _Parser:
+            def parse_args(self):
+                return argparse.Namespace(version=True, verbose=False)
+
+        monkeypatch.setattr(
+            cli,
+            "configure_utf8_stdio",
+            lambda **kwargs: events.append(("utf8", kwargs)),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            cli,
+            "_build_parser",
+            lambda: events.append(("parser", {})) or _Parser(),
+        )
+        monkeypatch.setattr(cli, "format_version_report", lambda **_kwargs: "version")
+
+        assert cli.main() == 0
+        assert capsys.readouterr().out == "version\n"
+        assert events == [("utf8", {"log": False}), ("parser", {})]


### PR DESCRIPTION
## Summary

Applies the existing UTF-8 stdio setup at the top-level CLI entry point before parser construction and command output.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Applies the existing UTF-8 stdio setup at the top-level CLI entry point before parser construction and command output.

## Changes

- Call `configure_utf8_stdio(log=False)` as the first operation in `cli.main()`.
- Add an ordering regression test around parser construction.

## Validation

```bash
python -m pytest tests/unit/cli/test_cli_parser.py tests/unit/utils/test_logging.py -q --basetemp .pytest-utf8-review -p no:cacheprovider
# 50 passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it (not applicable: scoped bug fix)
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (not applicable: restores intended behavior)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes for the affected scope
- [x] `black --check src/ tests/` passes for the affected scope
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` (not applicable: no frontend files)
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #214

## Notes for Reviewers

The implementation reuses the existing stdio helper and does not alter parser or command-dispatch semantics.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The full repository-wide unit/integration matrix, cross-platform jobs, frontend build, wheel build, and fork CI were not run locally for this isolated bug fix. Targeted affected-tier tests and scoped lint/format checks passed. This Draft PR is opened so the actual upstream PR CI can run the authoritative matrix. Frontend and e2e checks are not applicable to this scope.