### PR TITLE
fix(ui): wrap long hint tooltips within viewport

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/panels/modules/ModuleEditForm.vue
+++ b/src/kohakuterrarium-frontend/src/components/panels/modules/ModuleEditForm.vue
@@ -6,7 +6,7 @@
       <label class="text-[11px] text-warm-500 font-medium flex items-center gap-1 min-w-0">
         <span class="font-mono truncate">{{ entry.key }}</span>
         <span class="text-warm-400 font-normal text-[10px] shrink-0">({{ entry.spec?.type || "string" }})</span>
-        <el-tooltip v-if="entry.spec?.doc" :content="entry.spec.doc" placement="top" :show-after="300">
+        <el-tooltip v-if="entry.spec?.doc" :content="entry.spec.doc" placement="top" :show-after="300" popper-class="kt-hint-tooltip">
           <span class="i-carbon-information text-warm-400 hover:text-warm-600 dark:hover:text-warm-300 cursor-help text-[12px] shrink-0" />
         </el-tooltip>
       </label>

--- a/src/kohakuterrarium-frontend/src/components/panels/modules/ModulesPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/panels/modules/ModulesPanel.vue
@@ -30,7 +30,7 @@
           <div class="i-carbon-arrow-left text-[14px]" />
         </button>
         <span class="font-medium text-warm-700 dark:text-warm-300 text-xs truncate">{{ editTarget?.name }}</span>
-        <el-tooltip v-if="editTargetModule?.description" :content="editTargetModule.description" placement="bottom" :show-after="300">
+        <el-tooltip v-if="editTargetModule?.description" :content="editTargetModule.description" placement="bottom" :show-after="300" popper-class="kt-hint-tooltip">
           <span class="i-carbon-information text-warm-400 hover:text-warm-600 dark:hover:text-warm-300 cursor-help text-[12px]" />
         </el-tooltip>
         <span v-if="editTargetModule?.priority != null" class="text-[10px] text-warm-400 font-mono">p{{ editTargetModule.priority }}</span>
@@ -66,7 +66,7 @@
               <li v-for="m in group.items" :key="keyOf(m)" class="px-3 py-2 flex items-center gap-2 hover:bg-warm-100 dark:hover:bg-warm-800 transition-colors group cursor-pointer" @click="enterEdit(m)">
                 <span v-if="m.enabled !== null" class="w-1.5 h-1.5 rounded-full shrink-0" :class="m.enabled ? 'bg-aquamarine' : 'bg-warm-400'" />
                 <span class="font-medium text-warm-700 dark:text-warm-300 text-xs truncate">{{ m.name }}</span>
-                <el-tooltip v-if="m.description" :content="m.description" placement="top" :show-after="300">
+                <el-tooltip v-if="m.description" :content="m.description" placement="top" :show-after="300" popper-class="kt-hint-tooltip">
                   <span class="i-carbon-information text-warm-400 group-hover:text-warm-600 dark:group-hover:text-warm-300 text-[12px] cursor-help" @click.stop />
                 </el-tooltip>
                 <span v-if="m.priority != null" class="text-[10px] text-warm-400 font-mono">p{{ m.priority }}</span>

--- a/src/kohakuterrarium-frontend/src/style.css
+++ b/src/kohakuterrarium-frontend/src/style.css
@@ -276,6 +276,21 @@ body {
   }
 }
 
+/* ===== Descriptive hint tooltips ===================================
+ *
+ * Element Plus poppers have no default maximum width.  A moderately
+ * long module or option description therefore grows past the viewport
+ * before Popper can place it, leaving part of the hint unreadable.
+ * Scope the constraint to documentation hints so menus, selects, and
+ * other popper-based controls keep their own sizing behaviour. */
+.el-popper.kt-hint-tooltip {
+  box-sizing: border-box;
+  max-width: min(28rem, calc(100vw - 24px));
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 /* ===== Mobile dialogs / drawers → fullscreen ========================
  *
  * Element Plus dialogs hardcode pixel widths (520-820px) per component.

--- a/src/kohakuterrarium-frontend/src/style.hint-tooltip.test.js
+++ b/src/kohakuterrarium-frontend/src/style.hint-tooltip.test.js
@@ -21,6 +21,7 @@ describe("descriptive hint tooltip contracts", () => {
   it("keeps long hints inside the viewport and permits wrapping", () => {
     const hintRule = styleSource.match(/\.el-popper\.kt-hint-tooltip \{[\s\S]*?\n\}/)?.[0]
 
+    expect(hintRule).toContain("box-sizing: border-box;")
     expect(hintRule).toContain("max-width: min(28rem, calc(100vw - 24px));")
     expect(hintRule).toContain("white-space: normal;")
     expect(hintRule).toContain("overflow-wrap: anywhere;")

--- a/src/kohakuterrarium-frontend/src/style.hint-tooltip.test.js
+++ b/src/kohakuterrarium-frontend/src/style.hint-tooltip.test.js
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+import moduleEditFormSource from "@/components/panels/modules/ModuleEditForm.vue?raw"
+import modulesPanelSource from "@/components/panels/modules/ModulesPanel.vue?raw"
+
+const styleSource = readFileSync("src/style.css", "utf8")
+
+describe("descriptive hint tooltip contracts", () => {
+  it("marks every module documentation tooltip with the bounded hint class", () => {
+    const tooltipTags = `${modulesPanelSource}\n${moduleEditFormSource}`.match(
+      /<el-tooltip\b[^>]*>/g,
+    )
+
+    expect(tooltipTags).toHaveLength(3)
+    for (const tag of tooltipTags) {
+      expect(tag).toContain('popper-class="kt-hint-tooltip"')
+    }
+  })
+
+  it("keeps long hints inside the viewport and permits wrapping", () => {
+    const hintRule = styleSource.match(/\.el-popper\.kt-hint-tooltip \{[\s\S]*?\n\}/)?.[0]
+
+    expect(hintRule).toContain("max-width: min(28rem, calc(100vw - 24px));")
+    expect(hintRule).toContain("white-space: normal;")
+    expect(hintRule).toContain("overflow-wrap: anywhere;")
+    expect(hintRule).toContain("word-break: break-word;")
+  })
+})


### PR DESCRIPTION
## Summary

Keep long module and option documentation hints readable by bounding their tooltip width to the viewport and allowing both natural line wrapping and long-token breaks.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Element Plus poppers do not impose a default maximum width. Descriptive hints in the Modules panel therefore expanded beyond the desktop viewport as soon as their text became moderately long, hiding part of the documentation instead of wrapping it.

## Changes

- Mark the three module/option documentation tooltips with a dedicated `kt-hint-tooltip` popper class.
- Bound those hints to `min(28rem, 100vw - 24px)` without changing short-tooltip sizing.
- Allow normal sentence wrapping and emergency breaks for long configuration keys, URLs, or other unspaced content.
- Add regression contracts that pin both the tooltip coverage and the viewport/wrapping styles.

## Validation

```bash
npm run format:check
npm test -- --run src/style.hint-tooltip.test.js
npm test -- --exclude src/components/shell/MacroShell.test.js
npm run build
/Users/williamqin/KohakuTerrarium/.venv/bin/ruff check src/ tests/
/Users/williamqin/KohakuTerrarium/.venv/bin/black --check src/ tests/
git diff --check
```

Results:

- Tooltip regression tests: 2 passed.
- Frontend suite excluding the pre-existing local Monaco resolution failure: 113 files, 1095 tests passed.
- Production frontend build: passed.
- Prettier, Ruff, Black, and diff checks: passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #226

## Notes for Reviewers

The width rule is intentionally opt-in through `kt-hint-tooltip`. Applying it to every `.el-popper` would also resize Element Plus selects, menus, and general popovers.

## Screenshots / Logs (if applicable)

The reported desktop case was a long `compact.auto` description whose trailing text extended outside the usable viewport. With this change the same content wraps into a bounded multi-line tooltip.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- Python unit tests were not run because this PR changes only Vue templates, CSS, and a frontend Vitest contract. The Python lint and formatting suites passed, and upstream CI will run the Python matrix.
- The unfiltered local frontend suite reaches 1095 passing tests but fails to collect only `MacroShell.test.js` because the current local Vitest/Vite installation cannot resolve the existing dynamic `monaco-editor` import. The same failure reproduces from the unmodified main worktree. Running the remaining full suite with that single file excluded passes all 113 files / 1095 tests.
- The fork workflow does not run on pushes to non-main branches; the upstream pull-request workflow is authoritative.
- The first upstream run hit the existing Windows 3.12 timing-sensitive `TestSessionIndexHook.test_event_flush_debounced_by_time` failure after 12,135 unrelated Python tests passed. The second complete upstream run passed that job and the full matrix.
