### PR TITLE
fix(tui): show complete tool arguments and markdown scrollbars

### DIFF
--- a/src/kohakuterrarium/builtins/tui/app.py
+++ b/src/kohakuterrarium/builtins/tui/app.py
@@ -61,6 +61,7 @@ class AgentTUI(App):
 
     .chat-tab-scroll { height: 1fr; padding: 0 1; }
     .cull-header { height: 1; color: $text-muted; text-align: center; padding: 0 1; }
+    MarkdownFence { scrollbar-size-horizontal: 1; }
     """
 
     BINDINGS = [

--- a/src/kohakuterrarium/builtins/tui/output.py
+++ b/src/kohakuterrarium/builtins/tui/output.py
@@ -9,6 +9,10 @@ from textual.widgets import Markdown
 from kohakuterrarium.builtins.tui._injection import handle_user_input_injected
 from kohakuterrarium.builtins.tui.model_info import handle_session_info
 from kohakuterrarium.builtins.tui.session import CULL_KEEP, TUISession
+from kohakuterrarium.builtins.tui.tool_args import (
+    format_args_detail,
+    format_args_preview,
+)
 from kohakuterrarium.builtins.tui.widgets import (
     CompactSummaryBlock,
     LoadOlderButton,
@@ -414,8 +418,14 @@ class TUIOutput(BaseOutputModule):
     ) -> None:
         self._tui.end_streaming(target=self._target)
         self._turn_started = False
-        args_preview = _format_args_preview(name, args) or rest[:60]
-        self._tui.add_tool_block(name, args_preview, job_id, target=t)
+        args_preview = format_args_preview(name, args) or rest[:60]
+        self._tui.add_tool_block(
+            name,
+            args_preview,
+            job_id,
+            target=t,
+            args_detail=format_args_detail(name, args),
+        )
         is_bg = metadata.get("background", False)
         self._tui.update_running(job_id or name, name, promotable=not is_bg)
 
@@ -487,7 +497,7 @@ class TUIOutput(BaseOutputModule):
 
         if sub_activity == "tool_start":
             sub_args = (
-                _format_args_preview(tool_name, metadata.get("args", {}))
+                format_args_preview(tool_name, metadata.get("args", {}))
                 or sub_detail[:60]
             )
             self._tui.add_tool_block(tool_name, sub_args, target=t, agent_id=sa_job_id)
@@ -620,36 +630,6 @@ def _parse_detail(detail: str) -> tuple[str, str]:
         except (ValueError, IndexError):
             pass
     return "unknown", detail
-
-
-def _format_args_preview(tool_name: str, args: dict) -> str:
-    if not args:
-        return ""
-    match tool_name:
-        case "bash":
-            return args.get("command", "")[:60]
-        case "read":
-            return args.get("path", "")[:60]
-        case "write" | "edit":
-            return args.get("file_path", args.get("path", ""))[:60]
-        case "glob":
-            return args.get("pattern", "")[:60]
-        case "grep":
-            p = args.get("pattern", "")
-            path = args.get("path", "")
-            return f'"{p}" {path}'.strip()[:60]
-        case "send_message" | "terrarium_send":
-            return f"-> {args.get('channel', '')}"
-        case "terrarium_observe":
-            return f"<- {args.get('channel', '')}"
-        case "info":
-            return args.get("name", args.get("topic", ""))[:50]
-        case _:
-            for k, v in args.items():
-                if k == "content" or k.startswith("_"):
-                    continue
-                return f"{k}={str(v)[:40]}"
-    return ""
 
 
 def _command_name(metadata: dict) -> str:
@@ -805,12 +785,13 @@ def _build_turn_widgets(
             name = _clean_name(raw_name)
             call_id = data.get("call_id", "")
             args = data.get("args", {})
-            preview = _format_args_preview(name, args)
+            preview = format_args_preview(name, args)
+            detail = format_args_detail(name, args)
 
             if current_subagent:
                 current_subagent.add_tool_line(name, preview)
             else:
-                block = ToolBlock(name, preview, call_id)
+                block = ToolBlock(name, preview, call_id, args_detail=detail)
                 widgets.append(block)
             if call_id:
                 pending_tools[call_id] = name
@@ -921,8 +902,13 @@ def _render_turn_to_tui(tui, turn: dict) -> None:
             name = _clean_name(raw_name)
             call_id = data.get("call_id", "")
             args = data.get("args", {})
-            preview = _format_args_preview(name, args)
-            tui.add_tool_block(name, preview, call_id)
+            preview = format_args_preview(name, args)
+            tui.add_tool_block(
+                name,
+                preview,
+                call_id,
+                args_detail=format_args_detail(name, args),
+            )
             if call_id:
                 pending_tools[call_id] = name
 

--- a/src/kohakuterrarium/builtins/tui/session.py
+++ b/src/kohakuterrarium/builtins/tui/session.py
@@ -418,6 +418,7 @@ class TUISession(TabModelRegistryMixin):
         tool_id: str = "",
         target: str = "",
         agent_id: str = "",
+        args_detail: str = "",
     ) -> ToolBlock | None:
         key = target or "_default"
         sa_dict = self._current_subagents.get(key, {})
@@ -437,7 +438,12 @@ class TUISession(TabModelRegistryMixin):
 
             self._safe_call(_do)
             return None
-        block = ToolBlock(tool_name, args_preview, tool_id)
+        block = ToolBlock(
+            tool_name,
+            args_preview,
+            tool_id,
+            args_detail=args_detail,
+        )
         self._safe_mount(block, target=target)
         return block
 

--- a/src/kohakuterrarium/builtins/tui/tool_args.py
+++ b/src/kohakuterrarium/builtins/tui/tool_args.py
@@ -1,0 +1,68 @@
+"""Format tool arguments for compact and expanded TUI display."""
+
+_TOOL_DISPLAY_ARG_KEYS: dict[str, tuple[str, ...]] = {
+    "bash": ("command",),
+    "read": ("path",),
+    "write": ("file_path", "path"),
+    "edit": ("file_path", "path"),
+    "glob": ("pattern",),
+    "grep": ("pattern", "path"),
+    "send_message": ("channel",),
+    "terrarium_send": ("channel",),
+    "send_channel": ("channel",),
+    "group_send": ("to",),
+    "terrarium_observe": ("channel",),
+    "info": ("name", "topic"),
+}
+
+
+def _display_args(tool_name: str, args: dict) -> list[tuple[str, object]]:
+    """Return arguments permitted by the existing TUI preview boundary."""
+    if not isinstance(args, dict):
+        return []
+    allowed_keys = _TOOL_DISPLAY_ARG_KEYS.get(tool_name)
+    return [
+        (key, value)
+        for key, value in args.items()
+        if key != "content"
+        and not key.startswith("_")
+        and (allowed_keys is None or key in allowed_keys)
+    ]
+
+
+def format_args_detail(tool_name: str, args: dict) -> str:
+    """Format complete display-safe arguments for an expanded tool block."""
+    return "\n".join(f"{key}={value}" for key, value in _display_args(tool_name, args))
+
+
+def format_args_preview(tool_name: str, args: dict) -> str:
+    """Format the leading argument summary used in a tool title."""
+    if not args:
+        return ""
+    match tool_name:
+        case "bash":
+            return str(args.get("command", ""))
+        case "read":
+            return str(args.get("path", ""))
+        case "write" | "edit":
+            return str(args.get("file_path", args.get("path", "")))
+        case "glob":
+            return str(args.get("pattern", ""))
+        case "grep":
+            pattern = args.get("pattern", "")
+            path = args.get("path", "")
+            return f'"{pattern}" {path}'.strip()
+        case "send_message" | "terrarium_send" | "send_channel":
+            return f"-> {args.get('channel', '')}"
+        case "group_send":
+            return f"-> {args.get('to', '')}"
+        case "terrarium_observe":
+            return f"<- {args.get('channel', '')}"
+        case "info":
+            return str(args.get("name", args.get("topic", "")))
+        case _:
+            display_args = _display_args(tool_name, args)
+            if display_args:
+                key, value = display_args[0]
+                return f"{key}={value}"
+    return ""

--- a/src/kohakuterrarium/builtins/tui/widgets/blocks.py
+++ b/src/kohakuterrarium/builtins/tui/widgets/blocks.py
@@ -6,6 +6,16 @@ from textual.widgets import Collapsible, Static
 from kohakuterrarium.builtins.tui._safe_text import escape_markup, plain
 from kohakuterrarium.builtins.tui.widgets.helpers import _summarize_output
 
+_TITLE_ARGS_LIMIT = 50
+
+
+def _compact_args_preview(preview: str) -> str:
+    """Keep a title on one line and mark omitted argument text."""
+    compact = " ".join(preview.split())
+    if len(compact) <= _TITLE_ARGS_LIMIT:
+        return compact
+    return f"{compact[: _TITLE_ARGS_LIMIT - 1]}…"
+
 
 class ToolBlock(Collapsible):
     """Display a tool call and its result in a collapsible block."""
@@ -44,6 +54,12 @@ class ToolBlock(Collapsible):
         height: auto;
         color: $text-muted;
     }
+    .tool-args {
+        height: auto;
+        width: 1fr;
+        color: $text-muted;
+        text-wrap: wrap;
+    }
     """
 
     BUTTON_OPEN = "[-]"
@@ -54,17 +70,29 @@ class ToolBlock(Collapsible):
         tool_name: str,
         args_preview: str = "",
         tool_id: str = "",
+        args_detail: str = "",
         **kwargs,
     ):
         self.tool_name = tool_name
         self.tool_id = tool_id
         self.args_preview = args_preview
+        self.args_detail = args_detail
         self.state = "running"
         self.result_summary = ""
         self.start_time = time.monotonic()
+        self._args_widget = Static(
+            plain(f"Arguments:\n{args_detail}") if args_detail else "",
+            classes="tool-args",
+        )
         self._output_widget = Static("", classes="tool-output")
         title = self._build_title()
-        super().__init__(self._output_widget, title=title, collapsed=True, **kwargs)
+        super().__init__(
+            self._args_widget,
+            self._output_widget,
+            title=title,
+            collapsed=True,
+            **kwargs,
+        )
         self.add_class("-running")
 
     def _build_title(self) -> str:
@@ -72,14 +100,14 @@ class ToolBlock(Collapsible):
             elapsed = time.monotonic() - self.start_time
             parts = [f"\u25cb {self.tool_name}"]
             if self.args_preview:
-                parts.append(f"  {self.args_preview[:50]}")
+                parts.append(f"  {_compact_args_preview(self.args_preview)}")
             if elapsed >= 0.5:
                 parts.append(f"  ({elapsed:.1f}s)")
             return escape_markup("".join(parts))
         elif self.state == "done":
             parts = [f"\u25cf {self.tool_name}"]
             if self.args_preview:
-                parts.append(f"  {self.args_preview[:50]}")
+                parts.append(f"  {_compact_args_preview(self.args_preview)}")
             if self.result_summary:
                 parts.append(f"  ({self.result_summary})")
             return escape_markup("".join(parts))
@@ -229,7 +257,7 @@ class SubAgentBlock(Collapsible):
         self._tool_counter += 1
         text = f"\u25cb {tool_name}"
         if args_preview:
-            text += f"  {args_preview[:50]}"
+            text += f"  {_compact_args_preview(args_preview)}"
         line = Static(plain(text), classes="sa-tool-line")
         line._raw_text = text
         self._tool_lines[key] = line

--- a/tests/unit/builtins/tui/test_blocks.py
+++ b/tests/unit/builtins/tui/test_blocks.py
@@ -11,13 +11,35 @@ from kohakuterrarium.builtins.tui.widgets.blocks import (
 )
 
 HOSTILE_TEXT = "[/red] [done] [/etc/passwd] [] [b]x"
+LONG_ARGUMENT = "segment-without-spaces-" * 10
 
 
 class _BlockHost(App):
     def compose(self) -> ComposeResult:
-        yield ToolBlock(HOSTILE_TEXT, HOSTILE_TEXT, id="tool")
+        yield ToolBlock(
+            HOSTILE_TEXT,
+            HOSTILE_TEXT,
+            args_detail=HOSTILE_TEXT,
+            id="tool",
+        )
         yield SubAgentBlock(HOSTILE_TEXT, HOSTILE_TEXT, id="subagent")
         yield CompactSummaryBlock(HOSTILE_TEXT, id="compact")
+
+
+class _ToolArgsHost(App):
+    def compose(self) -> ComposeResult:
+        yield ToolBlock(
+            "short_tool",
+            "prompt=short",
+            args_detail="prompt=short",
+            id="short-tool",
+        )
+        yield ToolBlock(
+            "long_tool",
+            f"prompt={LONG_ARGUMENT}",
+            args_detail=f"prompt={LONG_ARGUMENT}\ncount=2",
+            id="long-tool",
+        )
 
 
 @pytest.mark.asyncio
@@ -34,6 +56,7 @@ async def test_dynamic_block_text_is_literal_during_layout_and_updates() -> None
         compact.mark_done(HOSTILE_TEXT)
         await pilot.pause()
 
+        assert tool._args_widget.render().plain == f"Arguments:\n{HOSTILE_TEXT}"
         assert tool._output_widget.render().plain == HOSTILE_TEXT
         assert HOSTILE_TEXT in tool.query_one(CollapsibleTitle).render().plain
         assert subagent._result_widget.render().plain == HOSTILE_TEXT
@@ -42,3 +65,25 @@ async def test_dynamic_block_text_is_literal_during_layout_and_updates() -> None
         assert tool.has_class("-done")
         assert subagent.has_class("-done")
         assert compact.has_class("-done")
+
+
+async def test_tool_block_marks_truncated_titles_and_reveals_full_arguments() -> None:
+    app = _ToolArgsHost()
+
+    async with app.run_test(size=(60, 20)) as pilot:
+        short_tool = app.query_one("#short-tool", ToolBlock)
+        long_tool = app.query_one("#long-tool", ToolBlock)
+
+        short_title = short_tool.query_one(CollapsibleTitle).render().plain
+        long_title = long_tool.query_one(CollapsibleTitle).render().plain
+        assert "prompt=short" in short_title
+        assert "…" not in short_title
+        assert "…" in long_title
+
+        long_tool.collapsed = False
+        await pilot.pause()
+
+        assert long_tool._args_widget.render().plain == (
+            f"Arguments:\nprompt={LONG_ARGUMENT}\ncount=2"
+        )
+        assert long_tool._args_widget.region.width <= long_tool.region.width

--- a/tests/unit/builtins/tui/test_output.py
+++ b/tests/unit/builtins/tui/test_output.py
@@ -1,4 +1,9 @@
+from textual.widgets import Label
+from textual.widgets._markdown import MarkdownFence
+
 from kohakuterrarium.builtins.tui.output import TUIOutput
+from kohakuterrarium.builtins.tui.session import TUISession
+from kohakuterrarium.builtins.tui.widgets.blocks import ToolBlock
 
 
 class FakeTUI:
@@ -60,3 +65,81 @@ def test_command_error_activity_renders_error_notice():
             "target": "general",
         }
     ]
+
+
+async def test_resume_restores_complete_markdown_and_safe_tool_arguments():
+    long_path = "/" + "restored-path-segment/" * 10 + "artifact.png"
+    long_prompt = "restored-prompt-" * 8
+    events = [
+        {"type": "user_input", "content": "restore this turn"},
+        {"type": "text", "content": f"```text\n{long_path}\n```"},
+        {
+            "type": "tool_call",
+            "name": "custom_tool",
+            "call_id": "call-1",
+            "args": {
+                "prompt": long_prompt,
+                "count": 2,
+                "content": "hidden content",
+                "_internal": "hidden internal",
+            },
+        },
+        {
+            "type": "tool_result",
+            "name": "custom_tool",
+            "call_id": "call-1",
+            "output": "OK",
+        },
+    ]
+    session = TUISession()
+    await session.start()
+    assert session._app is not None
+    output = TUIOutput()
+    output._tui = session
+
+    async with session._app.run_test(size=(60, 20)) as pilot:
+        await output.on_resume(events)
+        await pilot.pause()
+
+        fence = session._app.query_one(MarkdownFence)
+        assert fence.code == long_path
+        assert long_path in fence.query_one("#code-content", Label).render().plain
+
+        tool = session._app.query_one(ToolBlock)
+        assert tool._args_widget.render().plain == (
+            f"Arguments:\nprompt={long_prompt}\ncount=2"
+        )
+        assert "hidden content" not in tool._args_widget.render().plain
+        assert "hidden internal" not in tool._args_widget.render().plain
+
+
+async def test_live_tool_start_mounts_complete_safe_arguments():
+    long_prompt = "live-prompt-" * 12
+    session = TUISession()
+    await session.start()
+    assert session._app is not None
+    output = TUIOutput()
+    output._tui = session
+
+    async with session._app.run_test(size=(60, 20)) as pilot:
+        output.on_activity_with_metadata(
+            "tool_start",
+            "[custom_tool] fallback",
+            {
+                "job_id": "job-1",
+                "args": {
+                    "prompt": long_prompt,
+                    "count": 2,
+                    "content": "hidden content",
+                    "_internal": "hidden internal",
+                },
+            },
+        )
+        await pilot.pause()
+
+        tool = session._app.query_one(ToolBlock)
+        assert tool._args_widget.render().plain == (
+            f"Arguments:\nprompt={long_prompt}\ncount=2"
+        )
+        assert "hidden content" not in tool._args_widget.render().plain
+        assert "hidden internal" not in tool._args_widget.render().plain

--- a/tests/unit/builtins/tui/test_session.py
+++ b/tests/unit/builtins/tui/test_session.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from typing import Any
 
 from textual.containers import VerticalScroll
+from textual.widgets import Label
+from textual.widgets._markdown import MarkdownFence
 
 from kohakuterrarium.builtins.tui.app import _safe_id
 from kohakuterrarium.builtins.tui.session import TUISession
@@ -145,6 +147,30 @@ async def test_background_tab_culling_keeps_target_history_count() -> None:
         bob_chat = session._app.query_one(f"#chat-{_safe_id('bob')}", VerticalScroll)
         assert len(bob_chat.children) == 2
         assert session._culled_count == {"bob": 2}
+
+
+async def test_long_markdown_fence_keeps_content_and_has_visible_scrollbar() -> None:
+    long_path = "/" + "very-long-path-segment/" * 10 + "artifact.png"
+    session = TUISession()
+    await session.start()
+    assert session._app is not None
+
+    async with session._app.run_test(size=(60, 20)) as pilot:
+        session.begin_streaming()
+        session.append_stream(f"```text\n{long_path}\n```")
+        session.end_streaming()
+        await pilot.pause()
+
+        fence = session._app.query_one(MarkdownFence)
+        assert fence.code == long_path
+        assert long_path in fence.query_one("#code-content", Label).render().plain
+        assert fence.max_scroll_x > 0
+        assert fence.styles.scrollbar_size_horizontal == 1
+        assert fence.horizontal_scrollbar.region.height == 1
+
+        fence.scroll_to(x=fence.max_scroll_x, animate=False)
+        await pilot.pause()
+        assert fence.scroll_x == fence.max_scroll_x
 
 
 class TestModalShutdown:

--- a/tests/unit/builtins/tui/test_tool_args.py
+++ b/tests/unit/builtins/tui/test_tool_args.py
@@ -1,0 +1,42 @@
+"""Tests for TUI tool argument formatting."""
+
+from kohakuterrarium.builtins.tui.tool_args import (
+    format_args_detail,
+    format_args_preview,
+)
+
+
+def test_tool_argument_preview_and_safe_detail_formatting():
+    long_prompt = "describe-the-scene-" * 8
+    args = {
+        "prompt": long_prompt,
+        "count": 2,
+        "content": "hidden file content",
+        "_session_token": "hidden internal value",
+    }
+
+    assert format_args_preview("custom_tool", {"prompt": "short"}) == ("prompt=short")
+    assert format_args_preview("custom_tool", args) == f"prompt={long_prompt}"
+    assert format_args_detail("custom_tool", args) == (f"prompt={long_prompt}\ncount=2")
+    assert long_prompt in format_args_detail("custom_tool", args)
+    assert "hidden file content" not in format_args_detail("custom_tool", args)
+    assert "hidden internal value" not in format_args_detail("custom_tool", args)
+
+    assert (
+        format_args_detail(
+            "send_message",
+            {"channel": "review", "message": "private payload"},
+        )
+        == "channel=review"
+    )
+    assert (
+        format_args_detail(
+            "write",
+            {
+                "file_path": "/tmp/result.txt",
+                "content": "private file body",
+                "mode": "overwrite",
+            },
+        )
+        == "file_path=/tmp/result.txt"
+    )


### PR DESCRIPTION
## Summary

Fix two generic Textual TUI display issues: tool calls now show explicit title ellipses and complete display-safe arguments when expanded, while long Markdown code blocks expose a visible horizontal scrollbar without changing no-wrap semantics.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Tool argument previews were silently truncated twice and expanded blocks only contained results. Textual 8.2.8 also keeps long fenced-code lines in horizontal overflow while giving the horizontal scrollbar zero height, making intact paths look truncated.

## Changes

- preserve compact tool titles with an explicit ellipsis when shortened
- render complete TUI-display-safe arguments in expanded tool blocks with wrapping
- keep underscore-prefixed, content-bearing, and existing tool-specific payload fields hidden
- show a one-line horizontal scrollbar for overflowing Markdown fences
- cover live rendering, history restore, literal markup safety, and headless scrolling

## Validation

```bash
pytest tests/unit/builtins/tui -q
# 29 passed

pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
# 1708 passed

ruff check src/ tests/
black --check --fast src/ tests/
git diff --check
```

The new tests were written first and failed on the missing complete-argument path, unsupported `args_detail`, and zero-height Markdown fence scrollbar before the implementation.

Additional local coverage completed successfully:

```text
unit:        12150 passed, 1 skipped
integration: 173 passed
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #228

## Notes for Reviewers

The formatter remains TUI-only and does not change output events, Web rendering, non-TUI CLI output, background `output_preview`, or Grok-specific code.

No documentation or frontend build was needed because this is a bounded TUI bug fix with no config, API, CLI, or workflow contract change.

## Screenshots / Logs (if applicable)

Textual headless tests verify full content retention, visible horizontal overflow, and scrolling. A macOS real-terminal visual check confirmed that long paths show Textual's native one-cell horizontal scrollbar and retain the existing styling.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The upstream PR CI is the source of truth, so no separate fork preflight PR was opened. E2E was not run because this change does not touch multi-node, Studio, or serving paths.
