### PR TITLE
fix(launcher): lock a stable update anchor

### DIFF
--- a/src/kohakuterrarium/launcher/_lock.py
+++ b/src/kohakuterrarium/launcher/_lock.py
@@ -51,12 +51,11 @@ class UpdateLock:
             try:
                 self._release(self._fh)
             finally:
+                # Keep the sidecar: unlinking after unlock can delete a path
+                # another process has already opened and locked, allowing a
+                # third process to create and lock a different inode.
                 self._fh.close()
                 self._fh = None
-                try:
-                    self.path.unlink()
-                except OSError:
-                    pass
 
     @staticmethod
     def _acquire(fh: IO[bytes]) -> None:
@@ -64,6 +63,10 @@ class UpdateLock:
             import msvcrt
 
             try:
+                # ``msvcrt.locking`` starts at the current file position.
+                # ``ab+`` opens an existing sidecar at EOF, so always seek to
+                # the shared anchor byte before trying to acquire it.
+                fh.seek(0)
                 msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
             except OSError as e:
                 raise LockBusy(str(e)) from e

--- a/tests/unit/launcher/test_lock.py
+++ b/tests/unit/launcher/test_lock.py
@@ -1,0 +1,44 @@
+"""Tests for the launcher's cross-platform update lock."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from kohakuterrarium.launcher import _lock
+
+
+class TestUpdateLock:
+    def test_windows_acquire_locks_byte_zero(self, monkeypatch, tmp_path) -> None:
+        positions = []
+        fake_msvcrt = SimpleNamespace(
+            LK_NBLCK=1,
+            locking=lambda _fd, _mode, _count: positions.append(fh.tell()),
+        )
+        monkeypatch.setattr(_lock.sys, "platform", "win32")
+        monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+        path = tmp_path / ".update.lock"
+        path.write_bytes(b"stale holder metadata")
+        with open(path, "ab+") as fh:
+            _lock.UpdateLock._acquire(fh)
+
+        assert positions == [0]
+
+    def test_second_holder_is_rejected_and_sidecar_is_reused(self, tmp_path) -> None:
+        path = tmp_path / ".update.lock"
+        first = _lock.UpdateLock(path)
+        second = _lock.UpdateLock(path)
+        first.__enter__()
+        try:
+            with pytest.raises(_lock.LockBusy):
+                second.__enter__()
+        finally:
+            second.__exit__(None, None, None)
+            first.__exit__(None, None, None)
+
+        assert path.exists()
+
+        with _lock.UpdateLock(path):
+            pass
+        assert path.exists()


### PR DESCRIPTION
## Summary

Makes launcher-update contention use a stable byte and file identity across processes.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Makes launcher-update contention use a stable byte and file identity across processes.

## Changes

- Seek to byte zero before Windows `msvcrt.locking()`.
- Keep the lock sidecar after release to avoid unlock/unlink file-identity races.
- Add Windows anchor and cross-platform contention/reuse regression tests.

## Validation

```bash
python -m pytest tests/unit/launcher tests/integration/test_launcher.py -q --basetemp .pytest-launcher-review -p no:cacheprovider
# 91 passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it (not applicable: scoped bug fix)
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (not applicable: restores intended behavior)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes for the affected scope
- [x] `black --check src/ tests/` passes for the affected scope
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` (not applicable: no frontend files)
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #215

## Notes for Reviewers

The sidecar remains a small metadata file; stale detection and explicit `force_release()` remain available. The behavioral change is limited to avoiding unsafe automatic unlink after a normal release.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The full repository-wide unit/integration matrix, cross-platform jobs, frontend build, wheel build, and fork CI were not run locally for this isolated bug fix. Targeted affected-tier tests and scoped lint/format checks passed. This Draft PR is opened so the actual upstream PR CI can run the authoritative matrix. Frontend and e2e checks are not applicable to this scope.