### PR TITLE
Fix background tool failure context and inline attachments

### DIFF
--- a/src/kohakuterrarium/core/agent_lifecycle.py
+++ b/src/kohakuterrarium/core/agent_lifecycle.py
@@ -124,6 +124,10 @@ class AgentLifecycleMixin:
 
         await self._cancel_executor_tasks()
         await self.subagent_manager.cancel_all()
+        controller = getattr(self, "controller", None)
+        cleanup_inline_files = getattr(controller, "cleanup_inline_files", None)
+        if callable(cleanup_inline_files):
+            cleanup_inline_files()
         await self.trigger_manager.stop_all()
         await self.input.stop()
         if self.compact_manager:

--- a/src/kohakuterrarium/core/agent_mid_turn.py
+++ b/src/kohakuterrarium/core/agent_mid_turn.py
@@ -11,6 +11,7 @@ import asyncio
 from typing import Any
 
 from kohakuterrarium.core.controller import Controller
+from kohakuterrarium.core.controller_context import format_events_for_context
 from kohakuterrarium.core.events import TriggerEvent
 from kohakuterrarium.core.pending_input import pending_id_of
 from kohakuterrarium.llm.message import content_parts_to_dicts
@@ -214,17 +215,10 @@ class AgentMidTurnMixin:
         if evt.type == "user_input":
             return evt.content
         if evt.type == "tool_complete":
-            prefix = f"[Tool {evt.job_id} completed]"
-            if isinstance(evt.content, list):
-                # Multimodal result — keep image/file parts instead of
-                # flattening to text.
-                return [{"type": "text", "text": prefix}] + [
-                    p
-                    for p in content_parts_to_dicts(evt.content)
-                    if isinstance(p, dict)
-                ]
-            text = evt.get_text_content()
-            return f"{prefix}\n{text}" if text else prefix
+            formatted = format_events_for_context([evt])
+            if isinstance(formatted, list):
+                return content_parts_to_dicts(formatted)
+            return formatted
         if evt.type == "subagent_output":
             prefix = f"[Sub-agent {evt.job_id} output]"
             if isinstance(evt.content, list):

--- a/src/kohakuterrarium/core/agent_workspace.py
+++ b/src/kohakuterrarium/core/agent_workspace.py
@@ -94,6 +94,8 @@ class WorkspaceController:
             agent.config, "pwd_guard", "warn"
         )
         new_guard = PathBoundaryGuard(cwd=resolved, mode=mode)
+        for path in getattr(previous_guard, "session_allowed_paths", ()):
+            new_guard.allow_session_path(path)
         agent._path_guard = new_guard
         executor._path_guard = new_guard
 

--- a/src/kohakuterrarium/core/controller.py
+++ b/src/kohakuterrarium/core/controller.py
@@ -2,9 +2,10 @@
 
 import asyncio
 import base64
+import hashlib
 import re
 import tempfile
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
@@ -167,6 +168,12 @@ class Controller:
         # The parent agent attaches this after construction so generated binary
         # content shares the graph's session lifecycle.
         self.session_store: Any = None
+
+        # Browser uploads arrive as bytes rather than usable local paths. Keep
+        # one controller-owned materialization alive for the active session so
+        # provider retries and later tool calls see the same exact file.
+        self._inline_temp_dir: Any = None
+        self._inline_file_cache: dict[str, str] = {}
 
         # Event queue
         self._event_queue: asyncio.Queue[TriggerEvent] = asyncio.Queue()
@@ -608,20 +615,47 @@ class Controller:
             )
 
     async def _materialize_inline_file(self, part: FilePart) -> str | None:
-        """Materialize inline browser-uploaded content to a temp file for ReadTool."""
-        suffix = Path(part.name or "upload").suffix
-        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
-        try:
-            if part.data_base64 is not None:
-                temp_file.write(base64.b64decode(part.data_base64))
-            elif part.content is not None:
-                temp_file.write(part.content.encode("utf-8"))
-            else:
-                return None
-            temp_file.flush()
-            return temp_file.name
-        finally:
-            temp_file.close()
+        """Materialize and authorize one inline upload for the live session."""
+        if part.data_base64 is not None:
+            raw = base64.b64decode(part.data_base64)
+        elif part.content is not None:
+            raw = part.content.encode("utf-8")
+        else:
+            return None
+
+        name = Path((part.name or "attachment").replace("\\", "/")).name
+        full_safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", name) or "attachment"
+        suffix = Path(full_safe_name).suffix[:20]
+        stem = full_safe_name[: -len(suffix)] if suffix else full_safe_name
+        safe_name = f"{stem[:100]}{suffix}"
+        digest = hashlib.sha256(raw).hexdigest()
+        cache_key = f"{digest}:{full_safe_name}"
+        path = self._inline_file_cache.get(cache_key)
+        if path is None or not Path(path).is_file():
+            if self._inline_temp_dir is None:
+                self._inline_temp_dir = tempfile.TemporaryDirectory(
+                    prefix="kohakuterrarium-attachments-"
+                )
+            target = Path(self._inline_temp_dir.name) / f"{digest[:16]}-{safe_name}"
+            target.write_bytes(raw)
+            path = str(target)
+            self._inline_file_cache[cache_key] = path
+
+        guard = getattr(self.executor, "_path_guard", None) if self.executor else None
+        if guard is not None and hasattr(guard, "allow_session_path"):
+            guard.allow_session_path(path)
+        return path
+
+    def cleanup_inline_files(self) -> None:
+        """Revoke and remove every controller-owned live-session attachment."""
+        guard = getattr(self.executor, "_path_guard", None) if self.executor else None
+        if guard is not None and hasattr(guard, "revoke_session_path"):
+            for path in self._inline_file_cache.values():
+                guard.revoke_session_path(path)
+        self._inline_file_cache.clear()
+        if self._inline_temp_dir is not None:
+            self._inline_temp_dir.cleanup()
+            self._inline_temp_dir = None
 
     async def _resolve_file_part(self, part: FilePart) -> list[ContentPart]:
         """Resolve a custom file part using the internal read tool."""
@@ -642,8 +676,6 @@ class Controller:
             tool = ReadTool()
         if self.executor:
             context = self.executor._build_tool_context()
-            if temp_path:
-                context = replace(context, path_guard=None)
         else:
             return [
                 TextPart(
@@ -651,27 +683,25 @@ class Controller:
                 )
             ]
 
-        try:
-            result = await tool.execute({"path": path}, context=context)
-            if result.error:
-                return [
-                    TextPart(
-                        text=f"[File read failed: {part.name or path}: {result.error}]"
-                    )
-                ]
-            if isinstance(result.output, str):
-                return [TextPart(text=result.output)]
-            return result.output
-        finally:
-            if temp_path:
-                try:
-                    Path(temp_path).unlink(missing_ok=True)
-                except OSError:
-                    logger.warning(
-                        "Failed to clean temp upload",
-                        path=temp_path,
-                        exc_info=True,
-                    )
+        result = await tool.execute({"path": path}, context=context)
+        if result.error:
+            return [
+                TextPart(
+                    text=f"[File read failed: {part.name or path}: {result.error}]"
+                )
+            ]
+        resolved = (
+            [TextPart(text=result.output)]
+            if isinstance(result.output, str)
+            else result.output
+        )
+        if temp_path:
+            label = part.name or Path(temp_path).name
+            return [
+                TextPart(text=f"Attached file: {label}\nPath: {temp_path}"),
+                *resolved,
+            ]
+        return resolved
 
     async def _resolve_message_files(
         self, messages: list[dict[str, Any]]

--- a/src/kohakuterrarium/core/controller.py
+++ b/src/kohakuterrarium/core/controller.py
@@ -4,7 +4,7 @@ import asyncio
 import base64
 import re
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
@@ -642,6 +642,8 @@ class Controller:
             tool = ReadTool()
         if self.executor:
             context = self.executor._build_tool_context()
+            if temp_path:
+                context = replace(context, path_guard=None)
         else:
             return [
                 TextPart(

--- a/src/kohakuterrarium/core/controller_context.py
+++ b/src/kohakuterrarium/core/controller_context.py
@@ -1,8 +1,52 @@
 """Formatting of trigger events into provider-facing user context."""
 
+import re
+
 from kohakuterrarium.core.events import TriggerEvent
 from kohakuterrarium.core.tool_output import render_content_text
 from kohakuterrarium.llm.message import ContentPart, FilePart, ImagePart, TextPart
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_ERROR_SUMMARY_LIMIT = 512
+
+
+def _summarize_tool_error(error: str) -> str:
+    """Return a bounded diagnostic without provider-irrelevant traceback frames."""
+    cleaned = _ANSI_ESCAPE_RE.sub("", error).strip()
+    if "Traceback (most recent call last):" in cleaned:
+        lines = [line.strip() for line in cleaned.splitlines() if line.strip()]
+        cleaned = lines[-1] if lines else ""
+    else:
+        cleaned = " ".join(cleaned.split())
+    if len(cleaned) <= _ERROR_SUMMARY_LIMIT:
+        return cleaned
+    return cleaned[: _ERROR_SUMMARY_LIMIT - 1] + "…"
+
+
+def _tool_completion_prefix(event: TriggerEvent) -> str:
+    """Describe the actionable completion state of one tool event."""
+    context = event.context or {}
+    final_state = str(context.get("final_state", "")).lower()
+    cancelled = (
+        bool(context.get("cancelled"))
+        or bool(context.get("interrupted"))
+        or final_state in {"cancelled", "interrupted"}
+    )
+    if cancelled:
+        return f"[Tool {event.job_id} cancelled]"
+
+    exit_code = context.get("exit_code")
+    error = context.get("error")
+    if error or (exit_code is not None and exit_code != 0):
+        exit_detail = f", exit {exit_code}" if exit_code not in (None, 0) else ""
+        prefix = f"[Tool {event.job_id} failed{exit_detail}]"
+        if error:
+            summary = _summarize_tool_error(str(error))
+            if summary:
+                prefix = f"{prefix}\nError: {summary}"
+        return prefix
+
+    return f"[Tool {event.job_id} completed]"
 
 
 def format_events_for_context(
@@ -39,11 +83,14 @@ def format_events_for_context(
                 # Internal wakes only resume processing; their results already
                 # exist in conversation and must not become fabricated tool output.
                 continue
-            prefix = f"[Tool {event.job_id} completed]"
+            prefix = _tool_completion_prefix(event)
             if isinstance(event.content, list):
                 append_multimodal(prefix, event.content)
             else:
-                text_parts.append(f"{prefix}\n{event.get_text_content()}")
+                content_text = event.get_text_content()
+                text_parts.append(
+                    f"{prefix}\n{content_text}" if content_text else prefix
+                )
         elif event.type == "subagent_output":
             content_text = event.get_text_content()
             text_parts.append(f"[Sub-agent {event.job_id} output]\n{content_text}")

--- a/src/kohakuterrarium/core/executor.py
+++ b/src/kohakuterrarium/core/executor.py
@@ -414,12 +414,13 @@ class Executor:
 
             job_result = JobResult(job_id=job_id, error=error_msg)
             self.job_store.store_result(job_result)
-
             if not is_direct:
                 event = create_tool_complete_event(
                     job_id=job_id,
                     content="",
                     error=error_msg,
+                    cancelled=True,
+                    final_state="cancelled",
                 )
                 if self._on_complete:
                     self._on_complete(event)
@@ -477,6 +478,8 @@ class Executor:
             job_id=job_id,
             content="",
             error=error_msg,
+            cancelled=True,
+            final_state="cancelled",
         )
         if self._on_complete:
             self._on_complete(event)

--- a/src/kohakuterrarium/utils/file_guard.py
+++ b/src/kohakuterrarium/utils/file_guard.py
@@ -139,6 +139,22 @@ class PathBoundaryGuard:
         self.mode = mode
         # Paths that have been warned once (allowed on retry)
         self._warned_paths: set[str] = set()
+        # Exact files materialized from user-supplied inline attachments.
+        # The owning controller revokes them when its live session ends.
+        self._session_allowed_paths: set[str] = set()
+
+    def allow_session_path(self, path: str | Path) -> None:
+        """Allow one exact controller-owned attachment path for this session."""
+        self._session_allowed_paths.add(str(Path(path).resolve()))
+
+    def revoke_session_path(self, path: str | Path) -> None:
+        """Remove a previously registered session attachment path."""
+        self._session_allowed_paths.discard(str(Path(path).resolve()))
+
+    @property
+    def session_allowed_paths(self) -> frozenset[str]:
+        """Return the exact live-session paths carried across cwd switches."""
+        return frozenset(self._session_allowed_paths)
 
     def check(self, path: str) -> str | None:
         """Check if a path is within the working directory boundary.
@@ -150,6 +166,9 @@ class PathBoundaryGuard:
 
         resolved = Path(path).resolve()
         cwd = Path(self.cwd)
+
+        if str(resolved) in self._session_allowed_paths:
+            return None
 
         # Check if path is under cwd. Use relative_to rather than
         # ``str.startswith(self.cwd + os.sep)``: at a filesystem root

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -1680,6 +1680,53 @@ class TestCoreIntegration:
             )
             assert "inline-file-marker" in joined_file_call
 
+            # A browser-style inline image attachment is controller-owned:
+            # it is materialized outside the workspace, read once through
+            # the normal ReadTool validation path, and delivered as an image
+            # without weakening the agent's shared path guard.
+            png_b64 = (
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8"
+                "AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+            )
+            image_file_llm = ScriptedLLM(
+                [ScriptEntry("saw inline png", match="inspect-inline-png")]
+            )
+            agent.llm = image_file_llm
+            agent.controller.llm = image_file_llm
+            await agent.inject_input(
+                [
+                    TextPart(text="inspect-inline-png"),
+                    FilePart(
+                        name="pixel.png",
+                        mime="image/png",
+                        data_base64=png_b64,
+                        is_inline=True,
+                    ),
+                ],
+                source="chat",
+            )
+            assert image_file_llm.call_count == 1
+            assert "saw inline png" in _assistant_text(agent)
+            image_user_message = [
+                message
+                for message in image_file_llm.call_log[-1]
+                if message.get("role") == "user"
+            ][-1]
+            image_call_parts = [
+                part for part in image_user_message["content"] if isinstance(part, dict)
+            ]
+            assert any(
+                part.get("type") == "image_url"
+                and part.get("image_url", {})
+                .get("url", "")
+                .startswith("data:image/png;base64,")
+                for part in image_call_parts
+            ), image_call_parts
+            assert not any(
+                "File read failed" in str(part.get("text", ""))
+                for part in image_call_parts
+            )
+
             # --- run_event: correlated custom-event ingress (Phase E) ---
             # ``Agent.run_event`` drives a pre-built TriggerEvent (a Drive
             # delivery shape) and returns a correlated TurnResult whose

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -1746,7 +1746,14 @@ class TestCoreIntegration:
             resolved_again = await agent.controller._resolve_message_files(
                 agent.controller.conversation.to_messages()
             )
-            assert f"Path: {image_path}" in str(resolved_again)
+            assert any(
+                part.get("type") == "text"
+                and part.get("text") == f"Attached file: pixel.png\nPath: {image_path}"
+                for message in resolved_again
+                if isinstance(message.get("content"), list)
+                for part in message["content"]
+                if isinstance(part, dict)
+            )
 
             # --- run_event: correlated custom-event ingress (Phase E) ---
             # ``Agent.run_event`` drives a pre-built TriggerEvent (a Drive

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -1261,6 +1261,17 @@ class TestCoreIntegration:
                 if j.job_id.startswith("bgboom_")
             )
             assert bgboom_status.state.value == "error"
+            bg_provider_call = agent.llm.call_log[-1]
+            bg_user_message = [
+                message for message in bg_provider_call if message.get("role") == "user"
+            ][-1]
+            assert bg_user_message["content"].endswith(
+                f"[Tool {bgboom_status.job_id} failed]\n" "Error: background-kaboom"
+            )
+            assert (
+                f"[Tool {bgboom_status.job_id} completed]"
+                not in bg_user_message["content"]
+            )
             # ``executor.wait_all`` drains every tracked task and returns
             # the completed JobResults — the bg job's result carries its
             # error string.

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -1650,11 +1650,9 @@ class TestCoreIntegration:
             assert agent.controller.conversation.get_image_count() == 1
 
             # --- inline-file user input through inject_input -----------
-            # A ``FilePart`` carrying literal ``content`` (no path, not
-            # flagged ``is_inline``) is resolved by the controller's
-            # ``_resolve_message_files`` straight into a plain text part
-            # — the ``File: <name>\n<content>`` form the provider sees.
-            # The scripted reply is keyed on a substring of that content.
+            # Browser-style text uploads are materialized once for the live
+            # session. The provider sees both their content and the stable
+            # path that later read/write calls can use.
             file_llm = ScriptedLLM(
                 [ScriptEntry("read the attached file", match="inline-file-marker")]
             )
@@ -1666,6 +1664,7 @@ class TestCoreIntegration:
                     FilePart(
                         name="notes.txt",
                         content="inline-file-marker: hello from the file",
+                        is_inline=True,
                     ),
                 ],
                 source="chat",
@@ -1679,11 +1678,22 @@ class TestCoreIntegration:
                 str(m.get("content", "")) for m in file_call_msgs
             )
             assert "inline-file-marker" in joined_file_call
+            assert "Attached file: notes.txt" in joined_file_call
+            text_path = next(
+                part["text"].split("Path: ", 1)[1]
+                for message in file_call_msgs
+                if isinstance(message.get("content"), list)
+                for part in message["content"]
+                if isinstance(part, dict)
+                and part.get("type") == "text"
+                and "Attached file: notes.txt\nPath: " in part.get("text", "")
+            )
+            assert Path(text_path).is_file()
+            assert agent._path_guard.check(text_path) is None
 
             # A browser-style inline image attachment is controller-owned:
-            # it is materialized outside the workspace, read once through
-            # the normal ReadTool validation path, and delivered as an image
-            # without weakening the agent's shared path guard.
+            # it is materialized outside the workspace, retained for the live
+            # session, and delivered through the normal ReadTool validation path.
             png_b64 = (
                 "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8"
                 "AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
@@ -1726,6 +1736,17 @@ class TestCoreIntegration:
                 "File read failed" in str(part.get("text", ""))
                 for part in image_call_parts
             )
+            image_path = next(
+                part["text"].split("Path: ", 1)[1]
+                for part in image_call_parts
+                if part.get("type") == "text"
+                and "Attached file: pixel.png\nPath: " in part.get("text", "")
+            )
+            assert Path(image_path).is_file()
+            resolved_again = await agent.controller._resolve_message_files(
+                agent.controller.conversation.to_messages()
+            )
+            assert f"Path: {image_path}" in str(resolved_again)
 
             # --- run_event: correlated custom-event ingress (Phase E) ---
             # ``Agent.run_event`` drives a pre-built TriggerEvent (a Drive

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -5788,13 +5788,19 @@ class TestMidTurnBatchDrain:
             for evt in [
                 TriggerEvent(type="user_input", content="hello"),
                 create_tool_complete_event(job_id="bash_1", content="tool out"),
+                create_tool_complete_event(
+                    job_id="bash_2",
+                    content="partial",
+                    exit_code=3,
+                    error="permission denied",
+                ),
                 TriggerEvent(
                     type="subagent_output", content="sub out", job_id="agent_x"
                 ),
             ]:
                 agent._event_inbox.put(EventEnvelope(evt))
             count = await agent._drain_mid_turn_pending_inputs(agent.controller)
-            assert count == 3
+            assert count == 4
             user_msgs = [
                 m
                 for m in agent.controller.conversation.get_messages()
@@ -5803,6 +5809,10 @@ class TestMidTurnBatchDrain:
             combined = user_msgs[-1].content
             assert "hello" in combined
             assert "[Tool bash_1 completed]\ntool out" in combined
+            assert (
+                "[Tool bash_2 failed, exit 3]\nError: permission denied\npartial"
+                in combined
+            )
             assert "[Sub-agent agent_x output]\nsub out" in combined
             # Only the user-facing entry records a queued-banner frame —
             # tool/sub-agent completions already have their own

--- a/tests/unit/core/test_agent_workspace.py
+++ b/tests/unit/core/test_agent_workspace.py
@@ -77,6 +77,17 @@ class TestSet:
         assert a.session_store.meta["pwd"] == str(new_dir.resolve())
         assert a.session_store.touched == 1
 
+    def test_switch_preserves_live_session_attachment_paths(self, tmp_path):
+        new_dir = tmp_path / "subdir"
+        new_dir.mkdir()
+        attachment = tmp_path.parent / "attachment.txt"
+        a = _fake_agent(tmp_path, mode="block")
+        a._path_guard.allow_session_path(attachment)
+
+        WorkspaceController(a).set(new_dir)
+
+        assert a._path_guard.check(str(attachment)) is None
+
     def test_empty_path_rejected(self, tmp_path):
         a = _fake_agent(tmp_path)
         ws = WorkspaceController(a)

--- a/tests/unit/core/test_controller.py
+++ b/tests/unit/core/test_controller.py
@@ -479,14 +479,50 @@ class TestFormatEventsForContext:
         assert out[0].text == "describe"
 
     def test_tool_complete_text(self):
-        from kohakuterrarium.core.events import create_tool_complete_event
-
         c = self._ctrl()
         evt = create_tool_complete_event(job_id="bash_x", content="output", exit_code=0)
         out = c._format_events_for_context([evt])
-        # Contains the tool-complete header and the body.
-        assert "Tool bash_x" in out
-        assert "output" in out
+        assert out == "[Tool bash_x completed]\noutput"
+
+    def test_tool_failure_keeps_only_actionable_error(self):
+        c = self._ctrl()
+        evt = create_tool_complete_event(
+            job_id="bash_x",
+            content="partial output",
+            exit_code=2,
+            error=(
+                "\x1b[31mTraceback (most recent call last):\n"
+                '  File "worker.py", line 9, in run\n'
+                "RuntimeError: background-kaboom\x1b[0m"
+            ),
+        )
+        out = c._format_events_for_context([evt])
+        assert out == (
+            "[Tool bash_x failed, exit 2]\n"
+            "Error: RuntimeError: background-kaboom\n"
+            "partial output"
+        )
+        assert "Traceback" not in out
+        assert "worker.py" not in out
+
+    def test_tool_failure_error_is_bounded(self):
+        c = self._ctrl()
+        evt = create_tool_complete_event(job_id="bash_x", content="", error="x" * 600)
+        out = c._format_events_for_context([evt])
+        summary = out.split("Error: ", 1)[1]
+        assert len(summary) == 512
+        assert summary.endswith("…")
+
+    def test_interrupted_tool_is_cancelled_without_redundant_error(self):
+        c = self._ctrl()
+        evt = create_tool_complete_event(
+            job_id="bash_x",
+            content="",
+            error="User manually interrupted this job.",
+            interrupted=True,
+            final_state="interrupted",
+        )
+        assert c._format_events_for_context([evt]) == "[Tool bash_x cancelled]"
 
     def test_subagent_output(self):
         from kohakuterrarium.core.events import EventType

--- a/tests/unit/core/test_controller.py
+++ b/tests/unit/core/test_controller.py
@@ -675,6 +675,37 @@ class TestMaterializeInlineFile:
         path = await env.controller._materialize_inline_file(part)
         assert path is None
 
+    async def test_same_upload_reuses_path_until_controller_cleanup(self):
+        from pathlib import Path
+
+        env = TestAgentBuilder().with_llm_script(["x"]).build()
+        part = FilePart(name="notes.txt", content="stable", is_inline=True)
+
+        first = await env.controller._materialize_inline_file(part)
+        second = await env.controller._materialize_inline_file(part)
+
+        assert first == second
+        assert Path(first).is_file()
+
+        env.controller.cleanup_inline_files()
+
+        assert not Path(first).exists()
+
+    async def test_long_upload_name_still_materializes(self):
+        from pathlib import Path
+
+        env = TestAgentBuilder().with_llm_script(["x"]).build()
+        part = FilePart(
+            name=f"{'x' * 255}.txt",
+            content="long name",
+            is_inline=True,
+        )
+
+        path = await env.controller._materialize_inline_file(part)
+
+        assert Path(path).read_text() == "long name"
+        assert len(Path(path).name.encode()) <= 255
+
 
 class TestResolveFilePart:
     async def test_inline_content_returns_text(self):
@@ -714,10 +745,15 @@ class TestResolveFilePart:
         joined = " ".join(getattr(p, "text", "") for p in out)
         assert "File read failed" in joined or "missing" in joined.lower()
 
-    async def test_inline_base64_bypasses_guard_only_for_owned_temp(self, tmp_path):
+    async def test_inline_base64_allows_exact_live_session_copy(self, tmp_path):
         import base64
+        from pathlib import Path
+
+        from kohakuterrarium.builtins.tools.write import WriteTool
+        from kohakuterrarium.utils.file_guard import FileReadState
 
         env = TestAgentBuilder().with_llm_script(["x"]).build()
+        env.executor._file_read_state = FileReadState()
         guard = PathBoundaryGuard(
             env.executor._build_tool_context().working_dir, mode="warn"
         )
@@ -730,8 +766,21 @@ class TestResolveFilePart:
         out = await env.controller._resolve_file_part(part)
         joined = " ".join(getattr(p, "text", "") for p in out)
         assert "hello world" in joined
+        path = joined.split("Path: ", 1)[1].split()[0]
+        assert Path(path).is_file()
+        assert guard.session_allowed_paths == frozenset({str(Path(path).resolve())})
         assert guard._warned_paths == set()
         assert env.executor._build_tool_context().path_guard is guard
+
+        written = await WriteTool().execute(
+            {"path": path, "content": "updated attachment"},
+            context=env.executor._build_tool_context(),
+        )
+        assert written.success
+        reread = await env.controller._resolve_file_part(part)
+        reread_text = " ".join(getattr(p, "text", "") for p in reread)
+        assert "updated attachment" in reread_text
+        assert f"Path: {path}" in reread_text
 
         unrelated = tmp_path / "outside.txt"
         unrelated.write_text("must stay guarded")
@@ -741,6 +790,10 @@ class TestResolveFilePart:
         blocked_text = " ".join(getattr(p, "text", "") for p in blocked)
         assert "outside the working directory" in blocked_text
         assert str(unrelated.resolve()) in guard._warned_paths
+
+        env.controller.cleanup_inline_files()
+        assert not Path(path).exists()
+        assert guard.session_allowed_paths == frozenset()
 
 
 # ── _resolve_message_files multiple files + dispatch ─────────────

--- a/tests/unit/core/test_controller.py
+++ b/tests/unit/core/test_controller.py
@@ -22,12 +22,13 @@ from kohakuterrarium.core.events import (
 )
 from kohakuterrarium.core.job import JobResult
 from kohakuterrarium.core.registry import Registry
-from kohakuterrarium.llm.message import ImagePart
+from kohakuterrarium.llm.message import FilePart, ImagePart
 from kohakuterrarium.parsing.events import (
     TextEvent,
 )
 from kohakuterrarium.testing.agent import TestAgentBuilder
 from kohakuterrarium.testing.llm import ScriptedLLM, ScriptEntry
+from kohakuterrarium.utils.file_guard import PathBoundaryGuard
 
 # ── _merge_text_and_parts ────────────────────────────────────────
 
@@ -713,21 +714,33 @@ class TestResolveFilePart:
         joined = " ".join(getattr(p, "text", "") for p in out)
         assert "File read failed" in joined or "missing" in joined.lower()
 
-    async def test_inline_base64_materialised_to_temp(self):
+    async def test_inline_base64_bypasses_guard_only_for_owned_temp(self, tmp_path):
         import base64
 
-        from kohakuterrarium.llm.message import FilePart
-
         env = TestAgentBuilder().with_llm_script(["x"]).build()
+        guard = PathBoundaryGuard(
+            env.executor._build_tool_context().working_dir, mode="warn"
+        )
+        env.executor._path_guard = guard
         part = FilePart(
             name="x.txt",
             data_base64=base64.b64encode(b"hello world").decode(),
             is_inline=True,
         )
         out = await env.controller._resolve_file_part(part)
-        # The inline file part is materialised then read back through
-        # ReadTool — the resolved output is a non-empty parts list.
-        assert out
+        joined = " ".join(getattr(p, "text", "") for p in out)
+        assert "hello world" in joined
+        assert guard._warned_paths == set()
+        assert env.executor._build_tool_context().path_guard is guard
+
+        unrelated = tmp_path / "outside.txt"
+        unrelated.write_text("must stay guarded")
+        blocked = await env.controller._resolve_file_part(
+            FilePart(name="outside.txt", path=str(unrelated))
+        )
+        blocked_text = " ".join(getattr(p, "text", "") for p in blocked)
+        assert "outside the working directory" in blocked_text
+        assert str(unrelated.resolve()) in guard._warned_paths
 
 
 # ── _resolve_message_files multiple files + dispatch ─────────────

--- a/tests/unit/core/test_executor.py
+++ b/tests/unit/core/test_executor.py
@@ -866,7 +866,9 @@ class TestCancelledToolWithCallback:
         await ex.cancel(jid)
         await ex.wait_for(jid, timeout=1.0)
         # Callback received the cancellation event.
-        assert called
+        assert len(called) == 1
+        assert called[0].context["cancelled"] is True
+        assert called[0].context["final_state"] == "cancelled"
 
 
 class TestWaitForDeterministicTimeout:

--- a/tests/unit/utils/test_file_guard.py
+++ b/tests/unit/utils/test_file_guard.py
@@ -175,6 +175,25 @@ class TestPathBoundaryGuard:
         assert err2 is not None
         assert "Access denied" in err2
 
+    def test_exact_session_path_bypasses_block_until_revoked(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        attachment = tmp_path / "attachment.txt"
+        attachment.write_text("user supplied")
+        sibling = tmp_path / "sibling.txt"
+        sibling.write_text("not attached")
+        guard = PathBoundaryGuard(workspace, mode="block")
+
+        guard.allow_session_path(attachment)
+
+        assert guard.check(str(attachment)) is None
+        assert guard.check(str(sibling)) is not None
+        assert guard.session_allowed_paths == frozenset({str(attachment.resolve())})
+
+        guard.revoke_session_path(attachment)
+
+        assert guard.check(str(attachment)) is not None
+
     def test_warn_mode_first_blocked_then_allowed_on_retry(self, tmp_path):
         guard = PathBoundaryGuard(tmp_path, mode="warn")
         outside = tmp_path.parent / "y.txt"


### PR DESCRIPTION
## Summary

Surface failed background tool completions to the model with concise, actionable diagnostics, and keep controller-owned inline attachments available at one exact session-scoped path for later read or write tool calls.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Background tool errors were labeled as successful completions and could arrive with an empty body, leaving the model unable to respond to the failure. Separately, browser-provided inline attachments were materialized outside the workspace, rejected by the path guard, and deleted after each provider request. Models that retried the displayed path then saw a different or missing temporary file.

## Changes

- Format background tool completions as `completed`, `failed`, or `cancelled` and include only a bounded 512-character error summary with traceback frames removed.
- Reuse the same completion formatter for normal and mid-turn delivery.
- Mark executor cancellation events explicitly as cancelled.
- Materialize each inline attachment once in a controller-owned temporary directory and reuse the same path for the live agent session.
- Register only that exact canonical file with the existing path guard; unrelated files and the containing temporary directory remain guarded.
- Preserve existing tool policy for the session copy, including read-before-write checks and optional `permgate` approval when enabled.
- Revoke the path and remove the temporary directory during agent shutdown, while carrying live attachment paths across workspace switches.
- Expose the stable session-copy path to the model so later `read`, `write`, or `edit` calls can target the uploaded copy. The user's original local file is never overwritten.
- Add unit and core integration coverage for failure context, stable text/image attachment paths, modifying the session copy, unrelated-path rejection, cleanup, workspace switching, and long upload names.

## Validation

```bash
.venv/bin/pytest tests/unit/core/test_controller.py tests/unit/core/test_agent_real.py tests/unit/core/test_executor.py -q
.venv/bin/pytest tests/unit/utils/test_file_guard.py tests/unit/builtins/tools/test_json_write.py tests/unit/builtins/tools/test_read.py tests/unit/builtins/tools/test_write.py tests/unit/builtins/tools/test_json_read.py tests/unit/core/test_controller.py tests/unit/core/test_controller_tool_visibility.py tests/unit/core/test_controller_plugins.py tests/unit/core/test_controller_metrics.py tests/unit/core/test_agent_lifecycle_misc.py tests/unit/core/test_agent_workspace.py -q
.venv/bin/pytest tests/integration/test_core.py -q
.venv/bin/ruff check src/ tests/
.venv/bin/black --check src/ tests/
.venv/bin/pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
git diff --check
```

Results: 390 core affected unit tests passed; the focused attachment/path/tool suite passed 243 tests; 6 core integration workflows passed; and 1,728 file-size/dependency-graph guard cases passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #231
- Fixes #232

## Notes for Reviewers

The attachment exception is session-scoped and exact-file only. It does not disable the shared guard or trust an operating-system temporary directory. Browser uploads remain copies because the browser supplies bytes rather than the user's original local path; callers that intentionally need in-place modification can provide a real filesystem path instead.

## Screenshots / Logs (if applicable)

Not applicable; no UI changes.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

The complete unit matrix and cross-platform suite were not run locally. Per the requested workflow, implementation was reviewed first and the real PR CI is the authoritative validation. Frontend and e2e tests were not run because this PR changes neither the frontend nor multi-node, Studio, or serving behavior. The current PR CI run was started automatically by the pushed commit and was not manually triggered or re-run.
