### PR TITLE
fix(ui): escape dynamic markup fragments

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/app.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app.py
@@ -41,6 +41,7 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.styles import Style
 from rich.console import Console
+from rich.markup import escape
 from rich.text import Text
 
 from kohakuterrarium.builtins.cli_rich.app_drive import AppDriveMixin
@@ -681,17 +682,17 @@ class RichCLIApp(AppPickersMixin, AppOutputMixin, AppMultiCreatureMixin, AppDriv
         try:
             result = await target_agent._try_slash_command_text(text)
         except Exception as e:
-            self._commit_text(f"[red]Command error:[/red] {e}")
+            self._commit_text(f"[red]Command error:[/red] {escape(str(e))}")
             return
 
         if result is None:
-            self._commit_text(f"[red]Unknown command:[/red] /{name}")
+            self._commit_text(f"[red]Unknown command:[/red] /{escape(name)}")
             return
 
         if result.error:
-            self._commit_text(f"[red]{result.error}[/red]")
+            self._commit_text(f"[red]{escape(str(result.error))}[/red]")
         elif result.output and result.consumed:
-            self._commit_text(result.output)
+            self._commit_text(escape(str(result.output)))
         elif result.output:
             self._spawn_agent_turn(
                 result.output,

--- a/src/kohakuterrarium/builtins/cli_rich/app_multi.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app_multi.py
@@ -41,6 +41,8 @@ import asyncio
 from dataclasses import replace as _dc_replace
 from typing import Any
 
+from rich.markup import escape
+
 from kohakuterrarium.builtins.cli_rich.creature_status import (
     CreatureStatus,
     derive_status,
@@ -658,14 +660,14 @@ class AppMultiCreatureMixin:
         try:
             result = await cmd.execute(args, ctx)
         except Exception as e:
-            self._commit_text(f"[red]Command error:[/red] {e}")
+            self._commit_text(f"[red]Command error:[/red] {escape(str(e))}")
             return True
         if result is None:
-            self._commit_text(f"[red]Unknown command:[/red] /{name}")
+            self._commit_text(f"[red]Unknown command:[/red] /{escape(name)}")
         elif result.error:
-            self._commit_text(f"[red]{result.error}[/red]")
+            self._commit_text(f"[red]{escape(str(result.error))}[/red]")
         elif result.output:
-            self._commit_text(result.output)
+            self._commit_text(escape(str(result.output)))
         return True
 
 

--- a/src/kohakuterrarium/builtins/cli_rich/app_output.py
+++ b/src/kohakuterrarium/builtins/cli_rich/app_output.py
@@ -12,6 +12,7 @@ that file past the 600-line guard. They all share the same shape:
 Split as a mixin so ``app.py`` stays focused on lifecycle + layout.
 """
 
+from rich.markup import escape
 from rich.panel import Panel
 
 
@@ -143,7 +144,7 @@ class AppOutputMixin:
     def on_processing_error(self, error_type: str, error: str) -> None:
         """Surface a processing error as a red notice in scrollback."""
         self._flush_assistant_message()
-        self.committer.text(f"[red]✗ {error_type}:[/red] {error}")
+        self.committer.text(f"[red]✗ {escape(error_type)}:[/red] {escape(error)}")
         self._invalidate()
 
     def on_interrupt_notice(self, detail: str = "") -> None:
@@ -156,9 +157,9 @@ class AppOutputMixin:
         """Commit a background-result delivery notice to scrollback."""
         self._flush_assistant_message()
         noun = "result" if count == 1 else "results"
-        prefix = f"{kind} " if kind and kind != "mixed" else ""
+        prefix = f"{escape(kind)} " if kind and kind != "mixed" else ""
         self.committer.text(
-            f"[cyan]⟲ background {prefix}{noun} delivered: {label}[/cyan]"
+            f"[cyan]⟲ background {prefix}{noun} delivered: {escape(label)}[/cyan]"
         )
         self._invalidate()
 
@@ -172,33 +173,41 @@ class AppOutputMixin:
             "selection": "Selection requested",
         }
         title = title_map.get(event_type, event_type)
-        body_lines = [prompt] if prompt else []
+        body_lines = [escape(str(prompt))] if prompt else []
         if event_type == "confirm":
             options = payload.get("options") or []
             for opt in options:
                 body_lines.append(
-                    f"  • {opt.get('label', opt.get('id', '?'))}"
-                    f" ({opt.get('style', 'secondary')})"
+                    f"  • {escape(str(opt.get('label', opt.get('id', '?'))))}"
+                    f" ({escape(str(opt.get('style', 'secondary')))})"
                 )
             detail = payload.get("detail")
             if detail:
-                body_lines.insert(0, detail + "\n")
+                body_lines.insert(0, escape(str(detail)) + "\n")
         elif event_type == "ask_text":
             placeholder = payload.get("placeholder")
             if placeholder:
-                body_lines.append(f"  hint: {placeholder}")
+                body_lines.append(f"  hint: {escape(str(placeholder))}")
         elif event_type == "selection":
             options = payload.get("options") or []
             for i, opt in enumerate(options, 1):
                 desc = opt.get("description")
-                line = f"  [{i}] {opt.get('label', opt.get('id', '?'))}"
+                selection_index = escape(f"[{i}]")
+                line = (
+                    f"  {selection_index} "
+                    f"{escape(str(opt.get('label', opt.get('id', '?'))))}"
+                )
                 if desc:
-                    line += f"  — {desc}"
+                    line += f"  — {escape(str(desc))}"
                 body_lines.append(line)
         body_lines.append("")
         body_lines.append("[dim](respond via TUI or web frontend)[/dim]")
         self.committer.commit(
-            Panel("\n".join(body_lines), title=title, border_style="cyan")
+            Panel(
+                "\n".join(body_lines),
+                title=escape(str(title)),
+                border_style="cyan",
+            )
         )
         self._invalidate()
 
@@ -214,7 +223,7 @@ class AppOutputMixin:
         max_v = payload.get("max", 0)
         complete = bool(payload.get("complete"))
         if complete:
-            self.committer.text(f"[green]✓ {label}[/green]")
+            self.committer.text(f"[green]✓ {escape(str(label))}[/green]")
         elif update_target:
             pct = ""
             if (
@@ -223,9 +232,9 @@ class AppOutputMixin:
                 and max_v
             ):
                 pct = f" ({int(value * 100 / max_v)}%)"
-            self.committer.text(f"  … {label}{pct}")
+            self.committer.text(f"  … {escape(str(label))}{pct}")
         else:
-            self.committer.text(f"[cyan]▸ {label}[/cyan]")
+            self.committer.text(f"[cyan]▸ {escape(str(label))}[/cyan]")
         self._invalidate()
 
     def on_notification_event(self, payload: dict) -> None:
@@ -238,8 +247,12 @@ class AppOutputMixin:
             "warning": "yellow",
             "error": "red",
         }.get(level, "cyan")
-        prefix = f"[{color}]{title}:[/{color}] " if title else f"[{color}]·[/{color}] "
-        self.committer.text(prefix + text)
+        prefix = (
+            f"[{color}]{escape(str(title))}:[/{color}] "
+            if title
+            else f"[{color}]·[/{color}] "
+        )
+        self.committer.text(prefix + escape(str(text)))
         self._invalidate()
 
     def on_card_event(self, payload: dict) -> None:
@@ -259,30 +272,40 @@ class AppOutputMixin:
         }
         border = accent_map.get(accent, "white")
         header = f"{icon} {title}".strip() if icon else title
+        header = escape(str(header))
         if subtitle:
-            header = f"{header}  [dim]{subtitle}[/dim]"
+            header = f"{header}  [dim]{escape(str(subtitle))}[/dim]"
         body_parts: list[str] = []
         body = payload.get("body")
         if body:
-            body_parts.append(body)
+            body_parts.append(escape(str(body)))
         fields = payload.get("fields") or []
         if fields:
             field_lines = [
-                f"  [bold]{f.get('label', '')}:[/bold] {f.get('value', '')}"
+                f"  [bold]{escape(str(f.get('label', '')))}:[/bold] "
+                f"{escape(str(f.get('value', '')))}"
                 for f in fields
             ]
             body_parts.append("\n".join(field_lines))
         actions = payload.get("actions") or []
         if actions:
-            act_line = "  ".join(
-                f"[{a.get('style', 'secondary')}]\\[{a.get('label', a.get('id', '?'))}][/]"
-                for a in actions
-            )
+            action_colors = {
+                "primary": "cyan",
+                "secondary": "white",
+                "danger": "red",
+                "link": "blue",
+            }
+            action_parts = []
+            for action in actions:
+                action_style = action_colors.get(action.get("style"), "white")
+                action_label = escape(str(action.get("label", action.get("id", "?"))))
+                action_parts.append(f"[{action_style}]\\[{action_label}][/]")
+            act_line = "  ".join(action_parts)
             body_parts.append(act_line)
             body_parts.append("[dim](respond via TUI or web frontend)[/dim]")
         footer = payload.get("footer", "")
         if footer:
-            body_parts.append(f"[dim]{footer}[/dim]")
+            body_parts.append(f"[dim]{escape(str(footer))}[/dim]")
         self.committer.commit(
             Panel("\n\n".join(body_parts), title=header, border_style=border)
         )

--- a/src/kohakuterrarium/builtins/tui/_safe_text.py
+++ b/src/kohakuterrarium/builtins/tui/_safe_text.py
@@ -1,0 +1,14 @@
+"""Safe primitives for inserting runtime text into Textual markup slots."""
+
+from rich.markup import escape
+from textual.content import Content
+
+
+def plain(text: str) -> Content:
+    """Return literal Textual content without interpreting markup tags."""
+    return Content(text)
+
+
+def escape_markup(text: str) -> str:
+    """Escape a dynamic fragment for a Textual string markup slot."""
+    return escape(text)

--- a/src/kohakuterrarium/builtins/tui/app.py
+++ b/src/kohakuterrarium/builtins/tui/app.py
@@ -11,6 +11,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Footer, Header, Static, TabbedContent, TabPane
 
+from kohakuterrarium.builtins.tui._safe_text import plain
 from kohakuterrarium.builtins.tui.widgets import (
     ChatInput,
     LoadOlderButton,
@@ -159,7 +160,7 @@ class AgentTUI(App):
         try:
             status = self.query_one("#quick-status", Static)
             if event.hint:
-                status.update(event.hint)
+                status.update(plain(event.hint))
             elif not self._is_processing:
                 status.update(IDLE_STATUS)
         except Exception as e:
@@ -405,7 +406,7 @@ class AgentTUI(App):
 
     def _set_status_text(self, text: str) -> None:
         try:
-            self.query_one("#quick-status", Static).update(text)
+            self.query_one("#quick-status", Static).update(plain(text))
         except Exception as e:
             logger.warning("Failed to set status text", error=str(e), exc_info=True)
 

--- a/src/kohakuterrarium/builtins/tui/widgets/blocks.py
+++ b/src/kohakuterrarium/builtins/tui/widgets/blocks.py
@@ -3,6 +3,7 @@ import time
 from textual.containers import Vertical
 from textual.widgets import Collapsible, Static
 
+from kohakuterrarium.builtins.tui._safe_text import escape_markup, plain
 from kohakuterrarium.builtins.tui.widgets.helpers import _summarize_output
 
 
@@ -74,33 +75,26 @@ class ToolBlock(Collapsible):
                 parts.append(f"  {self.args_preview[:50]}")
             if elapsed >= 0.5:
                 parts.append(f"  ({elapsed:.1f}s)")
-            return "".join(parts)
+            return escape_markup("".join(parts))
         elif self.state == "done":
             parts = [f"\u25cf {self.tool_name}"]
             if self.args_preview:
                 parts.append(f"  {self.args_preview[:50]}")
             if self.result_summary:
                 parts.append(f"  ({self.result_summary})")
-            return "".join(parts)
+            return escape_markup("".join(parts))
         elif self.state == "error":
             parts = [f"\u2717 {self.tool_name}"]
             if self.result_summary:
                 parts.append(f"  {self.result_summary[:60]}")
-            return "".join(parts)
-        return f"? {self.tool_name}"
+            return escape_markup("".join(parts))
+        return escape_markup(f"? {self.tool_name}")
 
     def mark_done(self, output: str = "", summary: str = "") -> None:
         self.state = "done"
         self.result_summary = summary or _summarize_output(output)
         if output:
-            try:
-                self._output_widget.update(output[:3000])
-            except Exception as e:
-                _ = e
-                # Raw Content prevents tool output from being parsed as Textual markup.
-                from textual.content import Content
-
-                self._output_widget.update(Content(output[:3000]))
+            self._output_widget.update(plain(output[:3000]))
         self.remove_class("-running")
         self.add_class("-done")
         self.title = self._build_title()
@@ -109,14 +103,7 @@ class ToolBlock(Collapsible):
         self.state = "error"
         self.result_summary = error[:80]
         if error:
-            try:
-                self._output_widget.update(error[:3000])
-            except Exception as e:
-                _ = e
-                # Raw Content prevents tool output from being parsed as Textual markup.
-                from textual.content import Content
-
-                self._output_widget.update(Content(error[:3000]))
+            self._output_widget.update(plain(error[:3000]))
         self.remove_class("-running")
         self.add_class("-error")
         self.title = self._build_title()
@@ -222,19 +209,19 @@ class SubAgentBlock(Collapsible):
                 parts.append(f"  {self.sa_task[:40]}")
             if elapsed >= 0.5:
                 parts.append(f"  ({elapsed:.1f}s)")
-            return "".join(parts)
+            return escape_markup("".join(parts))
         elif self.state == "done":
             parts = [f"\u25cf {self.agent_name}"]
             if self.result_summary:
                 parts.append(f"  ({self.result_summary})")
-            return "".join(parts)
+            return escape_markup("".join(parts))
         elif self.state == "interrupted":
-            return f"\u25cb {self.agent_name}  (interrupted)"
+            return escape_markup(f"\u25cb {self.agent_name}  (interrupted)")
         else:
             parts = [f"\u2717 {self.agent_name}"]
             if self.result_summary:
                 parts.append(f"  {self.result_summary[:50]}")
-            return "".join(parts)
+            return escape_markup("".join(parts))
 
     def add_tool_line(self, tool_name: str, args_preview: str = "") -> str:
         """Add a tool entry and return its update key."""
@@ -243,7 +230,7 @@ class SubAgentBlock(Collapsible):
         text = f"\u25cb {tool_name}"
         if args_preview:
             text += f"  {args_preview[:50]}"
-        line = Static(text, classes="sa-tool-line")
+        line = Static(plain(text), classes="sa-tool-line")
         line._raw_text = text
         self._tool_lines[key] = line
         self._tool_name_keys.setdefault(tool_name, []).append(key)
@@ -282,7 +269,7 @@ class SubAgentBlock(Collapsible):
         old_text = getattr(line, "_raw_text", "")
         new_text = old_text.replace("\u25cb ", "\u25cf " if done else "\u2717 ", 1)
         line._raw_text = new_text
-        line.update(new_text)
+        line.update(plain(new_text))
         cls = "-error" if error else "-done"
         # Preserve state for lines whose widgets have not mounted yet.
         line._deferred_class = cls
@@ -305,7 +292,7 @@ class SubAgentBlock(Collapsible):
             parts.append(f"{duration:.1f}s")
         self.result_summary = "; ".join(parts) if parts else ""
         if output:
-            self._result_widget.update(output[:2000])
+            self._result_widget.update(plain(output[:2000]))
         self.remove_class("-running")
         self.add_class("-done")
         self.title = self._build_title()
@@ -364,7 +351,7 @@ class CompactSummaryBlock(Collapsible):
     BUTTON_CLOSED = "[+]"
 
     def __init__(self, summary: str, done: bool = False, **kwargs):
-        self._body = Static(summary, classes="compact-body")
+        self._body = Static(plain(summary), classes="compact-body")
         if done:
             title = "\u25cf Context auto-compact"
         else:
@@ -374,7 +361,7 @@ class CompactSummaryBlock(Collapsible):
 
     def mark_done(self, summary: str) -> None:
         """Complete the compaction block with its summary."""
-        self._body.update(summary)
+        self._body.update(plain(summary))
         self.title = "\u25cf Context auto-compact"
         self.remove_class("-running")
         self.add_class("-done")

--- a/src/kohakuterrarium/builtins/tui/widgets/bus_blocks.py
+++ b/src/kohakuterrarium/builtins/tui/widgets/bus_blocks.py
@@ -7,6 +7,8 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Markdown, ProgressBar, Static
 
+from kohakuterrarium.builtins.tui._safe_text import escape_markup, plain
+
 _ACCENT_COLOR_MAP = {
     "primary": "#5A4FCF",  # iolite
     "info": "#0F52BA",  # sapphire
@@ -87,9 +89,9 @@ class CardBlock(Vertical):
 
         header = f"{icon} {title}".strip() if icon else title
         if header:
-            yield Static(header, classes="card-header")
+            yield Static(plain(str(header)), classes="card-header")
         if subtitle:
-            yield Static(subtitle, classes="card-subtitle")
+            yield Static(plain(str(subtitle)), classes="card-subtitle")
         if body:
             yield Markdown(body)
         if fields:
@@ -97,7 +99,12 @@ class CardBlock(Vertical):
             for f in fields:
                 label = f.get("label", "")
                 value = f.get("value", "")
-                field_rows.append(Static(f"[bold]{label}:[/bold] {value}"))
+                field_rows.append(
+                    Static(
+                        f"[bold]{escape_markup(str(label))}:[/bold] "
+                        f"{escape_markup(str(value))}"
+                    )
+                )
             yield Vertical(*field_rows, classes="card-fields")
         interactive = bool(actions) and self._on_action is not None
         if interactive:
@@ -114,7 +121,7 @@ class CardBlock(Vertical):
                 variant = variant_map.get(style, "default")
                 buttons.append(
                     Button(
-                        label,
+                        plain(str(label)),
                         id=f"act-{a.get('id', '')}",
                         variant=variant,
                     )
@@ -136,13 +143,13 @@ class CardBlock(Vertical):
                 colour = colour_map.get(style, "#888888")
                 chips.append(
                     Static(
-                        f"[on {colour}] {label} [/]",
+                        f"[on {colour}] {escape_markup(str(label))} [/]",
                         classes="card-action",
                     )
                 )
             yield Horizontal(*chips, classes="card-actions")
         if footer:
-            yield Static(footer, classes="card-footer")
+            yield Static(plain(str(footer)), classes="card-footer")
 
     def on_mount(self) -> None:
         accent = self._payload.get("accent", "neutral")
@@ -187,7 +194,7 @@ class CardBlock(Vertical):
             for btn in self.query(Button):
                 btn.disabled = True
             line = self.query_one("#card-resolved-line", Static)
-            line.update(f"[#888888]→ {action_id}[/]")
+            line.update(f"[#888888]→ {escape_markup(action_id)}[/]")
         except Exception:
             # Resolution state still prevents duplicate replies if widgets unmount early.
             pass
@@ -226,7 +233,7 @@ class ProgressBlock(Vertical):
         self._indeterminate = indeterminate
 
     def compose(self) -> ComposeResult:
-        yield Static(self._label_text, classes="progress-label")
+        yield Static(plain(self._label_text), classes="progress-label")
         total = None if self._indeterminate or self._max is None else float(self._max)
         bar = ProgressBar(total=total, show_eta=False)
         yield bar
@@ -241,7 +248,7 @@ class ProgressBlock(Vertical):
     ) -> None:
         try:
             if label is not None:
-                self.query_one(".progress-label", Static).update(label)
+                self.query_one(".progress-label", Static).update(plain(label))
                 self._label_text = label
             bar = self.query_one(ProgressBar)
             if indeterminate:
@@ -255,7 +262,7 @@ class ProgressBlock(Vertical):
                 if max_value is not None:
                     bar.update(progress=float(max_value))
                 self.query_one(".progress-label", Static).update(
-                    f"[#4C9989]✓[/] {self._label_text}"
+                    f"[#4C9989]✓[/] {escape_markup(self._label_text)}"
                 )
         except Exception:
             # Updates may arrive before mount or after removal; stored values remain valid.

--- a/src/kohakuterrarium/builtins/tui/widgets/messages.py
+++ b/src/kohakuterrarium/builtins/tui/widgets/messages.py
@@ -1,5 +1,7 @@
 from textual.widgets import Collapsible, Static
 
+from kohakuterrarium.builtins.tui._safe_text import escape_markup, plain
+
 
 class UserMessage(Static):
     DEFAULT_CSS = """
@@ -14,7 +16,7 @@ class UserMessage(Static):
     """
 
     def __init__(self, text: str, **kwargs):
-        super().__init__(text, **kwargs)
+        super().__init__(plain(text), **kwargs)
         self.border_title = "You"
 
 
@@ -34,7 +36,7 @@ class QueuedMessage(Static):
     """
 
     def __init__(self, text: str, **kwargs):
-        super().__init__(text, **kwargs)
+        super().__init__(plain(text), **kwargs)
         self.border_title = "Queued"
         self.message_text = text
 
@@ -68,8 +70,8 @@ class SystemNotice(Static):
     """
 
     def __init__(self, text: str, command: str = "", error: bool = False, **kwargs):
-        super().__init__(text, **kwargs)
-        self.border_title = f"/{command}" if command else "system"
+        super().__init__(plain(text), **kwargs)
+        self.border_title = f"/{escape_markup(command)}" if command else "system"
         if error:
             self.add_class("--error")
 
@@ -110,10 +112,10 @@ class TriggerMessage(Collapsible):
 
     def __init__(self, label: str, content: str = "", **kwargs):
         preview = content[:80].replace("\n", " ") if content else ""
-        title = f"\u25cf {label}"
+        title = f"\u25cf {escape_markup(label)}"
         if preview:
-            title += f"  {preview}"
-        self._body = Static(content, classes="trigger-body")
+            title += f"  {escape_markup(preview)}"
+        self._body = Static(plain(content), classes="trigger-body")
         super().__init__(
             self._body,
             title=title,
@@ -139,7 +141,7 @@ class StreamingText(Static):
 
     def append(self, chunk: str) -> None:
         self._chunks.append(chunk)
-        self.update("".join(self._chunks))
+        self.update(plain("".join(self._chunks)))
 
     def get_text(self) -> str:
         return "".join(self._chunks)

--- a/src/kohakuterrarium/builtins/tui/widgets/panels.py
+++ b/src/kohakuterrarium/builtins/tui/widgets/panels.py
@@ -3,6 +3,7 @@ import time
 from textual.message import Message
 from textual.widgets import Static
 
+from kohakuterrarium.builtins.tui._safe_text import plain
 from kohakuterrarium.builtins.tui.widgets.helpers import _fmt_tokens
 
 
@@ -106,7 +107,7 @@ class RunningPanel(Static):
             else:
                 lines.append(f"○ {label}  ({elapsed:.0f}s)")
         self.border_title = f"Running ({len(self._items)})"
-        self.update("\n".join(lines))
+        self.update(plain("\n".join(lines)))
 
 
 class ScratchpadPanel(Static):
@@ -130,7 +131,7 @@ class ScratchpadPanel(Static):
             self.update("(empty)")
             return
         lines = [f"{k}: {str(v)[:60]}" for k, v in data.items()]
-        self.update("\n".join(lines))
+        self.update(plain("\n".join(lines)))
 
 
 class SessionInfoPanel(Static):
@@ -245,7 +246,7 @@ class SessionInfoPanel(Static):
             lines.append(
                 f"Context: {ctx_used}/{_fmt_tokens(max_ctx)}" f" ({pct}%{compact_pct})"
             )
-        self.update("\n".join(lines))
+        self.update(plain("\n".join(lines)))
 
 
 class TerrariumPanel(Static):
@@ -294,7 +295,7 @@ class TerrariumPanel(Static):
             for ch in self._channels:
                 ctype = ch.get("type", "queue")
                 lines.append(f"  {ch['name']}  ({ctype})")
-        self.update("\n".join(lines) if lines else "(no topology)")
+        self.update(plain("\n".join(lines) if lines else "(no topology)"))
 
 
 class LoadOlderButton(Static):

--- a/tests/unit/builtins/cli_rich/test_app_layout_integration.py
+++ b/tests/unit/builtins/cli_rich/test_app_layout_integration.py
@@ -19,6 +19,7 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+from rich.text import Text
 
 from kohakuterrarium.builtins.cli_rich.app import RichCLIApp
 
@@ -314,3 +315,25 @@ class TestPickerIntegration:
         app._picker_handle_text("b")
         app._picker_handle_text("o")
         assert app.agent_overlay.state.filter_text == "bo"
+
+
+@pytest.mark.asyncio
+async def test_consumed_slash_output_is_committed_as_literal_text() -> None:
+    hostile = "[/red] [done] [/etc/passwd] [] [b]x"
+    agent = _FakeAgent()
+
+    async def try_slash(_text):
+        return SimpleNamespace(error=None, output=hostile, consumed=True)
+
+    async def skip_topology(_name, _args):
+        return False
+
+    agent._try_slash_command_text = try_slash
+    app = RichCLIApp(agent)
+    app.dispatch_topology_command = skip_topology
+    committed = []
+    app._commit_text = committed.append
+
+    await app._handle_slash("/literal")
+
+    assert Text.from_markup(committed[0]).plain == hostile

--- a/tests/unit/builtins/cli_rich/test_app_multi_creature.py
+++ b/tests/unit/builtins/cli_rich/test_app_multi_creature.py
@@ -21,6 +21,7 @@ import weakref
 from types import SimpleNamespace
 
 import pytest
+from rich.text import Text
 
 from kohakuterrarium.builtins.cli_rich.app import RichCLIApp
 from kohakuterrarium.builtins.cli_rich.multiplex import MultiplexedRichOutput
@@ -279,6 +280,28 @@ class TestEngineAwareCommandDispatch:
         self._assert_trusted_context(
             command.contexts[-1], engine, "solo", creature.agent
         )
+
+    @pytest.mark.asyncio
+    async def test_engine_command_output_is_committed_as_literal_text(self):
+        hostile = "[/red] [done] [/etc/passwd] [] [b]x"
+        creature = _FakeCreature(creature_id="solo", name="solo")
+        engine = _FakeEngine([creature])
+        command = _EngineCommand()
+
+        async def execute(_args, _context):
+            return UserCommandResult(output=hostile)
+
+        command.execute = execute
+        app = RichCLIApp(creature.agent)
+        app.setup_single_creature(engine, "solo")
+        app._command_registry = {command.name: command}
+        committed = []
+        app._commit_text = committed.append
+
+        handled = await app.dispatch_topology_command(command.name, "list")
+
+        assert handled is True
+        assert Text.from_markup(committed[0]).plain == hostile
 
 
 class TestHandleCreatureEventRouting:

--- a/tests/unit/builtins/cli_rich/test_app_output.py
+++ b/tests/unit/builtins/cli_rich/test_app_output.py
@@ -1,0 +1,78 @@
+"""Tests for Rich CLI output event formatting."""
+
+from rich.text import Text
+
+from kohakuterrarium.builtins.cli_rich.app_output import AppOutputMixin
+
+HOSTILE_TEXT = "[/red] [done] [/etc/passwd] [] [b]x"
+
+
+class _Committer:
+    def __init__(self) -> None:
+        self.markup: list[str] = []
+        self.renderables: list[object] = []
+
+    def text(self, markup: str) -> None:
+        self.markup.append(markup)
+
+    def commit(self, renderable: object) -> None:
+        self.renderables.append(renderable)
+
+
+class _OutputHost(AppOutputMixin):
+    def __init__(self) -> None:
+        self.committer = _Committer()
+
+    def _flush_assistant_message(self) -> None:
+        pass
+
+    def _invalidate(self) -> None:
+        pass
+
+
+def test_dynamic_notice_fragments_are_escaped_without_losing_fixed_styles() -> None:
+    host = _OutputHost()
+
+    host.on_processing_error(HOSTILE_TEXT, HOSTILE_TEXT)
+    host.on_background_result(HOSTILE_TEXT, HOSTILE_TEXT)
+    host.on_progress_event(None, None, {"label": HOSTILE_TEXT})
+    host.on_notification_event({"title": HOSTILE_TEXT, "text": HOSTILE_TEXT})
+
+    parsed = [Text.from_markup(markup) for markup in host.committer.markup]
+    assert all(HOSTILE_TEXT in text.plain for text in parsed)
+    assert any(span.style == "red" for span in parsed[0].spans)
+    assert any(span.style == "cyan" for span in parsed[1].spans)
+    assert any(span.style == "cyan" for span in parsed[2].spans)
+    assert any(span.style == "cyan" for span in parsed[3].spans)
+
+
+def test_dynamic_panel_fragments_are_literal_with_fixed_styles() -> None:
+    host = _OutputHost()
+
+    host.on_ui_event_panel(
+        "selection",
+        {
+            "prompt": HOSTILE_TEXT,
+            "options": [{"label": HOSTILE_TEXT, "description": HOSTILE_TEXT}],
+        },
+    )
+    host.on_card_event(
+        {
+            "title": HOSTILE_TEXT,
+            "subtitle": HOSTILE_TEXT,
+            "body": HOSTILE_TEXT,
+            "fields": [{"label": HOSTILE_TEXT, "value": HOSTILE_TEXT}],
+            "actions": [{"style": "danger", "label": HOSTILE_TEXT}],
+            "footer": HOSTILE_TEXT,
+        }
+    )
+
+    selection_panel, card_panel = host.committer.renderables
+    selection_body = Text.from_markup(selection_panel.renderable)
+    card_title = Text.from_markup(card_panel.title)
+    card_body = Text.from_markup(card_panel.renderable)
+    assert selection_body.plain.count(HOSTILE_TEXT) == 3
+    assert HOSTILE_TEXT in card_title.plain
+    assert card_body.plain.count(HOSTILE_TEXT) == 5
+    assert any(span.style == "bold" for span in card_body.spans)
+    assert any(span.style == "red" for span in card_body.spans)

--- a/tests/unit/builtins/tui/test_blocks.py
+++ b/tests/unit/builtins/tui/test_blocks.py
@@ -1,0 +1,44 @@
+"""Tests for TUI activity blocks."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets._collapsible import CollapsibleTitle
+
+from kohakuterrarium.builtins.tui.widgets.blocks import (
+    CompactSummaryBlock,
+    SubAgentBlock,
+    ToolBlock,
+)
+
+HOSTILE_TEXT = "[/red] [done] [/etc/passwd] [] [b]x"
+
+
+class _BlockHost(App):
+    def compose(self) -> ComposeResult:
+        yield ToolBlock(HOSTILE_TEXT, HOSTILE_TEXT, id="tool")
+        yield SubAgentBlock(HOSTILE_TEXT, HOSTILE_TEXT, id="subagent")
+        yield CompactSummaryBlock(HOSTILE_TEXT, id="compact")
+
+
+@pytest.mark.asyncio
+async def test_dynamic_block_text_is_literal_during_layout_and_updates() -> None:
+    app = _BlockHost()
+
+    async with app.run_test() as pilot:
+        tool = app.query_one("#tool", ToolBlock)
+        tool.mark_done(HOSTILE_TEXT, HOSTILE_TEXT)
+        subagent = app.query_one("#subagent", SubAgentBlock)
+        subagent.add_tool_line(HOSTILE_TEXT, HOSTILE_TEXT)
+        subagent.mark_done(HOSTILE_TEXT)
+        compact = app.query_one("#compact", CompactSummaryBlock)
+        compact.mark_done(HOSTILE_TEXT)
+        await pilot.pause()
+
+        assert tool._output_widget.render().plain == HOSTILE_TEXT
+        assert HOSTILE_TEXT in tool.query_one(CollapsibleTitle).render().plain
+        assert subagent._result_widget.render().plain == HOSTILE_TEXT
+        assert HOSTILE_TEXT in subagent.query_one(CollapsibleTitle).render().plain
+        assert compact._body.render().plain == HOSTILE_TEXT
+        assert tool.has_class("-done")
+        assert subagent.has_class("-done")
+        assert compact.has_class("-done")

--- a/tests/unit/builtins/tui/test_bus_blocks.py
+++ b/tests/unit/builtins/tui/test_bus_blocks.py
@@ -1,0 +1,46 @@
+"""Tests for TUI card and progress event blocks."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+from kohakuterrarium.builtins.tui.widgets.bus_blocks import CardBlock, ProgressBlock
+
+HOSTILE_TEXT = "[/red] [done] [/etc/passwd] [] [b]x"
+
+
+class _BusBlockHost(App):
+    def compose(self) -> ComposeResult:
+        yield CardBlock(
+            {
+                "title": HOSTILE_TEXT,
+                "subtitle": HOSTILE_TEXT,
+                "fields": [{"label": HOSTILE_TEXT, "value": HOSTILE_TEXT}],
+                "footer": HOSTILE_TEXT,
+                "actions": [{"id": "safe", "label": HOSTILE_TEXT}],
+            },
+            on_action=lambda _event_id, _action_id: None,
+            event_id="event",
+        )
+        yield ProgressBlock("safe", HOSTILE_TEXT)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_card_and_progress_text_is_literal() -> None:
+    app = _BusBlockHost()
+
+    async with app.run_test() as pilot:
+        progress = app.query_one("#progress-safe", ProgressBlock)
+        progress.update_progress(HOSTILE_TEXT, 1, 1, False, True)
+        await pilot.pause()
+
+        card = app.query_one(CardBlock)
+        assert card.query_one(".card-header", Static).render().plain == HOSTILE_TEXT
+        assert card.query_one(".card-subtitle", Static).render().plain == HOSTILE_TEXT
+        field = card.query_one(".card-fields").query_one(Static)
+        assert field.render().plain == f"{HOSTILE_TEXT}: {HOSTILE_TEXT}"
+        assert card.query_one(".card-footer", Static).render().plain == HOSTILE_TEXT
+        assert card.query_one(Button).label.plain == HOSTILE_TEXT
+        assert (
+            HOSTILE_TEXT in progress.query_one(".progress-label", Static).render().plain
+        )

--- a/tests/unit/builtins/tui/test_messages.py
+++ b/tests/unit/builtins/tui/test_messages.py
@@ -1,0 +1,45 @@
+"""Tests for TUI conversation message widgets."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+from textual.widgets._collapsible import CollapsibleTitle
+
+from kohakuterrarium.builtins.tui.widgets.messages import (
+    QueuedMessage,
+    StreamingText,
+    SystemNotice,
+    TriggerMessage,
+    UserMessage,
+)
+
+HOSTILE_TEXT = "[/red] [done] [/etc/passwd] [] [b]x"
+
+
+class _MessageHost(App):
+    def compose(self) -> ComposeResult:
+        yield UserMessage(HOSTILE_TEXT, id="user")
+        yield QueuedMessage(HOSTILE_TEXT, id="queued")
+        yield SystemNotice(HOSTILE_TEXT, command=HOSTILE_TEXT, error=True, id="notice")
+        yield TriggerMessage(HOSTILE_TEXT, HOSTILE_TEXT, id="trigger")
+        yield StreamingText(id="stream")
+
+
+@pytest.mark.asyncio
+async def test_dynamic_message_text_is_literal_during_layout() -> None:
+    app = _MessageHost()
+
+    async with app.run_test() as pilot:
+        app.query_one("#stream", StreamingText).append(HOSTILE_TEXT)
+        await pilot.pause()
+
+        for selector in ("#user", "#queued", "#notice", "#stream"):
+            assert app.query_one(selector, Static).render().plain == HOSTILE_TEXT
+
+        trigger = app.query_one("#trigger", TriggerMessage)
+        assert trigger._body.render().plain == HOSTILE_TEXT
+        title = trigger.query_one(CollapsibleTitle).render().plain
+        assert HOSTILE_TEXT in title
+        notice = app.query_one("#notice", SystemNotice)
+        assert notice.render_str(notice.border_title).plain == f"/{HOSTILE_TEXT}"
+        assert notice.has_class("--error")

--- a/tests/unit/builtins/tui/test_panels.py
+++ b/tests/unit/builtins/tui/test_panels.py
@@ -1,0 +1,50 @@
+"""Tests for TUI information panels."""
+
+import pytest
+from textual.app import App, ComposeResult
+
+from kohakuterrarium.builtins.tui.widgets.panels import (
+    RunningPanel,
+    ScratchpadPanel,
+    SessionInfoPanel,
+    TerrariumPanel,
+)
+
+HOSTILE_TEXT = "[/red] [done] [/etc/passwd] [] [b]x"
+
+
+class _PanelHost(App):
+    def compose(self) -> ComposeResult:
+        yield RunningPanel(id="running")
+        yield ScratchpadPanel(id="scratchpad")
+        yield SessionInfoPanel(id="session")
+        yield TerrariumPanel(id="terrarium")
+
+
+@pytest.mark.asyncio
+async def test_dynamic_panel_text_is_literal() -> None:
+    app = _PanelHost()
+
+    async with app.run_test() as pilot:
+        app.query_one("#running", RunningPanel).add_item("job", HOSTILE_TEXT)
+        app.query_one("#scratchpad", ScratchpadPanel).update_data(
+            {HOSTILE_TEXT: HOSTILE_TEXT}
+        )
+        app.query_one("#session", SessionInfoPanel).set_info(
+            session_id=HOSTILE_TEXT,
+            model=HOSTILE_TEXT,
+            agent_name=HOSTILE_TEXT,
+        )
+        app.query_one("#terrarium", TerrariumPanel).set_topology(
+            [{"name": HOSTILE_TEXT, "running": True}],
+            [{"name": HOSTILE_TEXT, "type": HOSTILE_TEXT}],
+        )
+        await pilot.pause()
+
+        for selector, panel_type in (
+            ("#running", RunningPanel),
+            ("#scratchpad", ScratchpadPanel),
+            ("#session", SessionInfoPanel),
+            ("#terrarium", TerrariumPanel),
+        ):
+            assert HOSTILE_TEXT in app.query_one(selector, panel_type).render().plain


### PR DESCRIPTION
## Summary

Treats runtime TUI and Rich CLI text as literal content while preserving framework-owned styles and the card Markdown-body contract.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Treats runtime TUI and Rich CLI text as literal content while preserving framework-owned styles and the card Markdown-body contract.

## Changes

- Add small TUI helpers for literal `Content` and escaped string-only markup slots.
- Use literal content for messages, streaming output, tool/sub-agent blocks, cards, progress labels, and information panels.
- Escape only dynamic fragments inside Rich CLI fixed templates and command-result output.
- Add layout-level hostile-input, text-fidelity, and fixed-style regression coverage.

## Validation

```bash
python -m pytest tests/unit/builtins/tui tests/unit/builtins/cli_rich tests/unit/test_file_sizes.py tests/integration/test_repro_ui_bugs.py tests/integration/test_tui_cli_mid_turn_injection.py -q --basetemp .pytest-markup-final -p no:cacheprovider
# 1967 passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it (not applicable: scoped bug fix)
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (not applicable: restores intended behavior)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes for the affected scope
- [x] `black --check src/ tests/` passes for the affected scope
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` (not applicable: no frontend files)
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #217

## Notes for Reviewers

The hostile-input tests produced five failures before the source fix. Fixed `[red]`, `[cyan]`, `[bold]`, CSS state classes, and Markdown body rendering remain intact.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The full repository-wide unit/integration matrix, cross-platform jobs, frontend build, wheel build, and fork CI were not run locally for this isolated bug fix. Targeted affected-tier tests and scoped lint/format checks passed. This Draft PR is opened so the actual upstream PR CI can run the authoritative matrix. Frontend and e2e checks are not applicable to this scope.