### PR TITLE
fix(desktop): upgrade pywebview to 6.2.1

### DIFF
--- a/packaging/android/postcreate.py
+++ b/packaging/android/postcreate.py
@@ -260,7 +260,7 @@ _ANDROID_DROP_PACKAGES: tuple[str, ...] = (
     # has no Android wheel (Android uses a native WebView via
     # MainActivity.java + a WebView widget).  Briefcase
     # concatenates ``[tool.briefcase.app.kohakuterrarium].requires``
-    # (which contains ``pywebview==6.1`` for the desktop launcher
+    # (which contains ``pywebview==6.2.1`` for the desktop launcher
     # venv) into every platform's requires — see Briefcase docs:
     # "the final set of requirements will be the concatenation of
     # requirements from all levels, starting from least to most

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ client = []
 # pywebview shell for desktop bundles. Kept out of core deps so the Android
 # build (native WebView) doesn't try to install it.
 desktop = [
-    "pywebview==6.1",
+    "pywebview==6.2.1",
 ]
 
 discord = [
@@ -205,7 +205,7 @@ startup_module = "kohakuterrarium.__briefcase__"
 # Windows briefcase shell). pywebview = splash UI; zstandard = tarball decomp.
 requires = [
     "packaging>=26.0",
-    "pywebview==6.1",
+    "pywebview==6.2.1",
     "zstandard>=0.22",
 ]
 # proxy_tools (a pywebview dep) is sdist-only on PyPI — pre-built into wheels/ by CI.

--- a/tests/unit/packaging/test_android_release_config.py
+++ b/tests/unit/packaging/test_android_release_config.py
@@ -18,6 +18,23 @@ def _load_module(name: str, path: Path):
 
 
 class TestAndroidReleaseConfig:
+    def test_desktop_pywebview_pins_stay_aligned(self):
+        config = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+        app_config = config["tool"]["briefcase"]["app"]["kohakuterrarium"]
+
+        desktop_pin = next(
+            requirement
+            for requirement in config["project"]["optional-dependencies"]["desktop"]
+            if requirement.startswith("pywebview")
+        )
+        launcher_pin = next(
+            requirement
+            for requirement in app_config["requires"]
+            if requirement.startswith("pywebview")
+        )
+
+        assert desktop_pin == launcher_pin == "pywebview==6.2.1"
+
     def test_version_code_matches_project_version(self):
         config = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
         major, minor, patch = map(int, config["project"]["version"].split("."))

--- a/tests/unit/packaging/test_postcreate.py
+++ b/tests/unit/packaging/test_postcreate.py
@@ -428,7 +428,7 @@ class TestPatchAndroidRequirements:
         self._seed_pyproject(fake_repo, "kohakuvault>=0.8.5")
         self._seed_requirements(
             gen,
-            "fastapi>=0.115.0\npywebview==6.1\nkohakuvault>=0.8.5\n",
+            "fastapi>=0.115.0\npywebview==6.2.1\nkohakuvault>=0.8.5\n",
         )
         monkeypatch.setattr(postcreate, "REPO_ROOT", fake_repo)
         postcreate.patch_android_requirements(gen)


### PR DESCRIPTION
## Summary

Upgrade the desktop pywebview pin from 6.1 to 6.2.1. This picks up pywebview 6.2's Cocoa wildcard MIME/UTType fix so native macOS file pickers no longer grey out images for `accept="image/*"`; 6.2.1 is the current stable patch release containing that fix.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The macOS desktop GUI could open the image picker, but PNG/JPEG files were disabled because pywebview 6.1 did not correctly expand wildcard MIME types in its Cocoa backend. The frontend attachment contract is unchanged.

## Changes

- Pin both the `desktop` extra and Briefcase launcher to `pywebview==6.2.1`.
- Keep Android excluding pywebview by package name and update its packaging fixture/comment.
- Add a configuration consistency test so the desktop and launcher pins cannot drift.
- Leave Vue sources, `web_dist`, window parameters, and `uv.lock` unchanged.

## Validation

```bash
uv pip check
pytest tests/unit/packaging/test_android_release_config.py tests/unit/packaging/test_postcreate.py tests/unit/serving/test_web.py tests/unit/launcher/test_splash_server.py -q
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/ -q --ignore=test_file_sizes --ignore=test_dep_graph_lint
pytest tests/integration/ -q
pytest tests/e2e/ -q
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
pytest tests/unit/test_no_real_config_pollution.py::test_no_writes_to_real_kohakuterrarium_dir -q
npm run format:check
CHOKIDAR_USEPOLLING=true npm run build
uv build --wheel --out-dir /private/tmp/kt-pywebview-wheel-233
```

- Isolated `.[dev,desktop]` environment imports pywebview 6.2.1 and PyObjC successfully; dependency consistency passes.
- Targeted tests: 63 passed.
- Unit suite: 12,154 passed, 1 skipped; the pollution guard failed once because the manually running GUI wrote its normal log/artifact, then passed when rerun after closing the GUI.
- Integration suite: 173 passed.
- Guard suites: 1,708 passed.
- Frontend format check and production build passed; the build produced no tracked `web_dist` diff.
- Wheel metadata contains `Requires-Dist: pywebview==6.2.1; extra == "desktop"`.
- macOS native `kt app` manual verification passed for PNG/JPEG selection in both the main composer and message editor, attachment display/delivery, restart/close, HTTP 200, and no pywebview log errors. `kt web` behavior remains unchanged.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #233
- Approved in the 2026-08-25 community discussion by maintainer 琥珀青葉 ("升"). This implementation strictly matches the approved dependency-only scope.

## Notes for Reviewers

The first `npm run build` hit the host's `EMFILE` watcher limit; rerunning with `CHOKIDAR_USEPOLLING=true` passed. The attachment UI and `accept="image/*"` were intentionally not changed.

## Exceptions / Not Run

- Full e2e completed with 77 passed and 3 failures in unchanged API creature/multi-node paths; per project policy e2e is not run in CI, and this PR changes no runtime source used by those tests.
- Windows and Linux native window behavior was not manually verified on this macOS host.
- Fork CI will be represented by the PR checks triggered after opening this PR.
