### PR TITLE
feat(llm): add Codex Spark subscription support

### DIFF
--- a/docs/en/reference/builtins.md
+++ b/docs/en/reference/builtins.md
@@ -386,6 +386,7 @@ Naming convention (post-2026-04 refactor):
 
 ### OpenAI via Codex OAuth
 
+- `gpt-5.3-codex-spark` (ChatGPT Pro research preview; text-only)
 - `gpt-5.5`
 - `gpt-5.4` (aliases: `gpt5`, `gpt54`)
 - `gpt-5.3-codex` (`gpt53`)
@@ -547,6 +548,7 @@ fixed.
 
 | Preset | Group | Options |
 |---|---|---|
+| `gpt-5.3-codex-spark` | `reasoning` | `low`, `medium`, `high`, `xhigh` |
 | `gpt-5.5` | `reasoning` | `none`, `low`, `medium`, `high`, `xhigh` |
 | `gpt-5.5` | `speed` | `normal`, `fast` (maps to `service_tier: priority`) |
 | `gpt-5.4` | `reasoning` | `none`, `low`, `medium`, `high`, `xhigh` |

--- a/docs/zh-CN/reference/builtins.md
+++ b/docs/zh-CN/reference/builtins.md
@@ -323,6 +323,7 @@ LLM 可输出的内嵌指令，可替换工具调用。它们会直接与框架�
 
 ### OpenAI via Codex OAuth
 
+- `gpt-5.3-codex-spark`（ChatGPT Pro 研究预览；仅文本）
 - `gpt-5.4` (别名：`gpt5`、`gpt54`)
 - `gpt-5.3-codex` (`gpt53`)
 - `gpt-5.1`
@@ -473,6 +474,7 @@ Variation group 让一个 preset 可以暴露多个旋钮而不必重复条目�
 
 | Preset | Group | Options |
 |---|---|---|
+| `gpt-5.3-codex-spark` | `reasoning` | `low`、`medium`、`high`、`xhigh` |
 | `gpt-5.4` | `reasoning` | `none`、`low`、`medium`、`high`、`xhigh` |
 | `gpt-5.4` | `speed` | `normal`、`fast` (映射到 `service_tier: priority`) |
 | `gpt-5.3-codex` | `reasoning` | `none`、`low`、`medium`、`high`、`xhigh` |

--- a/docs/zh-TW/reference/builtins.md
+++ b/docs/zh-TW/reference/builtins.md
@@ -323,6 +323,7 @@ LLM 可輸出的內嵌指令，可取代工具呼叫。它們會直接與框架�
 
 ### OpenAI 透過 Codex OAuth
 
+- `gpt-5.3-codex-spark`（ChatGPT Pro 研究預覽；僅文字）
 - `gpt-5.4` (別名：`gpt5`、`gpt54`)
 - `gpt-5.3-codex` (`gpt53`)
 - `gpt-5.1`
@@ -473,6 +474,7 @@ Variation group 讓單一 preset 暴露多組旋鈕而不用重複建立條目�
 
 | Preset | Group | Options |
 |---|---|---|
+| `gpt-5.3-codex-spark` | `reasoning` | `low`、`medium`、`high`、`xhigh` |
 | `gpt-5.4` | `reasoning` | `none`、`low`、`medium`、`high`、`xhigh` |
 | `gpt-5.4` | `speed` | `normal`、`fast` (對映 `service_tier: priority`) |
 | `gpt-5.3-codex` | `reasoning` | `none`、`low`、`medium`、`high`、`xhigh` |

--- a/src/kohakuterrarium/llm/presets.py
+++ b/src/kohakuterrarium/llm/presets.py
@@ -62,6 +62,8 @@ PRESETS: dict[str, dict[str, Any]] = {
         # Codex OAuth currently lets the backend choose the actual output cap.
         "max_output": 65536,
         "reasoning_effort": "high",
+        # Spark is text-only; do not inherit Codex's provider-wide image tool.
+        "provider_native_tools": [],
         "variation_groups": {"reasoning": _CODEX_REASONING_GROUP},
     },
     "gpt-5.6-sol": {

--- a/src/kohakuterrarium/llm/presets.py
+++ b/src/kohakuterrarium/llm/presets.py
@@ -54,6 +54,16 @@ PRESETS: dict[str, dict[str, Any]] = {
     #  fast mode (priority tier). The Codex/GPT lines merged at
     #  5.4 — there is no separate ``-codex`` model anymore.
     # ═══════════════════════════════════════════════════════
+    "gpt-5.3-codex-spark": {
+        "provider": "codex",
+        "model": "gpt-5.3-codex-spark",
+        # Subscription-only research preview metadata from Codex's model catalog.
+        "max_context": 128000,
+        # Codex OAuth currently lets the backend choose the actual output cap.
+        "max_output": 65536,
+        "reasoning_effort": "high",
+        "variation_groups": {"reasoning": _CODEX_REASONING_GROUP},
+    },
     "gpt-5.6-sol": {
         "provider": "codex",
         "model": "gpt-5.6-sol",

--- a/src/kohakuterrarium/llm/profile_types.py
+++ b/src/kohakuterrarium/llm/profile_types.py
@@ -56,6 +56,7 @@ class LLMPreset:
     service_tier: str = ""
     extra_body: dict[str, Any] = field(default_factory=dict)
     retry_policy: dict[str, Any] | None = None
+    provider_native_tools: list[str] | None = None
     variation_groups: dict[str, dict[str, dict[str, Any]]] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -76,6 +77,8 @@ class LLMPreset:
             data["extra_body"] = self.extra_body
         if self.retry_policy:
             data["retry_policy"] = self.retry_policy
+        if self.provider_native_tools is not None:
+            data["provider_native_tools"] = list(self.provider_native_tools)
         if self.variation_groups:
             data["variation_groups"] = self.variation_groups
         return data
@@ -83,6 +86,9 @@ class LLMPreset:
     @classmethod
     def from_dict(cls, name: str, data: dict[str, Any]) -> "LLMPreset":
         provider = data.get("provider", "") or data.get("backend", "")
+        native_tools = data.get("provider_native_tools")
+        if native_tools is not None and not isinstance(native_tools, list):
+            native_tools = None
         return cls(
             name=name,
             model=data.get("model", ""),
@@ -94,6 +100,11 @@ class LLMPreset:
             service_tier=data.get("service_tier", ""),
             extra_body=data.get("extra_body", {}),
             retry_policy=data.get("retry_policy"),
+            provider_native_tools=(
+                [str(tool) for tool in native_tools if tool]
+                if native_tools is not None
+                else None
+            ),
             variation_groups=data.get("variation_groups", {}) or {},
         )
 

--- a/src/kohakuterrarium/llm/profiles.py
+++ b/src/kohakuterrarium/llm/profiles.py
@@ -114,6 +114,7 @@ def _resolve_preset(
     )
     resolved_preset = LLMPreset.from_dict(preset.name, resolved_dict)
     resolved_preset.provider = preset.provider
+    preset_native_tools = resolved_preset.provider_native_tools
 
     return LLMProfile(
         name=resolved_preset.name,
@@ -131,7 +132,11 @@ def _resolve_preset(
         retry_policy=deepcopy(resolved_preset.retry_policy),
         selected_variations=normalized,
         backend_provider_name=provider.provider_name if provider else "",
-        backend_native_tools=(list(provider.provider_native_tools) if provider else []),
+        backend_native_tools=(
+            list(provider.provider_native_tools)
+            if preset_native_tools is None and provider
+            else list(preset_native_tools or [])
+        ),
     )
 
 
@@ -220,6 +225,11 @@ def save_profile(profile: LLMProfile | LLMPreset) -> None:
             service_tier=profile.service_tier,
             extra_body=profile.extra_body,
             retry_policy=profile.retry_policy,
+            provider_native_tools=(
+                deepcopy(existing_preset.provider_native_tools)
+                if existing_preset
+                else None
+            ),
             variation_groups=(
                 deepcopy(existing_preset.variation_groups) if existing_preset else {}
             ),

--- a/tests/unit/bootstrap/test_llm.py
+++ b/tests/unit/bootstrap/test_llm.py
@@ -423,6 +423,21 @@ class TestApplyBackendNativeIdentity:
         # provider_name was empty → not overwritten.
         assert p.provider_name == "default"
 
+    def test_spark_profile_constructs_without_image_generation(self):
+        profile = LLMProfile(
+            name="gpt-5.3-codex-spark",
+            model="gpt-5.3-codex-spark",
+            provider="codex",
+            backend_type="codex",
+            backend_provider_name="codex",
+            backend_native_tools=[],
+        )
+
+        provider = _create_from_profile(profile)
+
+        assert isinstance(provider, CodexOAuthProvider)
+        assert provider.provider_native_tools == frozenset()
+
 
 # ── fake_test backend — provider-resolution path for multi-node tests ─────
 

--- a/tests/unit/llm/test_presets.py
+++ b/tests/unit/llm/test_presets.py
@@ -183,9 +183,30 @@ class TestPresetsDataIntegrity:
 
     def test_codex_presets_use_codex_provider(self):
         # the headline ChatGPT-subscription presets bind to the codex provider
+        assert PRESETS["gpt-5.3-codex-spark"]["provider"] == "codex"
         assert PRESETS["gpt-5.4"]["provider"] == "codex"
         assert PRESETS["gpt-5.5"]["provider"] == "codex"
         assert PRESETS["gpt-5.6-sol"]["provider"] == "codex"
+
+    def test_codex_spark_uses_subscription_catalog_defaults(self):
+        preset = PRESETS["gpt-5.3-codex-spark"]
+        assert preset["model"] == "gpt-5.3-codex-spark"
+        assert preset["max_context"] == 128000
+        assert preset["max_output"] == 65536
+        assert preset["reasoning_effort"] == "high"
+        assert set(preset["variation_groups"]["reasoning"]) == {
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+        }
+        assert "service_tier" not in preset
+        assert "websocket_mode" not in preset.get("extra_body", {})
+
+        all_presets = get_all_presets()
+        assert ("codex", "gpt-5.3-codex-spark") in all_presets
+        assert ("openai", "gpt-5.3-codex-spark") not in all_presets
+        assert ("openrouter", "gpt-5.3-codex-spark") not in all_presets
 
     def test_gpt56_effort_scales_top_out_at_max(self):
         # ``ultra`` is deliberately not exposed on any GPT-5.6 variant:

--- a/tests/unit/llm/test_presets.py
+++ b/tests/unit/llm/test_presets.py
@@ -194,6 +194,7 @@ class TestPresetsDataIntegrity:
         assert preset["max_context"] == 128000
         assert preset["max_output"] == 65536
         assert preset["reasoning_effort"] == "high"
+        assert preset["provider_native_tools"] == []
         assert set(preset["variation_groups"]["reasoning"]) == {
             "low",
             "medium",

--- a/tests/unit/llm/test_profile_types.py
+++ b/tests/unit/llm/test_profile_types.py
@@ -87,6 +87,7 @@ class TestLLMPreset:
         assert preset.max_output == 65536
         assert preset.temperature is None
         assert preset.reasoning_effort == ""
+        assert preset.provider_native_tools is None
         assert preset.variation_groups == {}
 
     def test_to_dict_minimal(self):
@@ -107,6 +108,7 @@ class TestLLMPreset:
             service_tier="priority",
             extra_body={"reasoning": {"effort": "high"}},
             retry_policy={"max": 3},
+            provider_native_tools=[],
             variation_groups={"r": {"low": {}}},
         )
         d = preset.to_dict()
@@ -116,6 +118,7 @@ class TestLLMPreset:
         assert d["service_tier"] == "priority"
         assert d["extra_body"] == {"reasoning": {"effort": "high"}}
         assert d["retry_policy"] == {"max": 3}
+        assert d["provider_native_tools"] == []
         assert d["variation_groups"] == {"r": {"low": {}}}
 
     def test_to_dict_temperature_zero_is_kept(self):
@@ -153,6 +156,11 @@ class TestLLMPreset:
     def test_from_dict_none_variation_groups_coerced_to_empty(self):
         preset = LLMPreset.from_dict("p", {"model": "m", "variation_groups": None})
         assert preset.variation_groups == {}
+
+    def test_from_dict_preserves_explicit_empty_native_tools(self):
+        preset = LLMPreset.from_dict("p", {"model": "m", "provider_native_tools": []})
+        assert preset.provider_native_tools == []
+        assert preset.to_dict()["provider_native_tools"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/llm/test_profiles.py
+++ b/tests/unit/llm/test_profiles.py
@@ -658,6 +658,7 @@ class TestLoadProfilesAndListAll:
     def test_list_all_includes_builtin_presets(self):
         entries = list_all()
         keys = {(e["provider"], e["name"]) for e in entries}
+        assert ("codex", "gpt-5.3-codex-spark") in keys
         assert ("codex", "gpt-5.4") in keys
         grok_names = {
             name for provider, name in keys if provider == "grok-subscription"

--- a/tests/unit/llm/test_profiles.py
+++ b/tests/unit/llm/test_profiles.py
@@ -109,6 +109,12 @@ class TestGetProfile:
         assert profile.provider == "codex"
         assert profile.backend_type == "codex"
         assert profile.max_context == 400000
+        assert profile.backend_native_tools == ["image_gen"]
+
+    def test_spark_opts_out_of_codex_image_generation(self):
+        profile = get_profile("codex/gpt-5.3-codex-spark")
+        assert profile is not None
+        assert profile.backend_native_tools == []
 
     @pytest.mark.parametrize(
         ("preset", "model", "max_context"),


### PR DESCRIPTION
## Summary

Add GPT-5.3-Codex-Spark as a built-in Codex OAuth preset for eligible subscription accounts. The preset appears in the standard model selector with the current catalog defaults and explicitly disables Codex image generation because Spark is text-only.

## PR Type

- [ ] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Eligible ChatGPT Pro / Codex users can access Spark through a separate subscription usage pool, but KohakuTerrarium currently requires them to define a custom preset. Issue #16 enabled that custom-preset path; this PR adds the maintained built-in selection requested in #237.

## Changes

- Add a Codex OAuth-only `gpt-5.3-codex-spark` preset with a 128,000-token context window, `high` default reasoning, and `low` / `medium` / `high` / `xhigh` options.
- Add an optional preset-level provider-native-tool override, preserving the distinction between inheritance (`None`) and explicitly disabling all provider-native tools (`[]`).
- Prevent Spark requests from inheriting Codex's `image_generation` tool while leaving other Codex presets unchanged.
- Document the built-in model and reasoning options in English, Simplified Chinese, and Traditional Chinese.
- Add preset, profile-resolution, serialization, and provider-construction regression coverage.

## Validation

```bash
KT_CONFIG_DIR=/private/tmp/kt-spark-review-config PYTHONPATH=/private/tmp/kt-codex-spark/src /Users/williamqin/KohakuTerrarium/.venv/bin/pytest tests/unit/bootstrap/test_llm.py tests/unit/llm/test_presets.py tests/unit/llm/test_profile_types.py tests/unit/llm/test_profiles.py -q
# 205 passed

/Users/williamqin/KohakuTerrarium/.venv/bin/ruff check src/kohakuterrarium/llm/presets.py src/kohakuterrarium/llm/profile_types.py src/kohakuterrarium/llm/profiles.py tests/unit/bootstrap/test_llm.py tests/unit/llm/test_presets.py tests/unit/llm/test_profile_types.py tests/unit/llm/test_profiles.py
# All checks passed

/Users/williamqin/KohakuTerrarium/.venv/bin/black --check src/kohakuterrarium/llm/presets.py src/kohakuterrarium/llm/profile_types.py src/kohakuterrarium/llm/profiles.py tests/unit/bootstrap/test_llm.py tests/unit/llm/test_presets.py tests/unit/llm/test_profile_types.py tests/unit/llm/test_profiles.py
# 7 files would be left unchanged
```

Manual macOS GUI verification also completed successful Spark text and function-tool turns through a Codex subscription account. The initial unsupported `image_generation` request was reproduced, then verified fixed by the explicit native-tool override.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Closes #237
- Related to #16
- Approved by maintainer @KohakuBlueleaf in the project QQ group on 2026-08-26. The implementation matches the approved scope: built-in Codex subscription selection for GPT-5.3-Codex-Spark with the recommended capability metadata.

## Notes for Reviewers

- The Codex catalog currently reports Spark as subscription-only, text-only, unavailable through the public API catalog, and without service tiers. Accordingly, this PR adds no OpenAI API or OpenRouter variants and does not force WebSocket mode.
- `max_output` remains local profile metadata for the Codex OAuth path; the backend chooses the actual output cap.
- Account entitlement remains enforced by the Codex backend. KohakuTerrarium exposes the model but does not attempt to infer subscription eligibility.

## Screenshots / Logs (if applicable)

No UI files changed. The existing selector renders the new built-in preset from the shared model catalog.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- Full-repository Ruff, Black, and unit suites were not rerun for this focused change; the affected 205 tests and all seven changed Python files pass locally, and upstream PR CI will run the complete required matrix.
- Fork Actions is enabled, but the repository workflow only triggers on pushes to `main` or pull requests targeting `main`, and it has no manual trigger. Therefore this feature branch has no fork CI run; upstream PR CI is the validation boundary.
- No frontend files changed, so the checked frontend item is not applicable.
- E2E was not run because this change does not alter Studio serving, multi-node behavior, or frontend code.
