### PR TITLE
fix(cli): preserve foreign shim files

### DIFF
--- a/src/kohakuterrarium/cli/shims.py
+++ b/src/kohakuterrarium/cli/shims.py
@@ -198,8 +198,14 @@ def apply_plan(plan: ShimPlan) -> list[str]:
         if item.action == "skip":
             messages.append(f"skip {item.name}: {item.reason}")
             continue
-        # Replacement is intentional so reinstalling repairs stale shims.
+        # Replacement is intentional only for shims we own, so reinstalling
+        # repairs stale targets without deleting an unrelated user command.
         if item.dest.is_symlink() or item.dest.exists():
+            if not _is_ours(item.dest):
+                messages.append(
+                    f"skip {item.name}: {item.dest} is not a kohakuterrarium shim"
+                )
+                continue
             try:
                 item.dest.unlink()
             except OSError as exc:

--- a/tests/unit/cli/test_shims.py
+++ b/tests/unit/cli/test_shims.py
@@ -174,6 +174,26 @@ class TestApplyAndUninstall:
         if os.name == "posix":
             assert os.access(kc, os.X_OK)
 
+    def test_apply_leaves_foreign_file_untouched(self, tmp_path):
+        tgt = tmp_path / "local"
+        tgt.mkdir()
+        foreign = tgt / "kt"
+        foreign.write_text("a user's own command\n", encoding="utf-8")
+        plan = shims.build_plan(
+            system="Linux",
+            bundle=True,
+            target_dir=tgt,
+            executable="/A/STUB",
+            path_env="",
+        )
+
+        messages = shims.apply_plan(plan)
+
+        assert foreign.read_text(encoding="utf-8") == "a user's own command\n"
+        assert any(
+            "skip kt:" in message and "not a kohaku" in message for message in messages
+        )
+
     def test_uninstall_leaves_foreign_file(self, tmp_path, monkeypatch):
         tgt = tmp_path / "local"
         tgt.mkdir()


### PR DESCRIPTION
## Summary

Prevents shim installation from deleting unrelated commands while retaining repair behavior for KohakuTerrarium-owned shims.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Prevents shim installation from deleting unrelated commands while retaining repair behavior for KohakuTerrarium-owned shims.

## Changes

- Check destination ownership before unlinking an existing file or symlink.
- Skip foreign destinations with an explicit message.
- Reuse the same ownership rule already used by uninstall.

## Validation

```bash
python -m pytest tests/unit/cli/test_shims.py -q --basetemp .pytest-shims-review -p no:cacheprovider
# 11 passed, 3 skipped
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it (not applicable: scoped bug fix)
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (not applicable: restores intended behavior)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes for the affected scope
- [x] `black --check src/ tests/` passes for the affected scope
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` (not applicable: no frontend files)
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #216

## Notes for Reviewers

Platform-specific skips are existing test behavior. The new negative case proves foreign file content remains unchanged.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The full repository-wide unit/integration matrix, cross-platform jobs, frontend build, wheel build, and fork CI were not run locally for this isolated bug fix. Targeted affected-tier tests and scoped lint/format checks passed. This Draft PR is opened so the actual upstream PR CI can run the authoritative matrix. Frontend and e2e checks are not applicable to this scope.