### PR TITLE
fix(sessions): open exact sub-agent conversations

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.test.js
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import ToolCallBlock from "./ToolCallBlock.vue"
 import { useChatStore } from "@/stores/chat"
-import { terrariumAPI } from "@/utils/api"
+import { sessionAPI, terrariumAPI } from "@/utils/api"
 
 beforeEach(() => {
   const values = new Map()
@@ -198,7 +198,10 @@ describe("ToolCallBlock — sub-agent conversation (UXI-05)", () => {
     await flushPromises()
 
     // Live block identifies by the job_id it already holds.
-    expect(getConv).toHaveBeenCalledWith("g1", "root", { jobId: "job_x" })
+    expect(getConv).toHaveBeenCalledWith("g1", "root", {
+      jobId: "job_x",
+      name: "explore",
+    })
     const textarea = wrapper.find("textarea")
     expect(textarea.exists()).toBe(true)
     expect(textarea.classes()).toEqual(
@@ -224,6 +227,35 @@ describe("ToolCallBlock — sub-agent conversation (UXI-05)", () => {
 
     getConv.mockRestore()
     send.mockRestore()
+  })
+
+  it("uses the persisted viewer API inside saved session history", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session:saved-session"
+    chat._instanceGraphId = null
+    chat.activeTab = "root"
+    const liveRead = vi.spyOn(terrariumAPI, "getSubagentConversation")
+    const savedRead = vi.spyOn(sessionAPI, "getSubagentConversation").mockResolvedValue({
+      live: false,
+      can_receive: false,
+      messages: [{ role: "assistant", content: "saved answer" }],
+    })
+
+    const wrapper = mountBlock(subagentTc())
+    await convButton(wrapper).trigger("click")
+    await flushPromises()
+
+    expect(liveRead).not.toHaveBeenCalled()
+    expect(savedRead).toHaveBeenCalledWith("saved-session", {
+      parent: "root",
+      jobId: "job_x",
+      name: "explore",
+    })
+    expect(wrapper.text()).toContain("saved answer")
+    expect(wrapper.find("textarea").exists()).toBe(false)
+
+    liveRead.mockRestore()
+    savedRead.mockRestore()
   })
 
   it("polls the open transcript while the run is live and stops once it settles", async () => {

--- a/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ToolCallBlock.vue
@@ -71,64 +71,7 @@
             <span class="flex-1" />
             <span class="i-carbon-chevron-down text-[10px] transition-transform shrink-0" :class="{ 'rotate-180': convOpen }" />
           </button>
-          <div v-if="convOpen" class="m-2 rounded overflow-hidden bg-taaffeite/6 dark:bg-taaffeite/10 border border-taaffeite/20 dark:border-taaffeite/25 flex flex-col gap-2 p-2 min-w-0">
-            <div v-if="convLoading" class="text-[11px] text-warm-400">{{ t("common.loading") }}</div>
-            <div v-else-if="convError" class="text-[11px] text-coral">{{ convError }}</div>
-            <template v-else>
-              <div class="max-h-72 overflow-y-auto flex flex-col gap-2 min-w-0">
-                <div v-for="(item, i) in convBlocks" :key="i" class="min-w-0">
-                  <!-- system: collapsed disclosure — never dumped inline -->
-                  <template v-if="item.kind === 'system'">
-                    <button class="w-full flex items-center gap-1.5 text-left text-[10px] text-warm-400 hover:text-warm-500" @click.stop="toggleSystem(i)">
-                      <span class="i-carbon-chevron-right text-[9px] transition-transform shrink-0" :class="{ 'rotate-90': expandedSystem.has(i) }" />
-                      <span class="font-mono uppercase">system</span>
-                      <span class="italic">prompt ({{ item.text.length }} chars)</span>
-                    </button>
-                    <pre v-if="expandedSystem.has(i)" class="mt-1 font-mono whitespace-pre-wrap break-all max-h-40 overflow-y-auto bg-warm-100/70 dark:bg-warm-900/50 rounded px-2 py-1 text-[10px] text-warm-500 dark:text-warm-400">{{ item.text }}</pre>
-                  </template>
-
-                  <!-- user bubble (right-aligned, chat-style) -->
-                  <div v-else-if="item.kind === 'user'" class="ml-auto max-w-[85%] rounded-lg bg-warm-100 dark:bg-warm-800/80 border border-warm-200/60 dark:border-warm-700/60 px-2.5 py-1.5 min-w-0">
-                    <div class="text-[9px] uppercase tracking-wide text-warm-400 mb-0.5">user</div>
-                    <div v-if="item.parts" class="flex flex-col gap-1 text-body">
-                      <template v-for="(part, pi) in item.parts" :key="pi">
-                        <MarkdownRenderer v-if="part.type === 'text' && part.text" :content="part.text" />
-                        <img v-else-if="part.type === 'image_url'" :src="part.image_url?.url" class="tool-inline-image" />
-                      </template>
-                    </div>
-                    <div v-else class="text-body">
-                      <MarkdownRenderer :content="item.content" />
-                    </div>
-                  </div>
-
-                  <!-- assistant bubble + real tool-call accordions -->
-                  <div v-else class="max-w-[92%] min-w-0">
-                    <div class="text-[9px] uppercase tracking-wide text-warm-400 mb-0.5">assistant</div>
-                    <div v-if="item.parts" class="flex flex-col gap-1 text-body">
-                      <template v-for="(part, pi) in item.parts" :key="pi">
-                        <MarkdownRenderer v-if="part.type === 'text' && part.text" :content="part.text" />
-                        <img v-else-if="part.type === 'image_url'" :src="part.image_url?.url" class="tool-inline-image" />
-                      </template>
-                    </div>
-                    <div v-else-if="item.content" class="text-body">
-                      <MarkdownRenderer :content="item.content" />
-                    </div>
-                    <div v-if="item.toolCalls.length" class="flex flex-col gap-1.5 mt-1.5 min-w-0">
-                      <ToolCallBlock v-for="call in item.toolCalls" :key="call.id" :tc="call" :depth="depth + 1" :expanded="convToolExpanded.has(call.id)" @toggle="toggleConvTool(call.id)" />
-                    </div>
-                  </div>
-                </div>
-                <div v-if="!convBlocks.length" class="text-[11px] text-warm-400 italic">{{ t("chat.subagent.empty") }}</div>
-              </div>
-              <div v-if="canReceive" class="flex items-end gap-2 pt-1 border-t border-taaffeite/15 dark:border-taaffeite/20">
-                <textarea v-model="sendText" rows="1" :placeholder="t('chat.subagent.placeholder')" class="flex-1 min-w-0 resize-none rounded border border-warm-200 dark:border-warm-700 bg-warm-50 dark:bg-warm-950 px-2 py-1 text-[11px] text-warm-800 dark:text-warm-200 placeholder-warm-400 dark:placeholder-warm-500 focus:outline-none focus:border-taaffeite" @keydown.enter.exact.prevent="submitSend" />
-                <button class="text-[11px] px-2 py-1 rounded bg-taaffeite/20 text-taaffeite-shadow dark:text-taaffeite-light hover:bg-taaffeite/30 disabled:opacity-50 shrink-0" :disabled="sending || !sendText.trim()" @click.stop="submitSend">
-                  {{ t("chat.subagent.send") }}
-                </button>
-              </div>
-              <div v-else class="text-[10px] text-warm-400 italic">{{ t("chat.subagent.readOnly") }}</div>
-            </template>
-          </div>
+          <SubagentConversationPanel v-if="convOpen" class="m-2" :session-id="conversationSessionId" :parent="chat.activeTab || ''" :job-id="tc.jobId || ''" :name="tc.name" :run="tc.run" :status="tc.status" :depth="depth" :live="conversationLive" />
         </div>
       </template>
       <template v-else>
@@ -162,8 +105,8 @@
 <script setup>
 import MarkdownRenderer from "@/components/common/MarkdownRenderer.vue"
 import VideoFilePreview from "@/components/chat/VideoFilePreview.vue"
+import SubagentConversationPanel from "@/components/subagents/SubagentConversationPanel.vue"
 import { useChatStore } from "@/stores/chat"
-import { terrariumAPI } from "@/utils/api"
 import { safeArtifactUrl, safeMediaParts } from "@/utils/artifacts"
 import { useI18n } from "@/utils/i18n"
 
@@ -187,200 +130,11 @@ const artifactLinks = computed(() =>
     .filter((artifact) => artifact.url && typeof artifact.relative_path === "string"),
 )
 
-// ── Sub-agent inner conversation (UXI-05) ──
-// Read a sub-agent run's transcript by its live job_id (fallback to its
-// name). The backend's ``can_receive`` says whether the run can be
-// messaged (true for ANY live, still-running sub-agent) — that gates the
-// send box; completed / persisted runs stay read-only. sid/cid come from
-// the scoped chat store (active creature).
 const convOpen = ref(false)
-const convLoading = ref(false)
-const convError = ref("")
-const convMessages = ref([])
-const canReceive = ref(false)
-const sendText = ref("")
-const sending = ref(false)
-// System prompts render collapsed; these track which system / tool blocks
-// are expanded (system by convBlocks index, tools by tool_call id).
-const expandedSystem = ref(new Set())
-const convToolExpanded = ref(new Set())
-
-// ── OpenAI-shape → main-chat block model (UXI-05) ──
-// The read route returns ``{role, content: str|parts, tool_calls?, name?,
-// tool_call_id?}``. We render it with the SAME idiom as the main chat:
-// user/assistant bubbles (markdown) and each assistant tool_call paired
-// with its ``tool`` result (by tool_call_id) into a ``ToolCallBlock``
-// accordion — exactly the shape ``ChatMessage`` feeds its tool blocks.
-function msgText(m) {
-  if (typeof m?.content === "string") return m.content
-  if (Array.isArray(m?.content)) {
-    return m.content
-      .filter((p) => p?.type === "text")
-      .map((p) => p.text || "")
-      .join("\n")
-  }
-  return ""
-}
-
-function msgParts(m) {
-  return Array.isArray(m?.content) ? m.content : null
-}
-
-function toolText(m) {
-  return typeof m?.content === "string" ? m.content : msgText(m)
-}
-
-function _parseArgs(raw) {
-  if (!raw) return {}
-  if (typeof raw !== "string") return raw
-  try {
-    return JSON.parse(raw)
-  } catch {
-    return { raw }
-  }
-}
-
-const convBlocks = computed(() => {
-  const msgs = convMessages.value
-  const resultById = {}
-  for (const m of msgs) {
-    if (m?.role === "tool" && m.tool_call_id != null) resultById[m.tool_call_id] = toolText(m)
-  }
-  const items = []
-  msgs.forEach((m, mi) => {
-    const role = m?.role
-    if (role === "tool") return // folded into the assistant tool_call below
-    if (role === "system") {
-      items.push({ kind: "system", text: msgText(m) })
-      return
-    }
-    if (role === "user") {
-      items.push({ kind: "user", content: msgText(m), parts: msgParts(m) })
-      return
-    }
-    const toolCalls = (m?.tool_calls || []).map((call, ci) => ({
-      type: "tool",
-      id: call.id || `sa_${mi}_${ci}`,
-      name: call.function?.name || "tool",
-      kind: "tool",
-      args: _parseArgs(call.function?.arguments),
-      status: "done",
-      result: call.id != null ? resultById[call.id] || "" : "",
-      children: [],
-    }))
-    items.push({ kind: "assistant", content: msgText(m), parts: msgParts(m), toolCalls })
-  })
-  return items
-})
-
-function toggleConvTool(id) {
-  const s = new Set(convToolExpanded.value)
-  if (s.has(id)) s.delete(id)
-  else s.add(id)
-  convToolExpanded.value = s
-}
-
-function toggleSystem(i) {
-  const s = new Set(expandedSystem.value)
-  if (s.has(i)) s.delete(i)
-  else s.add(i)
-  expandedSystem.value = s
-}
-
-async function loadConversation({ silent = false } = {}) {
-  const sid = chat._instanceGraphId
-  const cid = chat.activeTab
-  if (!sid || !cid) {
-    convError.value = t("chat.subagent.unavailable")
-    return
-  }
-  // Silent refresh keeps the rendered transcript (and the user's expanded
-  // accordions) in place; only the first load shows the loading state.
-  if (!silent) convLoading.value = true
-  convError.value = ""
-  try {
-    const ident = props.tc.jobId ? { jobId: props.tc.jobId } : { name: props.tc.name }
-    const data = await terrariumAPI.getSubagentConversation(sid, cid, ident)
-    convMessages.value = data.messages || []
-    canReceive.value = !!data.can_receive
-  } catch (err) {
-    if (silent) return // transient poll failure must not wipe the transcript
-    convError.value = err?.response?.data?.detail || t("chat.subagent.unavailable")
-    convMessages.value = []
-    canReceive.value = false
-  } finally {
-    if (!silent) convLoading.value = false
-  }
-}
-
-// Live refresh: while the accordion is open and the run is still live
-// (block streaming or backend can_receive), poll the transcript so new
-// turns appear without re-toggling. Stops when the run settles or the
-// accordion closes; a status flip to terminal triggers one final load.
-const CONV_POLL_MS = 1500
-let convTimer = null
-
-function _convIsLive() {
-  return props.tc.status === "running" || canReceive.value
-}
-
-function _stopConvPolling() {
-  if (convTimer) {
-    clearInterval(convTimer)
-    convTimer = null
-  }
-}
-
-function _startConvPolling() {
-  if (convTimer) return
-  convTimer = setInterval(() => {
-    if (!convOpen.value || !_convIsLive()) {
-      _stopConvPolling()
-      return
-    }
-    if (!convLoading.value && !sending.value) loadConversation({ silent: true })
-  }, CONV_POLL_MS)
-}
-
-watch(convOpen, (open) => {
-  if (open) _startConvPolling()
-  else _stopConvPolling()
-})
-
-watch(
-  () => props.tc.status,
-  (status, prev) => {
-    if (!convOpen.value) return
-    if (prev === "running" && status !== "running") loadConversation({ silent: true })
-    else if (status === "running") _startConvPolling()
-  },
-)
-
-onUnmounted(_stopConvPolling)
-
+const conversationLive = computed(() => !String(chat._instanceId || "").startsWith("session:"))
+const conversationSessionId = computed(() => (conversationLive.value ? chat._instanceGraphId || "" : String(chat._instanceId || "").slice("session:".length)))
 function toggleConversation() {
   convOpen.value = !convOpen.value
-  if (convOpen.value && !convMessages.value.length && !convLoading.value) loadConversation()
-}
-
-async function submitSend() {
-  const text = sendText.value.trim()
-  if (!text || sending.value) return
-  const sid = chat._instanceGraphId
-  const cid = chat.activeTab
-  if (!sid || !cid) return
-  sending.value = true
-  convError.value = ""
-  try {
-    // Pass job_id so the backend targets THIS live run precisely.
-    await terrariumAPI.sendSubagentMessage(sid, cid, props.tc.name, text, props.tc.jobId)
-    sendText.value = ""
-    await loadConversation()
-  } catch (err) {
-    convError.value = err?.response?.data?.detail || t("chat.subagent.sendFailed")
-  } finally {
-    sending.value = false
-  }
 }
 
 // Track expanded state for child tool blocks

--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.pagination.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.pagination.test.js
@@ -59,7 +59,9 @@ vi.mock("@/utils/i18n", () => ({
 }))
 
 import TraceTab from "./TraceTab.vue"
+import TraceEventDetail from "@/components/sessions/trace/TraceEventDetail.vue"
 import TraceTimeline from "@/components/sessions/trace/TraceTimeline.vue"
+import SubagentConversationPanel from "@/components/subagents/SubagentConversationPanel.vue"
 
 beforeEach(() => {
   state.detail = reactive({
@@ -105,6 +107,36 @@ beforeEach(() => {
 })
 
 describe("TraceTab long-session navigation", () => {
+  it("opens a sub-agent conversation without changing the trace agent", async () => {
+    const wrapper = shallowMount(TraceTab, {
+      global: { stubs: { "el-drawer": { template: "<div><slot /></div>" } } },
+    })
+    await flushPromises()
+
+    const filtersBefore = state.rollup.agent
+    const loadCallsBefore = state.rollup.load.mock.calls.length
+    wrapper.findComponent(TraceEventDetail).vm.$emit("open-conversation", {
+      jobId: "agent_explore_11111111",
+      name: "explore",
+      run: 2,
+      parent: "alice",
+    })
+    await flushPromises()
+
+    const panel = wrapper.findComponent(SubagentConversationPanel)
+    expect(panel.exists()).toBe(true)
+    expect(panel.props()).toMatchObject({
+      sessionId: "session-a",
+      parent: "alice",
+      jobId: "agent_explore_11111111",
+      name: "explore",
+      run: 2,
+      live: false,
+    })
+    expect(state.rollup.agent).toBe(filtersBefore)
+    expect(state.rollup.load).toHaveBeenCalledTimes(loadCallsBefore)
+  })
+
   it("resolves a missing turn before routing to a selected timeline span", async () => {
     const wrapper = shallowMount(TraceTab)
     await flushPromises()

--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.pagination.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.pagination.test.js
@@ -69,6 +69,8 @@ beforeEach(() => {
     agents: ["alice"],
     reloadKey: 0,
     summary: { error_turns: [] },
+    meta: null,
+    live: false,
   })
   state.rollup = reactive({
     sessionName: "session-a",
@@ -135,6 +137,30 @@ describe("TraceTab long-session navigation", () => {
     })
     expect(state.rollup.agent).toBe(filtersBefore)
     expect(state.rollup.load).toHaveBeenCalledTimes(loadCallsBefore)
+  })
+
+  it("uses the runtime graph scope for a store-backed conversation in a live Inspector", async () => {
+    state.detail.live = true
+    state.detail.meta = { session_id: "creature-123" }
+    state.detail.name = "graph-456"
+    const wrapper = shallowMount(TraceTab, {
+      global: { stubs: { "el-drawer": { template: "<div><slot /></div>" } } },
+    })
+    await flushPromises()
+
+    wrapper.findComponent(TraceEventDetail).vm.$emit("open-conversation", {
+      jobId: "agent_explore_11111111",
+      name: "explore",
+      run: 2,
+      parent: "alice",
+    })
+    await flushPromises()
+
+    expect(wrapper.findComponent(SubagentConversationPanel).props()).toMatchObject({
+      sessionId: "graph-456",
+      parent: "alice",
+      live: false,
+    })
   })
 
   it("resolves a missing turn before routing to a selected timeline span", async () => {

--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.pagination.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.pagination.test.js
@@ -160,7 +160,36 @@ describe("TraceTab long-session navigation", () => {
       sessionId: "graph-456",
       parent: "alice",
       live: false,
+      fill: true,
+      showBack: true,
     })
+
+    wrapper.findComponent(SubagentConversationPanel).vm.$emit("back")
+    await flushPromises()
+
+    expect(wrapper.findComponent(SubagentConversationPanel).exists()).toBe(false)
+    expect(wrapper.findComponent(TraceEventDetail).exists()).toBe(true)
+  })
+
+  it("feeds terminal completion ids from turn rollup breakdowns to the detail pane", async () => {
+    state.rollup.turns = [
+      {
+        turn_index: 1001,
+        subagent_breakdown: [
+          { job_id: "agent_explore_11111111", has_error: false },
+          { job_id: "", has_error: false },
+        ],
+      },
+      { turn_index: 1002 },
+    ]
+    const wrapper = shallowMount(TraceTab, {
+      global: { stubs: { "el-drawer": { template: "<div><slot /></div>" } } },
+    })
+    await flushPromises()
+
+    expect(wrapper.findComponent(TraceEventDetail).props("completedJobIds")).toEqual([
+      "agent_explore_11111111",
+    ])
   })
 
   it("resolves a missing turn before routing to a selected timeline span", async () => {

--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
@@ -40,7 +40,8 @@
 
     <!-- Event detail drawer -->
     <el-drawer v-model="detailOpen" :title="t('sessionViewer.detail.title')" direction="rtl" size="40%" :modal="false" :destroy-on-close="false">
-      <TraceEventDetail :event="selectedEvent" @open-agent="onOpenSubagent" />
+      <SubagentConversationPanel v-if="conversationRef" :session-id="conversationSessionId" :parent="conversationRef.parent" :job-id="conversationRef.jobId" :name="conversationRef.name" :run="conversationRef.run" :live="detail.live" />
+      <TraceEventDetail v-else :event="selectedEvent" :parent-agent="rollup.agent || filters.agent" @open-conversation="onOpenSubagent" />
     </el-drawer>
   </div>
 </template>
@@ -51,6 +52,7 @@ import { computed, nextTick, ref, watch } from "vue"
 import { useRoute, useRouter } from "vue-router"
 
 import TraceEventDetail from "@/components/sessions/trace/TraceEventDetail.vue"
+import SubagentConversationPanel from "@/components/subagents/SubagentConversationPanel.vue"
 import TraceTab_TraceFilters from "@/components/sessions/trace/TraceFilters.vue"
 import TraceTab_TraceTimeline from "@/components/sessions/trace/TraceTimeline.vue"
 import TraceTab_TraceTurnGroup from "@/components/sessions/trace/TraceTurnGroup.vue"
@@ -111,21 +113,20 @@ const zeroMatchTurns = ref(new Set())
 
 // Event-detail panel state.
 const selectedEvent = ref(null)
+const conversationRef = ref(null)
 const detailOpen = ref(false)
+const conversationSessionId = computed(() => (detail.live ? detail.meta?.session_id || detail.name : detail.name))
 const selectedEventId = computed(() => (selectedEvent.value && typeof selectedEvent.value.event_id === "number" ? selectedEvent.value.event_id : null))
 
 function onSelectEvent(ev) {
   selectedEvent.value = ev
+  conversationRef.value = null
   detailOpen.value = true
 }
 
-function onOpenSubagent(namespace) {
-  if (!namespace) return
-  // Switch the agent filter — this re-fetches turns + events for the
-  // sub-agent's namespace. Close the drawer so the user can see the
-  // new trace; selectedEvent is preserved in case they reopen.
-  filters.value = { ...filters.value, agent: namespace }
-  detailOpen.value = false
+function onOpenSubagent(reference) {
+  if (!reference) return
+  conversationRef.value = reference
 }
 
 const agents = computed(() => detail.agents || [])

--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
@@ -40,7 +40,7 @@
 
     <!-- Event detail drawer -->
     <el-drawer v-model="detailOpen" :title="t('sessionViewer.detail.title')" direction="rtl" size="40%" :modal="false" :destroy-on-close="false">
-      <SubagentConversationPanel v-if="conversationRef" :session-id="conversationSessionId" :parent="conversationRef.parent" :job-id="conversationRef.jobId" :name="conversationRef.name" :run="conversationRef.run" :live="detail.live" />
+      <SubagentConversationPanel v-if="conversationRef" :session-id="conversationSessionId" :parent="conversationRef.parent" :job-id="conversationRef.jobId" :name="conversationRef.name" :run="conversationRef.run" :live="false" />
       <TraceEventDetail v-else :event="selectedEvent" :parent-agent="rollup.agent || filters.agent" @open-conversation="onOpenSubagent" />
     </el-drawer>
   </div>
@@ -115,7 +115,7 @@ const zeroMatchTurns = ref(new Set())
 const selectedEvent = ref(null)
 const conversationRef = ref(null)
 const detailOpen = ref(false)
-const conversationSessionId = computed(() => (detail.live ? detail.meta?.session_id || detail.name : detail.name))
+const conversationSessionId = computed(() => detail.name)
 const selectedEventId = computed(() => (selectedEvent.value && typeof selectedEvent.value.event_id === "number" ? selectedEvent.value.event_id : null))
 
 function onSelectEvent(ev) {

--- a/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/tabs/TraceTab.vue
@@ -40,8 +40,10 @@
 
     <!-- Event detail drawer -->
     <el-drawer v-model="detailOpen" :title="t('sessionViewer.detail.title')" direction="rtl" size="40%" :modal="false" :destroy-on-close="false">
-      <SubagentConversationPanel v-if="conversationRef" :session-id="conversationSessionId" :parent="conversationRef.parent" :job-id="conversationRef.jobId" :name="conversationRef.name" :run="conversationRef.run" :live="false" />
-      <TraceEventDetail v-else :event="selectedEvent" :parent-agent="rollup.agent || filters.agent" @open-conversation="onOpenSubagent" />
+      <div class="h-full min-h-0 flex flex-col">
+        <SubagentConversationPanel v-if="conversationRef" :session-id="conversationSessionId" :parent="conversationRef.parent" :job-id="conversationRef.jobId" :name="conversationRef.name" :run="conversationRef.run" :live="false" fill show-back @back="onCloseConversation" />
+        <TraceEventDetail v-else :event="selectedEvent" :parent-agent="rollup.agent || filters.agent" :completed-job-ids="completedJobIds" @open-conversation="onOpenSubagent" />
+      </div>
     </el-drawer>
   </div>
 </template>
@@ -128,6 +130,25 @@ function onOpenSubagent(reference) {
   if (!reference) return
   conversationRef.value = reference
 }
+
+function onCloseConversation() {
+  conversationRef.value = null
+}
+
+// Jobs with a persisted terminal outcome anywhere in the session.
+// Rollup ``subagent_breakdown`` rows are written only once a run
+// finished (managed or synthetic), covering every turn without
+// requiring any turn to be expanded client-side.
+const completedJobIds = computed(() => {
+  const ids = []
+  for (const turn of rollup.turns || []) {
+    for (const row of turn.subagent_breakdown || []) {
+      const jobId = row?.job_id
+      if (jobId && !ids.includes(jobId)) ids.push(jobId)
+    }
+  }
+  return ids
+})
 
 const agents = computed(() => detail.agents || [])
 

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.test.js
@@ -1,0 +1,26 @@
+import { mount } from "@vue/test-utils"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("vue-router", () => ({ useRoute: () => ({ params: { name: "saved" } }) }))
+vi.mock("@/utils/i18n", () => ({ useI18n: () => ({ t: (key) => key }) }))
+
+import TraceEventDetail from "./TraceEventDetail.vue"
+
+describe("TraceEventDetail sub-agent conversation navigation", () => {
+  it("emits the persisted conversation reference with its parent agent", async () => {
+    const wrapper = mount(TraceEventDetail, {
+      props: {
+        parentAgent: "root",
+        event: { type: "subagent_result", job_id: "j1", subagent_name: "research", run: 3 },
+      },
+    })
+    const button = wrapper
+      .findAll("button")
+      .find((item) => item.text().includes("openSubagentConversation"))
+    expect(button.text().toLowerCase()).not.toContain("trace")
+    await button.trigger("click")
+    expect(wrapper.emitted("open-conversation")).toEqual([
+      [expect.objectContaining({ jobId: "j1", name: "research", run: 3, parent: "root" })],
+    ])
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.test.js
@@ -7,16 +7,36 @@ vi.mock("@/utils/i18n", () => ({ useI18n: () => ({ t: (key) => key }) }))
 import TraceEventDetail from "./TraceEventDetail.vue"
 
 describe("TraceEventDetail sub-agent conversation navigation", () => {
-  it("does not offer an Inspector conversation for a running call event", () => {
+  it("renders a disabled conversation entry for an unfinished call event", async () => {
     const wrapper = mount(TraceEventDetail, {
       props: {
         parentAgent: "root",
         event: { type: "subagent_call", job_id: "j1", name: "research" },
       },
     })
-    expect(
-      wrapper.findAll("button").some((item) => item.text().includes("openSubagentConversation")),
-    ).toBe(false)
+    const button = wrapper.find("[data-test='subagent-open-conversation']")
+    expect(button.exists()).toBe(true)
+    expect(button.attributes("disabled")).toBeDefined()
+    expect(button.attributes("title")).toBe("sessionViewer.detail.conversationPending")
+    await button.trigger("click")
+    expect(wrapper.emitted("open-conversation")).toBeUndefined()
+  })
+
+  it("enables the entry for any sub-agent event whose job already finished", async () => {
+    const wrapper = mount(TraceEventDetail, {
+      props: {
+        parentAgent: "root",
+        completedJobIds: ["j1"],
+        event: { type: "subagent_tool", job_id: "j1", name: "research" },
+      },
+    })
+    const button = wrapper.find("[data-test='subagent-open-conversation']")
+    expect(button.attributes("disabled")).toBeUndefined()
+    await button.trigger("click")
+    expect(wrapper.emitted("open-conversation")).toEqual([
+      [expect.objectContaining({ jobId: "j1", name: "research" })],
+    ])
+    expect(wrapper.emitted("open-conversation")[0][0].ready).toBe(true)
   })
 
   it("emits the persisted conversation reference with its parent agent", async () => {

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.test.js
@@ -7,6 +7,18 @@ vi.mock("@/utils/i18n", () => ({ useI18n: () => ({ t: (key) => key }) }))
 import TraceEventDetail from "./TraceEventDetail.vue"
 
 describe("TraceEventDetail sub-agent conversation navigation", () => {
+  it("does not offer an Inspector conversation for a running call event", () => {
+    const wrapper = mount(TraceEventDetail, {
+      props: {
+        parentAgent: "root",
+        event: { type: "subagent_call", job_id: "j1", name: "research" },
+      },
+    })
+    expect(
+      wrapper.findAll("button").some((item) => item.text().includes("openSubagentConversation")),
+    ).toBe(false)
+  })
+
   it("emits the persisted conversation reference with its parent agent", async () => {
     const wrapper = mount(TraceEventDetail, {
       props: {

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.vue
@@ -21,7 +21,7 @@
         <div class="text-[11px] text-warm-400 uppercase tracking-wider">{{ t("sessionViewer.tree.attached") }}</div>
         <div class="font-mono text-warm-700 dark:text-warm-300 truncate">{{ subagentRef.label }}</div>
       </div>
-      <button class="text-[11px] px-2 py-1 rounded border border-iolite/40 text-iolite hover:bg-iolite/10" @click="$emit('open-conversation', subagentRef)">{{ t("sessionViewer.detail.openSubagentConversation") }}</button>
+      <button :disabled="!subagentRef.ready" data-test="subagent-open-conversation" :title="subagentRef.ready ? '' : t('sessionViewer.detail.conversationPending')" class="text-[11px] px-2 py-1 rounded border border-iolite/40 text-iolite hover:bg-iolite/10 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent shrink-0" @click="subagentRef.ready && $emit('open-conversation', subagentRef)">{{ t("sessionViewer.detail.openSubagentConversation") }}</button>
     </div>
 
     <!-- Primary content (text-y fields) -->
@@ -88,6 +88,7 @@ const route = useRoute()
 const props = defineProps({
   event: { type: Object, default: null },
   parentAgent: { type: String, default: "" },
+  completedJobIds: { type: Array, default: () => [] },
 })
 defineEmits(["open-conversation"])
 
@@ -194,13 +195,16 @@ const tokens = computed(() => {
 const subagentRef = computed(() => {
   const e = props.event
   if (!e) return null
-  const isTerminal = ["subagent_result", "subagent_error"].includes(String(e.type || ""))
-  if (!isTerminal) return null
+  const type = String(e.type || "")
+  if (!type.startsWith("subagent_")) return null
   const name = e.name || e.subagent_name || ""
-  const run = e.run ?? e.subagent_run ?? null
   if (!name) return null
+  const jobId = e.job_id || ""
+  const isTerminalHere = type === "subagent_result" || type === "subagent_error"
+  const done = isTerminalHere || (Boolean(jobId) && props.completedJobIds.includes(jobId))
+  const run = e.run ?? e.subagent_run ?? null
   const label = run != null ? `${name} (run ${run})` : String(name)
-  return { jobId: e.job_id || "", name, run, parent: props.parentAgent, label }
+  return { jobId, name, run, parent: props.parentAgent, label, ready: Boolean(done) }
 })
 
 const reasoningSegments = computed(() => {

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.vue
@@ -194,8 +194,8 @@ const tokens = computed(() => {
 const subagentRef = computed(() => {
   const e = props.event
   if (!e) return null
-  const isSub = String(e.type || "").startsWith("subagent_")
-  if (!isSub) return null
+  const isTerminal = ["subagent_result", "subagent_error"].includes(String(e.type || ""))
+  if (!isTerminal) return null
   const name = e.name || e.subagent_name || ""
   const run = e.run ?? e.subagent_run ?? null
   if (!name) return null

--- a/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/trace/TraceEventDetail.vue
@@ -21,7 +21,7 @@
         <div class="text-[11px] text-warm-400 uppercase tracking-wider">{{ t("sessionViewer.tree.attached") }}</div>
         <div class="font-mono text-warm-700 dark:text-warm-300 truncate">{{ subagentRef.label }}</div>
       </div>
-      <button v-if="subagentRef.namespace" class="text-[11px] px-2 py-1 rounded border border-iolite/40 text-iolite hover:bg-iolite/10" @click="$emit('open-agent', subagentRef.namespace)">{{ t("sessionViewer.detail.openSubagent") }}</button>
+      <button class="text-[11px] px-2 py-1 rounded border border-iolite/40 text-iolite hover:bg-iolite/10" @click="$emit('open-conversation', subagentRef)">{{ t("sessionViewer.detail.openSubagentConversation") }}</button>
     </div>
 
     <!-- Primary content (text-y fields) -->
@@ -87,8 +87,9 @@ const route = useRoute()
 
 const props = defineProps({
   event: { type: Object, default: null },
+  parentAgent: { type: String, default: "" },
 })
-defineEmits(["open-agent"])
+defineEmits(["open-conversation"])
 
 const TYPE_TONE = {
   tool_call: "text-warm-700 dark:text-warm-300",
@@ -195,18 +196,11 @@ const subagentRef = computed(() => {
   if (!e) return null
   const isSub = String(e.type || "").startsWith("subagent_")
   if (!isSub) return null
-  // Best-effort namespace recovery — backend writes nested-agent
-  // namespaces under ``<host>:<name>:<run>:e<seq>`` in the events
-  // table. We have parts of that here but not always; offer the
-  // navigate button only when we can construct the param.
   const name = e.name || e.subagent_name || ""
   const run = e.run ?? e.subagent_run ?? null
   if (!name) return null
   const label = run != null ? `${name} (run ${run})` : String(name)
-  // Namespace is best-effort; the trace tab agent filter accepts any
-  // string from /tree's attached-agent list.
-  const namespace = e.namespace || (run != null ? `${name}:${run}` : name)
-  return { label, namespace }
+  return { jobId: e.job_id || "", name, run, parent: props.parentAgent, label }
 })
 
 const reasoningSegments = computed(() => {

--- a/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.test.js
@@ -1,5 +1,5 @@
 import { flushPromises, mount } from "@vue/test-utils"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import SubagentConversationPanel from "./SubagentConversationPanel.vue"
 import { sessionAPI } from "@/utils/api"
@@ -7,6 +7,12 @@ import { sessionAPI } from "@/utils/api"
 vi.mock("@/utils/i18n", () => ({ useI18n: () => ({ t: (key) => key }) }))
 
 describe("SubagentConversationPanel ambiguity selector", () => {
+  beforeEach(() => {
+    // Individual tests also restore locally; this guards against an
+    // aborted test leaking once-queues into later mounts.
+    vi.restoreAllMocks()
+  })
+
   it("lists ambiguous candidates and opens the selected exact run", async () => {
     const conflict = Object.assign(new Error("ambiguous"), {
       response: { status: 409, data: { detail: "multiple legacy runs" } },
@@ -18,6 +24,11 @@ describe("SubagentConversationPanel ambiguity selector", () => {
         live: false,
         can_receive: false,
         messages: [{ role: "assistant", content: "selected answer" }],
+      })
+      .mockResolvedValue({
+        live: false,
+        can_receive: false,
+        messages: [{ role: "assistant", content: "first answer full" }],
       })
     const list = vi.spyOn(sessionAPI, "listSubagents").mockResolvedValue({
       runs: [
@@ -81,6 +92,182 @@ describe("SubagentConversationPanel ambiguity selector", () => {
     })
     expect(wrapper.text()).toContain("selected answer")
     expect(wrapper.find("textarea").exists()).toBe(false)
+
+    await wrapper.find("[data-test='subagent-back-to-runs']").trigger("click")
+    await flushPromises()
+    expect(wrapper.text()).toContain("first task")
+    expect(wrapper.text()).not.toContain("selected answer")
+
+    await wrapper.find("[data-test='subagent-run-0']").trigger("click")
+    await flushPromises()
+    expect(getConversation).toHaveBeenLastCalledWith("session-a", {
+      parent: "old-parent",
+      name: "explore",
+      run: 0,
+    })
+    expect(wrapper.text()).toContain("first answer full")
+
+    getConversation.mockRestore()
+    list.mockRestore()
+  })
+
+  it("supports drawer-level back navigation and full-height layout", async () => {
+    vi.spyOn(sessionAPI, "getSubagentConversation").mockResolvedValue({
+      live: false,
+      can_receive: false,
+      messages: [{ role: "assistant", content: "direct answer" }],
+    })
+
+    const wrapper = mount(SubagentConversationPanel, {
+      props: {
+        sessionId: "session-a",
+        parent: "root",
+        jobId: "agent_explore_11111111",
+        name: "explore",
+        live: false,
+        fill: true,
+        showBack: true,
+      },
+      global: { stubs: { MarkdownRenderer: true, ToolCallBlock: true } },
+    })
+    await flushPromises()
+
+    const root = wrapper.find("div.rounded")
+    expect(root.classes()).toContain("h-full")
+    const list = wrapper.find("[data-test='subagent-messages']")
+    expect(list.classes()).toContain("flex-1")
+    expect(list.classes()).not.toContain("max-h-72")
+
+    const outer = wrapper.find("[data-test='subagent-back']")
+    await outer.trigger("click")
+    expect(wrapper.emitted("back")).toHaveLength(1)
+
+    // No ambiguity list was ever fetched, so no inner back link appears.
+    expect(wrapper.find("[data-test='subagent-back-to-runs']").exists()).toBe(false)
+    vi.restoreAllMocks()
+  })
+
+  it("drops stale target responses after switching sub-agent targets", async () => {
+    let resolveStale
+    const staleLoad = new Promise((resolve) => {
+      resolveStale = resolve
+    })
+    const getConversation = vi
+      .spyOn(sessionAPI, "getSubagentConversation")
+      .mockImplementationOnce(() => staleLoad)
+      .mockResolvedValueOnce({
+        live: false,
+        can_receive: false,
+        messages: [{ role: "assistant", content: "target-b transcript" }],
+      })
+
+    const wrapper = mount(SubagentConversationPanel, {
+      props: {
+        sessionId: "session-a",
+        parent: "root",
+        jobId: "job-a",
+        name: "explore",
+        live: false,
+      },
+      global: {
+        stubs: {
+          MarkdownRenderer: { props: ["content"], template: "<span>{{ content }}</span>" },
+          ToolCallBlock: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    await wrapper.setProps({ jobId: "job-b" })
+    await flushPromises()
+    expect(wrapper.text()).toContain("target-b transcript")
+
+    resolveStale({
+      live: false,
+      can_receive: false,
+      messages: [{ role: "assistant", content: "stale-a transcript" }],
+    })
+    await flushPromises()
+    expect(wrapper.text()).not.toContain("stale-a transcript")
+    expect(wrapper.text()).toContain("target-b transcript")
+
+    wrapper.unmount()
+    vi.restoreAllMocks()
+  })
+
+  it("disables selector entries while a selection is in flight and resets expansion state", async () => {
+    let resolveFirst
+    const firstPick = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+    const conflict = Object.assign(new Error("ambiguous"), {
+      response: { status: 409, data: { detail: "multiple legacy runs" } },
+    })
+    const getConversation = vi
+      .spyOn(sessionAPI, "getSubagentConversation")
+      .mockRejectedValueOnce(conflict)
+      .mockImplementationOnce(() => firstPick)
+      .mockResolvedValueOnce({
+        live: false,
+        can_receive: false,
+        messages: [
+          { role: "system", content: "system prompt for run two" },
+          { role: "assistant", content: "run two answer" },
+        ],
+      })
+    const list = vi.spyOn(sessionAPI, "listSubagents").mockResolvedValue({
+      runs: [
+        { parent: "p", name: "explore", run: 0, task: "t0", job_id: null },
+        { parent: "p", name: "explore", run: 1, task: "t1", job_id: null },
+      ],
+    })
+
+    const wrapper = mount(SubagentConversationPanel, {
+      props: {
+        sessionId: "session-a",
+        parent: "root",
+        jobId: "agent_explore_11111111",
+        name: "explore",
+        live: false,
+      },
+      global: { stubs: { MarkdownRenderer: true, ToolCallBlock: true } },
+    })
+    await flushPromises()
+
+    await wrapper.find("[data-test='subagent-run-0']").trigger("click")
+    expect(wrapper.find("[data-test='subagent-run-0']").attributes("disabled")).toBeDefined()
+
+    resolveFirst({
+      live: false,
+      can_receive: false,
+      messages: [
+        { role: "system", content: "system prompt for run one" },
+        { role: "assistant", content: "run one answer" },
+      ],
+    })
+    await flushPromises()
+
+    const systemToggle = wrapper.findAll("button").find((b) => b.text().includes("system"))
+    await systemToggle.trigger("click")
+    expect(wrapper.text()).toContain("system prompt for run one")
+
+    await wrapper.find("[data-test='subagent-back-to-runs']").trigger("click")
+    await flushPromises()
+    await wrapper.find("[data-test='subagent-run-1']").trigger("click")
+    await flushPromises()
+
+    expect(getConversation).toHaveBeenLastCalledWith("session-a", {
+      parent: "p",
+      name: "explore",
+      run: 1,
+    })
+    expect(wrapper.text()).not.toContain("run one answer")
+    // Expansion state was reset for the newly selected transcript: its
+    // own system prompt exists but stays collapsed until toggled.
+    expect(wrapper.text()).not.toContain("system prompt for run two")
+    const nextToggle = wrapper.findAll("button").find((b) => b.text().includes("system"))
+    await nextToggle.trigger("click")
+    expect(wrapper.text()).toContain("system prompt for run two")
 
     getConversation.mockRestore()
     list.mockRestore()

--- a/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.test.js
@@ -1,0 +1,122 @@
+import { flushPromises, mount } from "@vue/test-utils"
+import { describe, expect, it, vi } from "vitest"
+
+import SubagentConversationPanel from "./SubagentConversationPanel.vue"
+import { sessionAPI } from "@/utils/api"
+
+vi.mock("@/utils/i18n", () => ({ useI18n: () => ({ t: (key) => key }) }))
+
+describe("SubagentConversationPanel ambiguity selector", () => {
+  it("lists ambiguous candidates and opens the selected exact run", async () => {
+    const conflict = Object.assign(new Error("ambiguous"), {
+      response: { status: 409, data: { detail: "multiple legacy runs" } },
+    })
+    const getConversation = vi
+      .spyOn(sessionAPI, "getSubagentConversation")
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce({
+        live: false,
+        can_receive: false,
+        messages: [{ role: "assistant", content: "selected answer" }],
+      })
+    const list = vi.spyOn(sessionAPI, "listSubagents").mockResolvedValue({
+      runs: [
+        {
+          parent: "old-parent",
+          name: "explore",
+          run: 0,
+          job_id: null,
+          task: "first task",
+          success: true,
+          ts: 100,
+          output_preview: "first answer",
+          source: "session_output",
+        },
+        {
+          parent: "renamed-parent",
+          name: "explore",
+          run: 1,
+          job_id: null,
+          task: "second task",
+          success: false,
+          ts: 200,
+          output_preview: "second answer",
+          source: "managed",
+        },
+      ],
+    })
+
+    const wrapper = mount(SubagentConversationPanel, {
+      props: {
+        sessionId: "session-a",
+        parent: "current-parent",
+        jobId: "agent_explore_11111111",
+        name: "explore",
+        live: false,
+      },
+      global: {
+        stubs: {
+          MarkdownRenderer: { props: ["content"], template: "<div>{{ content }}</div>" },
+          ToolCallBlock: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(list).toHaveBeenCalledWith("session-a", {
+      parent: "current-parent",
+      jobId: "agent_explore_11111111",
+      name: "explore",
+    })
+    expect(wrapper.text()).toContain("first task")
+    expect(wrapper.text()).toContain("second task")
+
+    await wrapper.find("[data-test='subagent-run-1']").trigger("click")
+    await flushPromises()
+
+    expect(getConversation).toHaveBeenLastCalledWith("session-a", {
+      parent: "renamed-parent",
+      name: "explore",
+      run: 1,
+    })
+    expect(wrapper.text()).toContain("selected answer")
+    expect(wrapper.find("textarea").exists()).toBe(false)
+
+    getConversation.mockRestore()
+    list.mockRestore()
+  })
+
+  it("keeps cross-member ambiguity fail-closed", async () => {
+    const conflict = Object.assign(new Error("ambiguous"), {
+      response: { status: 409, data: { detail: "ambiguous across members" } },
+    })
+    vi.spyOn(sessionAPI, "getSubagentConversation").mockRejectedValueOnce(conflict)
+    vi.spyOn(sessionAPI, "listSubagents").mockResolvedValue({
+      runs: [
+        {
+          member_sid: "member-a",
+          parent: "root",
+          name: "explore",
+          run: 0,
+          task: "remote candidate",
+        },
+      ],
+    })
+
+    const wrapper = mount(SubagentConversationPanel, {
+      props: {
+        sessionId: "cluster-a",
+        parent: "root",
+        jobId: "agent_explore_11111111",
+        name: "explore",
+        live: false,
+      },
+      global: { stubs: { MarkdownRenderer: true, ToolCallBlock: true } },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain("ambiguous across members")
+    expect(wrapper.find("[data-test='subagent-run-0']").exists()).toBe(false)
+    vi.restoreAllMocks()
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="rounded overflow-hidden bg-taaffeite/6 dark:bg-taaffeite/10 border border-taaffeite/20 dark:border-taaffeite/25 flex flex-col gap-2 p-2 min-w-0">
-    <div v-if="loading" class="text-[11px] text-warm-400">{{ t("common.loading") }}</div>
-    <div v-else-if="candidates.length" class="flex flex-col gap-2">
+  <div :class="['rounded overflow-hidden bg-taaffeite/6 dark:bg-taaffeite/10 border border-taaffeite/20 dark:border-taaffeite/25 flex flex-col gap-2 p-2 min-w-0', fill ? 'h-full min-h-0' : '']">
+    <div v-if="showBack" class="shrink-0">
+      <button data-test="subagent-back" class="text-[11px] text-warm-500 hover:text-warm-700 dark:hover:text-warm-300" @click="$emit('back')">← {{ t("common.back") }}</button>
+    </div>
+    <div v-if="stage === 'selector' && candidates.length" :class="['flex flex-col gap-2', fill ? 'flex-1 min-h-0 overflow-y-auto' : '']">
       <div class="text-[11px] text-warm-500">{{ t("chat.subagent.chooseRun") }}</div>
-      <button v-for="candidate in candidates" :key="`${candidate.member_sid || ''}:${candidate.parent}:${candidate.name}:${candidate.run}`" type="button" :data-test="`subagent-run-${candidate.run}`" class="rounded border border-iolite/20 bg-iolite/5 p-2 text-left hover:bg-iolite/10" @click.stop="selectCandidate(candidate)">
+      <button v-for="candidate in candidates" :key="`${candidate.member_sid || ''}:${candidate.parent}:${candidate.name}:${candidate.run}`" type="button" :disabled="loading" :data-test="`subagent-run-${candidate.run}`" class="rounded border border-iolite/20 bg-iolite/5 p-2 text-left hover:bg-iolite/10 disabled:opacity-50 disabled:cursor-not-allowed" @click.stop="selectCandidate(candidate)">
         <div class="flex items-center gap-2 text-[10px] font-mono text-warm-500">
           <span>{{ candidate.parent }} / {{ candidate.name }} / run {{ candidate.run }}</span>
           <span v-if="candidate.success === true" class="text-sage">success</span>
@@ -15,9 +17,14 @@
         <div v-if="candidate.ts" class="mt-1 text-[9px] text-warm-400">{{ formatTimestamp(candidate.ts) }}</div>
       </button>
     </div>
+    <div v-else-if="loading && !blocks.length" class="text-[11px] text-warm-400">{{ t("common.loading") }}</div>
+    <div v-else-if="stage === 'selector'" class="text-[11px] text-warm-400 italic">{{ t("chat.subagent.empty") }}</div>
     <div v-else-if="error" class="text-[11px] text-coral">{{ error }}</div>
     <template v-else>
-      <div class="max-h-72 overflow-y-auto flex flex-col gap-2 min-w-0">
+      <div v-if="selectorAvailable" class="shrink-0">
+        <button data-test="subagent-back-to-runs" class="text-[11px] text-iolite hover:underline" @click.stop="backToRuns">← {{ t("chat.subagent.backToRuns") }}</button>
+      </div>
+      <div data-test="subagent-messages" :class="['flex flex-col gap-2 min-w-0', fill ? 'flex-1 min-h-0 overflow-y-auto' : 'max-h-72 overflow-y-auto']">
         <div v-for="(item, i) in blocks" :key="i" class="min-w-0">
           <template v-if="item.kind === 'system'">
             <button class="w-full flex items-center gap-1.5 text-left text-[10px] text-warm-400 hover:text-warm-500" @click.stop="toggleSystem(i)">
@@ -82,7 +89,11 @@ const props = defineProps({
   live: { type: Boolean, default: false },
   status: { type: String, default: "" },
   depth: { type: Number, default: 0 },
+  fill: { type: Boolean, default: false },
+  showBack: { type: Boolean, default: false },
 })
+
+defineEmits(["back"])
 
 const { t } = useI18n()
 const loading = ref(false)
@@ -94,7 +105,25 @@ const sendText = ref("")
 const sending = ref(false)
 const expandedSystem = ref(new Set())
 const expandedTools = ref(new Set())
+const stage = ref("conversation")
+const selectorAvailable = ref(false)
 let timer = null
+// Out-of-order guard: only the newest target/request may mutate state,
+// and nothing may mutate after the panel is destroyed.
+let requestGeneration = 0
+let disposed = false
+
+function backToRuns() {
+  stage.value = "selector"
+  if (!candidates.value.length) {
+    const generation = ++requestGeneration
+    loadCandidates().catch(() => {
+      if (!disposed && generation === requestGeneration) {
+        error.value = t("chat.subagent.unavailable")
+      }
+    })
+  }
+}
 
 function messageText(message) {
   if (typeof message?.content === "string") return message.content
@@ -185,42 +214,56 @@ function formatTimestamp(value) {
 }
 
 async function loadCandidates() {
+  const generation = requestGeneration
   const data = await sessionAPI.listSubagents(props.sessionId, {
     ...(props.parent ? { parent: props.parent } : {}),
     ...(props.jobId ? { jobId: props.jobId } : {}),
     ...(props.name ? { name: props.name } : {}),
   })
+  if (disposed || generation !== requestGeneration) return
   const runs = data.runs || []
   candidates.value = runs.some((candidate) => candidate.member_sid) ? [] : runs
+  if (candidates.value.length) {
+    selectorAvailable.value = true
+    stage.value = "selector"
+  }
 }
 
 async function selectCandidate(candidate) {
+  if (loading.value) return
+  const generation = ++requestGeneration
   loading.value = true
   error.value = ""
+  expandedSystem.value = new Set()
+  expandedTools.value = new Set()
   try {
     const data = await sessionAPI.getSubagentConversation(props.sessionId, {
       parent: candidate.parent,
       name: candidate.name,
       run: candidate.run,
     })
+    if (disposed || generation !== requestGeneration) return
     messages.value = data.messages || []
     canReceive.value = false
-    candidates.value = []
+    stage.value = "conversation"
   } catch (err) {
+    if (disposed || generation !== requestGeneration) return
     error.value = err?.response?.data?.detail || t("chat.subagent.unavailable")
   } finally {
-    loading.value = false
+    if (!disposed && generation === requestGeneration) loading.value = false
   }
 }
 
 async function loadConversation({ silent = false } = {}) {
   if (!props.sessionId || !props.parent) {
-    error.value = t("chat.subagent.unavailable")
+    if (!silent) error.value = t("chat.subagent.unavailable")
     return
   }
+  const generation = requestGeneration
   if (!silent) loading.value = true
   error.value = ""
   candidates.value = []
+  selectorAvailable.value = false
   try {
     const ident = identifier()
     const data = props.live
@@ -229,10 +272,12 @@ async function loadConversation({ silent = false } = {}) {
           parent: props.parent,
           ...ident,
         })
+    if (disposed || generation !== requestGeneration) return
     messages.value = data.messages || []
     canReceive.value = props.live && !!data.can_receive
+    stage.value = "conversation"
   } catch (err) {
-    if (silent) return
+    if (silent || disposed || generation !== requestGeneration) return
     messages.value = []
     canReceive.value = false
     if (!props.live && err?.response?.status === 409) {
@@ -243,9 +288,10 @@ async function loadConversation({ silent = false } = {}) {
         candidates.value = []
       }
     }
+    if (disposed || generation !== requestGeneration) return
     error.value = err?.response?.data?.detail || t("chat.subagent.unavailable")
   } finally {
-    if (!silent) loading.value = false
+    if (!disposed && generation === requestGeneration && !silent) loading.value = false
   }
 }
 
@@ -290,9 +336,28 @@ watch(
   },
 )
 
+watch([() => props.sessionId, () => props.parent, () => props.jobId, () => props.name], () => {
+  stopPolling()
+  requestGeneration += 1
+  messages.value = []
+  candidates.value = []
+  error.value = ""
+  sendText.value = ""
+  selectorAvailable.value = false
+  stage.value = "conversation"
+  expandedSystem.value = new Set()
+  expandedTools.value = new Set()
+  loadConversation().then(() => {
+    if (!disposed) startPolling()
+  })
+})
+
 onMounted(async () => {
   await loadConversation()
-  startPolling()
+  if (!disposed) startPolling()
 })
-onUnmounted(stopPolling)
+onUnmounted(() => {
+  disposed = true
+  stopPolling()
+})
 </script>

--- a/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.vue
@@ -1,0 +1,239 @@
+<template>
+  <div class="rounded overflow-hidden bg-taaffeite/6 dark:bg-taaffeite/10 border border-taaffeite/20 dark:border-taaffeite/25 flex flex-col gap-2 p-2 min-w-0">
+    <div v-if="loading" class="text-[11px] text-warm-400">{{ t("common.loading") }}</div>
+    <div v-else-if="error" class="text-[11px] text-coral">{{ error }}</div>
+    <template v-else>
+      <div class="max-h-72 overflow-y-auto flex flex-col gap-2 min-w-0">
+        <div v-for="(item, i) in blocks" :key="i" class="min-w-0">
+          <template v-if="item.kind === 'system'">
+            <button class="w-full flex items-center gap-1.5 text-left text-[10px] text-warm-400 hover:text-warm-500" @click.stop="toggleSystem(i)">
+              <span class="i-carbon-chevron-right text-[9px] transition-transform shrink-0" :class="{ 'rotate-90': expandedSystem.has(i) }" />
+              <span class="font-mono uppercase">system</span>
+              <span class="italic">prompt ({{ item.text.length }} chars)</span>
+            </button>
+            <pre v-if="expandedSystem.has(i)" class="mt-1 font-mono whitespace-pre-wrap break-all max-h-40 overflow-y-auto bg-warm-100/70 dark:bg-warm-900/50 rounded px-2 py-1 text-[10px] text-warm-500 dark:text-warm-400">{{ item.text }}</pre>
+          </template>
+
+          <div v-else-if="item.kind === 'user'" class="ml-auto max-w-[85%] rounded-lg bg-warm-100 dark:bg-warm-800/80 border border-warm-200/60 dark:border-warm-700/60 px-2.5 py-1.5 min-w-0">
+            <div class="text-[9px] uppercase tracking-wide text-warm-400 mb-0.5">user</div>
+            <div v-if="item.parts" class="flex flex-col gap-1 text-body">
+              <template v-for="(part, pi) in item.parts" :key="pi">
+                <MarkdownRenderer v-if="part.type === 'text' && part.text" :content="part.text" />
+                <img v-else-if="part.type === 'image_url'" :src="part.image_url?.url" class="tool-inline-image" />
+              </template>
+            </div>
+            <div v-else class="text-body"><MarkdownRenderer :content="item.content" /></div>
+          </div>
+
+          <div v-else class="max-w-[92%] min-w-0">
+            <div class="text-[9px] uppercase tracking-wide text-warm-400 mb-0.5">assistant</div>
+            <div v-if="item.parts" class="flex flex-col gap-1 text-body">
+              <template v-for="(part, pi) in item.parts" :key="pi">
+                <MarkdownRenderer v-if="part.type === 'text' && part.text" :content="part.text" />
+                <img v-else-if="part.type === 'image_url'" :src="part.image_url?.url" class="tool-inline-image" />
+              </template>
+            </div>
+            <div v-else-if="item.content" class="text-body"><MarkdownRenderer :content="item.content" /></div>
+            <div v-if="item.toolCalls.length" class="flex flex-col gap-1.5 mt-1.5 min-w-0">
+              <ToolCallBlock v-for="call in item.toolCalls" :key="call.id" :tc="call" :depth="depth + 1" :expanded="expandedTools.has(call.id)" @toggle="toggleTool(call.id)" />
+            </div>
+          </div>
+        </div>
+        <div v-if="!blocks.length" class="text-[11px] text-warm-400 italic">{{ t("chat.subagent.empty") }}</div>
+      </div>
+      <div v-if="canReceive" class="flex items-end gap-2 pt-1 border-t border-taaffeite/15 dark:border-taaffeite/20">
+        <textarea v-model="sendText" rows="1" :placeholder="t('chat.subagent.placeholder')" class="flex-1 min-w-0 resize-none rounded border border-warm-200 dark:border-warm-700 bg-warm-50 dark:bg-warm-950 px-2 py-1 text-[11px] text-warm-800 dark:text-warm-200 placeholder-warm-400 dark:placeholder-warm-500 focus:outline-none focus:border-taaffeite" @keydown.enter.exact.prevent="submitSend" />
+        <button class="text-[11px] px-2 py-1 rounded bg-taaffeite/20 text-taaffeite-shadow dark:text-taaffeite-light hover:bg-taaffeite/30 disabled:opacity-50 shrink-0" :disabled="sending || !sendText.trim()" @click.stop="submitSend">{{ t("chat.subagent.send") }}</button>
+      </div>
+      <div v-else class="text-[10px] text-warm-400 italic">{{ t("chat.subagent.readOnly") }}</div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, defineAsyncComponent, onMounted, onUnmounted, ref, watch } from "vue"
+
+import MarkdownRenderer from "@/components/common/MarkdownRenderer.vue"
+import { sessionAPI, terrariumAPI } from "@/utils/api"
+import { useI18n } from "@/utils/i18n"
+
+const ToolCallBlock = defineAsyncComponent(() => import("@/components/chat/ToolCallBlock.vue"))
+
+const props = defineProps({
+  sessionId: { type: String, required: true },
+  parent: { type: String, required: true },
+  jobId: { type: String, default: "" },
+  name: { type: String, default: "" },
+  run: { type: [String, Number], default: null },
+  live: { type: Boolean, default: false },
+  status: { type: String, default: "" },
+  depth: { type: Number, default: 0 },
+})
+
+const { t } = useI18n()
+const loading = ref(false)
+const error = ref("")
+const messages = ref([])
+const canReceive = ref(false)
+const sendText = ref("")
+const sending = ref(false)
+const expandedSystem = ref(new Set())
+const expandedTools = ref(new Set())
+let timer = null
+
+function messageText(message) {
+  if (typeof message?.content === "string") return message.content
+  if (!Array.isArray(message?.content)) return ""
+  return message.content
+    .filter((part) => part?.type === "text")
+    .map((part) => part.text || "")
+    .join("\n")
+}
+
+function messageParts(message) {
+  return Array.isArray(message?.content) ? message.content : null
+}
+
+function parseArgs(raw) {
+  if (!raw) return {}
+  if (typeof raw !== "string") return raw
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return { raw }
+  }
+}
+
+const blocks = computed(() => {
+  const resultById = {}
+  for (const message of messages.value) {
+    if (message?.role === "tool" && message.tool_call_id != null) {
+      resultById[message.tool_call_id] = messageText(message)
+    }
+  }
+  const items = []
+  messages.value.forEach((message, messageIndex) => {
+    if (message?.role === "tool") return
+    if (message?.role === "system") {
+      items.push({ kind: "system", text: messageText(message) })
+      return
+    }
+    if (message?.role === "user") {
+      items.push({ kind: "user", content: messageText(message), parts: messageParts(message) })
+      return
+    }
+    const toolCalls = (message?.tool_calls || []).map((call, callIndex) => ({
+      type: "tool",
+      id: call.id || `sa_${messageIndex}_${callIndex}`,
+      name: call.function?.name || "tool",
+      kind: "tool",
+      args: parseArgs(call.function?.arguments),
+      status: "done",
+      result: call.id != null ? resultById[call.id] || "" : "",
+      children: [],
+    }))
+    items.push({
+      kind: "assistant",
+      content: messageText(message),
+      parts: messageParts(message),
+      toolCalls,
+    })
+  })
+  return items
+})
+
+function toggleSystem(index) {
+  const next = new Set(expandedSystem.value)
+  if (next.has(index)) next.delete(index)
+  else next.add(index)
+  expandedSystem.value = next
+}
+
+function toggleTool(id) {
+  const next = new Set(expandedTools.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  expandedTools.value = next
+}
+
+function identifier() {
+  if (props.jobId) return { jobId: props.jobId, ...(props.name ? { name: props.name } : {}) }
+  const result = { name: props.name }
+  if (props.run != null) result.run = props.run
+  return result
+}
+
+async function loadConversation({ silent = false } = {}) {
+  if (!props.sessionId || !props.parent) {
+    error.value = t("chat.subagent.unavailable")
+    return
+  }
+  if (!silent) loading.value = true
+  error.value = ""
+  try {
+    const ident = identifier()
+    const data = props.live
+      ? await terrariumAPI.getSubagentConversation(props.sessionId, props.parent, ident)
+      : await sessionAPI.getSubagentConversation(props.sessionId, {
+          parent: props.parent,
+          ...ident,
+        })
+    messages.value = data.messages || []
+    canReceive.value = props.live && !!data.can_receive
+  } catch (err) {
+    if (silent) return
+    error.value = err?.response?.data?.detail || t("chat.subagent.unavailable")
+    messages.value = []
+    canReceive.value = false
+  } finally {
+    if (!silent) loading.value = false
+  }
+}
+
+async function submitSend() {
+  const content = sendText.value.trim()
+  if (!content || sending.value || !props.live) return
+  sending.value = true
+  error.value = ""
+  try {
+    await terrariumAPI.sendSubagentMessage(props.sessionId, props.parent, props.name, content, props.jobId)
+    sendText.value = ""
+    await loadConversation()
+  } catch (err) {
+    error.value = err?.response?.data?.detail || t("chat.subagent.sendFailed")
+  } finally {
+    sending.value = false
+  }
+}
+
+function isLive() {
+  return props.status === "running" || canReceive.value
+}
+
+function stopPolling() {
+  if (timer) clearInterval(timer)
+  timer = null
+}
+
+function startPolling() {
+  if (timer || !props.live || !isLive()) return
+  timer = setInterval(() => {
+    if (isLive()) loadConversation({ silent: true })
+    else stopPolling()
+  }, 1500)
+}
+
+watch(
+  () => props.status,
+  (status, previous) => {
+    if (previous === "running" && status !== "running") loadConversation({ silent: true })
+    if (status === "running") startPolling()
+  },
+)
+
+onMounted(async () => {
+  await loadConversation()
+  startPolling()
+})
+onUnmounted(stopPolling)
+</script>

--- a/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.vue
@@ -1,6 +1,20 @@
 <template>
   <div class="rounded overflow-hidden bg-taaffeite/6 dark:bg-taaffeite/10 border border-taaffeite/20 dark:border-taaffeite/25 flex flex-col gap-2 p-2 min-w-0">
     <div v-if="loading" class="text-[11px] text-warm-400">{{ t("common.loading") }}</div>
+    <div v-else-if="candidates.length" class="flex flex-col gap-2">
+      <div class="text-[11px] text-warm-500">{{ t("chat.subagent.chooseRun") }}</div>
+      <button v-for="candidate in candidates" :key="`${candidate.member_sid || ''}:${candidate.parent}:${candidate.name}:${candidate.run}`" type="button" :data-test="`subagent-run-${candidate.run}`" class="rounded border border-iolite/20 bg-iolite/5 p-2 text-left hover:bg-iolite/10" @click.stop="selectCandidate(candidate)">
+        <div class="flex items-center gap-2 text-[10px] font-mono text-warm-500">
+          <span>{{ candidate.parent }} / {{ candidate.name }} / run {{ candidate.run }}</span>
+          <span v-if="candidate.success === true" class="text-sage">success</span>
+          <span v-else-if="candidate.success === false" class="text-coral">error</span>
+          <span v-if="candidate.source" class="ml-auto">{{ candidate.source }}</span>
+        </div>
+        <div v-if="candidate.task" class="mt-1 text-[11px] text-warm-700 dark:text-warm-300">{{ candidate.task }}</div>
+        <div v-if="candidate.output_preview" class="mt-1 text-[10px] text-warm-500 line-clamp-2">{{ candidate.output_preview }}</div>
+        <div v-if="candidate.ts" class="mt-1 text-[9px] text-warm-400">{{ formatTimestamp(candidate.ts) }}</div>
+      </button>
+    </div>
     <div v-else-if="error" class="text-[11px] text-coral">{{ error }}</div>
     <template v-else>
       <div class="max-h-72 overflow-y-auto flex flex-col gap-2 min-w-0">
@@ -74,6 +88,7 @@ const { t } = useI18n()
 const loading = ref(false)
 const error = ref("")
 const messages = ref([])
+const candidates = ref([])
 const canReceive = ref(false)
 const sendText = ref("")
 const sending = ref(false)
@@ -163,6 +178,41 @@ function identifier() {
   return result
 }
 
+function formatTimestamp(value) {
+  const millis = Number(value) < 10_000_000_000 ? Number(value) * 1000 : Number(value)
+  const date = new Date(millis)
+  return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString()
+}
+
+async function loadCandidates() {
+  const data = await sessionAPI.listSubagents(props.sessionId, {
+    ...(props.parent ? { parent: props.parent } : {}),
+    ...(props.jobId ? { jobId: props.jobId } : {}),
+    ...(props.name ? { name: props.name } : {}),
+  })
+  const runs = data.runs || []
+  candidates.value = runs.some((candidate) => candidate.member_sid) ? [] : runs
+}
+
+async function selectCandidate(candidate) {
+  loading.value = true
+  error.value = ""
+  try {
+    const data = await sessionAPI.getSubagentConversation(props.sessionId, {
+      parent: candidate.parent,
+      name: candidate.name,
+      run: candidate.run,
+    })
+    messages.value = data.messages || []
+    canReceive.value = false
+    candidates.value = []
+  } catch (err) {
+    error.value = err?.response?.data?.detail || t("chat.subagent.unavailable")
+  } finally {
+    loading.value = false
+  }
+}
+
 async function loadConversation({ silent = false } = {}) {
   if (!props.sessionId || !props.parent) {
     error.value = t("chat.subagent.unavailable")
@@ -170,6 +220,7 @@ async function loadConversation({ silent = false } = {}) {
   }
   if (!silent) loading.value = true
   error.value = ""
+  candidates.value = []
   try {
     const ident = identifier()
     const data = props.live
@@ -182,9 +233,17 @@ async function loadConversation({ silent = false } = {}) {
     canReceive.value = props.live && !!data.can_receive
   } catch (err) {
     if (silent) return
-    error.value = err?.response?.data?.detail || t("chat.subagent.unavailable")
     messages.value = []
     canReceive.value = false
+    if (!props.live && err?.response?.status === 409) {
+      try {
+        await loadCandidates()
+        if (candidates.value.length) return
+      } catch {
+        candidates.value = []
+      }
+    }
+    error.value = err?.response?.data?.detail || t("chat.subagent.unavailable")
   } finally {
     if (!silent) loading.value = false
   }

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -712,9 +712,13 @@ export const sessionAPI = {
     return data
   },
 
-  async listSubagents(session, parent = "") {
+  async listSubagents(session, { parent, jobId, name } = {}) {
+    const params = {}
+    if (parent) params.parent = parent
+    if (jobId) params.job_id = jobId
+    if (name) params.name = name
     const { data } = await api.get(`/sessions/${encodeTarget(session)}/subagents`, {
-      params: parent ? { parent } : {},
+      params,
     })
     return data
   },

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -701,6 +701,24 @@ export const filesAPI = {
  *  are kept for the per-creature URL methods.
  */
 export const sessionAPI = {
+  async getSubagentConversation(session, { parent, jobId, name, run } = {}) {
+    const params = { parent }
+    if (jobId) params.job_id = jobId
+    if (name) params.name = name
+    if (run != null) params.run = run
+    const { data } = await api.get(`/sessions/${encodeTarget(session)}/subagents/conversation`, {
+      params,
+    })
+    return data
+  },
+
+  async listSubagents(session, parent = "") {
+    const { data } = await api.get(`/sessions/${encodeTarget(session)}/subagents`, {
+      params: parent ? { parent } : {},
+    })
+    return data
+  },
+
   /** Conversations that are still open, whether live or dormant. */
   async listOpen() {
     const { data } = await api.get("/sessions/open")

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -1114,7 +1114,7 @@ export default {
   "sessionViewer.detail.tokens": "Tokens",
   "sessionViewer.detail.reasoning": "Reasoning",
   "sessionViewer.detail.rawJson": "Raw JSON",
-  "sessionViewer.detail.openSubagent": "Open sub-agent trace",
+  "sessionViewer.detail.openSubagentConversation": "Open sub-agent conversation",
 
   "sessionViewer.tabs.diff": "Diff",
 

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -6,6 +6,7 @@ export default {
   "common.available": "Available",
   "common.cached": "Cached",
   "common.cancel": "Cancel",
+  "common.back": "Back",
   "workspaceResume.title": "Workspace unavailable",
   "workspaceResume.body":
     "The saved workspace is unavailable. Choose an existing folder to replace only this missing workspace group, view the saved history, or cancel without resuming.",
@@ -432,6 +433,7 @@ export default {
   "chat.subagent.send": "Send",
   "chat.subagent.unavailable": "Conversation not available.",
   "chat.subagent.chooseRun": "Multiple saved runs match. Choose a conversation:",
+  "chat.subagent.backToRuns": "Saved runs",
   "chat.subagent.sendFailed": "Failed to send message.",
   "chat.processing": "KohakUwUing...",
   "chat.bgResultTool": "background tool result delivered: {label}",
@@ -1116,6 +1118,7 @@ export default {
   "sessionViewer.detail.reasoning": "Reasoning",
   "sessionViewer.detail.rawJson": "Raw JSON",
   "sessionViewer.detail.openSubagentConversation": "Open sub-agent conversation",
+  "sessionViewer.detail.conversationPending": "Opens once this run finishes",
 
   "sessionViewer.tabs.diff": "Diff",
 

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -431,6 +431,7 @@ export default {
   "chat.subagent.placeholder": "Message this sub-agent…",
   "chat.subagent.send": "Send",
   "chat.subagent.unavailable": "Conversation not available.",
+  "chat.subagent.chooseRun": "Multiple saved runs match. Choose a conversation:",
   "chat.subagent.sendFailed": "Failed to send message.",
   "chat.processing": "KohakUwUing...",
   "chat.bgResultTool": "background tool result delivered: {label}",

--- a/src/kohakuterrarium/api/app.py
+++ b/src/kohakuterrarium/api/app.py
@@ -100,6 +100,7 @@ from kohakuterrarium.api.routes.persistence import (
 from kohakuterrarium.api.routes.persistence import open_sessions as persistence_open
 from kohakuterrarium.api.routes.persistence import resume as persistence_resume
 from kohakuterrarium.api.routes.persistence import saved as persistence_saved
+from kohakuterrarium.api.routes.persistence import subagents as persistence_subagents
 from kohakuterrarium.api.routes.persistence import viewer as persistence_viewer
 from kohakuterrarium.api.routes.persistence import saved_drives as persistence_drives
 from kohakuterrarium.api.routes import runtime_graph as runtime_graph_route
@@ -543,6 +544,9 @@ def create_app(
     )
     app.include_router(
         persistence_viewer.router, prefix="/api/sessions", tags=["sessions"]
+    )
+    app.include_router(
+        persistence_subagents.router, prefix="/api/sessions", tags=["sessions"]
     )
     app.include_router(
         sessions_memory.router, prefix="/api/sessions", tags=["sessions"]

--- a/src/kohakuterrarium/api/routes/persistence/subagents.py
+++ b/src/kohakuterrarium/api/routes/persistence/subagents.py
@@ -28,13 +28,16 @@ async def get_session_subagents(
     session_name: str,
     parent: str | None = None,
     name: str | None = None,
+    job_id: str | None = None,
     service: TerrariumService = Depends(get_service),
 ) -> dict[str, Any]:
     """List persisted sub-agent runs in one session or cluster."""
     members = await _resolve_cluster_or_404(session_name, service)
 
     def _build(store, canonical: str) -> dict[str, Any]:
-        return build_subagent_runs_payload(store, canonical, parent=parent, name=name)
+        return build_subagent_runs_payload(
+            store, canonical, parent=parent, name=name, job_id=job_id
+        )
 
     if len(members) == 1:
         return await _build_single(service, members[0][0], members[0][1], _build)
@@ -90,8 +93,18 @@ async def get_session_subagent_conversation(
                 conflicts.append(exc)
             except InvalidRequestError as exc:
                 invalid.append(exc)
-        if any(payload.get("resolution") == "exact_job_id" for _, payload in resolved):
-            return resolved
+        exact = [
+            entry for entry in resolved if entry[1].get("resolution") == "exact_job_id"
+        ]
+        if exact:
+            duplicate_exact = [
+                conflict
+                for conflict in conflicts
+                if "multiple persisted runs match job_id" in str(conflict)
+            ]
+            if duplicate_exact:
+                raise duplicate_exact[0]
+            return exact
         if conflicts:
             raise conflicts[0]
         if resolved:

--- a/src/kohakuterrarium/api/routes/persistence/subagents.py
+++ b/src/kohakuterrarium/api/routes/persistence/subagents.py
@@ -1,0 +1,118 @@
+"""Read-only persisted sub-agent conversation endpoints."""
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from kohakuterrarium.api.deps import get_service
+from kohakuterrarium.errors import ConflictError, InvalidRequestError, NotFoundError
+from kohakuterrarium.studio.persistence.viewer.subagents import (
+    build_subagent_conversation_payload,
+    build_subagent_runs_payload,
+)
+from kohakuterrarium.terrarium.service import TerrariumService
+
+from .viewer import (
+    _build_single,
+    _resolve_cluster_or_404,
+    _run_per_member,
+    _run_with_store,
+)
+
+router = APIRouter()
+
+
+@router.get("/{session_name}/subagents")
+async def get_session_subagents(
+    session_name: str,
+    parent: str | None = None,
+    name: str | None = None,
+    service: TerrariumService = Depends(get_service),
+) -> dict[str, Any]:
+    """List persisted sub-agent runs in one session or cluster."""
+    members = await _resolve_cluster_or_404(session_name, service)
+
+    def _build(store, canonical: str) -> dict[str, Any]:
+        return build_subagent_runs_payload(store, canonical, parent=parent, name=name)
+
+    if len(members) == 1:
+        return await _build_single(service, members[0][0], members[0][1], _build)
+    per_member = await asyncio.to_thread(_run_per_member, members, _build)
+    runs = []
+    for member_sid, payload in per_member:
+        runs.extend({**row, "member_sid": member_sid} for row in payload["runs"])
+    return {"session_name": session_name, "runs": runs}
+
+
+@router.get("/{session_name}/subagents/conversation")
+async def get_session_subagent_conversation(
+    session_name: str,
+    parent: str,
+    job_id: str | None = None,
+    name: str | None = None,
+    run: int | None = None,
+    service: TerrariumService = Depends(get_service),
+) -> dict[str, Any]:
+    """Read an exact persisted conversation with safe legacy fallback."""
+    members = await _resolve_cluster_or_404(session_name, service)
+
+    def _build(store, canonical: str) -> dict[str, Any]:
+        return build_subagent_conversation_payload(
+            store,
+            canonical,
+            parent=parent,
+            job_id=job_id,
+            name=name,
+            run=run,
+        )
+
+    if len(members) == 1:
+        try:
+            return await _build_single(service, members[0][0], members[0][1], _build)
+        except NotFoundError as exc:
+            raise HTTPException(404, str(exc)) from exc
+        except InvalidRequestError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        except ConflictError as exc:
+            raise HTTPException(409, str(exc)) from exc
+
+    def _build_cluster() -> list[tuple[str, dict[str, Any]]]:
+        resolved: list[tuple[str, dict[str, Any]]] = []
+        conflicts: list[ConflictError] = []
+        invalid: list[InvalidRequestError] = []
+        for member_sid, path in members:
+            try:
+                resolved.append((member_sid, _run_with_store(path, _build)))
+            except NotFoundError:
+                continue
+            except ConflictError as exc:
+                conflicts.append(exc)
+            except InvalidRequestError as exc:
+                invalid.append(exc)
+        if any(payload.get("resolution") == "exact_job_id" for _, payload in resolved):
+            return resolved
+        if conflicts:
+            raise conflicts[0]
+        if resolved:
+            return resolved
+        if invalid:
+            raise invalid[0]
+        return []
+
+    try:
+        per_member = await asyncio.to_thread(_build_cluster)
+    except InvalidRequestError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except ConflictError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    if not per_member:
+        raise HTTPException(404, "sub-agent conversation not found")
+    exact = [
+        entry for entry in per_member if entry[1].get("resolution") == "exact_job_id"
+    ]
+    selected = exact if exact else per_member
+    if len(selected) > 1:
+        raise HTTPException(409, "sub-agent conversation is ambiguous across members")
+    member_sid, payload = selected[0]
+    return {**payload, "member_sid": member_sid}

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_subagents.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_subagents.py
@@ -33,8 +33,8 @@ async def read_subagent_conversation_route(
 ):
     """Return a live or persisted sub-agent conversation.
 
-    A job identifier targets a live task and falls back to its latest persisted
-    run. A name targets a live interactive child or its latest persisted run; a
+    A job identifier targets a live task and falls back to its exact persisted
+    run, or one unambiguous legacy run. A name targets a live interactive child or its latest persisted run; a
     run number selects a specific snapshot. Only live, running instances report
     ``can_receive`` and accept messages.
     """
@@ -47,6 +47,8 @@ async def read_subagent_conversation_route(
         raise HTTPException(404, str(exc))
     except InvalidRequestError as exc:
         raise HTTPException(400, str(exc))
+    except ConflictError as exc:
+        raise HTTPException(409, str(exc))
     except KeyError:
         raise HTTPException(404, f"creature {creature_id!r} not found")
 

--- a/src/kohakuterrarium/modules/subagent/base.py
+++ b/src/kohakuterrarium/modules/subagent/base.py
@@ -67,6 +67,7 @@ class SubAgent:
         self._session_store: Any = None
         self._parent_name: str = ""
         self._run_index: int = 0
+        self._job_id: str = ""
 
         # A shared budget coordinates parent and child iteration limits when configured.
         self.iteration_budget: IterationBudget | None = None
@@ -579,6 +580,7 @@ class SubAgent:
                     name=self.config.name,
                     run=self._run_index,
                     meta={
+                        "job_id": self._job_id,
                         "task": (
                             self.conversation.to_messages()[1].get("content", "")
                             if len(self.conversation.to_messages()) > 1

--- a/src/kohakuterrarium/modules/subagent/manager.py
+++ b/src/kohakuterrarium/modules/subagent/manager.py
@@ -197,6 +197,8 @@ class SubAgentManager(InteractiveManagerMixin):
             compact_manager=compact_manager,
         )
 
+        subagent._job_id = job_id
+
         # Preserve the legacy shared-budget contract when configured.
         subagent.iteration_budget = self._resolve_child_budget(config)
         await load_and_wrap_plugins(plugin_manager, subagent, llm, self.agent_path)
@@ -254,6 +256,39 @@ class SubAgentManager(InteractiveManagerMixin):
         job_id = await self.spawn(event.name, task, background=True)
         return job_id, is_background
 
+    def _update_persisted_result(self, job_id: str, result: SubAgentResult) -> None:
+        """Keep canonical persisted metadata aligned with transformed results."""
+        store = self._session_store
+        find_run = (
+            getattr(store, "find_subagent_run", None) if store is not None else None
+        )
+        if not callable(find_run):
+            return
+        row = find_run(job_id, parent=self._parent_name)
+        if row is None:
+            return
+        meta = dict(row.get("meta") or {})
+        meta.update(
+            {
+                "success": result.success,
+                "error": result.error,
+                "interrupted": result.interrupted,
+                "cancelled": result.cancelled,
+                "turns": result.turns,
+                "duration": result.duration,
+                "total_tokens": result.total_tokens,
+                "prompt_tokens": result.prompt_tokens,
+                "completion_tokens": result.completion_tokens,
+                "cached_tokens": result.cached_tokens,
+            }
+        )
+        store.save_subagent(
+            parent=str(row["parent"]),
+            name=str(row["name"]),
+            run=int(row["run"]),
+            meta=meta,
+        )
+
     @staticmethod
     def _stamp_model_metadata(result: SubAgentResult, subagent: SubAgent) -> None:
         result.metadata.update(
@@ -295,6 +330,7 @@ class SubAgentManager(InteractiveManagerMixin):
                         exc_info=True,
                     )
             self._stamp_model_metadata(result, job.subagent)
+            self._update_persisted_result(job_id, result)
             self._results[job_id] = result
 
             if result.interrupted or result.cancelled:

--- a/src/kohakuterrarium/session/output.py
+++ b/src/kohakuterrarium/session/output.py
@@ -594,7 +594,12 @@ class SessionOutput(OutputModule):
         task_record = self._subagent_tasks.pop(job_id, None)
         task_text = task_record.get("task", "") if task_record is not None else ""
         try:
-            # Never replace a full managed conversation with a synthetic stub.
+            find_run = getattr(self._store, "find_subagent_run", None)
+            if (
+                callable(find_run)
+                and find_run(job_id, parent=self._agent_name) is not None
+            ):
+                return
             run = self._store.next_subagent_run(self._agent_name, name)
             convo = [
                 {"role": "user", "content": task_text},
@@ -605,6 +610,7 @@ class SessionOutput(OutputModule):
                 name=name,
                 run=run,
                 meta={
+                    "job_id": job_id,
                     "task": task_text,
                     "turns": metadata.get("turns", 0),
                     "tools_used": metadata.get("tools_used", []),

--- a/src/kohakuterrarium/session/store.py
+++ b/src/kohakuterrarium/session/store.py
@@ -603,6 +603,55 @@ class SessionStore:
         except KeyError:
             return None
 
+    def list_subagent_runs(
+        self, *, parent: str | None = None, name: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Return persisted sub-agent run metadata in key order."""
+        rows: list[dict[str, Any]] = []
+        for key_bytes in sorted(iter_kv_keys(self.subagents)):
+            key = (
+                key_bytes.decode("utf-8", errors="replace")
+                if isinstance(key_bytes, bytes)
+                else key_bytes
+            )
+            if not key.endswith(":meta"):
+                continue
+            prefix = key[: -len(":meta")]
+            identity = prefix.rsplit(":", 2)
+            if len(identity) != 3:
+                continue
+            entry_parent, entry_name, run_text = identity
+            try:
+                run = int(run_text)
+                meta = self.subagents[key_bytes]
+            except (KeyError, TypeError, ValueError):
+                continue
+            if parent is not None and entry_parent != parent:
+                continue
+            if name is not None and entry_name != name:
+                continue
+            rows.append(
+                {
+                    "parent": entry_parent,
+                    "name": entry_name,
+                    "run": run,
+                    "job_id": meta.get("job_id") if isinstance(meta, dict) else None,
+                    "meta": meta,
+                }
+            )
+        return rows
+
+    def find_subagent_run(
+        self, job_id: str, *, parent: str | None = None
+    ) -> dict[str, Any] | None:
+        """Return the persisted run carrying an exact job identifier."""
+        if not job_id:
+            return None
+        for row in self.list_subagent_runs(parent=parent):
+            if row.get("job_id") == job_id:
+                return row
+        return None
+
     def save_job(self, job_id: str, data: dict) -> None:
         """Save a job execution record."""
         if "ts" not in data:

--- a/src/kohakuterrarium/studio/persistence/viewer/subagents.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/subagents.py
@@ -1,0 +1,115 @@
+"""Build read-only persisted sub-agent run and conversation payloads."""
+
+from typing import Any
+
+from kohakuterrarium.core.conversation import Conversation
+from kohakuterrarium.errors import ConflictError, InvalidRequestError, NotFoundError
+from kohakuterrarium.session.store import SessionStore
+
+
+def _public_run(row: dict[str, Any]) -> dict[str, Any]:
+    meta = row.get("meta") if isinstance(row.get("meta"), dict) else {}
+    return {
+        "parent": row["parent"],
+        "name": row["name"],
+        "run": row["run"],
+        "job_id": row.get("job_id"),
+        "task": meta.get("task", ""),
+        "success": meta.get("success"),
+        "turns": meta.get("turns", 0),
+        "ts": meta.get("ts"),
+        "output_preview": meta.get("output_preview", ""),
+        "source": meta.get("source"),
+    }
+
+
+def build_subagent_runs_payload(
+    store: SessionStore,
+    session_name: str,
+    *,
+    parent: str | None,
+    name: str | None,
+) -> dict[str, Any]:
+    """Return persisted sub-agent runs suitable for viewer selection."""
+    runs = [
+        _public_run(row) for row in store.list_subagent_runs(parent=parent, name=name)
+    ]
+    return {"session_name": session_name, "runs": runs}
+
+
+def build_subagent_conversation_payload(
+    store: SessionStore,
+    session_name: str,
+    *,
+    parent: str,
+    job_id: str | None,
+    name: str | None,
+    run: int | None,
+) -> dict[str, Any]:
+    """Return one persisted conversation with honest legacy resolution."""
+    if not parent:
+        raise InvalidRequestError("parent is required")
+
+    resolution = "explicit_run"
+    row: dict[str, Any] | None = None
+    if job_id:
+        row = store.find_subagent_run(job_id, parent=parent)
+        if row is not None:
+            resolution = "exact_job_id"
+            if name is not None and row["name"] != name:
+                raise ConflictError(
+                    "job_id does not match the requested sub-agent name"
+                )
+            if run is not None and row["run"] != run:
+                raise ConflictError("job_id does not match the requested sub-agent run")
+        elif name:
+            candidates = store.list_subagent_runs(parent=parent, name=name)
+            legacy = [
+                candidate for candidate in candidates if not candidate.get("job_id")
+            ]
+            if len(legacy) == 1:
+                row = legacy[0]
+                resolution = "unique_legacy_candidate"
+            elif len(legacy) > 1:
+                raise ConflictError(
+                    f"multiple legacy runs match sub-agent {parent}:{name}"
+                )
+    elif name and run is not None:
+        meta = store.load_subagent_meta(parent, name, run)
+        if meta is not None:
+            row = {
+                "parent": parent,
+                "name": name,
+                "run": run,
+                "job_id": meta.get("job_id") if isinstance(meta, dict) else None,
+                "meta": meta,
+            }
+    else:
+        raise InvalidRequestError("provide job_id, or name and run")
+
+    if row is None:
+        raise NotFoundError("sub-agent conversation not found")
+
+    resolved_name = str(row["name"])
+    resolved_run = int(row["run"])
+    conv_json = store.load_subagent_conversation(parent, resolved_name, resolved_run)
+    meta = row.get("meta") if isinstance(row.get("meta"), dict) else None
+    if conv_json is None and meta is None:
+        raise NotFoundError(
+            f"sub-agent run {parent}:{resolved_name}:{resolved_run} not found"
+        )
+    messages = Conversation.from_json(conv_json).to_messages() if conv_json else []
+    return {
+        "session_id": store.session_id,
+        "session_name": session_name,
+        "parent": parent,
+        "name": resolved_name,
+        "run": resolved_run,
+        "job_id": row.get("job_id"),
+        "live": False,
+        "interactive": False,
+        "can_receive": False,
+        "messages": messages,
+        "meta": meta,
+        "resolution": resolution,
+    }

--- a/src/kohakuterrarium/studio/persistence/viewer/subagents.py
+++ b/src/kohakuterrarium/studio/persistence/viewer/subagents.py
@@ -29,11 +29,20 @@ def build_subagent_runs_payload(
     *,
     parent: str | None,
     name: str | None,
+    job_id: str | None = None,
 ) -> dict[str, Any]:
     """Return persisted sub-agent runs suitable for viewer selection."""
-    runs = [
-        _public_run(row) for row in store.list_subagent_runs(parent=parent, name=name)
-    ]
+    rows = store.list_subagent_runs(
+        parent=None if job_id else parent, name=None if job_id else name
+    )
+    if job_id:
+        exact = [row for row in rows if row.get("job_id") == job_id]
+        rows = exact or [
+            row
+            for row in store.list_subagent_runs(parent=parent, name=name)
+            if not row.get("job_id")
+        ]
+    runs = [_public_run(row) for row in rows]
     return {"session_name": session_name, "runs": runs}
 
 
@@ -53,15 +62,16 @@ def build_subagent_conversation_payload(
     resolution = "explicit_run"
     row: dict[str, Any] | None = None
     if job_id:
-        row = store.find_subagent_run(job_id, parent=parent)
+        exact = [
+            candidate
+            for candidate in store.list_subagent_runs()
+            if candidate.get("job_id") == job_id
+        ]
+        if len(exact) > 1:
+            raise ConflictError(f"multiple persisted runs match job_id {job_id!r}")
+        row = exact[0] if exact else None
         if row is not None:
             resolution = "exact_job_id"
-            if name is not None and row["name"] != name:
-                raise ConflictError(
-                    "job_id does not match the requested sub-agent name"
-                )
-            if run is not None and row["run"] != run:
-                raise ConflictError("job_id does not match the requested sub-agent run")
         elif name:
             candidates = store.list_subagent_runs(parent=parent, name=name)
             legacy = [
@@ -90,19 +100,22 @@ def build_subagent_conversation_payload(
     if row is None:
         raise NotFoundError("sub-agent conversation not found")
 
+    resolved_parent = str(row["parent"])
     resolved_name = str(row["name"])
     resolved_run = int(row["run"])
-    conv_json = store.load_subagent_conversation(parent, resolved_name, resolved_run)
+    conv_json = store.load_subagent_conversation(
+        resolved_parent, resolved_name, resolved_run
+    )
     meta = row.get("meta") if isinstance(row.get("meta"), dict) else None
     if conv_json is None and meta is None:
         raise NotFoundError(
-            f"sub-agent run {parent}:{resolved_name}:{resolved_run} not found"
+            f"sub-agent run {resolved_parent}:{resolved_name}:{resolved_run} not found"
         )
     messages = Conversation.from_json(conv_json).to_messages() if conv_json else []
     return {
         "session_id": store.session_id,
         "session_name": session_name,
-        "parent": parent,
+        "parent": resolved_parent,
         "name": resolved_name,
         "run": resolved_run,
         "job_id": row.get("job_id"),

--- a/src/kohakuterrarium/studio/sessions/creature_subagents.py
+++ b/src/kohakuterrarium/studio/sessions/creature_subagents.py
@@ -97,10 +97,9 @@ def read_subagent_conversation(
 ) -> dict[str, Any]:
     """Return a sub-agent run's conversation.
 
-    ``job_id`` reads a live task sub-agent, falling back to the LATEST
-    persisted run for the name encoded in the job id when the job is no
-    longer live (e.g. a resumed process, whose ``_jobs`` is empty — the
-    event log carries only the job id, not the run index). ``name`` alone
+    ``job_id`` reads a live task sub-agent, falling back to the exact
+    persisted run carrying that identifier when the job is no longer live.
+    ``name`` alone
     reads a live interactive child, else falls back to the LATEST
     persisted run for that name; ``name`` + ``run`` reads a specific
     persisted snapshot. Raises :class:`NotFoundError` when the referenced
@@ -198,7 +197,7 @@ def _read_persisted(
         session_id,
         name=name,
         run=run,
-        job_id=None,
+        job_id=meta.get("job_id") if isinstance(meta, dict) else None,
         live=False,
         interactive=False,
         can_receive=False,
@@ -213,16 +212,35 @@ def _read_persisted_by_job_id(
     session_id: str,
     job_id: str,
 ) -> dict[str, Any] | None:
-    """Resolve a non-live ``job_id`` to the latest persisted run for the
-    sub-agent name it encodes, or ``None`` when nothing is persisted."""
-    name = _subagent_name_from_job_id(job_id)
+    """Resolve a non-live job exactly, or by one legacy candidate."""
     store = getattr(agent, "session_store", None)
-    if not name or store is None:
+    find_run = getattr(store, "find_subagent_run", None) if store is not None else None
+    if not callable(find_run):
         return None
-    run = _latest_persisted_run(store, _parent_name(agent), name)
-    if run is None:
+    parent = _parent_name(agent)
+    row = find_run(job_id, parent=parent)
+    if row is None:
+        name = _subagent_name_from_job_id(job_id)
+        list_runs = getattr(store, "list_subagent_runs", None)
+        if not name or not callable(list_runs):
+            return None
+        legacy = [
+            candidate
+            for candidate in list_runs(parent=parent, name=name)
+            if not candidate.get("job_id")
+        ]
+        if len(legacy) > 1:
+            raise ConflictError(f"multiple legacy runs match sub-agent {parent}:{name}")
+        row = legacy[0] if legacy else None
+    if row is None:
         return None
-    return _read_persisted(agent, creature_id, session_id, name, run)
+    return _read_persisted(
+        agent,
+        creature_id,
+        session_id,
+        str(row["name"]),
+        int(row["run"]),
+    )
 
 
 async def send_to_subagent(

--- a/src/kohakuterrarium/terrarium/creature_host.py
+++ b/src/kohakuterrarium/terrarium/creature_host.py
@@ -724,6 +724,9 @@ def apply_creature_name(creature: "Creature", name: str) -> None:
     compact_manager = getattr(agent, "compact_manager", None)
     if compact_manager is not None and hasattr(compact_manager, "_agent_name"):
         compact_manager._agent_name = name
+    subagent_manager = getattr(agent, "subagent_manager", None)
+    if subagent_manager is not None and hasattr(subagent_manager, "_parent_name"):
+        subagent_manager._parent_name = name
     # A SessionOutput attached BEFORE the rename keeps recording events
     # under the old name — but the history/read side resolves events by
     # the creature's display name, so the rename must follow it onto the

--- a/tests/integration/test_modules.py
+++ b/tests/integration/test_modules.py
@@ -847,7 +847,7 @@ class TestModulesIntegration:
         finally:
             await agent.stop()
 
-    async def test_subagent_dispatch_and_routing(self, make_agent):
+    async def test_subagent_dispatch_and_routing(self, make_agent, tmp_path):
         """subagent protocol — a real :class:`SubAgentConfig` is
         registered on the agent, the controller dispatches it via a
         ``[/...]`` block, the :class:`SubAgentManager` spawns it, the
@@ -878,6 +878,15 @@ class TestModulesIntegration:
         )
         agent.subagent_manager.register(worker_cfg)
         agent.registry.register_subagent("worker", worker_cfg)
+        store = SessionStore(str(tmp_path / "subagent-routing.kohakutr"))
+        store.init_meta(
+            "subagent-routing",
+            "agent",
+            str(tmp_path),
+            str(tmp_path),
+            ["modules_agent"],
+        )
+        agent.attach_session_store(store)
         assert "worker" in agent.subagent_manager.list_subagents()
         # The registered config is retrievable + projects a SubAgentInfo.
         assert agent.subagent_manager.get_config("worker") is worker_cfg
@@ -915,6 +924,15 @@ class TestModulesIntegration:
             last = agent.controller.conversation.get_last_assistant_message()
             assert last is not None
             assert "worker finished" in last.get_text_content()
+            first_job_id = next(iter(agent.subagent_manager._results))
+            persisted = store.list_subagent_runs(parent="modules_agent", name="worker")
+            assert [(row["run"], row["job_id"]) for row in persisted] == [
+                (0, first_job_id)
+            ]
+            assert (
+                store.load_subagent_conversation("modules_agent", "worker", 0)
+                is not None
+            )
 
             # ── Programmatic spawn path (background=False) ──
             # The same SubAgentManager also drives a direct spawn: the
@@ -998,6 +1016,7 @@ class TestModulesIntegration:
             agent.subagent_manager._current_depth = 0
         finally:
             await agent.stop()
+            store.close()
 
     async def test_interactive_subagent_stays_alive(self, make_agent):
         """subagent protocol — an interactive sub-agent (``interactive:

--- a/tests/unit/api/test_persistence_viewer_routes.py
+++ b/tests/unit/api/test_persistence_viewer_routes.py
@@ -6,12 +6,14 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from kohakuterrarium.api.routes.persistence import subagents as subagents_mod
 from kohakuterrarium.api.routes.persistence import viewer as viewer_mod
 
 
 def _app() -> FastAPI:
     app = FastAPI()
     app.include_router(viewer_mod.router, prefix="/sessions")
+    app.include_router(subagents_mod.router, prefix="/sessions")
     return app
 
 
@@ -102,6 +104,122 @@ class TestSummary:
         # The closure passed the normalized stem + the agent query param.
         assert captured["canonical"] == "alice"
         assert captured["agent"] == "alice"
+
+
+# ── persisted sub-agent conversations ───────────────────────────
+
+
+class TestPersistedSubagents:
+    def test_saved_conversation_reads_exact_job(self, monkeypatch, tmp_path):
+        from kohakuterrarium.session.store import SessionStore
+
+        path = tmp_path / "subagents.kohakutr"
+        store = SessionStore(str(path))
+        store.init_meta("subagents", "agent", "/p", "/w", ["parent"])
+        store.save_subagent(
+            "parent",
+            "explore",
+            0,
+            {
+                "job_id": "agent_explore_11111111",
+                "task": "first",
+                "success": True,
+            },
+            conv_json='{"messages":[{"role":"assistant","content":"first answer"}]}',
+        )
+        store.close()
+        monkeypatch.setattr(viewer_mod, "resolve_session_path_default", lambda n: path)
+
+        client = TestClient(_app())
+        response = client.get(
+            "/sessions/subagents/subagents/conversation",
+            params={
+                "parent": "parent",
+                "name": "explore",
+                "job_id": "agent_explore_11111111",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["job_id"] == "agent_explore_11111111"
+        assert response.json()["messages"][-1]["content"] == "first answer"
+
+    def test_cluster_legacy_ambiguity_is_not_hidden_by_one_unique_member(
+        self, monkeypatch, tmp_path
+    ):
+        from kohakuterrarium.session.store import SessionStore
+
+        unique_path = tmp_path / "unique.kohakutr"
+        unique = SessionStore(str(unique_path))
+        unique.init_meta("unique", "agent", "/p", "/w", ["parent"])
+        unique.save_subagent(
+            "parent",
+            "explore",
+            0,
+            {"task": "unique legacy"},
+            conv_json='{"messages":[{"role":"assistant","content":"unique"}]}',
+        )
+        unique.close()
+
+        ambiguous_path = tmp_path / "ambiguous.kohakutr"
+        ambiguous = SessionStore(str(ambiguous_path))
+        ambiguous.init_meta("ambiguous", "agent", "/p", "/w", ["parent"])
+        for run in (0, 1):
+            ambiguous.save_subagent(
+                "parent",
+                "explore",
+                run,
+                {"task": f"ambiguous {run}"},
+                conv_json=(
+                    '{"messages":[{"role":"assistant","content":"ambiguous %d"}]}' % run
+                ),
+            )
+        ambiguous.close()
+
+        async def _members(session_name, service):
+            return [("unique", unique_path), ("ambiguous", ambiguous_path)]
+
+        monkeypatch.setattr(subagents_mod, "_resolve_cluster_or_404", _members)
+
+        response = TestClient(_app()).get(
+            "/sessions/cluster/subagents/conversation",
+            params={
+                "parent": "parent",
+                "name": "explore",
+                "job_id": "agent_explore_11111111",
+            },
+        )
+        assert response.status_code == 409
+
+    def test_ambiguous_legacy_conversation_returns_conflict(
+        self, monkeypatch, tmp_path
+    ):
+        from kohakuterrarium.session.store import SessionStore
+
+        path = tmp_path / "legacy-subagents.kohakutr"
+        store = SessionStore(str(path))
+        store.init_meta("legacy", "agent", "/p", "/w", ["parent"])
+        for run in (0, 1):
+            store.save_subagent(
+                "parent",
+                "explore",
+                run,
+                {"task": f"legacy {run}"},
+                conv_json=(
+                    '{"messages":[{"role":"assistant","content":"legacy %d"}]}' % run
+                ),
+            )
+        store.close()
+        monkeypatch.setattr(viewer_mod, "resolve_session_path_default", lambda n: path)
+
+        response = TestClient(_app()).get(
+            "/sessions/legacy/subagents/conversation",
+            params={
+                "parent": "parent",
+                "name": "explore",
+                "job_id": "agent_explore_11111111",
+            },
+        )
+        assert response.status_code == 409
 
 
 # ── live-session resolution (graph_id ≠ on-disk file stem) ──────

--- a/tests/unit/api/test_persistence_viewer_routes.py
+++ b/tests/unit/api/test_persistence_viewer_routes.py
@@ -190,6 +190,52 @@ class TestPersistedSubagents:
         )
         assert response.status_code == 409
 
+    def test_cluster_duplicate_exact_conflict_is_not_hidden_by_unique_exact_member(
+        self, monkeypatch, tmp_path
+    ):
+        from kohakuterrarium.session.store import SessionStore
+
+        unique_path = tmp_path / "unique-exact.kohakutr"
+        unique = SessionStore(str(unique_path))
+        unique.init_meta("unique-exact", "agent", "/p", "/w", ["parent"])
+        unique.save_subagent(
+            "parent",
+            "explore",
+            0,
+            {"job_id": "agent_explore_11111111", "task": "unique"},
+            conv_json='{"messages":[{"role":"assistant","content":"unique"}]}',
+        )
+        unique.close()
+
+        duplicate_path = tmp_path / "duplicate-exact.kohakutr"
+        duplicate = SessionStore(str(duplicate_path))
+        duplicate.init_meta("duplicate-exact", "terrarium", "/p", "/w", ["a", "b"])
+        for parent in ("a", "b"):
+            duplicate.save_subagent(
+                parent,
+                "explore",
+                0,
+                {"job_id": "agent_explore_11111111", "task": parent},
+                conv_json=(
+                    '{"messages":[{"role":"assistant","content":"%s"}]}' % parent
+                ),
+            )
+        duplicate.close()
+
+        async def _members(session_name, service):
+            return [("unique", unique_path), ("duplicate", duplicate_path)]
+
+        monkeypatch.setattr(subagents_mod, "_resolve_cluster_or_404", _members)
+        response = TestClient(_app()).get(
+            "/sessions/cluster/subagents/conversation",
+            params={
+                "parent": "parent",
+                "name": "explore",
+                "job_id": "agent_explore_11111111",
+            },
+        )
+        assert response.status_code == 409
+
     def test_ambiguous_legacy_conversation_returns_conflict(
         self, monkeypatch, tmp_path
     ):

--- a/tests/unit/modules/subagent/test_base.py
+++ b/tests/unit/modules/subagent/test_base.py
@@ -452,6 +452,7 @@ class TestSessionStorePersistence:
         sa._session_store = _FakeStore()
         sa._parent_name = "controller"
         sa._run_index = 2
+        sa._job_id = "agent_explore_12345678"
         result = await sa.run("find the bug")
         assert result.success is True
         # The sub-agent conversation was persisted with the right lineage.
@@ -459,6 +460,7 @@ class TestSessionStorePersistence:
         assert saved[0]["parent"] == "controller"
         assert saved[0]["name"] == "explore"
         assert saved[0]["run"] == 2
+        assert saved[0]["meta"]["job_id"] == "agent_explore_12345678"
 
     async def test_conversation_preserves_reasoning_extra_fields(self):
         saved: list[dict] = []

--- a/tests/unit/modules/subagent/test_manager.py
+++ b/tests/unit/modules/subagent/test_manager.py
@@ -14,6 +14,8 @@ from kohakuterrarium.core.job import JobState, JobType
 from kohakuterrarium.core.registry import Registry
 from kohakuterrarium.modules.subagent.config import SubAgentConfig
 from kohakuterrarium.modules.subagent.manager import SubAgentManager
+from kohakuterrarium.modules.subagent.result import SubAgentResult
+from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.testing.llm import ScriptedLLM
 
 
@@ -94,6 +96,34 @@ class TestSpawn:
         status = mgr.get_status(job_id)
         assert status.state is JobState.DONE
         assert status.job_type is JobType.SUBAGENT
+
+    async def test_post_hook_updates_persisted_canonical_metadata(self, tmp_path):
+        class _Plugins:
+            async def run_pre_hooks(self, hook, result, **kwargs):
+                assert hook == "post_subagent_run"
+                return SubAgentResult(
+                    output="rewritten failure",
+                    success=False,
+                    error="rejected",
+                    turns=result.turns,
+                )
+
+        store = SessionStore(str(tmp_path / "hook-result.kohakutr"))
+        store.init_meta("hook", "agent", str(tmp_path), str(tmp_path), ["parent"])
+        mgr = _manager(ScriptedLLM(["original success"]))
+        mgr._session_store = store
+        mgr._parent_name = "parent"
+        mgr._parent_plugins = _Plugins()
+        mgr.register(SubAgentConfig(name="explore", max_turns=1))
+        try:
+            job_id = await mgr.spawn("explore", "task", background=False)
+            result = mgr.get_result(job_id)
+            meta = store.find_subagent_run(job_id, parent="parent")["meta"]
+            assert result.success is False
+            assert meta["success"] is False
+            assert meta["error"] == "rejected"
+        finally:
+            store.close()
 
     async def test_spawn_background_returns_before_completion(self):
         mgr = _manager(ScriptedLLM(["bg result"]))

--- a/tests/unit/session/test_output.py
+++ b/tests/unit/session/test_output.py
@@ -697,6 +697,50 @@ class TestActivityHandlers:
             parsed = json.loads(convo)
             assert parsed[0]["role"] == "user"
             assert parsed[1]["content"] == "found"
+            assert store.load_subagent_meta("alice", "explore", 0)["job_id"] == "j1"
+        finally:
+            store.close()
+
+    def test_subagent_done_does_not_duplicate_exact_managed_run(self, tmp_path):
+        store, out = _make(tmp_path)
+        try:
+            store.save_subagent(
+                "alice",
+                "explore",
+                0,
+                {
+                    "job_id": "agent_explore_abc12345",
+                    "task": "find x",
+                    "success": True,
+                },
+                conv_json='{"messages":[{"role":"assistant","content":"full"}]}',
+            )
+            out.on_activity_with_metadata(
+                "subagent_start",
+                "[explore] task",
+                {
+                    "job_id": "agent_explore_abc12345",
+                    "task": "find x",
+                    "subagent": "explore",
+                },
+            )
+            out.on_activity_with_metadata(
+                "subagent_done",
+                "[explore] done",
+                {
+                    "job_id": "agent_explore_abc12345",
+                    "result": "found",
+                    "subagent": "explore",
+                },
+            )
+
+            runs = store.list_subagent_runs(parent="alice", name="explore")
+            assert [(row["run"], row["job_id"]) for row in runs] == [
+                (0, "agent_explore_abc12345")
+            ]
+            assert store.load_subagent_conversation("alice", "explore", 0).endswith(
+                '"full"}]}'
+            )
         finally:
             store.close()
 

--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -458,6 +458,39 @@ class TestSubagents:
         finally:
             s.close()
 
+    def test_lists_runs_and_finds_exact_job_id(self, tmp_path):
+        s = _store(tmp_path)
+        try:
+            s.save_subagent(
+                "p",
+                "explore",
+                0,
+                {"job_id": "agent_explore_11111111", "task": "first"},
+            )
+            s.save_subagent(
+                "p",
+                "explore",
+                1,
+                {"job_id": "agent_explore_22222222", "task": "second"},
+            )
+            s.save_subagent("other", "explore", 0, {"job_id": "other-job"})
+
+            runs = s.list_subagent_runs(parent="p", name="explore")
+            assert [(row["run"], row["job_id"]) for row in runs] == [
+                (0, "agent_explore_11111111"),
+                (1, "agent_explore_22222222"),
+            ]
+            found = s.find_subagent_run("agent_explore_11111111", parent="p")
+            assert found is not None
+            assert found["parent"] == "p"
+            assert found["name"] == "explore"
+            assert found["run"] == 0
+            assert found["job_id"] == "agent_explore_11111111"
+            assert found["meta"]["task"] == "first"
+            assert s.find_subagent_run("missing", parent="p") is None
+        finally:
+            s.close()
+
 
 # ── jobs ──────────────────────────────────────────────────────────
 

--- a/tests/unit/studio/persistence/viewer/test_subagents.py
+++ b/tests/unit/studio/persistence/viewer/test_subagents.py
@@ -63,9 +63,7 @@ class TestSubagentViewerPayloads:
         finally:
             store.close()
 
-    def test_job_id_takes_precedence_and_rejects_conflicting_coordinates(
-        self, tmp_path
-    ):
+    def test_job_id_takes_precedence_over_stale_parent_and_coordinates(self, tmp_path):
         store = SessionStore(str(tmp_path / "precedence.kohakutr"))
         try:
             store.init_meta("precedence", "agent", "/p", "/w", ["parent"])
@@ -84,15 +82,55 @@ class TestSubagentViewerPayloads:
                 conv_json='{"messages":[{"role":"assistant","content":"second"}]}',
             )
 
-            with pytest.raises(ConflictError, match="requested sub-agent run"):
+            payload = build_subagent_conversation_payload(
+                store,
+                "precedence",
+                parent="renamed-parent",
+                job_id="agent_explore_11111111",
+                name="stale-name",
+                run=99,
+            )
+            assert payload["parent"] == "parent"
+            assert payload["name"] == "explore"
+            assert payload["run"] == 0
+            assert payload["messages"][-1]["content"] == "first"
+        finally:
+            store.close()
+
+    def test_duplicate_exact_job_ids_are_ambiguous(self, tmp_path):
+        store = SessionStore(str(tmp_path / "duplicate-job.kohakutr"))
+        try:
+            store.init_meta("duplicate-job", "terrarium", "/p", "/w", ["a", "b"])
+            for parent in ("a", "b"):
+                store.save_subagent(
+                    parent,
+                    "explore",
+                    0,
+                    {"job_id": "agent_explore_11111111", "task": parent},
+                    conv_json=(
+                        '{"messages":[{"role":"assistant","content":"%s"}]}' % parent
+                    ),
+                )
+
+            with pytest.raises(
+                ConflictError, match="multiple persisted runs match job_id"
+            ):
                 build_subagent_conversation_payload(
                     store,
-                    "precedence",
-                    parent="parent",
+                    "duplicate-job",
+                    parent="a",
                     job_id="agent_explore_11111111",
                     name="explore",
-                    run=1,
+                    run=None,
                 )
+            listed = build_subagent_runs_payload(
+                store,
+                "duplicate-job",
+                parent=None,
+                name=None,
+                job_id="agent_explore_11111111",
+            )
+            assert {row["parent"] for row in listed["runs"]} == {"a", "b"}
         finally:
             store.close()
 
@@ -126,6 +164,13 @@ class TestSubagentViewerPayloads:
                 {"task": "legacy second"},
                 conv_json='{"messages":[{"role":"assistant","content":"legacy two"}]}',
             )
+            store.save_subagent(
+                "parent",
+                "explore",
+                2,
+                {"job_id": "agent_explore_22222222", "task": "unrelated modern"},
+                conv_json='{"messages":[{"role":"assistant","content":"modern"}]}',
+            )
             with pytest.raises(ConflictError, match="multiple legacy runs"):
                 build_subagent_conversation_payload(
                     store,
@@ -135,6 +180,14 @@ class TestSubagentViewerPayloads:
                     name="explore",
                     run=None,
                 )
+            listed = build_subagent_runs_payload(
+                store,
+                "legacy",
+                parent="parent",
+                name="explore",
+                job_id="agent_explore_11111111",
+            )
+            assert [row["run"] for row in listed["runs"]] == [0, 1]
         finally:
             store.close()
 

--- a/tests/unit/studio/persistence/viewer/test_subagents.py
+++ b/tests/unit/studio/persistence/viewer/test_subagents.py
@@ -1,0 +1,155 @@
+"""Unit tests for persisted sub-agent viewer payloads."""
+
+import pytest
+
+from kohakuterrarium.errors import ConflictError, NotFoundError
+from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.studio.persistence.viewer.subagents import (
+    build_subagent_conversation_payload,
+    build_subagent_runs_payload,
+)
+
+
+class TestSubagentViewerPayloads:
+    def test_lists_and_reads_exact_job(self, tmp_path):
+        store = SessionStore(str(tmp_path / "session.kohakutr"))
+        try:
+            store.init_meta("session", "agent", "/p", "/w", ["parent"])
+            store.save_subagent(
+                "parent",
+                "explore",
+                0,
+                {
+                    "job_id": "agent_explore_11111111",
+                    "task": "first task",
+                    "success": True,
+                },
+                conv_json='{"messages":[{"role":"assistant","content":"first"}]}',
+            )
+            store.save_subagent(
+                "parent",
+                "explore",
+                1,
+                {
+                    "job_id": "agent_explore_22222222",
+                    "task": "second task",
+                    "success": True,
+                },
+                conv_json='{"messages":[{"role":"assistant","content":"second"}]}',
+            )
+
+            listed = build_subagent_runs_payload(
+                store, "session", parent="parent", name="explore"
+            )
+            assert [row["job_id"] for row in listed["runs"]] == [
+                "agent_explore_11111111",
+                "agent_explore_22222222",
+            ]
+
+            payload = build_subagent_conversation_payload(
+                store,
+                "session",
+                parent="parent",
+                job_id="agent_explore_11111111",
+                name="explore",
+                run=None,
+            )
+            assert payload["run"] == 0
+            assert payload["job_id"] == "agent_explore_11111111"
+            assert payload["live"] is False
+            assert payload["can_receive"] is False
+            assert payload["messages"][-1]["content"] == "first"
+            assert payload["resolution"] == "exact_job_id"
+        finally:
+            store.close()
+
+    def test_job_id_takes_precedence_and_rejects_conflicting_coordinates(
+        self, tmp_path
+    ):
+        store = SessionStore(str(tmp_path / "precedence.kohakutr"))
+        try:
+            store.init_meta("precedence", "agent", "/p", "/w", ["parent"])
+            store.save_subagent(
+                "parent",
+                "explore",
+                0,
+                {"job_id": "agent_explore_11111111", "task": "first"},
+                conv_json='{"messages":[{"role":"assistant","content":"first"}]}',
+            )
+            store.save_subagent(
+                "parent",
+                "explore",
+                1,
+                {"job_id": "agent_explore_22222222", "task": "second"},
+                conv_json='{"messages":[{"role":"assistant","content":"second"}]}',
+            )
+
+            with pytest.raises(ConflictError, match="requested sub-agent run"):
+                build_subagent_conversation_payload(
+                    store,
+                    "precedence",
+                    parent="parent",
+                    job_id="agent_explore_11111111",
+                    name="explore",
+                    run=1,
+                )
+        finally:
+            store.close()
+
+    def test_legacy_fallback_requires_one_unambiguous_candidate(self, tmp_path):
+        store = SessionStore(str(tmp_path / "legacy.kohakutr"))
+        try:
+            store.init_meta("legacy", "agent", "/p", "/w", ["parent"])
+            store.save_subagent(
+                "parent",
+                "explore",
+                0,
+                {"task": "legacy first"},
+                conv_json='{"messages":[{"role":"assistant","content":"legacy one"}]}',
+            )
+
+            unique = build_subagent_conversation_payload(
+                store,
+                "legacy",
+                parent="parent",
+                job_id="agent_explore_11111111",
+                name="explore",
+                run=None,
+            )
+            assert unique["run"] == 0
+            assert unique["resolution"] == "unique_legacy_candidate"
+
+            store.save_subagent(
+                "parent",
+                "explore",
+                1,
+                {"task": "legacy second"},
+                conv_json='{"messages":[{"role":"assistant","content":"legacy two"}]}',
+            )
+            with pytest.raises(ConflictError, match="multiple legacy runs"):
+                build_subagent_conversation_payload(
+                    store,
+                    "legacy",
+                    parent="parent",
+                    job_id="agent_explore_11111111",
+                    name="explore",
+                    run=None,
+                )
+        finally:
+            store.close()
+
+    def test_missing_identifiers_or_runs_are_not_found(self, tmp_path):
+        store = SessionStore(str(tmp_path / "missing.kohakutr"))
+        try:
+            store.init_meta("missing", "agent", "/p", "/w", ["parent"])
+            with pytest.raises(NotFoundError):
+                build_subagent_conversation_payload(
+                    store,
+                    "missing",
+                    parent="parent",
+                    job_id="agent_explore_11111111",
+                    name="explore",
+                    run=None,
+                )
+        finally:
+            store.close()

--- a/tests/unit/studio/test_creature_subagents.py
+++ b/tests/unit/studio/test_creature_subagents.py
@@ -58,6 +58,17 @@ class _Store:
         self.queried.append(("meta", parent, name, run))
         return self._meta
 
+    def find_subagent_run(self, job_id, *, parent=None):
+        if not isinstance(self._meta, dict) or self._meta.get("job_id") != job_id:
+            return None
+        return {
+            "parent": parent or "controller",
+            "name": "explore",
+            "run": 0,
+            "job_id": job_id,
+            "meta": self._meta,
+        }
+
 
 class _RunStore:
     """Persisted-run store double: ``(parent, name, run) -> (conv_json, meta)``
@@ -74,6 +85,38 @@ class _RunStore:
     def load_subagent_meta(self, parent, name, run):
         entry = self._data.get((parent, name, run))
         return entry[1] if entry else None
+
+    def find_subagent_run(self, job_id, *, parent=None):
+        for (entry_parent, name, run), (_, meta) in self._data.items():
+            if parent is not None and entry_parent != parent:
+                continue
+            if meta.get("job_id") == job_id:
+                return {
+                    "parent": entry_parent,
+                    "name": name,
+                    "run": run,
+                    "job_id": job_id,
+                    "meta": meta,
+                }
+        return None
+
+    def list_subagent_runs(self, *, parent=None, name=None):
+        rows = []
+        for (entry_parent, entry_name, run), (_, meta) in self._data.items():
+            if parent is not None and entry_parent != parent:
+                continue
+            if name is not None and entry_name != name:
+                continue
+            rows.append(
+                {
+                    "parent": entry_parent,
+                    "name": entry_name,
+                    "run": run,
+                    "job_id": meta.get("job_id"),
+                    "meta": meta,
+                }
+            )
+        return rows
 
 
 def _install(monkeypatch, agent):
@@ -134,21 +177,29 @@ class TestReadLiveJob:
 
 
 class TestJobIdPersistedFallback:
-    async def test_dead_job_id_reads_latest_persisted_run(self, monkeypatch):
-        # After resume ``_jobs`` is empty and the FE sends only job_id;
-        # the read must fall back to the LATEST persisted run for the name.
-        latest = Conversation()
-        latest.append("user", "task")
-        latest.append("assistant", "latest run answer")
-        older = Conversation()
-        older.append("assistant", "old run")
+    async def test_dead_job_id_reads_its_exact_persisted_run(self, monkeypatch):
+        first = Conversation()
+        first.append("user", "first task")
+        first.append("assistant", "first run answer")
+        second = Conversation()
+        second.append("user", "second task")
+        second.append("assistant", "second run answer")
         store = _RunStore(
             "controller",
             "explore",
-            {0: (older.to_json(), {"turns": 1}), 1: (latest.to_json(), {"turns": 2})},
+            {
+                0: (
+                    first.to_json(),
+                    {"turns": 1, "job_id": "agent_explore_a1b2c3d4"},
+                ),
+                1: (
+                    second.to_json(),
+                    {"turns": 2, "job_id": "agent_explore_deadbeef"},
+                ),
+            },
         )
         manager = SubAgentManager(Registry(), ScriptedLLM(["x"]))
-        manager._parent_name = "controller"  # _jobs empty
+        manager._parent_name = "controller"
         agent = _Agent(manager, store=store, name="controller")
         service = _install(monkeypatch, agent)
         out = acc.read_subagent_conversation(
@@ -156,9 +207,48 @@ class TestJobIdPersistedFallback:
         )
         assert out["live"] is False
         assert out["interactive"] is False
-        assert out["run"] == 1
+        assert out["run"] == 0
         joined = " ".join(str(m.get("content", "")) for m in out["messages"])
-        assert "latest run answer" in joined
+        assert "first run answer" in joined
+        assert "second run answer" not in joined
+
+    def test_dead_job_id_reads_one_unambiguous_legacy_run(self, monkeypatch):
+        legacy = Conversation()
+        legacy.append("assistant", "legacy answer")
+        store = _RunStore(
+            "controller",
+            "explore",
+            {0: (legacy.to_json(), {"turns": 1})},
+        )
+        manager = SubAgentManager(Registry(), ScriptedLLM(["x"]))
+        manager._parent_name = "controller"
+        service = _install(monkeypatch, _Agent(manager, store=store, name="controller"))
+        out = acc.read_subagent_conversation(
+            service, "g", "cid", job_id="agent_explore_a1b2c3d4"
+        )
+        assert out["run"] == 0
+        assert out["job_id"] is None
+
+    def test_dead_job_id_rejects_ambiguous_legacy_runs(self, monkeypatch):
+        first = Conversation()
+        first.append("assistant", "first legacy answer")
+        second = Conversation()
+        second.append("assistant", "second legacy answer")
+        store = _RunStore(
+            "controller",
+            "explore",
+            {
+                0: (first.to_json(), {"turns": 1}),
+                1: (second.to_json(), {"turns": 2}),
+            },
+        )
+        manager = SubAgentManager(Registry(), ScriptedLLM(["x"]))
+        manager._parent_name = "controller"
+        service = _install(monkeypatch, _Agent(manager, store=store, name="controller"))
+        with pytest.raises(ConflictError, match="multiple legacy runs"):
+            acc.read_subagent_conversation(
+                service, "g", "cid", job_id="agent_explore_a1b2c3d4"
+            )
 
     def test_dead_job_id_with_no_persisted_run_is_not_found(self, monkeypatch):
         store = _RunStore("controller", "explore", {})

--- a/tests/unit/terrarium/test_creature_host.py
+++ b/tests/unit/terrarium/test_creature_host.py
@@ -697,6 +697,7 @@ class TestApplyCreatureName:
             executor=SimpleNamespace(_agent_name=agent_name),
             trigger_manager=SimpleNamespace(_agent_name=agent_name),
             compact_manager=SimpleNamespace(_agent_name=agent_name),
+            subagent_manager=SimpleNamespace(_parent_name=agent_name),
             _session_output=session_output,
         )
         creature = SimpleNamespace(
@@ -717,6 +718,7 @@ class TestApplyCreatureName:
         # display name the history endpoint resolves.
         assert out._agent_name == "warm-ember"
         assert out._event_key_prefix == "warm-ember"
+        assert creature.agent.subagent_manager._parent_name == "warm-ember"
 
     def test_rename_keeps_custom_attached_prefix(self):
         from kohakuterrarium.terrarium.creature_host import apply_creature_name


### PR DESCRIPTION
## Summary

Fix vertical sub-agent conversation navigation and persistence identity. Inspector Trace now opens terminal, persisted child conversations instead of treating the sub-agent name as an event namespace. Active and saved sessions use the same store-backed read-only path, while running live conversations remain in Conversation/Chat. Local ambiguous histories now offer an explicit run selector.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Vertical sub-agents do not own session `/turns` namespaces, so the existing Inspector action requested `?agent=<subagent-name>` and returned HTTP 404. Persisted identity was also unsafe: successful jobs produced both full and synthetic runs, metadata omitted `job_id`, and completed-job lookup could return the latest same-name run rather than the requested job.

## Changes

- persist one canonical conversation run per managed sub-agent job and store its exact `job_id`;
- retain synthetic conversation persistence only as a fallback when no full managed record exists;
- resolve persisted transcripts by session-scoped exact job identity, independent of a renamed parent namespace;
- reject duplicate exact identifiers and ambiguous legacy histories with HTTP 409 instead of guessing;
- add a local persisted-run selector showing task, timestamp, status, source, and output preview;
- use the store-backed path for active and saved Inspector sessions, always read-only;
- keep running conversation polling and messaging in Conversation/Chat when `can_receive=true`;
- keep Lab/cross-member ambiguity fail-closed without adding member-targeted routes;
- add unit, integration, API, and frontend regression coverage.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
pytest -q \
  tests/unit/session/test_store.py \
  tests/unit/modules/subagent/test_base.py \
  tests/unit/modules/subagent/test_manager.py \
  tests/unit/session/test_output.py \
  tests/unit/studio/test_creature_subagents.py \
  tests/unit/studio/persistence/viewer/test_subagents.py \
  tests/unit/api/test_persistence_viewer_routes.py \
  tests/integration/test_modules.py
pytest tests/integration/ -q --tb=short

cd src/kohakuterrarium-frontend
npm test -- --run \
  src/components/sessions/trace/TraceEventDetail.test.js \
  src/components/chat/ToolCallBlock.test.js \
  src/components/sessions/tabs/TraceTab.pagination.test.js \
  src/utils/i18n.test.js
npm run format:check
npm run build
```

Results:

- Ruff and Black: passed
- file-size and dependency guards: 1,732 passed
- affected Python unit/integration coverage: 309 passed
- complete integration tier: 173 passed
- targeted frontend tests: 24 passed initially; latest Inspector/selector delta: 22 passed
- frontend formatting and production build: passed

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [ ] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #247

- Issue opened: 2026-08-26
- Maintainer approval: pending in #247
- Scope match: yes; the implementation is limited to exact local persisted conversation navigation, a local ambiguity selector, and persistence identity. It does not introduce an independent sub-agent trace namespace, member-targeted Lab selection, sub-agent table mirroring, or multi-node live inspection.

## Notes for Reviewers

Please focus on:

- the invariant that one managed job maps to one canonical persisted run;
- exact `job_id` precedence over name/run and legacy fallback;
- session-scoped exact `job_id` lookup across parent renames;
- local ambiguity selector behavior and exclusion of unrelated modern runs;
- the shared panel's distinction between store-backed Inspector reads and Conversation/Chat live reads;
- Lab/cross-member ambiguity remaining fail-closed.

Explicitly deferred: member-targeted Lab/cross-member selection, sub-agent table mirroring, and independent sub-agent event traces.

## Screenshots / Logs (if applicable)

Not included. The regression is covered at the service/API and Vue component levels.

## Breaking Changes (if applicable)

None. New sessions gain exact persisted identity. Legacy sessions with multiple same-name candidates now fail explicitly instead of silently returning the latest run.

## Exceptions / Not Run

Maintainer approval is pending in #247. The PR is marked draft until the proposed public API/behavior scope is approved.

No standalone documentation was added because the new HTTP route backs the existing Inspector/session-viewer UI rather than a documented end-user API surface. If maintainers consider it public API, I will add the requested API documentation before marking the PR ready.

The complete Python unit suite was attempted locally. It reached 13,947 passed / 10 skipped with 12 unrelated environment failures:

- local WebSocket tests inherited a configured SOCKS proxy without `python-socks`;
- Dulwich integration fixtures assumed a `master` default branch while the local Git default was different;
- the real-config pollution guard observed concurrent writes from the running local application.

The complete frontend Vitest suite was also attempted through the worktree's shared `node_modules` junction; unrelated tests failed because that setup did not provide test `localStorage`, failed one Monaco resolution path, and hit existing 5-second timeouts. All changed frontend tests, Prettier checks, and the production build pass.

The fork's `ci.yml` only triggers on pushes to `main` or pull requests targeting `main`, so pushing this feature branch did not create a fork-side Actions run. The upstream PR CI is expected to exercise the full clean matrix.

