### PR TITLE
Fix false failure after setting the default model

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.test.js
+++ b/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.test.js
@@ -1,0 +1,66 @@
+import { flushPromises, shallowMount } from "@vue/test-utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createPinia, setActivePinia } from "pinia"
+import ElementPlus, { ElMessage } from "element-plus"
+
+vi.mock("@/utils/api", () => {
+  const settingsAPI = {
+    getKeys: vi.fn(),
+    getBackends: vi.fn(),
+    getNativeTools: vi.fn(),
+    listMCP: vi.fn(),
+    setDefaultModel: vi.fn(),
+  }
+  const configAPI = { getModels: vi.fn() }
+  return { configAPI, settingsAPI }
+})
+
+vi.mock("@/utils/i18n", () => ({
+  useI18n: () => ({
+    t: (key, params) => (params?.name ? `${key}:${params.name}` : key),
+  }),
+}))
+
+import SettingsPage from "./SettingsPage.vue"
+import { configAPI, settingsAPI } from "@/utils/api"
+
+describe("SettingsPage model presets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    })
+    setActivePinia(createPinia())
+    settingsAPI.getKeys.mockResolvedValue({ providers: [] })
+    settingsAPI.getBackends.mockResolvedValue({ backends: [] })
+    settingsAPI.getNativeTools.mockResolvedValue({ tools: [] })
+    settingsAPI.listMCP.mockResolvedValue({ servers: [] })
+    settingsAPI.setDefaultModel.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("refreshes the selected preset without reporting a successful default change as failed", async () => {
+    const preset = { name: "fast", provider: "openai", source: "user", is_default: false }
+    const refreshed = { ...preset, is_default: true }
+    configAPI.getModels.mockResolvedValueOnce([preset]).mockResolvedValueOnce([refreshed])
+    const success = vi.spyOn(ElMessage, "success").mockImplementation(() => {})
+    const error = vi.spyOn(ElMessage, "error").mockImplementation(() => {})
+
+    const wrapper = shallowMount(SettingsPage, { global: { plugins: [ElementPlus] } })
+    await flushPromises()
+    wrapper.vm.selectPreset(preset)
+
+    await wrapper.vm.handleSetDefault(preset)
+
+    expect(settingsAPI.setDefaultModel).toHaveBeenCalledWith("fast")
+    expect(success).toHaveBeenCalledOnce()
+    expect(error).not.toHaveBeenCalled()
+    expect(wrapper.vm.editorPreset).toEqual(refreshed)
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.vue
+++ b/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.vue
@@ -874,9 +874,6 @@ async function handleSetDefault(preset) {
     await settingsAPI.setDefaultModel(preset.name)
     ElMessage.success(t("settings.models.defaultSet", { name: preset.name }))
     await loadPresets()
-    // Refresh the editor's bound preset so the badge flips.
-    const refreshed = (presets.value || []).find((p) => p.name === preset.name && p.provider === preset.provider)
-    if (refreshed) editorPreset.value = refreshed
   } catch (err) {
     ElMessage.error(err.response?.data?.detail || t("settings.models.defaultSetFailed"))
   }


### PR DESCRIPTION
## Summary

Remove the invalid post-refresh lookup from the default-model handler. The existing `loadPresets()` path already rebinds the selected editor preset from `allPresets`, so the successful save now completes without a false error toast.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The backend save succeeds, but `handleSetDefault` then references an undefined `presets` variable. The resulting `ReferenceError` is caught as if the API call failed.

## Changes

- Remove the redundant lookup through the nonexistent `presets` ref.
- Add a mounted regression test that verifies the success toast, absence of an error toast, and refreshed editor state.

## Validation

```bash
npm test -- src/components/settings/SettingsPage.test.js
npm run format:check
CHOKIDAR_USEPOLLING=true npm run build
```

The targeted test passed, formatting passed, and the production build completed. A full local `npm test` run reached 1114 passing tests but also hit one unrelated existing chat-store timeout and one collection failure caused by the shared worktree dependency layout; PR CI is the final full-suite authority.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [ ] `ruff check src/ tests/` passes
- [ ] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #240

## Notes for Reviewers

`loadPresets()` already refreshes `allPresets` and rebinds `editorPreset` using `selectedPresetKey`; no replacement state path is introduced.

## Screenshots / Logs (if applicable)

Not applicable. This fixes a deterministic error path without changing layout.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

Python-only checks are not applicable to this frontend-only change. Per the requested workflow, fork CI was not awaited before opening the PR; the PR CI result is authoritative.