### PR TITLE
perf: reduce cold startup latency across runtime surfaces

### DIFF
--- a/docs/en/development/startup-profiling.md
+++ b/docs/en/development/startup-profiling.md
@@ -196,6 +196,27 @@ Fresh-process import p50 changed from about 4.97 seconds to 292.0 ms for
 2.17 seconds; its remaining cost is dominated by route modules whose runtime
 type dependencies still reach Terrarium and Studio session implementations.
 
+## Terminal runtime import optimization
+
+The fourth optimization pass defers the engine, recipe, Drive settings, session
+store, and ad-hoc topology modules until terminal runtime construction begins.
+It also keeps Textual out of the builtin input/output registries until the TUI
+class or `tui` factory is actually requested.
+
+Fresh-process import p50 changed from about 1130.5 ms to 429.6 ms for
+`kohakuterrarium.cli.run`; the engine import itself changed from about 1112.7 ms
+to 808.7 ms. A Windows source-checkout smoke run with a minimal creature
+produced:
+
+| Terminal milestone | Time from launch |
+| --- | ---: |
+| CLI `parser_ready` | 292.5 ms |
+| CLI `engine_create_begin` | 897.0 ms |
+| CLI `rich_cli_run_enter` | 1743.9 ms |
+| TUI `parser_ready` | 245.7 ms |
+| TUI `engine_create_begin` | 877.4 ms |
+| TUI `tui_mounted` | 1547.8 ms |
+
 ## Measurement limitations
 
 - Desktop `desktop_window_shown` was exercised once before and once after the

--- a/docs/en/development/startup-profiling.md
+++ b/docs/en/development/startup-profiling.md
@@ -150,11 +150,36 @@ runtime imports (about 4.0 seconds before engine construction). The next pass
 should therefore split those module-level dependency graphs rather than further
 optimizing argparse or the public facade.
 
+## Desktop loading-shell optimization
+
+The second optimization pass moved desktop bootstrap into a lightweight module.
+The launcher now creates and shows an inline native loading shell first, starts
+the heavy FastAPI/Uvicorn server graph after the shown event, and navigates the existing
+window to the verified fallback port when the server reports ready.
+
+A real Windows source-checkout smoke run produced:
+
+| Desktop milestone | Time from parent launch |
+| --- | ---: |
+| Parent parser ready | 206.6 ms |
+| Desktop UI child spawned | 215.8 ms |
+| Loading window created | 464.0 ms |
+| Loading window shown | 1080.5 ms |
+| Server child spawned | 1089.5 ms |
+| Server ready on fallback port 8002 | 6354.2 ms |
+
+The loading window is therefore visible about 5.3 seconds before the backend is
+ready, and about 9.7 seconds earlier than the original 10750.7 ms
+`desktop_window_shown` baseline. Server startup remains the next bottleneck; the
+loading shell changes T-visible without claiming that the application is fully
+ready.
+
 ## Measurement limitations
 
-- Desktop `desktop_window_shown` was exercised once on Windows, but remains a
-  manual GUI measurement. Repeat it on every supported desktop platform and
-  report a distribution before treating it as a budget.
+- Desktop `desktop_window_shown` was exercised once before and once after the
+  loading-shell change on Windows, but remains a manual GUI measurement. Repeat
+  it on every supported desktop platform and report a distribution before
+  treating it as a budget.
 - Browser FCP and Vue mount are not included. They need browser-side Performance
   API marks in a later frontend-specific pass.
 - Cold filesystem-cache and packaged Briefcase measurements remain separate

--- a/docs/en/development/startup-profiling.md
+++ b/docs/en/development/startup-profiling.md
@@ -174,6 +174,28 @@ ready, and about 9.7 seconds earlier than the original 10750.7 ms
 loading shell changes T-visible without claiming that the application is fully
 ready.
 
+## Web application import optimization
+
+The third optimization pass keeps the `serving.web` launcher independent from
+the API application graph and defers runtime-only imports until the selected
+provider, tool, local engine, Laboratory host, metrics endpoint, or uploaded
+file fallback actually needs them. The complete FastAPI route table is still
+registered before Uvicorn starts; this pass does not move startup cost into the
+first HTTP request.
+
+A real Windows source-checkout smoke run produced:
+
+| Web milestone | Before | After |
+| --- | ---: | ---: |
+| `web_config_dirs_resolved` | 4951.6 ms | 311.6 ms |
+| `web_app_created` | 4954.1 ms | 2103.4 ms |
+| `api_lifespan_ready` | 5059.9 ms | 2203.6 ms |
+
+Fresh-process import p50 changed from about 4.97 seconds to 292.0 ms for
+`kohakuterrarium.serving.web`. `kohakuterrarium.api.app` now imports in about
+2.17 seconds; its remaining cost is dominated by route modules whose runtime
+type dependencies still reach Terrarium and Studio session implementations.
+
 ## Measurement limitations
 
 - Desktop `desktop_window_shown` was exercised once before and once after the

--- a/docs/en/development/startup-profiling.md
+++ b/docs/en/development/startup-profiling.md
@@ -125,6 +125,31 @@ The dominant cost remains imports before the first parser milestone. Agent,
 engine, and UI setup add tens of milliseconds for the minimal fixture after
 imports complete.
 
+## First import-graph optimization
+
+The first optimization pass converted the public package facades to lazy
+exports, isolated Studio group-hook registration, and deferred CLI command and
+surface imports until dispatch. On the same machine and five-run methodology:
+
+| Measurement | Before p50 | After p50 | Change |
+| --- | ---: | ---: | ---: |
+| `import kohakuterrarium` | 4953.3 ms | 50.6 ms | -99.0% |
+| `import kohakuterrarium.cli` | 5780.5 ms | 200.1 ms | -96.5% |
+| `python -m kohakuterrarium --version` | 5881.0 ms | 440.2 ms | -92.5% |
+| Web `parser_ready` | 5011.6 ms | 183.7 ms | -96.3% |
+| CLI `parser_ready` | 8008.3 ms | 3212.8 ms | -59.9% |
+| TUI `parser_ready` | 8041.4 ms | 3204.9 ms | -60.1% |
+| Web `api_lifespan_ready` | 5109.2 ms | 5059.9 ms | -1.0% |
+| CLI `rich_cli_run_enter` | 8076.2 ms | 7292.6 ms | -9.7% |
+| TUI `tui_mounted` | 8160.6 ms | 7175.5 ms | -12.1% |
+
+The control result is important: parser latency fell sharply, while the final
+surface boundaries improved much less. The remaining cost moved behind dispatch
+into `serving.web` (about 5.0 seconds to import) and `cli.run` plus engine/UI
+runtime imports (about 4.0 seconds before engine construction). The next pass
+should therefore split those module-level dependency graphs rather than further
+optimizing argparse or the public facade.
+
 ## Measurement limitations
 
 - Desktop `desktop_window_shown` was exercised once on Windows, but remains a

--- a/docs/en/development/startup-profiling.md
+++ b/docs/en/development/startup-profiling.md
@@ -1,0 +1,141 @@
+# Startup profiling baseline
+
+This document records the pre-optimization startup baseline at commit
+`d8088ca9` and describes the opt-in trace used to compare later changes.
+
+## Enable the trace
+
+Set `KT_STARTUP_TRACE` to a JSONL base path before launching a surface. For
+process-launch measurements, also set the wall-clock origin immediately before
+starting the process:
+
+```powershell
+$env:KT_STARTUP_TRACE = "$PWD\startup.jsonl"
+$env:KT_STARTUP_ORIGIN_NS = python -c "import time; print(time.time_ns())"
+python -m kohakuterrarium web --dev
+```
+
+The tracer writes one process shard per PID, for example
+`startup.1234.jsonl`, preventing desktop parent and child writes from corrupting
+each other. Each line contains the event name, process ID, parent process ID,
+run ID, process-local elapsed time, wall-clock time, and `startup_ms`. The latter
+uses a shared `KT_STARTUP_ORIGIN_NS` propagated to child processes, so desktop
+parent and child events are comparable. If callers do not supply a run ID or
+origin, the first instrumented process creates and exports them, but that
+automatic origin starts at trace-module import rather than OS process launch.
+
+Tracing is disabled by default. File and serialization errors are ignored so
+profiling cannot prevent startup.
+
+## Baseline environment
+
+- Windows
+- Python 3.14.2
+- Source checkout at `d8088ca9`
+- Shared virtual environment, with `PYTHONPATH` forced to this worktree's `src`
+- Warm operating-system file cache
+- Five fresh process runs per reported median
+- Minimal terminal fixture with `input: none`, `output: none`, no session
+- `kt web --dev` used because `web_dist` is an untracked build artifact
+
+These numbers are for comparison on this machine, not cross-machine budgets.
+
+## Uninstrumented baseline
+
+| Measurement | p50 |
+| --- | ---: |
+| Python empty process | 44.9 ms |
+| `import kohakuterrarium` | 4953.3 ms |
+| `import kohakuterrarium.__main__` | 4928.2 ms |
+| `import kohakuterrarium.cli` | 5780.5 ms |
+| `python -m kohakuterrarium --version` | 5881.0 ms |
+| `kt web --dev` to `/healthz` HTTP 200 | 5218.9 ms |
+
+`-X importtime` loaded 4695 modules for `kohakuterrarium.cli`. Its main
+cumulative chain was `kohakuterrarium` -> `studio` ->
+`studio.editors.workspace_fs` -> `core.config`.
+
+Raw files are kept locally under `.startup-profile/before/`; this directory is
+not a committed benchmark artifact.
+
+## Instrumented surface baseline
+
+| Surface boundary | Samples (ms) | p50 |
+| --- | --- | ---: |
+| Web `api_lifespan_ready` | 5109, 5069, 5097, 5212, 5264 | 5109.2 ms |
+| Rich CLI `rich_cli_run_enter` | 8111, 8033, 8073, 8076, 8111 | 8076.2 ms |
+| Textual TUI `tui_mounted` | 8311, 8144, 8161, 8153, 8272 | 8160.6 ms |
+
+A single no-argument picker sample found 20 entries in 3 groups. Catalog-scanned
+was 8525.9 ms for CLI and 8208.0 ms for TUI, about 240 ms after their parser
+milestones.
+
+A manually exercised desktop run reached these cross-process milestones:
+
+| Desktop milestone | Time from parent launch |
+| --- | ---: |
+| Parent parser ready | 5062.9 ms |
+| Child spawned | 5073.1 ms |
+| Child app created | 9959.7 ms |
+| Child API lifespan ready | 10059.9 ms |
+| Desktop server ready | 10163.4 ms |
+| Native window created | 10164.4 ms |
+| Native window shown | 10750.7 ms |
+
+Port 8001 was already occupied during this sample, so the desktop child used
+its verified fallback port 8002. The duplicate `api_lifespan_ready` entry in
+that raw trace is consistent with the failed first bind attempt starting the
+app lifespan before the fallback server retried; it is a reminder to aggregate
+by the final `desktop_server_ready` boundary rather than assuming a single
+lifespan event.
+
+Representative p50 phase decomposition:
+
+### Web
+
+| Milestone | p50 from process launch |
+| --- | ---: |
+| CLI parser ready | 5011.6 ms |
+| Web app created | 5016.3 ms |
+| Uvicorn run entered | 5017.2 ms |
+| API lifespan ready | 5109.2 ms |
+
+### Rich CLI
+
+| Milestone | p50 from process launch |
+| --- | ---: |
+| Standalone parser ready | 8008.3 ms |
+| Engine creation begins | 8021.1 ms |
+| Creature added | 8067.8 ms |
+| Creature started | 8075.8 ms |
+| Rich CLI run entered | 8076.2 ms |
+
+### Textual TUI
+
+| Milestone | p50 from process launch |
+| --- | ---: |
+| Standalone parser ready | 8041.4 ms |
+| Engine creation begins | 8054.3 ms |
+| Creature added | 8101.9 ms |
+| Creatures started | 8108.0 ms |
+| Textual run entered | 8115.5 ms |
+| Textual mounted | 8160.6 ms |
+
+The dominant cost remains imports before the first parser milestone. Agent,
+engine, and UI setup add tens of milliseconds for the minimal fixture after
+imports complete.
+
+## Measurement limitations
+
+- Desktop `desktop_window_shown` was exercised once on Windows, but remains a
+  manual GUI measurement. Repeat it on every supported desktop platform and
+  report a distribution before treating it as a budget.
+- Browser FCP and Vue mount are not included. They need browser-side Performance
+  API marks in a later frontend-specific pass.
+- Cold filesystem-cache and packaged Briefcase measurements remain separate
+  follow-ups.
+- Enabling JSONL tracing added roughly 0.2 seconds to the very heavy
+  `--version` route in a small five-run sample. Compare optimization results
+  using the same trace configuration, and retain an uninstrumented control.
+- The baseline harness supplied a fresh external wall-clock origin for every
+  launched process. Runs that omit it measure from trace-module import instead.

--- a/scripts/dep_graph_allowlist.json
+++ b/scripts/dep_graph_allowlist.json
@@ -282,6 +282,24 @@
     "reason": "Briefcase cannot relaunch its stub with module arguments, so the heavy server graph is imported only after the loading window is visible."
   },
   {
+    "file": "src/kohakuterrarium/serving/desktop.py",
+    "function": "_set_windows_app_id",
+    "target": "ctypes",
+    "reason": "Windows shell integration stays out of the cross-platform lightweight desktop import path until a Windows desktop actually launches."
+  },
+  {
+    "file": "src/kohakuterrarium/serving/desktop.py",
+    "function": "_set_icon_windows",
+    "target": "ctypes",
+    "reason": "Win32 window icon APIs load only from the Windows shown callback, preserving lightweight startup on other platforms."
+  },
+  {
+    "file": "src/kohakuterrarium/serving/desktop.py",
+    "function": "_set_icon_macos",
+    "target": "PyObjCTools",
+    "reason": "The Cocoa main-thread dispatcher is available only on macOS and loads when the macOS shown callback restores the Dock icon."
+  },
+  {
     "file": "src/kohakuterrarium/api/app.py",
     "function": "lifespan",
     "target": "kohakuterrarium.laboratory",

--- a/scripts/dep_graph_allowlist.json
+++ b/scripts/dep_graph_allowlist.json
@@ -442,5 +442,47 @@
     "function": "_fetch_crawl4ai",
     "target": "crawl4ai",
     "reason": "Optional extractor is loaded only when the web_fetch tool executes the Crawl4AI backend."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_run",
+    "target": "kohakuterrarium.session.store",
+    "reason": "Session storage is loaded only after an executable path has been resolved and engine startup begins."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_run",
+    "target": "kohakuterrarium.studio.identity",
+    "reason": "Drive settings are loaded only when constructing the runtime engine."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_run",
+    "target": "kohakuterrarium.terrarium.config",
+    "reason": "Recipe parsing is loaded only when terminal runtime startup begins."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_run",
+    "target": "kohakuterrarium.terrarium.engine",
+    "reason": "The engine graph is deferred until after CLI dispatch and runnable resolution."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_apply_cli_topology",
+    "target": "kohakuterrarium.terrarium.channels",
+    "reason": "Channel mutation helpers are loaded only when --add or --channel topology is requested."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_apply_cli_topology",
+    "target": "kohakuterrarium.terrarium.topology",
+    "reason": "Topology mutation helpers are loaded only when --add or --channel is requested."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_session_preview",
+    "target": "kohakuterrarium.session.store",
+    "reason": "Session storage is loaded only when the resume picker reads a preview."
   }
 ]

--- a/scripts/dep_graph_allowlist.json
+++ b/scripts/dep_graph_allowlist.json
@@ -142,5 +142,131 @@
     "function": "_release",
     "target": "msvcrt",
     "reason": "Win32-only msvcrt import inside the `if sys.platform == 'win32'` branch of the cross-platform flock wrapper"
+  },
+  {
+    "file": "src/kohakuterrarium/builtins/user_commands/drives.py",
+    "function": "_drive_call",
+    "target": "kohakuterrarium.studio.sessions",
+    "reason": "Drive persistence is a Studio-only runtime path; deferring it keeps core Agent imports from pulling the full Studio session graph."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/__init__.py",
+    "function": "_build_parser",
+    "target": "kohakuterrarium.cli._main",
+    "reason": "The compatibility parser builder is loaded only when callers explicitly request the complete command parser."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/__init__.py",
+    "function": "_dispatch_surface",
+    "target": "kohakuterrarium.serving.web",
+    "reason": "Web and desktop serving dependencies are loaded only after the selected surface is known."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/__init__.py",
+    "function": "_dispatch_surface",
+    "target": "kohakuterrarium.cli.run",
+    "reason": "Agent and Terrarium runtime dependencies are loaded only for CLI or TUI execution."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/__init__.py",
+    "function": "main",
+    "target": "kohakuterrarium.cli._main",
+    "reason": "The full admin/package/session command graph is deferred until a non-fast-path command is selected."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/__init__.py",
+    "function": "main",
+    "target": "kohakuterrarium.cli.version",
+    "reason": "Version reporting is isolated so kt --version does not import command runtimes."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/__init__.py",
+    "function": "main",
+    "target": "kohakuterrarium.serving.web",
+    "reason": "The default desktop server is loaded only after the no-argument desktop branch is selected."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/entry_cli.py",
+    "function": "resume_cli",
+    "target": "kohakuterrarium.cli.resume",
+    "reason": "Standalone CLI resume dependencies are loaded only when --resume is used."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/entry_cli.py",
+    "function": "resolve_then_run",
+    "target": "kohakuterrarium.cli.run",
+    "reason": "Standalone CLI runtime dependencies are loaded only after argument parsing."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/entry_tui.py",
+    "function": "resume_cli",
+    "target": "kohakuterrarium.cli.resume",
+    "reason": "Standalone TUI resume dependencies are loaded only when --resume is used."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/entry_tui.py",
+    "function": "resolve_then_run",
+    "target": "kohakuterrarium.cli.run",
+    "reason": "Standalone TUI runtime dependencies are loaded only after argument parsing."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/picker.py",
+    "function": "pick_runnable",
+    "target": "kohakuterrarium.cli.select_cli",
+    "reason": "Prompt-toolkit picker is loaded only for the CLI surface."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/picker.py",
+    "function": "pick_runnable",
+    "target": "kohakuterrarium.cli.select_tui",
+    "reason": "Textual picker is loaded only for the TUI surface."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/resume.py",
+    "function": "run_engine_with_rich_cli",
+    "target": "kohakuterrarium.terrarium.engine_rich_cli",
+    "reason": "Rich terminal UI dependencies are loaded only for resumed CLI sessions."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/resume.py",
+    "function": "run_engine_with_tui",
+    "target": "kohakuterrarium.terrarium.engine_cli",
+    "reason": "Textual dependencies are loaded only for resumed TUI sessions."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_run",
+    "target": "kohakuterrarium.terrarium.engine_rich_cli",
+    "reason": "Rich terminal UI dependencies are loaded only after the CLI surface is selected."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/run.py",
+    "function": "_run",
+    "target": "kohakuterrarium.terrarium.engine_cli",
+    "reason": "Textual dependencies are loaded only after the TUI surface is selected."
+  },
+  {
+    "file": "src/kohakuterrarium/studio/hooks.py",
+    "function": "store_attach_hook",
+    "target": "kohakuterrarium.studio.sessions.lifecycle",
+    "reason": "Studio session persistence loads only when a group tool actually attaches a spawned creature."
+  },
+  {
+    "file": "src/kohakuterrarium/studio/hooks.py",
+    "function": "name_apply_hook",
+    "target": "kohakuterrarium.terrarium.creature_host",
+    "reason": "Creature runtime loads only when a group tool applies a spawned name."
+  },
+  {
+    "file": "src/kohakuterrarium/studio/hooks.py",
+    "function": "spawnable_hook",
+    "target": "kohakuterrarium.studio.catalog.spawnable",
+    "reason": "Catalog scanning loads only when group status requests spawnable creatures."
+  },
+  {
+    "file": "src/kohakuterrarium/studio/hooks.py",
+    "function": "resolve_workspace_hook",
+    "target": "kohakuterrarium.studio.editors.workspace_fs",
+    "reason": "Workspace editor dependencies load only when a group tool requests workspace resolution."
   }
 ]

--- a/scripts/dep_graph_allowlist.json
+++ b/scripts/dep_graph_allowlist.json
@@ -268,5 +268,23 @@
     "function": "resolve_workspace_hook",
     "target": "kohakuterrarium.studio.editors.workspace_fs",
     "reason": "Workspace editor dependencies load only when a group tool requests workspace resolution."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/__init__.py",
+    "function": "_dispatch_surface",
+    "target": "kohakuterrarium.serving.desktop",
+    "reason": "Desktop bootstrap stays out of web, terminal, and version paths until the app surface is selected."
+  },
+  {
+    "file": "src/kohakuterrarium/cli/__init__.py",
+    "function": "main",
+    "target": "kohakuterrarium.serving.desktop",
+    "reason": "The default native desktop bootstrap is loaded only for the no-argument desktop path."
+  },
+  {
+    "file": "src/kohakuterrarium/serving/desktop.py",
+    "function": "_start_in_process_server",
+    "target": "kohakuterrarium.serving.desktop_server",
+    "reason": "Briefcase cannot relaunch its stub with module arguments, so the heavy server graph is imported only after the loading window is visible."
   }
 ]

--- a/scripts/dep_graph_allowlist.json
+++ b/scripts/dep_graph_allowlist.json
@@ -180,12 +180,6 @@
     "reason": "Version reporting is isolated so kt --version does not import command runtimes."
   },
   {
-    "file": "src/kohakuterrarium/cli/__init__.py",
-    "function": "main",
-    "target": "kohakuterrarium.serving.web",
-    "reason": "The default desktop server is loaded only after the no-argument desktop branch is selected."
-  },
-  {
     "file": "src/kohakuterrarium/cli/entry_cli.py",
     "function": "resume_cli",
     "target": "kohakuterrarium.cli.resume",

--- a/scripts/dep_graph_allowlist.json
+++ b/scripts/dep_graph_allowlist.json
@@ -286,5 +286,161 @@
     "function": "_start_in_process_server",
     "target": "kohakuterrarium.serving.desktop_server",
     "reason": "Briefcase cannot relaunch its stub with module arguments, so the heavy server graph is imported only after the loading window is visible."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.laboratory",
+    "reason": "Laboratory host runtime is loaded only when lab-host mode is selected."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.laboratory._internal.host",
+    "reason": "Laboratory host engine is loaded only for the lab-host lifespan."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.laboratory._internal.transport_ws",
+    "reason": "Laboratory WebSocket transport is loaded only for the lab-host lifespan."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.laboratory.adapters",
+    "reason": "Laboratory adapters are loaded only for the lab-host lifespan."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.session.sync",
+    "reason": "Session mirroring is specific to lab-host mode."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.studio.sessions.registry",
+    "reason": "Lab-host session metadata lookup is loaded only in lab-host mode."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.terrarium",
+    "reason": "Terrarium host runtimes are loaded only when lab-host mode starts."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.terrarium.drive.config",
+    "reason": "Drive host configuration is loaded only in lab-host mode."
+  },
+  {
+    "file": "src/kohakuterrarium/api/app.py",
+    "function": "lifespan",
+    "target": "kohakuterrarium.terrarium.multi_node_channels",
+    "reason": "Cluster membership lookup is loaded only in lab-host mode."
+  },
+  {
+    "file": "src/kohakuterrarium/api/auth/engine_pool.py",
+    "function": "get_or_create",
+    "target": "kohakuterrarium",
+    "reason": "Per-user Terrarium runtime is loaded only when an engine is first created."
+  },
+  {
+    "file": "src/kohakuterrarium/api/deps.py",
+    "function": "_host_drive_kwargs",
+    "target": "kohakuterrarium.studio.identity",
+    "reason": "Drive settings are loaded only when constructing a standalone engine."
+  },
+  {
+    "file": "src/kohakuterrarium/api/deps.py",
+    "function": "_runtime_types",
+    "target": "kohakuterrarium.studio.sessions.registry",
+    "reason": "Session registry runtime is loaded only when resolving a local service."
+  },
+  {
+    "file": "src/kohakuterrarium/api/deps.py",
+    "function": "_runtime_types",
+    "target": "kohakuterrarium.terrarium",
+    "reason": "Terrarium runtime classes are loaded only when a local service is requested."
+  },
+  {
+    "file": "src/kohakuterrarium/api/routes/metrics.py",
+    "function": "_session_lifecycle",
+    "target": "kohakuterrarium.studio.sessions",
+    "reason": "Session lifecycle is loaded only when the metrics endpoint computes live gauges."
+  },
+  {
+    "file": "src/kohakuterrarium/bootstrap/agent_init.py",
+    "function": "_ensure_skill_tool_registered",
+    "target": "kohakuterrarium.builtins.tools.skill",
+    "reason": "Skill implementation is loaded only when an Agent registers the skill tool."
+  },
+  {
+    "file": "src/kohakuterrarium/bootstrap/llm.py",
+    "function": "_create_from_profile",
+    "target": "kohakuterrarium.llm.codex_provider",
+    "reason": "Provider implementation is loaded only for a selected Codex profile."
+  },
+  {
+    "file": "src/kohakuterrarium/bootstrap/llm.py",
+    "function": "_create_from_profile",
+    "target": "kohakuterrarium.llm.grok_provider",
+    "reason": "Provider implementation is loaded only for a selected Grok profile."
+  },
+  {
+    "file": "src/kohakuterrarium/bootstrap/llm.py",
+    "function": "_create_from_profile",
+    "target": "kohakuterrarium.llm.anthropic_provider",
+    "reason": "Provider implementation is loaded only for a selected Anthropic profile."
+  },
+  {
+    "file": "src/kohakuterrarium/bootstrap/llm.py",
+    "function": "_create_from_profile",
+    "target": "kohakuterrarium.llm.openai",
+    "reason": "Provider implementation is loaded only for an OpenAI-compatible profile."
+  },
+  {
+    "file": "src/kohakuterrarium/bootstrap/llm.py",
+    "function": "_create_from_inline",
+    "target": "kohakuterrarium.llm.codex_provider",
+    "reason": "Provider implementation is loaded only for selected inline Codex auth."
+  },
+  {
+    "file": "src/kohakuterrarium/bootstrap/llm.py",
+    "function": "_create_from_inline",
+    "target": "kohakuterrarium.llm.anthropic_provider",
+    "reason": "Provider implementation is loaded only for selected inline Anthropic auth."
+  },
+  {
+    "file": "src/kohakuterrarium/bootstrap/llm.py",
+    "function": "_create_from_inline",
+    "target": "kohakuterrarium.llm.openai",
+    "reason": "Provider implementation is loaded only for inline OpenAI-compatible auth."
+  },
+  {
+    "file": "src/kohakuterrarium/core/controller.py",
+    "function": "_resolve_file_part",
+    "target": "kohakuterrarium.builtins.tools.read",
+    "reason": "Read tool implementation is loaded only for inline file-part fallback."
+  },
+  {
+    "file": "src/kohakuterrarium/serving/desktop_server.py",
+    "function": "create_app",
+    "target": "kohakuterrarium.api.app",
+    "reason": "Desktop child defers the complete API route graph until server startup."
+  },
+  {
+    "file": "src/kohakuterrarium/serving/web.py",
+    "function": "create_app",
+    "target": "kohakuterrarium.api.app",
+    "reason": "Web module import remains lightweight until the server constructs its app."
+  },
+  {
+    "file": "src/kohakuterrarium/builtins/tools/web_fetch.py",
+    "function": "_fetch_crawl4ai",
+    "target": "crawl4ai",
+    "reason": "Optional extractor is loaded only when the web_fetch tool executes the Crawl4AI backend."
   }
 ]

--- a/src/kohakuterrarium/__init__.py
+++ b/src/kohakuterrarium/__init__.py
@@ -1,31 +1,28 @@
-"""
-Public API for building and running agent systems with KohakuTerrarium.
-"""
+"""Public API for building and running agent systems with KohakuTerrarium."""
 
-import kohakuterrarium.errors as errors
-from kohakuterrarium.studio import Studio
-from kohakuterrarium.terrarium import (
-    ConnectionResult,
-    Creature,
-    DisconnectionResult,
-    EngineEvent,
-    EventFilter,
-    EventKind,
-    Terrarium,
-)
+import importlib
 
-# Import after Studio and Terrarium to avoid re-entering a partial core.config.
-import kohakuterrarium.validate as validate  # noqa: E402
-from kohakuterrarium.core.agent import Agent  # noqa: E402
-from kohakuterrarium.core.turn import (  # noqa: E402
-    Activity,
-    TextChunk,
-    TurnEnded,
-    TurnResult,
-)
-from kohakuterrarium.modules.tool.function import FunctionTool, tool  # noqa: E402
-from kohakuterrarium.session.reader import SessionReader  # noqa: E402
-from kohakuterrarium.session.store import SessionStore  # noqa: E402
+_EXPORTS = {
+    "Activity": "kohakuterrarium.core.turn",
+    "Agent": "kohakuterrarium.core.agent",
+    "ConnectionResult": "kohakuterrarium.terrarium",
+    "Creature": "kohakuterrarium.terrarium",
+    "DisconnectionResult": "kohakuterrarium.terrarium",
+    "EngineEvent": "kohakuterrarium.terrarium",
+    "EventFilter": "kohakuterrarium.terrarium",
+    "EventKind": "kohakuterrarium.terrarium",
+    "FunctionTool": "kohakuterrarium.modules.tool.function",
+    "SessionReader": "kohakuterrarium.session.reader",
+    "SessionStore": "kohakuterrarium.session.store",
+    "Studio": "kohakuterrarium.studio",
+    "Terrarium": "kohakuterrarium.terrarium",
+    "TextChunk": "kohakuterrarium.core.turn",
+    "TurnEnded": "kohakuterrarium.core.turn",
+    "TurnResult": "kohakuterrarium.core.turn",
+    "errors": "kohakuterrarium.errors",
+    "tool": "kohakuterrarium.modules.tool.function",
+    "validate": "kohakuterrarium.validate",
+}
 
 __version__ = "2.1.0"
 
@@ -51,3 +48,20 @@ __all__ = [
     "validate",
     "__version__",
 ]
+
+
+def __getattr__(name: str):
+    module_path = _EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    if module_path.startswith("kohakuterrarium.terrarium"):
+        hooks = importlib.import_module("kohakuterrarium.studio.hooks")
+        hooks.register_group_hooks()
+    module = importlib.import_module(module_path)
+    value = module if name in {"errors", "validate"} else getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_EXPORTS))

--- a/src/kohakuterrarium/api/app.py
+++ b/src/kohakuterrarium/api/app.py
@@ -1,5 +1,7 @@
 """FastAPI application factory."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
@@ -29,27 +31,13 @@ from kohakuterrarium.terrarium.drive.errors import (
     DriveRegistrationNotFoundError,
     DriveTransitionError,
 )
-from kohakuterrarium.laboratory import HostConfig
 from kohakuterrarium.laboratory._internal.client import (
     RequestAbortedError,
     RequestTimeoutError,
 )
-from kohakuterrarium.laboratory._internal.host import HostEngine
 from kohakuterrarium.laboratory._internal.membership import MembershipEvent
-from kohakuterrarium.laboratory._internal.transport_ws import WebSocketTransport
-from kohakuterrarium.laboratory.adapters import (
-    StudioCatalogAdapter,
-    StudioIdentityAdapter,
-    TerrariumBroadcastAdapter,
-    TerrariumOutputWireAdapter,
-)
 from kohakuterrarium.serving.process_metrics import get_aggregator
-from kohakuterrarium.session.sync import SessionMirrorWriter
 from kohakuterrarium.studio.identity import drive_settings as _drive_settings
-from kohakuterrarium.studio.sessions.lifecycle import get_session_meta
-from kohakuterrarium.terrarium import MultiNodeTerrariumService, Terrarium
-from kohakuterrarium.terrarium.drive.config import DriveRuntimeConfig
-from kohakuterrarium.terrarium.multi_node_channels import cluster_members_for
 from kohakuterrarium.utils.logging import get_logger
 from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
@@ -169,6 +157,21 @@ async def lifespan(app: FastAPI):
     mirror_writer = None
 
     if lab_mode == "lab-host":
+        from kohakuterrarium.laboratory import HostConfig
+        from kohakuterrarium.laboratory._internal.host import HostEngine
+        from kohakuterrarium.laboratory._internal.transport_ws import WebSocketTransport
+        from kohakuterrarium.laboratory.adapters import (
+            StudioCatalogAdapter,
+            StudioIdentityAdapter,
+            TerrariumBroadcastAdapter,
+            TerrariumOutputWireAdapter,
+        )
+        from kohakuterrarium.session.sync import SessionMirrorWriter
+        from kohakuterrarium.studio.sessions.registry import get_session_meta
+        from kohakuterrarium.terrarium import MultiNodeTerrariumService, Terrarium
+        from kohakuterrarium.terrarium.drive.config import DriveRuntimeConfig
+        from kohakuterrarium.terrarium.multi_node_channels import cluster_members_for
+
         # Initialize shared mutable state before request tasks begin, avoiding
         # concurrent first-write handling in the lab-clients route.
         if not hasattr(app.state, "lab_blocklist"):

--- a/src/kohakuterrarium/api/app.py
+++ b/src/kohakuterrarium/api/app.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path
@@ -50,6 +51,7 @@ from kohakuterrarium.terrarium import MultiNodeTerrariumService, Terrarium
 from kohakuterrarium.terrarium.drive.config import DriveRuntimeConfig
 from kohakuterrarium.terrarium.multi_node_channels import cluster_members_for
 from kohakuterrarium.utils.logging import get_logger
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 logger = get_logger(__name__)
 
@@ -235,6 +237,10 @@ async def lifespan(app: FastAPI):
     # Only standalone mode has a local agent engine that can consume this prompt.
     if multi_node_service is None:
         get_engine()._runtime_prompt.attach()
+    mark_startup(
+        "api_lifespan_ready",
+        surface=os.environ.get("KT_STARTUP_SURFACE", "web"),
+    )
     try:
         yield
     finally:

--- a/src/kohakuterrarium/api/auth/engine_pool.py
+++ b/src/kohakuterrarium/api/auth/engine_pool.py
@@ -6,18 +6,22 @@ anonymous key preserves a shared-engine slot. A shared lock serializes construct
 and registry mutation, while slow shutdown work runs after releasing the lock.
 """
 
+from __future__ import annotations
+
 import asyncio
 import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from kohakuterrarium.terrarium import Terrarium
 from kohakuterrarium.utils.config_dir import config_dir
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from kohakuterrarium.terrarium import Terrarium
 
 
 _ANONYMOUS_KEY = "_anon"
@@ -73,6 +77,8 @@ class EnginePool:
 
             session_dir = _user_session_dir(user_id)
             session_dir.mkdir(parents=True, exist_ok=True)
+            from kohakuterrarium import Terrarium
+
             drive_kwargs = self._drive_resolver() if self._drive_resolver else {}
             engine = Terrarium(session_dir=str(session_dir), **drive_kwargs)
             self._engines[key] = engine

--- a/src/kohakuterrarium/api/deps.py
+++ b/src/kohakuterrarium/api/deps.py
@@ -6,8 +6,11 @@ engines. ``get_engine`` exposes only the local or coordination engine and theref
 cannot provide cross-node creature visibility.
 """
 
+from __future__ import annotations
+
 import os
 import sys
+from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
@@ -19,20 +22,16 @@ from kohakuterrarium.api.auth.dependencies import get_auth_config, get_optional_
 from kohakuterrarium.api.auth.engine_pool import EnginePool, _user_session_dir
 from kohakuterrarium.api.auth.models import User
 from kohakuterrarium.studio.hooks import register_group_hooks
-from kohakuterrarium.studio.identity import drive_settings as _drive_settings
-from kohakuterrarium.studio.sessions.lifecycle import get_session_meta
-from kohakuterrarium.terrarium import (
-    LocalTerrariumService,
-    Terrarium,
-    TerrariumService,
-)
 from kohakuterrarium.utils.config_dir import config_dir
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-_service: TerrariumService | None = None
-_engine_legacy: Terrarium | None = None
+if TYPE_CHECKING:
+    from kohakuterrarium.terrarium import Terrarium, TerrariumService
+
+_service: Any = None
+_engine_legacy: Any = None
 # Deduplicate warnings for call sites that request an engine without cross-node visibility.
 _engine_legacy_warned: set[str] = set()
 
@@ -55,7 +54,16 @@ _DEFAULT_SESSION_DIR = str(Path.home() / ".kohakuterrarium" / "sessions")
 
 def _host_drive_kwargs() -> dict:
     """Resolve one immutable host Drive configuration for a new engine."""
-    return _drive_settings.resolve_drive_kwargs()
+    from kohakuterrarium.studio.identity import drive_settings
+
+    return drive_settings.resolve_drive_kwargs()
+
+
+def _runtime_types():
+    from kohakuterrarium.studio.sessions.registry import get_session_meta
+    from kohakuterrarium.terrarium import LocalTerrariumService, Terrarium
+
+    return LocalTerrariumService, Terrarium, get_session_meta
 
 
 def set_service(service: TerrariumService | None) -> None:
@@ -79,6 +87,7 @@ def get_service(
     """
     global _service
     register_group_hooks()
+    LocalTerrariumService, Terrarium, get_session_meta = _runtime_types()
     # Multi-node services own their routing and must not be wrapped as local engines.
     if _service is not None and not isinstance(_service, LocalTerrariumService):
         return _service
@@ -158,6 +167,7 @@ def get_service_legacy() -> TerrariumService:
     """Return the process-wide service when no request identity is available."""
     global _service
     register_group_hooks()
+    LocalTerrariumService, Terrarium, get_session_meta = _runtime_types()
     if _service is None:
         engine = Terrarium(session_dir=_session_dir(), **_host_drive_kwargs())
         _service = LocalTerrariumService(engine)
@@ -172,6 +182,7 @@ def get_engine() -> Terrarium:
     that need creature state must depend on :func:`get_service` instead.
     """
     global _engine_legacy
+    LocalTerrariumService, _, _ = _runtime_types()
     svc = get_service_legacy()
     if isinstance(svc, LocalTerrariumService):
         _engine_legacy = svc.engine

--- a/src/kohakuterrarium/api/deps.py
+++ b/src/kohakuterrarium/api/deps.py
@@ -18,6 +18,7 @@ from starlette.requests import HTTPConnection
 from kohakuterrarium.api.auth.dependencies import get_auth_config, get_optional_user
 from kohakuterrarium.api.auth.engine_pool import EnginePool, _user_session_dir
 from kohakuterrarium.api.auth.models import User
+from kohakuterrarium.studio.hooks import register_group_hooks
 from kohakuterrarium.studio.identity import drive_settings as _drive_settings
 from kohakuterrarium.studio.sessions.lifecycle import get_session_meta
 from kohakuterrarium.terrarium import (
@@ -77,6 +78,7 @@ def get_service(
     isolation, all requests share the process-wide local service.
     """
     global _service
+    register_group_hooks()
     # Multi-node services own their routing and must not be wrapped as local engines.
     if _service is not None and not isinstance(_service, LocalTerrariumService):
         return _service
@@ -155,6 +157,7 @@ def resolve_request_session_dir(
 def get_service_legacy() -> TerrariumService:
     """Return the process-wide service when no request identity is available."""
     global _service
+    register_group_hooks()
     if _service is None:
         engine = Terrarium(session_dir=_session_dir(), **_host_drive_kwargs())
         _service = LocalTerrariumService(engine)

--- a/src/kohakuterrarium/api/routes/metrics.py
+++ b/src/kohakuterrarium/api/routes/metrics.py
@@ -16,10 +16,15 @@ from fastapi import APIRouter, Depends
 from kohakuterrarium.api.deps import get_service
 from kohakuterrarium.serving.process_metrics import get_aggregator
 from kohakuterrarium.studio._runtime import host_engine_or_none
-from kohakuterrarium.studio.sessions import lifecycle as sessions_lifecycle
 from kohakuterrarium.terrarium.service import TerrariumService
 
 router = APIRouter()
+
+
+def _session_lifecycle():
+    from kohakuterrarium.studio.sessions import lifecycle
+
+    return lifecycle
 
 
 @router.get("/snapshot")
@@ -46,6 +51,7 @@ def _build_gauges(service: TerrariumService) -> dict[str, int]:
     host-local creatures, so the MCP gauge is zero when the service has no host
     engine.
     """
+    sessions_lifecycle = _session_lifecycle()
     sessions = list(sessions_lifecycle.list_sessions(service))
     creatures_running = sum(1 for s in sessions if s.creatures <= 1)
     terrariums_running = sum(1 for s in sessions if s.creatures > 1)

--- a/src/kohakuterrarium/bootstrap/agent_init.py
+++ b/src/kohakuterrarium/bootstrap/agent_init.py
@@ -14,7 +14,6 @@ from kohakuterrarium.bootstrap.tools import init_tools
 from kohakuterrarium.bootstrap.triggers import init_triggers
 from kohakuterrarium.builtins.plugin_catalog import resolve_plugin_specs
 from kohakuterrarium.builtins.tool_catalog import get_builtin_tool
-from kohakuterrarium.builtins.tools.skill import SkillTool
 from kohakuterrarium.builtins.user_commands import (
     get_builtin_user_command,
     list_builtin_user_commands,
@@ -406,6 +405,8 @@ class AgentInitMixin:
         tool = get_builtin_tool("skill")
         if tool is None:
             try:
+                from kohakuterrarium.builtins.tools.skill import SkillTool
+
                 tool = SkillTool()
             except Exception as exc:
                 logger.warning(

--- a/src/kohakuterrarium/bootstrap/llm.py
+++ b/src/kohakuterrarium/bootstrap/llm.py
@@ -7,11 +7,7 @@ from typing import Any
 
 from kohakuterrarium.errors import LLMNotConfiguredError
 from kohakuterrarium.core.config import AgentConfig
-from kohakuterrarium.llm.anthropic_provider import AnthropicProvider
 from kohakuterrarium.llm.base import LLMConfig, LLMProvider
-from kohakuterrarium.llm.codex_provider import CodexOAuthProvider
-from kohakuterrarium.llm.grok_provider import GrokSubscriptionProvider
-from kohakuterrarium.llm.openai import OpenAIProvider
 from kohakuterrarium.llm import api_keys as _api_keys
 from kohakuterrarium.llm.profiles import (
     LLMProfile,
@@ -173,6 +169,8 @@ def _create_from_profile(profile: LLMProfile) -> LLMProvider:
         return provider
 
     if profile.backend_type == "codex":
+        from kohakuterrarium.llm.codex_provider import CodexOAuthProvider
+
         # A custom base URL requires API-key auth; the default endpoint uses OAuth.
         codex_base_url = _resolved_base_url(profile)
         codex_key: str | None = None
@@ -202,6 +200,8 @@ def _create_from_profile(profile: LLMProfile) -> LLMProvider:
         return provider
 
     if profile.backend_type == "grok-subscription":
+        from kohakuterrarium.llm.grok_provider import GrokSubscriptionProvider
+
         provider = GrokSubscriptionProvider(
             model=profile.model,
             temperature=profile.temperature,
@@ -255,6 +255,8 @@ def _create_from_profile(profile: LLMProfile) -> LLMProvider:
 
     base_url = _resolved_base_url(profile)
     if profile.backend_type == "anthropic":
+        from kohakuterrarium.llm.anthropic_provider import AnthropicProvider
+
         provider = AnthropicProvider(
             api_key=api_key,
             base_url=base_url,
@@ -266,6 +268,8 @@ def _create_from_profile(profile: LLMProfile) -> LLMProvider:
             retry_policy=retry_policy,
         )
     else:
+        from kohakuterrarium.llm.openai import OpenAIProvider
+
         provider = OpenAIProvider(
             api_key=api_key,
             base_url=base_url,
@@ -319,6 +323,8 @@ def _create_from_inline(config: AgentConfig) -> LLMProvider:
         )
 
     if config.auth_mode == "codex-oauth":
+        from kohakuterrarium.llm.codex_provider import CodexOAuthProvider
+
         provider = CodexOAuthProvider(
             model=config.model,
             reasoning_effort=config.reasoning_effort,
@@ -346,6 +352,8 @@ def _create_from_inline(config: AgentConfig) -> LLMProvider:
         )
 
     if config.auth_mode == "anthropic":
+        from kohakuterrarium.llm.anthropic_provider import AnthropicProvider
+
         return AnthropicProvider(
             api_key=api_key,
             base_url=config.base_url or None,
@@ -356,6 +364,8 @@ def _create_from_inline(config: AgentConfig) -> LLMProvider:
             service_tier=config.service_tier,
             retry_policy=config.retry_policy,
         )
+
+    from kohakuterrarium.llm.openai import OpenAIProvider
 
     return OpenAIProvider(
         api_key=api_key,

--- a/src/kohakuterrarium/builtins/__init__.py
+++ b/src/kohakuterrarium/builtins/__init__.py
@@ -5,7 +5,6 @@ import importlib
 from kohakuterrarium.builtins.inputs import (
     CLIInput,
     NonBlockingCLIInput,
-    TUIInput,
     create_builtin_input,
     get_builtin_input,
     is_builtin_input,
@@ -18,7 +17,6 @@ from kohakuterrarium.builtins.outputs import (
     StdoutOutput,
     TTSConfig,
     TTSModule,
-    TUIOutput,
     create_builtin_output,
     get_builtin_output,
     is_builtin_output,
@@ -44,6 +42,8 @@ _TOOL_EXPORTS = {
     "EditTool": "kohakuterrarium.builtins.tools",
     "GlobTool": "kohakuterrarium.builtins.tools",
     "GrepTool": "kohakuterrarium.builtins.tools",
+    "TUIInput": "kohakuterrarium.builtins.tui.input",
+    "TUIOutput": "kohakuterrarium.builtins.tui.output",
 }
 
 __all__ = [

--- a/src/kohakuterrarium/builtins/inputs/__init__.py
+++ b/src/kohakuterrarium/builtins/inputs/__init__.py
@@ -4,6 +4,8 @@ Contains terminal, TUI, and no-input implementations only. Audio examples
 (ASR/Whisper) live under ``examples/`` so core imports stay audio-free.
 """
 
+import importlib
+import threading
 from typing import Any
 
 from kohakuterrarium.builtins.inputs.cli import CLIInput, NonBlockingCLIInput
@@ -16,11 +18,14 @@ _BUILTIN_INPUTS: dict[str, type] = {
 }
 
 _BUILTIN_INPUT_FACTORIES: dict[str, Any] = {}
+_LAZY_INPUTS = {"tui": ("kohakuterrarium.builtins.tui.input", "TUIInput")}
+_INPUTS_LOCK = threading.Lock()
 
 
 def register_builtin_input(name: str, cls: type) -> None:
     """Register a builtin input type."""
-    _BUILTIN_INPUTS[name] = cls
+    with _INPUTS_LOCK:
+        _BUILTIN_INPUTS[name] = cls
 
 
 def register_builtin_input_factory(name: str, factory: Any) -> None:
@@ -30,7 +35,13 @@ def register_builtin_input_factory(name: str, factory: Any) -> None:
 
 def get_builtin_input(name: str) -> type | None:
     """Get a builtin input class by name."""
-    return _BUILTIN_INPUTS.get(name)
+    cls = _BUILTIN_INPUTS.get(name)
+    if cls is None and name in _LAZY_INPUTS:
+        module_name, class_name = _LAZY_INPUTS[name]
+        resolved = getattr(importlib.import_module(module_name), class_name)
+        with _INPUTS_LOCK:
+            cls = _BUILTIN_INPUTS.setdefault(name, resolved)
+    return cls
 
 
 def get_builtin_input_factory(name: str) -> Any | None:
@@ -40,12 +51,18 @@ def get_builtin_input_factory(name: str) -> Any | None:
 
 def is_builtin_input(name: str) -> bool:
     """Check if name is a builtin input type."""
-    return name in _BUILTIN_INPUTS or name in _BUILTIN_INPUT_FACTORIES
+    return (
+        name in _BUILTIN_INPUTS
+        or name in _BUILTIN_INPUT_FACTORIES
+        or name in _LAZY_INPUTS
+    )
 
 
 def list_builtin_inputs() -> list[str]:
     """List all builtin input type names."""
-    return list(set(_BUILTIN_INPUTS.keys()) | set(_BUILTIN_INPUT_FACTORIES.keys()))
+    return list(
+        set(_BUILTIN_INPUTS) | set(_BUILTIN_INPUT_FACTORIES) | set(_LAZY_INPUTS)
+    )
 
 
 def create_builtin_input(name: str, options: dict[str, Any] | None = None) -> Any:
@@ -57,17 +74,20 @@ def create_builtin_input(name: str, options: dict[str, Any] | None = None) -> An
         factory = _BUILTIN_INPUT_FACTORIES[name]
         return factory(options)
 
-    if name in _BUILTIN_INPUTS:
-        cls = _BUILTIN_INPUTS[name]
+    cls = get_builtin_input(name)
+    if cls is not None:
         return cls(**options)
 
     raise ValueError(f"Unknown builtin input type: {name}")
 
 
-# Delayed import avoids loading the TUI before the registry is initialized.
-from kohakuterrarium.builtins.tui.input import TUIInput
-
-register_builtin_input("tui", TUIInput)
+def __getattr__(name: str):
+    if name != "TUIInput":
+        raise AttributeError(name)
+    module_name, class_name = _LAZY_INPUTS["tui"]
+    value = getattr(importlib.import_module(module_name), class_name)
+    globals()[name] = value
+    return value
 
 
 __all__ = [

--- a/src/kohakuterrarium/builtins/outputs/__init__.py
+++ b/src/kohakuterrarium/builtins/outputs/__init__.py
@@ -1,5 +1,7 @@
 """Register and expose built-in terminal, null, TTS, and TUI outputs."""
 
+import importlib
+import threading
 from typing import Any
 
 from kohakuterrarium.builtins.outputs.none import NoneOutput
@@ -20,11 +22,14 @@ _BUILTIN_OUTPUTS: dict[str, type] = {
 }
 
 _BUILTIN_OUTPUT_FACTORIES: dict[str, Any] = {}
+_LAZY_OUTPUTS = {"tui": ("kohakuterrarium.builtins.tui.output", "TUIOutput")}
+_OUTPUTS_LOCK = threading.Lock()
 
 
 def register_builtin_output(name: str, cls: type) -> None:
     """Register a builtin output type."""
-    _BUILTIN_OUTPUTS[name] = cls
+    with _OUTPUTS_LOCK:
+        _BUILTIN_OUTPUTS[name] = cls
 
 
 def register_builtin_output_factory(name: str, factory: Any) -> None:
@@ -34,7 +39,13 @@ def register_builtin_output_factory(name: str, factory: Any) -> None:
 
 def get_builtin_output(name: str) -> type | None:
     """Get a builtin output class by name."""
-    return _BUILTIN_OUTPUTS.get(name)
+    cls = _BUILTIN_OUTPUTS.get(name)
+    if cls is None and name in _LAZY_OUTPUTS:
+        module_name, class_name = _LAZY_OUTPUTS[name]
+        resolved = getattr(importlib.import_module(module_name), class_name)
+        with _OUTPUTS_LOCK:
+            cls = _BUILTIN_OUTPUTS.setdefault(name, resolved)
+    return cls
 
 
 def get_builtin_output_factory(name: str) -> Any | None:
@@ -44,12 +55,18 @@ def get_builtin_output_factory(name: str) -> Any | None:
 
 def is_builtin_output(name: str) -> bool:
     """Check if name is a builtin output type."""
-    return name in _BUILTIN_OUTPUTS or name in _BUILTIN_OUTPUT_FACTORIES
+    return (
+        name in _BUILTIN_OUTPUTS
+        or name in _BUILTIN_OUTPUT_FACTORIES
+        or name in _LAZY_OUTPUTS
+    )
 
 
 def list_builtin_outputs() -> list[str]:
     """List all builtin output type names."""
-    return list(set(_BUILTIN_OUTPUTS.keys()) | set(_BUILTIN_OUTPUT_FACTORIES.keys()))
+    return list(
+        set(_BUILTIN_OUTPUTS) | set(_BUILTIN_OUTPUT_FACTORIES) | set(_LAZY_OUTPUTS)
+    )
 
 
 def create_builtin_output(name: str, options: dict[str, Any] | None = None) -> Any:
@@ -61,17 +78,20 @@ def create_builtin_output(name: str, options: dict[str, Any] | None = None) -> A
         factory = _BUILTIN_OUTPUT_FACTORIES[name]
         return factory(options)
 
-    if name in _BUILTIN_OUTPUTS:
-        cls = _BUILTIN_OUTPUTS[name]
+    cls = get_builtin_output(name)
+    if cls is not None:
         return cls(**options)
 
     raise ValueError(f"Unknown builtin output type: {name}")
 
 
-# Delayed import avoids loading the TUI before the registry is initialized.
-from kohakuterrarium.builtins.tui.output import TUIOutput
-
-register_builtin_output("tui", TUIOutput)
+def __getattr__(name: str):
+    if name != "TUIOutput":
+        raise AttributeError(name)
+    module_name, class_name = _LAZY_OUTPUTS["tui"]
+    value = getattr(importlib.import_module(module_name), class_name)
+    globals()[name] = value
+    return value
 
 
 __all__ = [

--- a/src/kohakuterrarium/builtins/tool_catalog.py
+++ b/src/kohakuterrarium/builtins/tool_catalog.py
@@ -16,6 +16,8 @@ Internal code (core, terrarium) should import from here, not from
 transitive dependencies.
 """
 
+import importlib
+import threading
 from typing import TYPE_CHECKING, Callable, TypeVar
 
 from kohakuterrarium.utils.logging import get_logger
@@ -58,6 +60,8 @@ _BUILTIN_TOOLS: dict[str, type["BaseTool"]] = {}
 # modules and trigger their @register_builtin decorators. Each loader is
 # called at most once (on first catalog miss), then removed.
 _DEFERRED_LOADERS: list[Callable[[], None]] = []
+_DEFAULT_TOOLS_LOADED = False
+_DEFAULT_TOOLS_LOCK = threading.Lock()
 
 T = TypeVar("T", bound="BaseTool")
 
@@ -94,8 +98,20 @@ def register_deferred_loader(loader: Callable[[], None]) -> None:
     _DEFERRED_LOADERS.append(loader)
 
 
+def _ensure_default_tools_loaded() -> None:
+    global _DEFAULT_TOOLS_LOADED
+    if _DEFAULT_TOOLS_LOADED:
+        return
+    with _DEFAULT_TOOLS_LOCK:
+        if _DEFAULT_TOOLS_LOADED:
+            return
+        importlib.import_module("kohakuterrarium.builtins.tools")
+        _DEFAULT_TOOLS_LOADED = True
+
+
 def _run_deferred_loaders() -> None:
     """Invoke and clear all deferred loaders."""
+    _ensure_default_tools_loaded()
     if not _DEFERRED_LOADERS:
         return
     # Copy + clear before calling to avoid re-entrance
@@ -122,7 +138,7 @@ def get_builtin_tool(
     if _is_hidden_under_mobile_profile(name):
         return None
     tool_cls = _BUILTIN_TOOLS.get(name)
-    if tool_cls is None and _DEFERRED_LOADERS:
+    if tool_cls is None:
         _run_deferred_loaders()
         tool_cls = _BUILTIN_TOOLS.get(name)
     if tool_cls:
@@ -138,6 +154,7 @@ def list_builtin_tools() -> list[str]:
     aggregator, `kt config tools list`, the frontend's Tools panel)
     see only the catalog that actually works on the device.
     """
+    _run_deferred_loaders()
     if is_mobile_profile() and _MOBILE_HIDDEN_TOOLS:
         return [n for n in _BUILTIN_TOOLS if n not in _MOBILE_HIDDEN_TOOLS]
     return list(_BUILTIN_TOOLS.keys())
@@ -151,6 +168,8 @@ def is_builtin_tool(name: str) -> bool:
     """
     if _is_hidden_under_mobile_profile(name):
         return False
+    if name not in _BUILTIN_TOOLS:
+        _run_deferred_loaders()
     return name in _BUILTIN_TOOLS
 
 
@@ -166,8 +185,7 @@ def list_provider_native_tools() -> list[dict[str, object]]:
     Fires deferred loaders first so terrarium-registered tools (and any
     other lazy additions) show up too.
     """
-    if _DEFERRED_LOADERS:
-        _run_deferred_loaders()
+    _run_deferred_loaders()
     out: list[dict[str, object]] = []
     for name, tool_cls in _BUILTIN_TOOLS.items():
         if not getattr(tool_cls, "is_provider_native", False):

--- a/src/kohakuterrarium/builtins/tools/web_fetch.py
+++ b/src/kohakuterrarium/builtins/tools/web_fetch.py
@@ -15,23 +15,6 @@ MAX_CONTENT_SIZE = 100_000  # Bound fetched pages before adding them to context.
 FETCH_TIMEOUT = 30.0
 USER_AGENT = "Mozilla/5.0 (compatible; KohakuTerrarium/1.0)"
 
-_HAS_CRAWL4AI = False
-_HAS_TRAFILATURA = False
-
-try:
-    import crawl4ai  # noqa: F401
-
-    _HAS_CRAWL4AI = True
-except ImportError:
-    pass
-
-try:
-    import trafilatura  # noqa: F401
-
-    _HAS_TRAFILATURA = True
-except ImportError:
-    pass
-
 
 @register_builtin("web_fetch")
 class WebFetchTool(BaseTool):
@@ -100,11 +83,11 @@ class _SkipBackend(Exception):
 
 async def _fetch_crawl4ai(url: str) -> str:
     """Render with Crawl4AI and prefer trafilatura extraction."""
-    if not _HAS_CRAWL4AI:
-        raise _SkipBackend
-
-    from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
-    from crawl4ai.async_logger import AsyncFileLogger
+    try:
+        from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
+        from crawl4ai.async_logger import AsyncFileLogger
+    except ImportError:
+        raise _SkipBackend from None
 
     browser_cfg = BrowserConfig(headless=True, verbose=False)
     run_cfg = CrawlerRunConfig(verbose=False, log_console=False)
@@ -115,18 +98,21 @@ async def _fetch_crawl4ai(url: str) -> str:
         if not result.success:
             raise _SkipBackend
 
-        if _HAS_TRAFILATURA and result.html:
-            import trafilatura
-
-            content = trafilatura.extract(
-                result.html,
-                output_format="markdown",
-                include_links=True,
-                include_images=False,
-                include_tables=True,
-            )
-            if content and content.strip():
-                return content
+        if result.html:
+            try:
+                import trafilatura
+            except ImportError:
+                trafilatura = None
+            if trafilatura is not None:
+                content = trafilatura.extract(
+                    result.html,
+                    output_format="markdown",
+                    include_links=True,
+                    include_images=False,
+                    include_tables=True,
+                )
+                if content and content.strip():
+                    return content
 
         md = result.markdown
         text = str(md) if md else ""
@@ -137,10 +123,10 @@ async def _fetch_crawl4ai(url: str) -> str:
 
 async def _fetch_trafilatura(url: str) -> str:
     """Fetch static HTML and extract its main content with trafilatura."""
-    if not _HAS_TRAFILATURA:
-        raise _SkipBackend
-
-    import trafilatura
+    try:
+        import trafilatura
+    except ImportError:
+        raise _SkipBackend from None
 
     async with httpx.AsyncClient(
         timeout=FETCH_TIMEOUT,

--- a/src/kohakuterrarium/builtins/user_commands/drives.py
+++ b/src/kohakuterrarium/builtins/user_commands/drives.py
@@ -13,7 +13,6 @@ from kohakuterrarium.modules.user_command.base import (
     ui_list,
     ui_text,
 )
-from kohakuterrarium.studio.sessions import drives as _drives
 from kohakuterrarium.terrarium.drive.errors import (
     DriveConflictError,
     DriveError,
@@ -30,6 +29,14 @@ _SUBCOMMANDS = frozenset(
     {"list", "show", "create", "pause", "resume", "wake", "cancel", "progress"}
 )
 _TRANSITIONS = {"pause": "paused", "resume": "active", "cancel": "cancelled"}
+
+
+async def _drive_call(name: str, *args, **kwargs):
+    from kohakuterrarium.studio.sessions import drives
+
+    return await getattr(drives, name)(*args, **kwargs)
+
+
 _USAGE = (
     "usage: /drives list [--mine|--assigned|--graph] [--status active,blocked] | "
     "show <id> | create --kind K --title T [--scope graph|creature] | "
@@ -87,7 +94,8 @@ class DrivesCommand(BaseUserCommand):
         flags, _ = _parse_flags(rest)
         graph_id = await _graph_of(ctx, ctx.creature_id)
         assignee = ctx.creature_id if "assigned" in flags else None
-        rows = await _drives.list_records(
+        rows = await _drive_call(
+            "list_records",
             ctx.service,
             graph_id=graph_id,
             actor=ctx.principal,
@@ -114,8 +122,12 @@ class DrivesCommand(BaseUserCommand):
     async def _show(self, drive_id: str, ctx: "_Resolved") -> UserCommandResult:
         if not drive_id:
             return UserCommandResult(error="usage: /drives show <id>")
-        record = await _drives.get_record(
-            ctx.service, drive_id, actor=ctx.principal, is_privileged=ctx.is_operator
+        record = await _drive_call(
+            "get_record",
+            ctx.service,
+            drive_id,
+            actor=ctx.principal,
+            is_privileged=ctx.is_operator,
         )
         if record is None:
             return UserCommandResult(error=f"no such drive: {drive_id}")
@@ -137,7 +149,8 @@ class DrivesCommand(BaseUserCommand):
             body["priority"] = _int_flag(flags["priority"], "priority")
         if "spec-json" in flags:
             body["spec"] = _json_flag(flags["spec-json"], "spec-json")
-        record = await _drives.create_record(
+        record = await _drive_call(
+            "create_record",
             ctx.service,
             graph_id=graph_id,
             actor=ctx.principal,
@@ -155,7 +168,8 @@ class DrivesCommand(BaseUserCommand):
         if not drive_id:
             return UserCommandResult(error=f"usage: /drives {sub} <id> --revision N")
         if sub == "wake":
-            record = await _drives.wake_record(
+            record = await _drive_call(
+                "wake_record",
                 ctx.service,
                 drive_id,
                 actor=ctx.principal,
@@ -164,7 +178,8 @@ class DrivesCommand(BaseUserCommand):
             )
             return _panel("Drive woken", record)
         revision = _require_revision(flags)
-        record = await _drives.transition_record(
+        record = await _drive_call(
+            "transition_record",
             ctx.service,
             drive_id,
             target_status=_TRANSITIONS[sub],
@@ -179,7 +194,8 @@ class DrivesCommand(BaseUserCommand):
         if len(parts) < 2 or not parts[1].strip():
             return UserCommandResult(error="usage: /drives progress <id> <summary>")
         drive_id, summary = parts[0], parts[1].strip()
-        await _drives.report_progress_record(
+        await _drive_call(
+            "report_progress_record",
             ctx.service,
             drive_id,
             summary=summary,

--- a/src/kohakuterrarium/cli/README.md
+++ b/src/kohakuterrarium/cli/README.md
@@ -1,13 +1,15 @@
 # cli/
 
-`kt` command dispatcher. One handler file per subcommand, with
-`cli/__init__.py:main()` as the single argparse + dispatch entry point.
+`kt` command dispatcher. One handler file per subcommand, with a lightweight
+`cli/__init__.py:main()` for common startup paths and `_main.py` for the full
+argparse command catalog.
 
 ## Files
 
 | File            | Subcommand(s)                                                                                                           |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `__init__.py`    | `main()`: argparse setup, `COMMANDS` dispatch table (+ `_aliases.py`, `_config_layers.py`, `_aio_entrypoint.py`)        |
+| `__init__.py`    | Lightweight `main()` dispatch for version, desktop, web, CLI, and TUI startup paths                                      |
+| `_main.py`       | Full argparse setup and `COMMANDS` dispatch table for the complete command catalog                                      |
 | `run.py`         | `kt run`: launch a creature or recipe through the Terrarium engine (rich CLI / TUI modes)                               |
 | `resume.py`      | `kt resume`: resume an agent or terrarium from a `.kohakutr` session file                                               |
 | `doctor.py`      | `kt doctor`: pre-flight environment + config validation (wraps `kohakuterrarium.validate`)                              |

--- a/src/kohakuterrarium/cli/README.md
+++ b/src/kohakuterrarium/cli/README.md
@@ -34,7 +34,7 @@ The top-level `kt run` entry point invokes `cli/__init__.py:main()` via the
 
 Imported only as the process entry point. Imports nearly everything it
 drives: `terrarium/engine` (+ `engine_cli` / `engine_rich_cli`),
-`serving/web` (web + desktop), `session/resume`, `session/store`, `llm/*`,
+`serving/web`, `serving/desktop`, `session/resume`, `session/store`, `llm/*`,
 `packages/`, `builtins/cli_rich`, `utils/logging`.
 
 Nothing inside the framework imports `cli/`; it is the top of the graph.
@@ -49,8 +49,9 @@ Nothing inside the framework imports `cli/`; it is the top of the graph.
 
 ## Notes
 
-- `web` and `app` commands delegate to `serving/web.py:run_web_server` /
-  `run_desktop_app` (Briefcase and pywebview integration).
+- `web` delegates to `serving/web.py:run_web_server`; `app` and no-argument
+  startup delegate to `serving/desktop.py:launch_desktop_app`, which displays a
+  lightweight pywebview loading shell before the server graph is imported.
 - `__run-server` is a hidden internal subcommand used by `kt serve start`
   to spawn the detached worker process with the right environment.
 - `_dispatch_*` helpers in `__init__.py` exist only to adapt between the

--- a/src/kohakuterrarium/cli/__init__.py
+++ b/src/kohakuterrarium/cli/__init__.py
@@ -75,9 +75,9 @@ def _dispatch_surface(command: str, args: argparse.Namespace) -> int:
             extra_creatures=args.add_creatures,
             extra_channels=args.add_channels,
         )
-    from kohakuterrarium.serving.web import run_desktop_app, run_web_server
-
     if command == "web":
+        from kohakuterrarium.serving.web import run_web_server
+
         run_web_server(
             host=args.host,
             port=args.port,
@@ -85,7 +85,9 @@ def _dispatch_surface(command: str, args: argparse.Namespace) -> int:
             log_level=args.log_level,
         )
     else:
-        run_desktop_app(port=args.port, log_level=args.log_level)
+        from kohakuterrarium.serving.desktop import launch_desktop_app
+
+        launch_desktop_app(port=args.port, log_level=args.log_level)
     return 0
 
 
@@ -100,11 +102,11 @@ def main() -> int:
         print(format_version_report(verbose="--verbose" in argv))
         return 0
     if not argv:
-        from kohakuterrarium.serving.web import run_desktop_app
+        from kohakuterrarium.serving.desktop import launch_desktop_app
 
         mark_startup("parser_ready", surface="desktop")
         mark_startup("dispatch_selected", surface="desktop", command="desktop")
-        run_desktop_app(log_level="INFO")
+        launch_desktop_app(log_level="INFO")
         return 0
     if argv[0] in {"cli", "tui", "web", "app"}:
         command = argv[0]

--- a/src/kohakuterrarium/cli/__init__.py
+++ b/src/kohakuterrarium/cli/__init__.py
@@ -46,6 +46,7 @@ from kohakuterrarium.cli.service import add_service_subparser, service_cli
 from kohakuterrarium.cli.version import format_version_report
 from kohakuterrarium.serving.web import run_desktop_app, run_web_server
 from kohakuterrarium.utils.logging import configure_utf8_stdio
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -624,18 +625,22 @@ def main() -> int:
     configure_utf8_stdio(log=False)
     parser = _build_parser()
     args = parser.parse_args()
+    mark_startup("parser_ready", surface="cli")
 
     if args.version:
+        mark_startup("dispatch_selected", surface="cli", command="version")
         print(format_version_report(verbose=args.verbose))
         return 0
 
     # No command given: launch desktop app (used by Briefcase and double-click)
     if not args.command:
+        mark_startup("dispatch_selected", surface="desktop", command="desktop")
         run_desktop_app(log_level="INFO")
         return 0
 
     handler = COMMANDS.get(args.command)
     if handler:
+        mark_startup("dispatch_selected", surface=args.command, command=args.command)
         return handler(args)
 
     parser.print_help()

--- a/src/kohakuterrarium/cli/__init__.py
+++ b/src/kohakuterrarium/cli/__init__.py
@@ -1,647 +1,119 @@
-"""KohakuTerrarium CLI — command dispatch and argument parsing.
-
-Importing this package also imports :mod:`kohakuterrarium.studio` for
-its side effect of registering studio-supplied hooks the terrarium
-group tools call into (session-store auto-attach, name propagation,
-spawnable creature catalog). Without this, ``kt run`` solo mode would
-boot with an empty spawnable list and no persistence on tool-spawned
-workers.
-"""
+"""KohakuTerrarium command-line entry point."""
 
 import argparse
+import sys
 
-import kohakuterrarium.studio  # noqa: F401 — registers terrarium.group_hooks
-from kohakuterrarium.cli._aliases import (
-    add_client_alias,
-    add_host_alias,
-    dispatch_client_alias,
-    dispatch_host_alias,
-)
-from kohakuterrarium.cli.admin import add_admin_subparser, admin_cli
-from kohakuterrarium.cli.auth import login_cli
-from kohakuterrarium.cli.config import add_config_subparser, config_cli
-from kohakuterrarium.cli.doctor import add_doctor_subparser, dispatch_doctor
-from kohakuterrarium.cli.drive import add_drive_subparser, drive_cli
-from kohakuterrarium.cli.extension import extension_info_cli, extension_list_cli
-from kohakuterrarium.cli.identity_mcp import list_for_agent_cli as mcp_list_cli
-from kohakuterrarium.cli.lab_client import add_lab_client_subparser, lab_client_cli
-from kohakuterrarium.cli.marketplace import marketplace_cli
-from kohakuterrarium.cli.memory import embedding_cli, search_cli
-from kohakuterrarium.cli.model import model_cli
-from kohakuterrarium.cli.packages import (
-    edit_cli,
-    install_cli,
-    list_cli,
-    show_agent_info_cli,
-    uninstall_cli,
-    update_cli,
-)
-from kohakuterrarium.cli.resume import resume_cli
-from kohakuterrarium.cli.run import resolve_then_run, run_agent_cli
 from kohakuterrarium.cli.select_args import add_run_like_args
-from kohakuterrarium.cli.self_update import add_self_update_subparser, self_update_cli
-from kohakuterrarium.cli.shims import add_shims_subparser, shims_cli
-from kohakuterrarium.cli.serve import add_serve_subparser, serve_cli
-from kohakuterrarium.cli.service import add_service_subparser, service_cli
-from kohakuterrarium.cli.version import format_version_report
-from kohakuterrarium.serving.web import run_desktop_app, run_web_server
 from kohakuterrarium.utils.logging import configure_utf8_stdio
 from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    """Build and return the CLI argument parser with all subcommands."""
-    parser = argparse.ArgumentParser(
-        prog="kt",
-        description="KohakuTerrarium - Universal Agent Framework",
-    )
-    parser.add_argument(
-        "--version",
-        action="store_true",
-        help="Show KohakuTerrarium version and runtime identity information",
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Show additional details for commands that support verbose output",
-    )
-    subparsers = parser.add_subparsers(dest="command", help="Commands")
+def _build_parser():
+    from kohakuterrarium.cli._main import _build_parser as build_parser
 
-    run_parser = subparsers.add_parser("run", help="Run an agent")
-    run_parser.add_argument(
-        "agent_path",
-        help="Path to agent config folder (e.g., agents/swe-agent)",
-    )
-    run_parser.add_argument(
-        "--log-level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default="INFO",
-        help="Logging level",
-    )
-    run_parser.add_argument(
-        "--log-stderr",
-        choices=["auto", "on", "off"],
-        default="auto",
-        help=(
-            "Mirror logs to stderr. auto=on when I/O is not cli/tui "
-            "(custom, package, stdout, plain), off=never, on=always"
-        ),
-    )
-    session_group = run_parser.add_mutually_exclusive_group()
-    session_group.add_argument(
-        "--session",
-        nargs="?",
-        const="__auto__",
-        default="__auto__",
-        help="Session file path (default: auto in ~/.kohakuterrarium/sessions/). Use --no-session to disable.",
-    )
-    session_group.add_argument(
-        "--no-session",
-        action="store_true",
-        help="Disable session persistence",
-    )
-    run_parser.add_argument(
-        "--llm",
-        default=None,
-        help="Override LLM profile (e.g., gpt-5.4, gemini, claude-sonnet-4)",
-    )
-    run_parser.add_argument(
-        "--mode",
-        choices=["cli", "plain", "tui", "none"],
-        default=None,
-        help=(
-            "Input/output mode. ``cli`` = rich inline prompt-toolkit "
-            "Application, ``tui`` = full-screen Textual app, "
-            "``plain`` = dumb stdout/stdin, ``none`` = headless: don't "
-            "mount any user-facing IO shell, let the creature drive "
-            "itself via its configured input/output modules (Discord "
-            "bot, webhook listener, etc.). When omitted, the choice "
-            "is auto-derived from the creature config's ``input.type`` "
-            "— ``cli`` / ``tui`` get the matching shell, anything "
-            "else (custom / package / none) runs headless."
-        ),
-    )
-    run_parser.add_argument(
-        "--add",
-        action="append",
-        default=[],
-        metavar="CONFIG",
-        dest="add_creatures",
-        help=(
-            "Spawn an additional creature into the same graph at startup. "
-            "Accepts a path or ``@pkg/creatures/<name>`` reference. May be "
-            "repeated to assemble an ad-hoc team without writing a recipe. "
-            "Spawned creatures are not privileged."
-        ),
-    )
-    run_parser.add_argument(
-        "--channel",
-        action="append",
-        default=[],
-        metavar="NAME",
-        dest="add_channels",
-        help=(
-            "Create a shared channel and wire every creature in the graph "
-            "as both listener and sender. May be repeated. Combined with "
-            "``--add`` this lets you compose a multi-creature graph from "
-            "the command line, e.g. ``kt run general --add critic "
-            "--channel reviews``."
-        ),
+    return build_parser()
+
+
+def _version_requested(argv: list[str]) -> bool:
+    return "--version" in argv and all(
+        arg in {"--version", "--verbose"} for arg in argv
     )
 
-    # Keep aliases on the shared argument builder so standalone and ``kt``
-    # entry points expose the same options.
-    cli_parser = subparsers.add_parser(
-        "cli",
-        help="Interactive rich CLI (optional creature; picker when omitted)",
-    )
-    add_run_like_args(cli_parser)
-    tui_parser = subparsers.add_parser(
-        "tui",
-        help="Full-screen Textual TUI (optional creature; picker when omitted)",
-    )
-    add_run_like_args(tui_parser)
 
-    add_shims_subparser(subparsers)
-
-    list_parser = subparsers.add_parser("list", help="List available agents")
-    list_parser.add_argument(
-        "--path",
-        default="agents",
-        help="Path to agents directory",
-    )
-
-    info_parser = subparsers.add_parser("info", help="Show agent info")
-    info_parser.add_argument(
-        "agent_path",
-        help="Path to agent config folder",
-    )
-
-    resume_parser = subparsers.add_parser(
-        "resume", help="Resume a session (by name, path, or list recent)"
-    )
-    resume_parser.add_argument(
-        "session",
-        nargs="?",
-        default=None,
-        help="Session name/prefix, full path, or omit to list recent sessions",
-    )
-    resume_parser.add_argument("--pwd", help="Override working directory")
-    resume_parser.add_argument(
-        "--last",
-        action="store_true",
-        help="Resume the most recent session",
-    )
-    resume_parser.add_argument(
-        "--mode",
-        choices=["cli", "plain", "tui"],
-        default=None,
-        help=(
-            "Input/output surface. cli/plain=rich inline CLI, "
-            "tui=full-screen Textual app. Omit for the default "
-            "full-screen TUI."
-        ),
-    )
-    resume_parser.add_argument(
-        "--llm",
-        default=None,
-        help="Override LLM profile (e.g., gpt-5.4, gemini, claude-sonnet-4.6)",
-    )
-    resume_parser.add_argument(
-        "--log-level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default="INFO",
-    )
-    resume_parser.add_argument(
-        "--log-stderr",
-        choices=["auto", "on", "off"],
-        default="auto",
-        help=(
-            "Mirror logs to stderr. auto=on when I/O is not cli/tui "
-            "(custom, package, stdout, plain), off=never, on=always"
-        ),
-    )
-
-    add_doctor_subparser(subparsers)
-
-    login_parser = subparsers.add_parser("login", help="Authenticate with a provider")
-    login_parser.add_argument(
-        "provider",
-        help="Provider or backend name to authenticate with",
-    )
-
-    install_parser = subparsers.add_parser(
-        "install", help="Install a creature/terrarium package"
-    )
-    install_parser.add_argument(
-        "source",
-        help=(
-            "Marketplace spec (@name, @name@version, @source/name), git URL, "
-            "or local path"
-        ),
-    )
-    install_parser.add_argument(
-        "-e",
-        "--editable",
-        action="store_true",
-        help="Install as editable (symlink, like pip -e)",
-    )
-    install_parser.add_argument("--name", default=None, help="Override package name")
-    install_parser.add_argument(
-        "--no-deps",
-        action="store_true",
-        help="Skip installing the package's declared Python dependencies",
-    )
-
-    uninstall_parser = subparsers.add_parser(
-        "uninstall", help="Remove an installed package"
-    )
-    uninstall_parser.add_argument("name", help="Package name to remove")
-
-    update_parser = subparsers.add_parser(
-        "update", help="Update installed package repositories"
-    )
-    update_parser.add_argument(
-        "target",
-        nargs="?",
-        default=None,
-        help="Package name or @package reference",
-    )
-    update_parser.add_argument(
-        "--all",
-        action="store_true",
-        help="Update all installed git-backed packages",
-    )
-
-    edit_parser = subparsers.add_parser(
-        "edit", help="Open a creature/terrarium config in editor"
-    )
-    edit_parser.add_argument(
-        "target",
-        help="@package/creatures/name or @package/terrariums/name",
-    )
-
-    embed_parser = subparsers.add_parser(
-        "embedding", help="Build embeddings for a session (offline indexing)"
-    )
-    embed_parser.add_argument("session", help="Session name/prefix or path")
-    embed_parser.add_argument(
-        "--provider",
-        choices=["auto", "model2vec", "sentence-transformer", "api"],
-        default="auto",
-        help="Embedding provider (default: auto, prefers jina v5 nano)",
-    )
-    embed_parser.add_argument(
-        "--model", default=None, help="Model name (default: provider-dependent)"
-    )
-    embed_parser.add_argument(
-        "--dimensions", type=int, default=None, help="Embedding dimensions (Matryoshka)"
-    )
-
-    search_parser = subparsers.add_parser("search", help="Search a session's memory")
-    search_parser.add_argument("session", help="Session name/prefix or path")
-    search_parser.add_argument("query", help="Search query")
-    search_parser.add_argument(
-        "--mode",
-        choices=["fts", "semantic", "hybrid", "auto"],
-        default="auto",
-        help="Search mode (default: auto)",
-    )
-    search_parser.add_argument("--agent", default=None, help="Filter by agent name")
-    search_parser.add_argument(
-        "-k", type=int, default=10, help="Max results (default: 10)"
-    )
-
-    web_parser = subparsers.add_parser(
-        "web", help="Serve web UI + API (single process)"
-    )
-    web_parser.add_argument(
-        "--host",
-        default="127.0.0.1",
-        help="Bind host (default: 127.0.0.1, use 0.0.0.0 for LAN)",
-    )
-    web_parser.add_argument(
-        "--port",
-        type=int,
-        default=8001,
-        help="Bind port (auto-increments if busy)",
-    )
-    web_parser.add_argument(
-        "--dev",
-        action="store_true",
-        help="API-only mode (run vite dev server separately)",
-    )
-    web_parser.add_argument(
-        "--log-level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default="INFO",
-        help="Logging level",
-    )
-
-    app_parser = subparsers.add_parser(
-        "app", help="Launch native desktop UI (requires pywebview)"
-    )
-    app_parser.add_argument(
-        "--port", type=int, default=8001, help="Internal server port"
-    )
-    app_parser.add_argument(
-        "--log-level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default="INFO",
-        help="Logging level",
-    )
-
-    model_parser = subparsers.add_parser("model", help="Manage LLM profiles")
-    model_sub = model_parser.add_subparsers(dest="model_command")
-    model_sub.add_parser("list", help="List all profiles and presets")
-    model_default_parser = model_sub.add_parser("default", help="Set default model")
-    model_default_parser.add_argument("name", help="Model/profile name")
-    model_show_parser = model_sub.add_parser("show", help="Show profile details")
-    model_show_parser.add_argument("name", help="Model/profile name")
-
-    ext_parser = subparsers.add_parser(
-        "extension", help="Manage package extension modules"
-    )
-    ext_sub = ext_parser.add_subparsers(dest="extension_command")
-    ext_sub.add_parser("list", help="List all installed extension modules")
-    ext_info_parser = ext_sub.add_parser(
-        "info", help="Show details of a specific package"
-    )
-    ext_info_parser.add_argument("name", help="Package name")
-
-    # Marketplace browsing and installation share the same configured sources.
-    mp_parser = subparsers.add_parser(
-        "marketplace",
-        help="Browse + manage TerrariumMarket sources (kt install @<name> uses these)",
-    )
-    mp_sub = mp_parser.add_subparsers(dest="marketplace_command")
-    mp_sub.add_parser("list", help="List configured marketplace sources")
-    mp_add_parser = mp_sub.add_parser("add", help="Add a marketplace source URL")
-    mp_add_parser.add_argument("url", help="https URL to a registry.yaml")
-    mp_add_parser.add_argument(
-        "--alias", default=None, help="Short name for the source (default: URL)"
-    )
-    mp_remove_parser = mp_sub.add_parser(
-        "remove", help="Remove a marketplace source by URL or alias"
-    )
-    mp_remove_parser.add_argument("target", help="URL or alias of the source")
-    mp_sub.add_parser("reset", help="Restore the built-in default source list")
-    mp_sub.add_parser("refresh", help="Force cache bust + re-fetch every source")
-    mp_search_parser = mp_sub.add_parser(
-        "search", help="Search packages across configured sources"
-    )
-    mp_search_parser.add_argument(
-        "query",
-        nargs="?",
-        default="",
-        help="Substring matched against name + description",
-    )
-    mp_search_parser.add_argument("--tag", default=None, help="Filter by tag")
-    mp_search_parser.add_argument("--author", default=None, help="Filter by author")
-    mp_search_parser.add_argument(
-        "--json", action="store_true", help="Emit machine-readable JSON"
-    )
-    mp_info_parser = mp_sub.add_parser(
-        "info", help="Show full detail for a marketplace entry"
-    )
-    mp_info_parser.add_argument(
-        "spec",
-        help="@name, @name@version, or @source/name (the leading @ is optional)",
-    )
-
-    mcp_parser = subparsers.add_parser("mcp", help="MCP server management")
-    mcp_sub = mcp_parser.add_subparsers(dest="mcp_command")
-    mcp_list_parser = mcp_sub.add_parser(
-        "list", help="List MCP servers from agent config"
-    )
-    mcp_list_parser.add_argument(
-        "--agent", required=True, help="Path to agent config folder"
-    )
-
-    add_drive_subparser(subparsers)
-
-    add_config_subparser(subparsers)
-
-    add_serve_subparser(subparsers)
-
-    add_lab_client_subparser(subparsers)
-
-    # Deployment aliases keep operator commands aligned with service and image names.
-    add_host_alias(subparsers)
-    add_client_alias(subparsers)
-
-    add_service_subparser(subparsers)
-
-    # Administrative commands operate on local state without requiring a server.
-    add_admin_subparser(subparsers)
-
-    add_self_update_subparser(subparsers)
-
-    internal_serve_parser = subparsers.add_parser(
-        "__run-server", help=argparse.SUPPRESS
-    )
-    internal_serve_parser.add_argument("--host", default="127.0.0.1")
-    internal_serve_parser.add_argument("--port", type=int, default=8001)
-    internal_serve_parser.add_argument("--dev", action="store_true")
-    internal_serve_parser.add_argument(
-        "--log-level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default="INFO",
-    )
-    internal_serve_parser.add_argument("--state-path", default=None)
-    internal_serve_parser.add_argument(
-        "--mode",
-        choices=["standalone", "lab-host"],
-        default="standalone",
-    )
-    internal_serve_parser.add_argument("--lab-bind", default=None)
-    internal_serve_parser.add_argument("--lab-token", default=None)
-
+def _build_surface_parser(command: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=f"kt {command}")
+    if command in {"cli", "tui"}:
+        add_run_like_args(parser)
+    elif command == "web":
+        parser.add_argument(
+            "--host",
+            default="127.0.0.1",
+            help="Bind host (default: 127.0.0.1, use 0.0.0.0 for LAN)",
+        )
+        parser.add_argument(
+            "--port",
+            type=int,
+            default=8001,
+            help="Bind port (auto-increments if busy)",
+        )
+        parser.add_argument(
+            "--dev",
+            action="store_true",
+            help="API-only mode (run vite dev server separately)",
+        )
+        parser.add_argument(
+            "--log-level",
+            choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+            default="INFO",
+            help="Logging level",
+        )
+    elif command == "app":
+        parser.add_argument(
+            "--port", type=int, default=8001, help="Internal server port"
+        )
+        parser.add_argument(
+            "--log-level",
+            choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+            default="INFO",
+            help="Logging level",
+        )
     return parser
 
 
-def _dispatch_run(args: argparse.Namespace) -> int:
-    """Handle the 'run' command.
+def _dispatch_surface(command: str, args: argparse.Namespace) -> int:
+    mark_startup("dispatch_selected", surface=command, command=command)
+    if command in {"cli", "tui"}:
+        from kohakuterrarium.cli.run import resolve_then_run
 
-    ``@pkg/...`` agent paths pass through verbatim — the config-loading
-    chokepoint (``load_agent_config`` / ``load_terrarium_config``)
-    resolves package references for every entry point.
-    """
-    agent_path = args.agent_path
-    session = None if args.no_session else args.session
-    extra_creatures = list(getattr(args, "add_creatures", None) or [])
-    return run_agent_cli(
-        agent_path,
-        args.log_level,
-        session=session,
-        io_mode=args.mode,
-        llm=args.llm,
-        log_stderr=args.log_stderr,
-        extra_creatures=extra_creatures,
-        extra_channels=list(getattr(args, "add_channels", None) or []),
-    )
+        return resolve_then_run(
+            args.agent_path,
+            io_mode=command,
+            log_level=args.log_level,
+            session=None if args.no_session else args.session,
+            llm=args.llm,
+            log_stderr=args.log_stderr,
+            extra_creatures=args.add_creatures,
+            extra_channels=args.add_channels,
+        )
+    from kohakuterrarium.serving.web import run_desktop_app, run_web_server
 
-
-def _resolve_then_run_from_args(args: argparse.Namespace, io_mode: str) -> int:
-    """Shared dispatch for the ``kt cli`` / ``kt tui`` subcommand aliases."""
-    session = None if args.no_session else args.session
-    return resolve_then_run(
-        args.agent_path,
-        io_mode=io_mode,
-        log_level=args.log_level,
-        session=session,
-        llm=args.llm,
-        log_stderr=args.log_stderr,
-        extra_creatures=list(getattr(args, "add_creatures", None) or []),
-        extra_channels=list(getattr(args, "add_channels", None) or []),
-    )
-
-
-def _dispatch_cli_mode(args: argparse.Namespace) -> int:
-    """Handle the 'cli' subcommand alias (rich inline mode)."""
-    return _resolve_then_run_from_args(args, "cli")
-
-
-def _dispatch_tui_mode(args: argparse.Namespace) -> int:
-    """Handle the 'tui' subcommand alias (full-screen mode)."""
-    return _resolve_then_run_from_args(args, "tui")
-
-
-def _dispatch_resume(args: argparse.Namespace) -> int:
-    """Handle the 'resume' command."""
-    return resume_cli(
-        args.session,
-        args.pwd,
-        args.log_level,
-        last=args.last,
-        io_mode=args.mode,
-        llm=args.llm,
-        log_stderr=args.log_stderr,
-    )
-
-
-def _dispatch_embedding(args: argparse.Namespace) -> int:
-    """Handle the 'embedding' command."""
-    return embedding_cli(args.session, args.provider, args.model, args.dimensions)
-
-
-def _dispatch_search(args: argparse.Namespace) -> int:
-    """Handle the 'search' command."""
-    return search_cli(args.session, args.query, args.mode, args.agent, args.k)
-
-
-def _dispatch_web(args: argparse.Namespace) -> int:
-    """Handle the 'web' command."""
-    run_web_server(
-        host=args.host,
-        port=args.port,
-        dev=args.dev,
-        log_level=args.log_level,
-    )
-    return 0
-
-
-def _dispatch_app(args: argparse.Namespace) -> int:
-    """Handle the 'app' command."""
-    run_desktop_app(port=args.port, log_level=args.log_level)
-    return 0
-
-
-def _dispatch_extension(args: argparse.Namespace) -> int:
-    """Handle the 'extension' command group."""
-    sub = getattr(args, "extension_command", None)
-    if sub == "list":
-        return extension_list_cli()
-    elif sub == "info":
-        return extension_info_cli(args.name)
-    else:
-        parser = _build_parser()
-        parser.parse_args(["extension", "--help"])
-        return 0
-
-
-def _dispatch_mcp(args: argparse.Namespace) -> int:
-    """Handle the 'mcp' command group."""
-    sub = getattr(args, "mcp_command", None)
-    if sub == "list":
-        return mcp_list_cli(args.agent)
-    else:
-        parser = _build_parser()
-        parser.parse_args(["mcp", "--help"])
-        return 0
-
-
-COMMANDS: dict[str, callable] = {
-    "run": _dispatch_run,
-    "cli": _dispatch_cli_mode,
-    "tui": _dispatch_tui_mode,
-    "shims": shims_cli,
-    "resume": _dispatch_resume,
-    "doctor": dispatch_doctor,
-    "list": lambda args: list_cli(args.path),
-    "info": lambda args: show_agent_info_cli(args.agent_path),
-    "login": lambda args: login_cli(args.provider),
-    "install": lambda args: install_cli(
-        args.source, args.editable, args.name, args.no_deps
-    ),
-    "uninstall": lambda args: uninstall_cli(args.name),
-    "update": lambda args: update_cli(args.target, args.all),
-    "edit": lambda args: edit_cli(args.target),
-    "embedding": _dispatch_embedding,
-    "search": _dispatch_search,
-    "web": _dispatch_web,
-    "app": _dispatch_app,
-    "model": lambda args: model_cli(args),
-    "drive": drive_cli,
-    "config": lambda args: config_cli(args),
-    "serve": lambda args: serve_cli(args),
-    "__run-server": lambda args: serve_cli(
-        argparse.Namespace(
-            serve_command="__run-server",
+    if command == "web":
+        run_web_server(
             host=args.host,
             port=args.port,
             dev=args.dev,
             log_level=args.log_level,
-            state_path=args.state_path,
-            mode=getattr(args, "mode", "standalone"),
-            lab_bind=getattr(args, "lab_bind", None),
-            lab_token=getattr(args, "lab_token", None),
         )
-    ),
-    "lab-client": lab_client_cli,
-    "host": dispatch_host_alias,
-    "client": dispatch_client_alias,
-    "service": service_cli,
-    "self-update": self_update_cli,
-    "extension": _dispatch_extension,
-    "mcp": _dispatch_mcp,
-    "marketplace": marketplace_cli,
-    "admin": admin_cli,
-}
+    else:
+        run_desktop_app(port=args.port, log_level=args.log_level)
+    return 0
 
 
 def main() -> int:
-    """Main CLI entry point."""
     configure_utf8_stdio(log=False)
-    parser = _build_parser()
-    args = parser.parse_args()
-    mark_startup("parser_ready", surface="cli")
+    argv = sys.argv[1:]
+    if _version_requested(argv):
+        from kohakuterrarium.cli.version import format_version_report
 
-    if args.version:
+        mark_startup("parser_ready", surface="cli")
         mark_startup("dispatch_selected", surface="cli", command="version")
-        print(format_version_report(verbose=args.verbose))
+        print(format_version_report(verbose="--verbose" in argv))
         return 0
+    if not argv:
+        from kohakuterrarium.serving.web import run_desktop_app
 
-    # No command given: launch desktop app (used by Briefcase and double-click)
-    if not args.command:
+        mark_startup("parser_ready", surface="desktop")
         mark_startup("dispatch_selected", surface="desktop", command="desktop")
         run_desktop_app(log_level="INFO")
         return 0
+    if argv[0] in {"cli", "tui", "web", "app"}:
+        command = argv[0]
+        args = _build_surface_parser(command).parse_args(argv[1:])
+        mark_startup("parser_ready", surface=command)
+        return _dispatch_surface(command, args)
+    from kohakuterrarium.cli._main import main as cli_main
 
-    handler = COMMANDS.get(args.command)
-    if handler:
-        mark_startup("dispatch_selected", surface=args.command, command=args.command)
-        return handler(args)
+    return cli_main()
 
-    parser.print_help()
-    return 0
+
+__all__ = ["main"]

--- a/src/kohakuterrarium/cli/_main.py
+++ b/src/kohakuterrarium/cli/_main.py
@@ -1,0 +1,647 @@
+"""KohakuTerrarium CLI — command dispatch and argument parsing.
+
+Importing this package also imports :mod:`kohakuterrarium.studio` for
+its side effect of registering studio-supplied hooks the terrarium
+group tools call into (session-store auto-attach, name propagation,
+spawnable creature catalog). Without this, ``kt run`` solo mode would
+boot with an empty spawnable list and no persistence on tool-spawned
+workers.
+"""
+
+import argparse
+
+import kohakuterrarium.studio  # noqa: F401 — registers terrarium.group_hooks
+from kohakuterrarium.cli._aliases import (
+    add_client_alias,
+    add_host_alias,
+    dispatch_client_alias,
+    dispatch_host_alias,
+)
+from kohakuterrarium.cli.admin import add_admin_subparser, admin_cli
+from kohakuterrarium.cli.auth import login_cli
+from kohakuterrarium.cli.config import add_config_subparser, config_cli
+from kohakuterrarium.cli.doctor import add_doctor_subparser, dispatch_doctor
+from kohakuterrarium.cli.drive import add_drive_subparser, drive_cli
+from kohakuterrarium.cli.extension import extension_info_cli, extension_list_cli
+from kohakuterrarium.cli.identity_mcp import list_for_agent_cli as mcp_list_cli
+from kohakuterrarium.cli.lab_client import add_lab_client_subparser, lab_client_cli
+from kohakuterrarium.cli.marketplace import marketplace_cli
+from kohakuterrarium.cli.memory import embedding_cli, search_cli
+from kohakuterrarium.cli.model import model_cli
+from kohakuterrarium.cli.packages import (
+    edit_cli,
+    install_cli,
+    list_cli,
+    show_agent_info_cli,
+    uninstall_cli,
+    update_cli,
+)
+from kohakuterrarium.cli.resume import resume_cli
+from kohakuterrarium.cli.run import resolve_then_run, run_agent_cli
+from kohakuterrarium.cli.select_args import add_run_like_args
+from kohakuterrarium.cli.self_update import add_self_update_subparser, self_update_cli
+from kohakuterrarium.cli.shims import add_shims_subparser, shims_cli
+from kohakuterrarium.cli.serve import add_serve_subparser, serve_cli
+from kohakuterrarium.cli.service import add_service_subparser, service_cli
+from kohakuterrarium.cli.version import format_version_report
+from kohakuterrarium.serving.web import run_desktop_app, run_web_server
+from kohakuterrarium.utils.logging import configure_utf8_stdio
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build and return the CLI argument parser with all subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="kt",
+        description="KohakuTerrarium - Universal Agent Framework",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Show KohakuTerrarium version and runtime identity information",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show additional details for commands that support verbose output",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Commands")
+
+    run_parser = subparsers.add_parser("run", help="Run an agent")
+    run_parser.add_argument(
+        "agent_path",
+        help="Path to agent config folder (e.g., agents/swe-agent)",
+    )
+    run_parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Logging level",
+    )
+    run_parser.add_argument(
+        "--log-stderr",
+        choices=["auto", "on", "off"],
+        default="auto",
+        help=(
+            "Mirror logs to stderr. auto=on when I/O is not cli/tui "
+            "(custom, package, stdout, plain), off=never, on=always"
+        ),
+    )
+    session_group = run_parser.add_mutually_exclusive_group()
+    session_group.add_argument(
+        "--session",
+        nargs="?",
+        const="__auto__",
+        default="__auto__",
+        help="Session file path (default: auto in ~/.kohakuterrarium/sessions/). Use --no-session to disable.",
+    )
+    session_group.add_argument(
+        "--no-session",
+        action="store_true",
+        help="Disable session persistence",
+    )
+    run_parser.add_argument(
+        "--llm",
+        default=None,
+        help="Override LLM profile (e.g., gpt-5.4, gemini, claude-sonnet-4)",
+    )
+    run_parser.add_argument(
+        "--mode",
+        choices=["cli", "plain", "tui", "none"],
+        default=None,
+        help=(
+            "Input/output mode. ``cli`` = rich inline prompt-toolkit "
+            "Application, ``tui`` = full-screen Textual app, "
+            "``plain`` = dumb stdout/stdin, ``none`` = headless: don't "
+            "mount any user-facing IO shell, let the creature drive "
+            "itself via its configured input/output modules (Discord "
+            "bot, webhook listener, etc.). When omitted, the choice "
+            "is auto-derived from the creature config's ``input.type`` "
+            "— ``cli`` / ``tui`` get the matching shell, anything "
+            "else (custom / package / none) runs headless."
+        ),
+    )
+    run_parser.add_argument(
+        "--add",
+        action="append",
+        default=[],
+        metavar="CONFIG",
+        dest="add_creatures",
+        help=(
+            "Spawn an additional creature into the same graph at startup. "
+            "Accepts a path or ``@pkg/creatures/<name>`` reference. May be "
+            "repeated to assemble an ad-hoc team without writing a recipe. "
+            "Spawned creatures are not privileged."
+        ),
+    )
+    run_parser.add_argument(
+        "--channel",
+        action="append",
+        default=[],
+        metavar="NAME",
+        dest="add_channels",
+        help=(
+            "Create a shared channel and wire every creature in the graph "
+            "as both listener and sender. May be repeated. Combined with "
+            "``--add`` this lets you compose a multi-creature graph from "
+            "the command line, e.g. ``kt run general --add critic "
+            "--channel reviews``."
+        ),
+    )
+
+    # Keep aliases on the shared argument builder so standalone and ``kt``
+    # entry points expose the same options.
+    cli_parser = subparsers.add_parser(
+        "cli",
+        help="Interactive rich CLI (optional creature; picker when omitted)",
+    )
+    add_run_like_args(cli_parser)
+    tui_parser = subparsers.add_parser(
+        "tui",
+        help="Full-screen Textual TUI (optional creature; picker when omitted)",
+    )
+    add_run_like_args(tui_parser)
+
+    add_shims_subparser(subparsers)
+
+    list_parser = subparsers.add_parser("list", help="List available agents")
+    list_parser.add_argument(
+        "--path",
+        default="agents",
+        help="Path to agents directory",
+    )
+
+    info_parser = subparsers.add_parser("info", help="Show agent info")
+    info_parser.add_argument(
+        "agent_path",
+        help="Path to agent config folder",
+    )
+
+    resume_parser = subparsers.add_parser(
+        "resume", help="Resume a session (by name, path, or list recent)"
+    )
+    resume_parser.add_argument(
+        "session",
+        nargs="?",
+        default=None,
+        help="Session name/prefix, full path, or omit to list recent sessions",
+    )
+    resume_parser.add_argument("--pwd", help="Override working directory")
+    resume_parser.add_argument(
+        "--last",
+        action="store_true",
+        help="Resume the most recent session",
+    )
+    resume_parser.add_argument(
+        "--mode",
+        choices=["cli", "plain", "tui"],
+        default=None,
+        help=(
+            "Input/output surface. cli/plain=rich inline CLI, "
+            "tui=full-screen Textual app. Omit for the default "
+            "full-screen TUI."
+        ),
+    )
+    resume_parser.add_argument(
+        "--llm",
+        default=None,
+        help="Override LLM profile (e.g., gpt-5.4, gemini, claude-sonnet-4.6)",
+    )
+    resume_parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+    )
+    resume_parser.add_argument(
+        "--log-stderr",
+        choices=["auto", "on", "off"],
+        default="auto",
+        help=(
+            "Mirror logs to stderr. auto=on when I/O is not cli/tui "
+            "(custom, package, stdout, plain), off=never, on=always"
+        ),
+    )
+
+    add_doctor_subparser(subparsers)
+
+    login_parser = subparsers.add_parser("login", help="Authenticate with a provider")
+    login_parser.add_argument(
+        "provider",
+        help="Provider or backend name to authenticate with",
+    )
+
+    install_parser = subparsers.add_parser(
+        "install", help="Install a creature/terrarium package"
+    )
+    install_parser.add_argument(
+        "source",
+        help=(
+            "Marketplace spec (@name, @name@version, @source/name), git URL, "
+            "or local path"
+        ),
+    )
+    install_parser.add_argument(
+        "-e",
+        "--editable",
+        action="store_true",
+        help="Install as editable (symlink, like pip -e)",
+    )
+    install_parser.add_argument("--name", default=None, help="Override package name")
+    install_parser.add_argument(
+        "--no-deps",
+        action="store_true",
+        help="Skip installing the package's declared Python dependencies",
+    )
+
+    uninstall_parser = subparsers.add_parser(
+        "uninstall", help="Remove an installed package"
+    )
+    uninstall_parser.add_argument("name", help="Package name to remove")
+
+    update_parser = subparsers.add_parser(
+        "update", help="Update installed package repositories"
+    )
+    update_parser.add_argument(
+        "target",
+        nargs="?",
+        default=None,
+        help="Package name or @package reference",
+    )
+    update_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Update all installed git-backed packages",
+    )
+
+    edit_parser = subparsers.add_parser(
+        "edit", help="Open a creature/terrarium config in editor"
+    )
+    edit_parser.add_argument(
+        "target",
+        help="@package/creatures/name or @package/terrariums/name",
+    )
+
+    embed_parser = subparsers.add_parser(
+        "embedding", help="Build embeddings for a session (offline indexing)"
+    )
+    embed_parser.add_argument("session", help="Session name/prefix or path")
+    embed_parser.add_argument(
+        "--provider",
+        choices=["auto", "model2vec", "sentence-transformer", "api"],
+        default="auto",
+        help="Embedding provider (default: auto, prefers jina v5 nano)",
+    )
+    embed_parser.add_argument(
+        "--model", default=None, help="Model name (default: provider-dependent)"
+    )
+    embed_parser.add_argument(
+        "--dimensions", type=int, default=None, help="Embedding dimensions (Matryoshka)"
+    )
+
+    search_parser = subparsers.add_parser("search", help="Search a session's memory")
+    search_parser.add_argument("session", help="Session name/prefix or path")
+    search_parser.add_argument("query", help="Search query")
+    search_parser.add_argument(
+        "--mode",
+        choices=["fts", "semantic", "hybrid", "auto"],
+        default="auto",
+        help="Search mode (default: auto)",
+    )
+    search_parser.add_argument("--agent", default=None, help="Filter by agent name")
+    search_parser.add_argument(
+        "-k", type=int, default=10, help="Max results (default: 10)"
+    )
+
+    web_parser = subparsers.add_parser(
+        "web", help="Serve web UI + API (single process)"
+    )
+    web_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind host (default: 127.0.0.1, use 0.0.0.0 for LAN)",
+    )
+    web_parser.add_argument(
+        "--port",
+        type=int,
+        default=8001,
+        help="Bind port (auto-increments if busy)",
+    )
+    web_parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="API-only mode (run vite dev server separately)",
+    )
+    web_parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Logging level",
+    )
+
+    app_parser = subparsers.add_parser(
+        "app", help="Launch native desktop UI (requires pywebview)"
+    )
+    app_parser.add_argument(
+        "--port", type=int, default=8001, help="Internal server port"
+    )
+    app_parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Logging level",
+    )
+
+    model_parser = subparsers.add_parser("model", help="Manage LLM profiles")
+    model_sub = model_parser.add_subparsers(dest="model_command")
+    model_sub.add_parser("list", help="List all profiles and presets")
+    model_default_parser = model_sub.add_parser("default", help="Set default model")
+    model_default_parser.add_argument("name", help="Model/profile name")
+    model_show_parser = model_sub.add_parser("show", help="Show profile details")
+    model_show_parser.add_argument("name", help="Model/profile name")
+
+    ext_parser = subparsers.add_parser(
+        "extension", help="Manage package extension modules"
+    )
+    ext_sub = ext_parser.add_subparsers(dest="extension_command")
+    ext_sub.add_parser("list", help="List all installed extension modules")
+    ext_info_parser = ext_sub.add_parser(
+        "info", help="Show details of a specific package"
+    )
+    ext_info_parser.add_argument("name", help="Package name")
+
+    # Marketplace browsing and installation share the same configured sources.
+    mp_parser = subparsers.add_parser(
+        "marketplace",
+        help="Browse + manage TerrariumMarket sources (kt install @<name> uses these)",
+    )
+    mp_sub = mp_parser.add_subparsers(dest="marketplace_command")
+    mp_sub.add_parser("list", help="List configured marketplace sources")
+    mp_add_parser = mp_sub.add_parser("add", help="Add a marketplace source URL")
+    mp_add_parser.add_argument("url", help="https URL to a registry.yaml")
+    mp_add_parser.add_argument(
+        "--alias", default=None, help="Short name for the source (default: URL)"
+    )
+    mp_remove_parser = mp_sub.add_parser(
+        "remove", help="Remove a marketplace source by URL or alias"
+    )
+    mp_remove_parser.add_argument("target", help="URL or alias of the source")
+    mp_sub.add_parser("reset", help="Restore the built-in default source list")
+    mp_sub.add_parser("refresh", help="Force cache bust + re-fetch every source")
+    mp_search_parser = mp_sub.add_parser(
+        "search", help="Search packages across configured sources"
+    )
+    mp_search_parser.add_argument(
+        "query",
+        nargs="?",
+        default="",
+        help="Substring matched against name + description",
+    )
+    mp_search_parser.add_argument("--tag", default=None, help="Filter by tag")
+    mp_search_parser.add_argument("--author", default=None, help="Filter by author")
+    mp_search_parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON"
+    )
+    mp_info_parser = mp_sub.add_parser(
+        "info", help="Show full detail for a marketplace entry"
+    )
+    mp_info_parser.add_argument(
+        "spec",
+        help="@name, @name@version, or @source/name (the leading @ is optional)",
+    )
+
+    mcp_parser = subparsers.add_parser("mcp", help="MCP server management")
+    mcp_sub = mcp_parser.add_subparsers(dest="mcp_command")
+    mcp_list_parser = mcp_sub.add_parser(
+        "list", help="List MCP servers from agent config"
+    )
+    mcp_list_parser.add_argument(
+        "--agent", required=True, help="Path to agent config folder"
+    )
+
+    add_drive_subparser(subparsers)
+
+    add_config_subparser(subparsers)
+
+    add_serve_subparser(subparsers)
+
+    add_lab_client_subparser(subparsers)
+
+    # Deployment aliases keep operator commands aligned with service and image names.
+    add_host_alias(subparsers)
+    add_client_alias(subparsers)
+
+    add_service_subparser(subparsers)
+
+    # Administrative commands operate on local state without requiring a server.
+    add_admin_subparser(subparsers)
+
+    add_self_update_subparser(subparsers)
+
+    internal_serve_parser = subparsers.add_parser(
+        "__run-server", help=argparse.SUPPRESS
+    )
+    internal_serve_parser.add_argument("--host", default="127.0.0.1")
+    internal_serve_parser.add_argument("--port", type=int, default=8001)
+    internal_serve_parser.add_argument("--dev", action="store_true")
+    internal_serve_parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+    )
+    internal_serve_parser.add_argument("--state-path", default=None)
+    internal_serve_parser.add_argument(
+        "--mode",
+        choices=["standalone", "lab-host"],
+        default="standalone",
+    )
+    internal_serve_parser.add_argument("--lab-bind", default=None)
+    internal_serve_parser.add_argument("--lab-token", default=None)
+
+    return parser
+
+
+def _dispatch_run(args: argparse.Namespace) -> int:
+    """Handle the 'run' command.
+
+    ``@pkg/...`` agent paths pass through verbatim — the config-loading
+    chokepoint (``load_agent_config`` / ``load_terrarium_config``)
+    resolves package references for every entry point.
+    """
+    agent_path = args.agent_path
+    session = None if args.no_session else args.session
+    extra_creatures = list(getattr(args, "add_creatures", None) or [])
+    return run_agent_cli(
+        agent_path,
+        args.log_level,
+        session=session,
+        io_mode=args.mode,
+        llm=args.llm,
+        log_stderr=args.log_stderr,
+        extra_creatures=extra_creatures,
+        extra_channels=list(getattr(args, "add_channels", None) or []),
+    )
+
+
+def _resolve_then_run_from_args(args: argparse.Namespace, io_mode: str) -> int:
+    """Shared dispatch for the ``kt cli`` / ``kt tui`` subcommand aliases."""
+    session = None if args.no_session else args.session
+    return resolve_then_run(
+        args.agent_path,
+        io_mode=io_mode,
+        log_level=args.log_level,
+        session=session,
+        llm=args.llm,
+        log_stderr=args.log_stderr,
+        extra_creatures=list(getattr(args, "add_creatures", None) or []),
+        extra_channels=list(getattr(args, "add_channels", None) or []),
+    )
+
+
+def _dispatch_cli_mode(args: argparse.Namespace) -> int:
+    """Handle the 'cli' subcommand alias (rich inline mode)."""
+    return _resolve_then_run_from_args(args, "cli")
+
+
+def _dispatch_tui_mode(args: argparse.Namespace) -> int:
+    """Handle the 'tui' subcommand alias (full-screen mode)."""
+    return _resolve_then_run_from_args(args, "tui")
+
+
+def _dispatch_resume(args: argparse.Namespace) -> int:
+    """Handle the 'resume' command."""
+    return resume_cli(
+        args.session,
+        args.pwd,
+        args.log_level,
+        last=args.last,
+        io_mode=args.mode,
+        llm=args.llm,
+        log_stderr=args.log_stderr,
+    )
+
+
+def _dispatch_embedding(args: argparse.Namespace) -> int:
+    """Handle the 'embedding' command."""
+    return embedding_cli(args.session, args.provider, args.model, args.dimensions)
+
+
+def _dispatch_search(args: argparse.Namespace) -> int:
+    """Handle the 'search' command."""
+    return search_cli(args.session, args.query, args.mode, args.agent, args.k)
+
+
+def _dispatch_web(args: argparse.Namespace) -> int:
+    """Handle the 'web' command."""
+    run_web_server(
+        host=args.host,
+        port=args.port,
+        dev=args.dev,
+        log_level=args.log_level,
+    )
+    return 0
+
+
+def _dispatch_app(args: argparse.Namespace) -> int:
+    """Handle the 'app' command."""
+    run_desktop_app(port=args.port, log_level=args.log_level)
+    return 0
+
+
+def _dispatch_extension(args: argparse.Namespace) -> int:
+    """Handle the 'extension' command group."""
+    sub = getattr(args, "extension_command", None)
+    if sub == "list":
+        return extension_list_cli()
+    elif sub == "info":
+        return extension_info_cli(args.name)
+    else:
+        parser = _build_parser()
+        parser.parse_args(["extension", "--help"])
+        return 0
+
+
+def _dispatch_mcp(args: argparse.Namespace) -> int:
+    """Handle the 'mcp' command group."""
+    sub = getattr(args, "mcp_command", None)
+    if sub == "list":
+        return mcp_list_cli(args.agent)
+    else:
+        parser = _build_parser()
+        parser.parse_args(["mcp", "--help"])
+        return 0
+
+
+COMMANDS: dict[str, callable] = {
+    "run": _dispatch_run,
+    "cli": _dispatch_cli_mode,
+    "tui": _dispatch_tui_mode,
+    "shims": shims_cli,
+    "resume": _dispatch_resume,
+    "doctor": dispatch_doctor,
+    "list": lambda args: list_cli(args.path),
+    "info": lambda args: show_agent_info_cli(args.agent_path),
+    "login": lambda args: login_cli(args.provider),
+    "install": lambda args: install_cli(
+        args.source, args.editable, args.name, args.no_deps
+    ),
+    "uninstall": lambda args: uninstall_cli(args.name),
+    "update": lambda args: update_cli(args.target, args.all),
+    "edit": lambda args: edit_cli(args.target),
+    "embedding": _dispatch_embedding,
+    "search": _dispatch_search,
+    "web": _dispatch_web,
+    "app": _dispatch_app,
+    "model": lambda args: model_cli(args),
+    "drive": drive_cli,
+    "config": lambda args: config_cli(args),
+    "serve": lambda args: serve_cli(args),
+    "__run-server": lambda args: serve_cli(
+        argparse.Namespace(
+            serve_command="__run-server",
+            host=args.host,
+            port=args.port,
+            dev=args.dev,
+            log_level=args.log_level,
+            state_path=args.state_path,
+            mode=getattr(args, "mode", "standalone"),
+            lab_bind=getattr(args, "lab_bind", None),
+            lab_token=getattr(args, "lab_token", None),
+        )
+    ),
+    "lab-client": lab_client_cli,
+    "host": dispatch_host_alias,
+    "client": dispatch_client_alias,
+    "service": service_cli,
+    "self-update": self_update_cli,
+    "extension": _dispatch_extension,
+    "mcp": _dispatch_mcp,
+    "marketplace": marketplace_cli,
+    "admin": admin_cli,
+}
+
+
+def main() -> int:
+    """Main CLI entry point."""
+    configure_utf8_stdio(log=False)
+    parser = _build_parser()
+    args = parser.parse_args()
+    mark_startup("parser_ready", surface="cli")
+
+    if args.version:
+        mark_startup("dispatch_selected", surface="cli", command="version")
+        print(format_version_report(verbose=args.verbose))
+        return 0
+
+    # No command given: launch desktop app (used by Briefcase and double-click)
+    if not args.command:
+        mark_startup("dispatch_selected", surface="desktop", command="desktop")
+        run_desktop_app(log_level="INFO")
+        return 0
+
+    handler = COMMANDS.get(args.command)
+    if handler:
+        mark_startup("dispatch_selected", surface=args.command, command=args.command)
+        return handler(args)
+
+    parser.print_help()
+    return 0

--- a/src/kohakuterrarium/cli/_main.py
+++ b/src/kohakuterrarium/cli/_main.py
@@ -44,7 +44,8 @@ from kohakuterrarium.cli.shims import add_shims_subparser, shims_cli
 from kohakuterrarium.cli.serve import add_serve_subparser, serve_cli
 from kohakuterrarium.cli.service import add_service_subparser, service_cli
 from kohakuterrarium.cli.version import format_version_report
-from kohakuterrarium.serving.web import run_desktop_app, run_web_server
+from kohakuterrarium.serving.desktop import launch_desktop_app
+from kohakuterrarium.serving.web import run_web_server
 from kohakuterrarium.utils.logging import configure_utf8_stdio
 from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
@@ -543,7 +544,7 @@ def _dispatch_web(args: argparse.Namespace) -> int:
 
 def _dispatch_app(args: argparse.Namespace) -> int:
     """Handle the 'app' command."""
-    run_desktop_app(port=args.port, log_level=args.log_level)
+    launch_desktop_app(port=args.port, log_level=args.log_level)
     return 0
 
 
@@ -635,7 +636,7 @@ def main() -> int:
     # No command given: launch desktop app (used by Briefcase and double-click)
     if not args.command:
         mark_startup("dispatch_selected", surface="desktop", command="desktop")
-        run_desktop_app(log_level="INFO")
+        launch_desktop_app(log_level="INFO")
         return 0
 
     handler = COMMANDS.get(args.command)

--- a/src/kohakuterrarium/cli/entry_cli.py
+++ b/src/kohakuterrarium/cli/entry_cli.py
@@ -13,12 +13,14 @@ from kohakuterrarium.cli.resume import resume_cli
 from kohakuterrarium.cli.run import resolve_then_run
 from kohakuterrarium.cli.select_args import parse_standalone_args
 from kohakuterrarium.utils.logging import configure_utf8_stdio
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 
 def main() -> int:
     """Run the standalone rich CLI entry point."""
     configure_utf8_stdio(log=True)
     args = parse_standalone_args(prog="kt-cli")
+    mark_startup("parser_ready", surface="cli")
     if args.resume:
         return resume_cli(
             args.query,

--- a/src/kohakuterrarium/cli/entry_cli.py
+++ b/src/kohakuterrarium/cli/entry_cli.py
@@ -9,11 +9,21 @@ through the shared ``resolve_then_run`` / ``resume_cli`` cores.
 
 import sys
 
-from kohakuterrarium.cli.resume import resume_cli
-from kohakuterrarium.cli.run import resolve_then_run
 from kohakuterrarium.cli.select_args import parse_standalone_args
 from kohakuterrarium.utils.logging import configure_utf8_stdio
 from kohakuterrarium.utils.startup_trace import mark as mark_startup
+
+
+def resume_cli(*args, **kwargs):
+    from kohakuterrarium.cli.resume import resume_cli as resume
+
+    return resume(*args, **kwargs)
+
+
+def resolve_then_run(*args, **kwargs):
+    from kohakuterrarium.cli.run import resolve_then_run as run
+
+    return run(*args, **kwargs)
 
 
 def main() -> int:

--- a/src/kohakuterrarium/cli/entry_tui.py
+++ b/src/kohakuterrarium/cli/entry_tui.py
@@ -13,12 +13,14 @@ from kohakuterrarium.cli.resume import resume_cli
 from kohakuterrarium.cli.run import resolve_then_run
 from kohakuterrarium.cli.select_args import parse_standalone_args
 from kohakuterrarium.utils.logging import configure_utf8_stdio
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 
 def main() -> int:
     """Run the standalone TUI entry point."""
     configure_utf8_stdio(log=True)
     args = parse_standalone_args(prog="kt-tui")
+    mark_startup("parser_ready", surface="tui")
     if args.resume:
         return resume_cli(
             args.query,

--- a/src/kohakuterrarium/cli/entry_tui.py
+++ b/src/kohakuterrarium/cli/entry_tui.py
@@ -9,11 +9,21 @@ through the shared ``resolve_then_run`` / ``resume_cli`` cores.
 
 import sys
 
-from kohakuterrarium.cli.resume import resume_cli
-from kohakuterrarium.cli.run import resolve_then_run
 from kohakuterrarium.cli.select_args import parse_standalone_args
 from kohakuterrarium.utils.logging import configure_utf8_stdio
 from kohakuterrarium.utils.startup_trace import mark as mark_startup
+
+
+def resume_cli(*args, **kwargs):
+    from kohakuterrarium.cli.resume import resume_cli as resume
+
+    return resume(*args, **kwargs)
+
+
+def resolve_then_run(*args, **kwargs):
+    from kohakuterrarium.cli.run import resolve_then_run as run
+
+    return run(*args, **kwargs)
 
 
 def main() -> int:

--- a/src/kohakuterrarium/cli/lab_client.py
+++ b/src/kohakuterrarium/cli/lab_client.py
@@ -44,6 +44,7 @@ from kohakuterrarium.llm.codex_auth import (
     clear_codex_resolver,
     register_codex_resolver,
 )
+from kohakuterrarium.studio.hooks import register_group_hooks
 from kohakuterrarium.studio.identity import drive_settings as _drive_settings
 from kohakuterrarium.terrarium import Terrarium
 from kohakuterrarium.utils.logging import (
@@ -197,6 +198,7 @@ async def _run_worker(args: argparse.Namespace) -> None:
     )
     # Drive settings are node-local; invalid or disabled settings resolve to a
     # Drive-disabled engine rather than preventing worker startup.
+    register_group_hooks()
     drive_kwargs = _drive_settings.resolve_drive_kwargs()
     engine = Terrarium(**drive_kwargs)
     # The runtime adapter needs the attacher at construction time so newly

--- a/src/kohakuterrarium/cli/picker.py
+++ b/src/kohakuterrarium/cli/picker.py
@@ -8,8 +8,6 @@ the caller (``resolve_then_run``) before we get here.
 """
 
 from kohakuterrarium.cli.select import enumerate_runnables
-from kohakuterrarium.cli.select_cli import run_cli_picker
-from kohakuterrarium.cli.select_tui import run_tui_picker
 from kohakuterrarium.utils.logging import get_logger
 from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
@@ -37,5 +35,9 @@ def pick_runnable(io_mode: str) -> str | None:
         )
         return None
     if io_mode == "tui":
+        from kohakuterrarium.cli.select_tui import run_tui_picker
+
         return run_tui_picker(groups)
+    from kohakuterrarium.cli.select_cli import run_cli_picker
+
     return run_cli_picker(groups)

--- a/src/kohakuterrarium/cli/picker.py
+++ b/src/kohakuterrarium/cli/picker.py
@@ -11,6 +11,7 @@ from kohakuterrarium.cli.select import enumerate_runnables
 from kohakuterrarium.cli.select_cli import run_cli_picker
 from kohakuterrarium.cli.select_tui import run_tui_picker
 from kohakuterrarium.utils.logging import get_logger
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 logger = get_logger(__name__)
 
@@ -22,6 +23,12 @@ def pick_runnable(io_mode: str) -> str | None:
     or ``None`` when the catalog is empty or the user cancelled.
     """
     groups = enumerate_runnables()
+    mark_startup(
+        "picker_catalog_scanned",
+        surface=io_mode,
+        groups=len(groups),
+        entries=sum(len(group.items()) for group in groups),
+    )
     if not groups:
         print(
             "No creatures or terrariums found.\n"

--- a/src/kohakuterrarium/cli/resume.py
+++ b/src/kohakuterrarium/cli/resume.py
@@ -14,15 +14,28 @@ from typing import Literal
 
 from kohakuterrarium.cli.run import _resolve_session
 from kohakuterrarium.session.readonly import read_session_meta
+from kohakuterrarium.studio.hooks import register_group_hooks
 from kohakuterrarium.studio.persistence.resume import announce_migration_if_needed
 from kohakuterrarium.terrarium.engine import Terrarium
-from kohakuterrarium.terrarium.engine_cli import run_engine_with_tui
-from kohakuterrarium.terrarium.engine_rich_cli import run_engine_with_rich_cli
 from kohakuterrarium.utils.logging import (
     configure_utf8_stdio,
     enable_stderr_logging,
     set_level,
 )
+
+
+async def run_engine_with_rich_cli(engine, focus, store):
+    from kohakuterrarium.terrarium.engine_rich_cli import (
+        run_engine_with_rich_cli as run,
+    )
+
+    await run(engine, focus, store)
+
+
+async def run_engine_with_tui(engine, focus, store):
+    from kohakuterrarium.terrarium.engine_cli import run_engine_with_tui as run
+
+    await run(engine, focus, store)
 
 
 def resume_cli(
@@ -102,6 +115,7 @@ def _resolve_missing_pwd(path, pwd_override: str | None) -> str | None | Literal
 
 async def _run(path, pwd_override, llm, io_mode: str | None) -> int:
     """Resume the engine and run the selected interactive surface."""
+    register_group_hooks()
     engine = await Terrarium.resume(str(path), pwd=pwd_override, llm=llm)
     async with engine:
         graph_id = next(iter(engine._topology.graphs.keys()), None)

--- a/src/kohakuterrarium/cli/run.py
+++ b/src/kohakuterrarium/cli/run.py
@@ -14,17 +14,12 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
-import kohakuterrarium.terrarium.channels as _channels
-import kohakuterrarium.terrarium.topology as _topo
 from kohakuterrarium.cli.picker import pick_runnable
 from kohakuterrarium.packages.resolve import resolve_any_path
-from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio.hooks import register_group_hooks
-from kohakuterrarium.studio.identity import drive_settings as _drive_settings
-from kohakuterrarium.terrarium.config import load_terrarium_config
-from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.utils.config_dir import config_dir
 from kohakuterrarium.utils.logging import (
     configure_utf8_stdio,
@@ -35,6 +30,10 @@ from kohakuterrarium.utils.logging import (
 from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from kohakuterrarium.session.store import SessionStore
+    from kohakuterrarium.terrarium.engine import Terrarium
 
 _SESSION_DIR = Path.home() / ".kohakuterrarium" / "sessions"
 
@@ -186,13 +185,18 @@ async def _run(
     extra_creatures: list[str],
     extra_channels: list[str],
 ) -> int:
+    from kohakuterrarium.session.store import SessionStore
+    from kohakuterrarium.studio.identity import drive_settings
+    from kohakuterrarium.terrarium.config import load_terrarium_config
+    from kohakuterrarium.terrarium.engine import Terrarium
+
     register_group_hooks()
     pwd = str(Path.cwd())
     is_recipe = _looks_like_recipe(agent_path)
 
     # Resolve node-local Drive settings once; absent or disabled settings keep
     # the engine Drive-free.
-    drive_kwargs = _drive_settings.resolve_drive_kwargs()
+    drive_kwargs = drive_settings.resolve_drive_kwargs()
     surface = io_mode or "configured"
     mark_startup("engine_create_begin", surface=surface)
     async with Terrarium(pwd=pwd, **drive_kwargs) as engine:
@@ -296,7 +300,7 @@ async def _run(
 
 
 async def _apply_cli_topology(
-    engine: Terrarium,
+    engine: "Terrarium",
     *,
     graph_id: str,
     pwd: str,
@@ -315,6 +319,9 @@ async def _apply_cli_topology(
     """
     if not extra_creatures and not extra_channels:
         return
+    import kohakuterrarium.terrarium.channels as channels
+    import kohakuterrarium.terrarium.topology as topology
+
     for cfg_path in extra_creatures:
         try:
             await engine.add_creature(
@@ -345,13 +352,13 @@ async def _apply_cli_topology(
         graph = engine.get_graph(graph_id)
         for cid in sorted(graph.creature_ids):
             try:
-                _topo.set_listen(engine._topology, cid, ch_name, listening=True)
-                _topo.set_send(engine._topology, cid, ch_name, sending=True)
+                topology.set_listen(engine._topology, cid, ch_name, listening=True)
+                topology.set_send(engine._topology, cid, ch_name, sending=True)
                 creature = engine.get_creature(cid)
                 env = engine._environments.get(graph_id)
                 if env is None:
                     continue
-                _channels.inject_channel_trigger(
+                channels.inject_channel_trigger(
                     creature.agent,
                     subscriber_id=creature.name,
                     channel_name=ch_name,
@@ -392,7 +399,7 @@ def _looks_like_recipe(path: str) -> bool:
     return False
 
 
-def _pick_focus_creature(engine: Terrarium, graph_id: str) -> str:
+def _pick_focus_creature(engine: "Terrarium", graph_id: str) -> str:
     """Return the creature_id the TUI should focus on.
 
     Preference order: the privileged root (recipe-declared), the first
@@ -418,13 +425,13 @@ def _pick_focus_creature(engine: Terrarium, graph_id: str) -> str:
 
 
 async def _attach_session_store(
-    engine: Terrarium,
+    engine: "Terrarium",
     *,
     graph_id: str,
     session: str,
     config_path: str,
     config_type: str,
-) -> SessionStore:
+) -> "SessionStore":
     """Attach a session store to ``graph_id`` and return it.
 
     ``config_type`` is written after attachment because graph shape alone
@@ -531,6 +538,8 @@ def _session_preview(path: Path) -> str:
     try:
         # Read-only: a plain open+close here used to bump last_active,
         # corrupting the recency ordering the resume picker sorts by.
+        from kohakuterrarium.session.store import SessionStore
+
         store = SessionStore.open_readonly(path)
         meta = store.load_meta()
         config_type = meta.get("config_type", "?")

--- a/src/kohakuterrarium/cli/run.py
+++ b/src/kohakuterrarium/cli/run.py
@@ -21,11 +21,10 @@ import kohakuterrarium.terrarium.topology as _topo
 from kohakuterrarium.cli.picker import pick_runnable
 from kohakuterrarium.packages.resolve import resolve_any_path
 from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.studio.hooks import register_group_hooks
 from kohakuterrarium.studio.identity import drive_settings as _drive_settings
 from kohakuterrarium.terrarium.config import load_terrarium_config
 from kohakuterrarium.terrarium.engine import Terrarium
-from kohakuterrarium.terrarium.engine_cli import run_engine_with_tui
-from kohakuterrarium.terrarium.engine_rich_cli import run_engine_with_rich_cli
 from kohakuterrarium.utils.config_dir import config_dir
 from kohakuterrarium.utils.logging import (
     configure_utf8_stdio,
@@ -187,6 +186,7 @@ async def _run(
     extra_creatures: list[str],
     extra_channels: list[str],
 ) -> int:
+    register_group_hooks()
     pwd = str(Path.cwd())
     is_recipe = _looks_like_recipe(agent_path)
 
@@ -256,6 +256,10 @@ async def _run(
 
         try:
             if io_mode == "cli":
+                from kohakuterrarium.terrarium.engine_rich_cli import (
+                    run_engine_with_rich_cli,
+                )
+
                 mark_startup(
                     "surface_run_begin",
                     surface="cli",
@@ -263,6 +267,8 @@ async def _run(
                 )
                 await run_engine_with_rich_cli(engine, focus_creature_id, store)
             elif io_mode == "tui":
+                from kohakuterrarium.terrarium.engine_cli import run_engine_with_tui
+
                 mark_startup(
                     "surface_run_begin",
                     surface="tui",

--- a/src/kohakuterrarium/cli/run.py
+++ b/src/kohakuterrarium/cli/run.py
@@ -33,6 +33,7 @@ from kohakuterrarium.utils.logging import (
     get_logger,
     set_level,
 )
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 logger = get_logger(__name__)
 
@@ -192,7 +193,10 @@ async def _run(
     # Resolve node-local Drive settings once; absent or disabled settings keep
     # the engine Drive-free.
     drive_kwargs = _drive_settings.resolve_drive_kwargs()
+    surface = io_mode or "configured"
+    mark_startup("engine_create_begin", surface=surface)
     async with Terrarium(pwd=pwd, **drive_kwargs) as engine:
+        mark_startup("engine_entered", surface=surface)
         store: SessionStore | None = None
         focus_creature_id = ""
 
@@ -226,6 +230,12 @@ async def _run(
             )
             focus_creature_id = creature.creature_id
             graph_id = creature.graph_id
+            mark_startup(
+                "creature_added",
+                surface=surface,
+                creature_id=focus_creature_id,
+                graph_id=graph_id,
+            )
             if session is not None:
                 store = await _attach_session_store(
                     engine,
@@ -246,8 +256,18 @@ async def _run(
 
         try:
             if io_mode == "cli":
+                mark_startup(
+                    "surface_run_begin",
+                    surface="cli",
+                    creature_id=focus_creature_id,
+                )
                 await run_engine_with_rich_cli(engine, focus_creature_id, store)
             elif io_mode == "tui":
+                mark_startup(
+                    "surface_run_begin",
+                    surface="tui",
+                    creature_id=focus_creature_id,
+                )
                 await run_engine_with_tui(engine, focus_creature_id, store)
             else:
                 # Configured I/O owns the lifecycle; keep the event loop alive

--- a/src/kohakuterrarium/core/__init__.py
+++ b/src/kohakuterrarium/core/__init__.py
@@ -1,93 +1,51 @@
-"""
-Core module: fundamental abstractions and runtime components.
+"""Core agent abstractions and runtime components public facade."""
 
-Exports the main building blocks for constructing and running agents.
-"""
+import importlib
 
-from kohakuterrarium.core.config import (
-    AgentConfig,
-    InputConfig,
-    OutputConfig,
-    ToolConfigItem,
-    TriggerConfig,
-    load_agent_config,
-)
-from kohakuterrarium.core.controller import (
-    Controller,
-    ControllerConfig,
-    ControllerContext,
-)
-from kohakuterrarium.core.conversation import Conversation, ConversationConfig
-from kohakuterrarium.core.environment import Environment
-from kohakuterrarium.core.events import (
-    EventType,
-    TriggerEvent,
-    create_error_event,
-    create_tool_complete_event,
-    create_user_input_event,
-)
-from kohakuterrarium.core.executor import Executor
-from kohakuterrarium.core.job import (
-    JobResult,
-    JobState,
-    JobStatus,
-    JobStore,
-    JobType,
-    generate_job_id,
-)
-from kohakuterrarium.core.loader import (
-    ModuleLoader,
-    ModuleLoadError,
-    load_custom_module,
-)
-from kohakuterrarium.core.registry import Registry
+_EXPORTS = {
+    "Agent": "kohakuterrarium.core.agent",
+    "AgentConfig": "kohakuterrarium.core.config",
+    "Controller": "kohakuterrarium.core.controller",
+    "ControllerConfig": "kohakuterrarium.core.controller",
+    "ControllerContext": "kohakuterrarium.core.controller",
+    "Conversation": "kohakuterrarium.core.conversation",
+    "ConversationConfig": "kohakuterrarium.core.conversation",
+    "Environment": "kohakuterrarium.core.environment",
+    "EventType": "kohakuterrarium.core.events",
+    "Executor": "kohakuterrarium.core.executor",
+    "InputConfig": "kohakuterrarium.core.config",
+    "JobResult": "kohakuterrarium.core.job",
+    "JobState": "kohakuterrarium.core.job",
+    "JobStatus": "kohakuterrarium.core.job",
+    "JobStore": "kohakuterrarium.core.job",
+    "JobType": "kohakuterrarium.core.job",
+    "ModuleLoadError": "kohakuterrarium.core.loader",
+    "ModuleLoader": "kohakuterrarium.core.loader",
+    "OutputConfig": "kohakuterrarium.core.config",
+    "Registry": "kohakuterrarium.core.registry",
+    "ToolConfigItem": "kohakuterrarium.core.config",
+    "TriggerConfig": "kohakuterrarium.core.config",
+    "TriggerEvent": "kohakuterrarium.core.events",
+    "create_error_event": "kohakuterrarium.core.events",
+    "create_tool_complete_event": "kohakuterrarium.core.events",
+    "create_user_input_event": "kohakuterrarium.core.events",
+    "generate_job_id": "kohakuterrarium.core.job",
+    "load_agent_config": "kohakuterrarium.core.config",
+    "load_custom_module": "kohakuterrarium.core.loader",
+    "run_agent": "kohakuterrarium.core.agent",
+}
 
-__all__ = [
-    "Agent",
-    "run_agent",
-    "Environment",
-    "AgentConfig",
-    "InputConfig",
-    "OutputConfig",
-    "ToolConfigItem",
-    "TriggerConfig",
-    "load_agent_config",
-    "TriggerEvent",
-    "EventType",
-    "create_user_input_event",
-    "create_tool_complete_event",
-    "create_error_event",
-    "Conversation",
-    "ConversationConfig",
-    "Controller",
-    "ControllerConfig",
-    "ControllerContext",
-    "Executor",
-    "JobStatus",
-    "JobResult",
-    "JobState",
-    "JobType",
-    "JobStore",
-    "generate_job_id",
-    "Registry",
-    "ModuleLoader",
-    "ModuleLoadError",
-    "load_custom_module",
-]
+__all__ = list(_EXPORTS)
 
 
 def __getattr__(name: str):
-    """Resolve the lazily exported ``Agent`` and ``run_agent`` attributes.
+    module_path = _EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value
+    return value
 
-    ``builtins.inputs.cli`` imports ``core.events`` via ``core.__init__``;
-    eagerly importing ``core.agent`` here would pull in ``bootstrap.io`` which
-    imports ``builtins.inputs`` while it is still initialising. Module-level
-    ``__getattr__`` is the deliberate exception to the local-import audit.
-    """
-    if name in ("Agent", "run_agent"):
-        from kohakuterrarium.core.agent import Agent, run_agent
 
-        globals()["Agent"] = Agent
-        globals()["run_agent"] = run_agent
-        return Agent if name == "Agent" else run_agent
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_EXPORTS))

--- a/src/kohakuterrarium/core/agent.py
+++ b/src/kohakuterrarium/core/agent.py
@@ -45,6 +45,7 @@ from kohakuterrarium.llm.message import ContentPart
 from kohakuterrarium.modules.input.base import InputModule
 from kohakuterrarium.modules.output.base import OutputModule
 from kohakuterrarium.modules.plugin.base import PluginContext
+from kohakuterrarium.packages.walk import package_snapshot
 from kohakuterrarium.plugins_context import spawn_child_agent
 from kohakuterrarium.session.agent_attach import attach_to_session as _attach_to_session
 from kohakuterrarium.session.agent_attach import (
@@ -210,34 +211,35 @@ class Agent(
 
         # Initialize components (methods from AgentInitMixin)
         # Order matters: output before controller (need known_outputs for parser)
-        self._init_llm()
-        if hasattr(self.llm, "on_emergency_drop"):
-            self.llm.on_emergency_drop(self._on_provider_emergency_drop)
-        self._init_registry()
-        self._init_executor()
-        # Instance-injected tools (E7) — registered BEFORE the
-        # controller so they land in the initial system prompt.
-        for tool_instance in tools or []:
-            self.registry.register_tool(tool_instance)
-            self.executor.register_tool(tool_instance)
-        self._init_plugins()
-        for plugin_instance in plugins or []:
-            self.plugins.register(plugin_instance)
-        self._init_subagents()
-        for subagent_cfg in subagents or []:
-            self.subagent_manager.register(subagent_cfg)
-        self._init_iteration_budget()
-        self._init_output(output_module)  # Before controller - sets _known_outputs
-        # Instance-injected named outputs join before the parser learns
-        # the known-output set.
-        for output_name, extra_output in (outputs or {}).items():
-            self.output_router.named_outputs[output_name] = extra_output
-            self._known_outputs.add(output_name)
-        self._init_skills()  # Before controller so skill index is in prompt
-        self._init_controller()
-        self._init_input(input_module)
-        self._init_user_commands()
-        self._init_triggers()
+        with package_snapshot():
+            self._init_llm()
+            if hasattr(self.llm, "on_emergency_drop"):
+                self.llm.on_emergency_drop(self._on_provider_emergency_drop)
+            self._init_registry()
+            self._init_executor()
+            # Instance-injected tools (E7) — registered BEFORE the
+            # controller so they land in the initial system prompt.
+            for tool_instance in tools or []:
+                self.registry.register_tool(tool_instance)
+                self.executor.register_tool(tool_instance)
+            self._init_plugins()
+            for plugin_instance in plugins or []:
+                self.plugins.register(plugin_instance)
+            self._init_subagents()
+            for subagent_cfg in subagents or []:
+                self.subagent_manager.register(subagent_cfg)
+            self._init_iteration_budget()
+            self._init_output(output_module)  # Before controller - sets _known_outputs
+            # Instance-injected named outputs join before the parser learns
+            # the known-output set.
+            for output_name, extra_output in (outputs or {}).items():
+                self.output_router.named_outputs[output_name] = extra_output
+                self._known_outputs.add(output_name)
+            self._init_skills()  # Before controller so skill index is in prompt
+            self._init_controller()
+            self._init_input(input_module)
+            self._init_user_commands()
+            self._init_triggers()
 
         logger.info(
             "Agent initialized",

--- a/src/kohakuterrarium/core/agent_construct.py
+++ b/src/kohakuterrarium/core/agent_construct.py
@@ -14,6 +14,7 @@ from kohakuterrarium.core.config import AgentConfig, load_agent_config
 from kohakuterrarium.core.session import Session
 from kohakuterrarium.modules.input.base import InputModule
 from kohakuterrarium.modules.output.base import OutputModule
+from kohakuterrarium.packages.walk import package_snapshot
 
 if TYPE_CHECKING:
     from kohakuterrarium.core.agent import Agent
@@ -94,23 +95,24 @@ class AgentConstructMixin:
             input_module = NoneInput()
         if output_module is None and io == "headless":
             output_module = NoneOutput()
-        if not isinstance(config, AgentConfig):
-            config = load_agent_config(config)
-        return cls(
-            config,
-            llm=llm,
-            pwd=pwd,
-            strict=strict,
-            tools=tools,
-            plugins=plugins,
-            subagents=subagents,
-            outputs=outputs,
-            user_commands=user_commands,
-            input_module=input_module,
-            output_module=output_module,
-            session=session,
-            environment=environment,
-        )
+        with package_snapshot():
+            if not isinstance(config, AgentConfig):
+                config = load_agent_config(config)
+            return cls(
+                config,
+                llm=llm,
+                pwd=pwd,
+                strict=strict,
+                tools=tools,
+                plugins=plugins,
+                subagents=subagents,
+                outputs=outputs,
+                user_commands=user_commands,
+                input_module=input_module,
+                output_module=output_module,
+                session=session,
+                environment=environment,
+            )
 
     @classmethod
     def from_path(
@@ -146,16 +148,17 @@ class AgentConstructMixin:
         Returns:
             Configured Agent instance
         """
-        config = load_agent_config(config_path)
-        return cls(
-            config,
-            input_module=input_module,
-            output_module=output_module,
-            session=session,
-            environment=environment,
-            llm=llm,
-            pwd=pwd,
-            strict=strict,
-            tools=tools,
-            plugins=plugins,
-        )
+        with package_snapshot():
+            config = load_agent_config(config_path)
+            return cls(
+                config,
+                input_module=input_module,
+                output_module=output_module,
+                session=session,
+                environment=environment,
+                llm=llm,
+                pwd=pwd,
+                strict=strict,
+                tools=tools,
+                plugins=plugins,
+            )

--- a/src/kohakuterrarium/core/controller.py
+++ b/src/kohakuterrarium/core/controller.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 if TYPE_CHECKING:
     from kohakuterrarium.llm.base import ToolSchema
 
-from kohakuterrarium.builtins.tools.read import ReadTool
 from kohakuterrarium.commands.base import Command, CommandResult
 from kohakuterrarium.commands.read import (
     InfoCommand,
@@ -673,6 +672,8 @@ class Controller:
 
         tool = self.registry.get_tool("read") if self.registry else None
         if tool is None:
+            from kohakuterrarium.builtins.tools.read import ReadTool
+
             tool = ReadTool()
         if self.executor:
             context = self.executor._build_tool_context()

--- a/src/kohakuterrarium/llm/__init__.py
+++ b/src/kohakuterrarium/llm/__init__.py
@@ -1,58 +1,50 @@
-"""
-Expose provider abstractions, concrete adapters, messages, and tool-call types.
-"""
+"""LLM provider, message, and tool-call public facade."""
 
-from kohakuterrarium.llm.anthropic_provider import ANTHROPIC_BASE_URL, AnthropicProvider
-from kohakuterrarium.llm.base import (
-    BaseLLMProvider,
-    ChatChunk,
-    ChatResponse,
-    LLMConfig,
-    LLMProvider,
-    NativeToolCall,
-    ToolSchema,
-)
-from kohakuterrarium.llm.codex_provider import CodexOAuthProvider
-from kohakuterrarium.llm.message import (
-    AssistantMessage,
-    Message,
-    MessageList,
-    SystemMessage,
-    ToolMessage,
-    UserMessage,
-    create_message,
-    dicts_to_messages,
-    messages_to_dicts,
-)
-from kohakuterrarium.llm.openai import (
-    OPENAI_BASE_URL,
-    OPENROUTER_BASE_URL,
-    OpenAIProvider,
-)
+import importlib
 
-# Tool schema builders remain in llm.tools to avoid the core.registry import cycle.
+_EXPORTS = {
+    "ANTHROPIC_BASE_URL": "kohakuterrarium.llm.anthropic_provider",
+    "AnthropicProvider": "kohakuterrarium.llm.anthropic_provider",
+    "AssistantMessage": "kohakuterrarium.llm.message",
+    "BaseLLMProvider": "kohakuterrarium.llm.base",
+    "ChatChunk": "kohakuterrarium.llm.base",
+    "ChatResponse": "kohakuterrarium.llm.base",
+    "CodexOAuthProvider": "kohakuterrarium.llm.codex_provider",
+    "LLMConfig": "kohakuterrarium.llm.base",
+    "LLMProvider": "kohakuterrarium.llm.base",
+    "Message": "kohakuterrarium.llm.message",
+    "MessageList": "kohakuterrarium.llm.message",
+    "NativeToolCall": "kohakuterrarium.llm.base",
+    "OPENAI_BASE_URL": "kohakuterrarium.llm.openai",
+    "OPENROUTER_BASE_URL": "kohakuterrarium.llm.openai",
+    "OpenAIProvider": "kohakuterrarium.llm.openai",
+    "SystemMessage": "kohakuterrarium.llm.message",
+    "ToolMessage": "kohakuterrarium.llm.message",
+    "ToolSchema": "kohakuterrarium.llm.base",
+    "UserMessage": "kohakuterrarium.llm.message",
+    "create_message": "kohakuterrarium.llm.message",
+    "dicts_to_messages": "kohakuterrarium.llm.message",
+    "messages_to_dicts": "kohakuterrarium.llm.message",
+}
 
-__all__ = [
-    "LLMProvider",
-    "BaseLLMProvider",
-    "LLMConfig",
-    "ChatChunk",
-    "ChatResponse",
-    "ToolSchema",
-    "NativeToolCall",
-    "OpenAIProvider",
-    "OPENAI_BASE_URL",
-    "OPENROUTER_BASE_URL",
-    "AnthropicProvider",
-    "ANTHROPIC_BASE_URL",
-    "CodexOAuthProvider",
-    "Message",
-    "MessageList",
-    "SystemMessage",
-    "UserMessage",
-    "AssistantMessage",
-    "ToolMessage",
-    "create_message",
-    "messages_to_dicts",
-    "dicts_to_messages",
-]
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str):
+    module_path = _EXPORTS.get(name)
+    if module_path is None:
+        try:
+            return importlib.import_module(f"kohakuterrarium.llm.{name}")
+        except ModuleNotFoundError as exc:
+            if exc.name != f"kohakuterrarium.llm.{name}":
+                raise
+            raise AttributeError(
+                f"module {__name__!r} has no attribute {name!r}"
+            ) from None
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_EXPORTS))

--- a/src/kohakuterrarium/packages/walk.py
+++ b/src/kohakuterrarium/packages/walk.py
@@ -1,13 +1,40 @@
 """Package enumeration helpers."""
 
+from contextlib import contextmanager
+from copy import deepcopy
+from threading import local
+
 from kohakuterrarium.packages.locations import LINK_SUFFIX
 from kohakuterrarium.packages.locations import _packages_dir
 from kohakuterrarium.packages.locations import get_package_root
 from kohakuterrarium.packages.locations import read_link
 from kohakuterrarium.packages.manifest import _load_manifest
 
+_PACKAGE_SNAPSHOT = local()
+
+
+@contextmanager
+def package_snapshot():
+    """Reuse one package enumeration within a bounded construction scope."""
+    if getattr(_PACKAGE_SNAPSHOT, "packages", None) is not None:
+        yield
+        return
+    _PACKAGE_SNAPSHOT.packages = _list_packages_uncached()
+    try:
+        yield
+    finally:
+        del _PACKAGE_SNAPSHOT.packages
+
 
 def list_packages() -> list[dict]:
+    """List installed packages, reusing the active build-scoped snapshot."""
+    snapshot = getattr(_PACKAGE_SNAPSHOT, "packages", None)
+    if snapshot is not None:
+        return deepcopy(snapshot)
+    return _list_packages_uncached()
+
+
+def _list_packages_uncached() -> list[dict]:
     """List all installed packages with their creatures and terrariums."""
     # Honour test monkeypatches against ``locations.PACKAGES_DIR`` by
     # consulting ``_packages_dir()`` rather than the captured constant.

--- a/src/kohakuterrarium/serving/desktop.py
+++ b/src/kohakuterrarium/serving/desktop.py
@@ -1,0 +1,319 @@
+"""Lightweight native desktop bootstrap with a loading shell."""
+
+import argparse
+import html
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from kohakuterrarium.utils.logging import configure_utf8_stdio
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
+
+LOADING_HTML = """<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body{height:100%;margin:0;background:#151525;color:#e8e8f2;font:16px system-ui,sans-serif}
+body{display:grid;place-items:center}.shell{text-align:center}.spinner{width:34px;height:34px;
+margin:0 auto 18px;border:3px solid #373751;border-top-color:#9b87f5;border-radius:50%;
+animation:spin .8s linear infinite}@keyframes spin{to{transform:rotate(360deg)}}
+</style></head><body><div class="shell"><div class="spinner"></div>
+<div>Starting KohakuTerrarium…</div></div></body></html>"""
+
+
+class _InProcessServer:
+    def __init__(self, server):
+        self.server = server
+        self.pid = os.getpid()
+
+    def poll(self):
+        return None if not self.server.should_exit else 0
+
+    def terminate(self):
+        self.server.should_exit = True
+
+    def wait(self, timeout=None):
+        self.server.should_exit = True
+        thread = getattr(self.server, "_kt_thread", None)
+        if thread is not None:
+            thread.join(timeout)
+        return 0
+
+    def kill(self):
+        self.server.should_exit = True
+
+
+def _error_html(message: str) -> str:
+    escaped = html.escape(message)
+    return f"""<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{{height:100%;margin:0;background:#151525;color:#e8e8f2;font:16px system-ui,sans-serif}}
+body{{display:grid;place-items:center}}.shell{{max-width:640px;padding:32px}}h2{{color:#ff8f8f}}
+pre{{white-space:pre-wrap;color:#cfcfe5}}</style></head><body><div class="shell">
+<h2>Startup failed</h2><pre>{escaped}</pre></div></body></html>"""
+
+
+def _is_briefcase_runtime() -> bool:
+    if os.environ.get("KT_LAUNCHER_EXEC") == "1":
+        return True
+    try:
+        exe_dir = Path(sys.executable).resolve().parent
+    except OSError:
+        return False
+    return any(exe_dir.glob("python3*._pth"))
+
+
+def _load_webview():
+    try:
+        import webview
+    except ImportError:
+        print("pywebview is required for 'kt app'.")
+        print("Install: pip install 'KohakuTerrarium[desktop]'")
+        raise SystemExit(1) from None
+    return webview
+
+
+def _state_path() -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        prefix="kt-desktop-", suffix=".json", delete=False
+    )
+    handle.close()
+    return Path(handle.name)
+
+
+def launch_desktop_app(port: int = 8001, log_level: str = "INFO"):
+    """Detach a lightweight desktop UI process from a regular interpreter."""
+    if _is_briefcase_runtime():
+        run_desktop_app(port=port, log_level=log_level)
+        return None
+    cmd = [
+        sys.executable,
+        "-m",
+        "kohakuterrarium.serving.desktop",
+        "--port",
+        str(port),
+        "--log-level",
+        log_level,
+    ]
+    log_dir = Path.home() / ".kohakuterrarium"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = open(log_dir / "app.log", "w", encoding="utf-8")  # noqa: SIM115
+    kwargs: dict[str, object] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_file,
+        "stderr": log_file,
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+    else:
+        kwargs["start_new_session"] = True
+    child = subprocess.Popen(cmd, **kwargs)
+    log_file.close()
+    mark_startup(
+        "desktop_child_spawned",
+        surface="desktop",
+        child_pid=child.pid,
+        port=port,
+    )
+    return child
+
+
+def _start_subprocess_server(*, port: int, log_level: str, state_path: Path):
+    cmd = [
+        sys.executable,
+        "-m",
+        "kohakuterrarium.serving.desktop_server",
+        "--port",
+        str(port),
+        "--log-level",
+        log_level,
+        "--state-path",
+        str(state_path),
+        "--parent-pid",
+        str(os.getpid()),
+    ]
+    log_file = open(  # noqa: SIM115
+        Path.home() / ".kohakuterrarium" / "app.log", "a", encoding="utf-8"
+    )
+    kwargs: dict[str, object] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_file,
+        "stderr": log_file,
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+    else:
+        kwargs["start_new_session"] = True
+    child = subprocess.Popen(cmd, **kwargs)
+    log_file.close()
+    mark_startup(
+        "desktop_server_child_spawned",
+        surface="desktop",
+        child_pid=child.pid,
+        port=port,
+    )
+    return child
+
+
+def _start_in_process_server(*, port: int, log_level: str, state_path: Path):
+    from kohakuterrarium.serving.desktop_server import start_desktop_server
+
+    server, actual_port = start_desktop_server(port, log_level)
+    state_path.write_text(
+        json.dumps({"status": "ready", "port": actual_port}), encoding="utf-8"
+    )
+    return _InProcessServer(server)
+
+
+def _start_server(*, port: int, log_level: str, state_path: Path):
+    if _is_briefcase_runtime():
+        return _start_in_process_server(
+            port=port, log_level=log_level, state_path=state_path
+        )
+    return _start_subprocess_server(
+        port=port, log_level=log_level, state_path=state_path
+    )
+
+
+def _wait_for_server(child, state_path: Path, timeout: float = 30.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            data = json.loads(state_path.read_text(encoding="utf-8"))
+            if data.get("status") in {"ready", "error"}:
+                return data
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            pass
+        if child.poll() is not None:
+            return {"status": "error", "error": "Desktop server exited during startup."}
+        time.sleep(0.05)
+    return {"status": "error", "error": "Desktop server did not start in time."}
+
+
+def _stop_server_child(child, state_path: Path | None = None) -> None:
+    if child.poll() is not None:
+        return
+    if state_path is not None:
+        try:
+            state_path.write_text(json.dumps({"status": "shutdown"}), encoding="utf-8")
+            child.wait(timeout=5)
+            return
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    child.terminate()
+    try:
+        child.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait(timeout=5)
+
+
+def _run_startup(
+    window,
+    *,
+    port: int,
+    log_level: str,
+    state_path: Path,
+    child_ref: list,
+    closed: threading.Event,
+) -> None:
+    try:
+        if closed.is_set():
+            return
+        child = _start_server(port=port, log_level=log_level, state_path=state_path)
+        child_ref.append(child)
+        if closed.is_set():
+            _stop_server_child(child, state_path)
+            return
+        result = _wait_for_server(child, state_path)
+        if closed.is_set():
+            _stop_server_child(child, state_path)
+            return
+        if result.get("status") == "ready":
+            actual_port = int(result["port"])
+            mark_startup("desktop_server_ready", surface="desktop", port=actual_port)
+            window.load_url(f"http://127.0.0.1:{actual_port}")
+            return
+        error = str(result.get("error") or "Unknown desktop startup error")
+    except Exception as exc:
+        error = str(exc)
+    mark_startup("desktop_startup_failed", surface="desktop", error=error)
+    window.load_html(_error_html(error))
+
+
+def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
+    """Show a native loading shell, then start and navigate to the local server."""
+    configure_utf8_stdio(log=True)
+    os.environ["KT_STARTUP_SURFACE"] = "desktop"
+    webview = _load_webview()
+    state_path = _state_path()
+    child_ref: list = []
+    closed = threading.Event()
+    window = webview.create_window(
+        "KohakuTerrarium",
+        html=LOADING_HTML,
+        width=1280,
+        height=800,
+        min_size=(800, 500),
+        zoomable=True,
+        text_select=True,
+        confirm_close=True,
+        background_color="#1a1a2e",
+    )
+    mark_startup("desktop_window_created", surface="desktop", window="loading")
+
+    def _start_after_shown():
+        mark_startup("desktop_window_shown", surface="desktop", window="loading")
+        threading.Thread(
+            target=_run_startup,
+            kwargs={
+                "window": window,
+                "port": port,
+                "log_level": log_level,
+                "state_path": state_path,
+                "child_ref": child_ref,
+                "closed": closed,
+            },
+            daemon=True,
+            name="desktop-server-startup",
+        ).start()
+
+    window.events.shown += _start_after_shown
+
+    def _closed():
+        closed.set()
+        if child_ref:
+            _stop_server_child(child_ref[0], state_path)
+        try:
+            state_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    window.events.closed += _closed
+
+    if sys.platform == "darwin":
+        webview.start(gui="cocoa")
+    elif sys.platform == "win32":
+        webview.start()
+    else:
+        icon = Path(__file__).parent.parent / "app_icons" / "window.png"
+        webview.start(icon=str(icon) if icon.exists() else None)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=8001)
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+    )
+    args = parser.parse_args()
+    run_desktop_app(port=args.port, log_level=args.log_level)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kohakuterrarium/serving/desktop.py
+++ b/src/kohakuterrarium/serving/desktop.py
@@ -75,6 +75,53 @@ def _load_webview():
     return webview
 
 
+def _set_windows_app_id() -> None:
+    try:
+        import ctypes
+
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+            "KohakuLab.KohakuTerrarium"
+        )
+    except Exception:
+        pass
+
+
+def _set_icon_windows(icon_path: Path) -> None:
+    try:
+        import ctypes
+
+        if not icon_path.exists():
+            return
+        user32 = ctypes.windll.user32
+        hicon = user32.LoadImageW(None, str(icon_path), 1, 0, 0, 0x00000010)
+        if not hicon:
+            return
+        hwnd = user32.FindWindowW(None, "KohakuTerrarium")
+        if hwnd:
+            user32.SendMessageW(hwnd, 0x0080, 0, hicon)
+            user32.SendMessageW(hwnd, 0x0080, 1, hicon)
+    except Exception:
+        pass
+
+
+def _set_icon_macos(icon_path: Path) -> None:
+    try:
+        if not icon_path.exists():
+            return
+        from AppKit import NSApp, NSApplication, NSImage
+        from PyObjCTools import AppHelper
+
+        def apply_icon():
+            app = NSApp() or NSApplication.sharedApplication()
+            image = NSImage.alloc().initWithContentsOfFile_(str(icon_path))
+            if image:
+                app.setApplicationIconImage_(image)
+
+        AppHelper.callAfter(apply_icon)
+    except Exception:
+        pass
+
+
 def _state_path() -> Path:
     handle = tempfile.NamedTemporaryFile(
         prefix="kt-desktop-", suffix=".json", delete=False
@@ -248,6 +295,11 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
     configure_utf8_stdio(log=True)
     os.environ["KT_STARTUP_SURFACE"] = "desktop"
     webview = _load_webview()
+    icons_dir = Path(__file__).parent.parent / "app_icons"
+    icon_ico = icons_dir / "window.ico"
+    icon_png = icons_dir / "window.png"
+    if sys.platform == "win32":
+        _set_windows_app_id()
     state_path = _state_path()
     child_ref: list = []
     closed = threading.Event()
@@ -266,6 +318,10 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
 
     def _shown():
         mark_startup("desktop_window_shown", surface="desktop", window="loading")
+        if sys.platform == "win32":
+            _set_icon_windows(icon_ico)
+        elif sys.platform == "darwin":
+            _set_icon_macos(icon_png)
 
     window.events.shown += _shown
 
@@ -298,8 +354,7 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
     elif sys.platform == "win32":
         webview.start()
     else:
-        icon = Path(__file__).parent.parent / "app_icons" / "window.png"
-        webview.start(icon=str(icon) if icon.exists() else None)
+        webview.start(icon=str(icon_png) if icon_png.exists() else None)
 
 
 def main() -> int:

--- a/src/kohakuterrarium/serving/desktop.py
+++ b/src/kohakuterrarium/serving/desktop.py
@@ -264,23 +264,10 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
     )
     mark_startup("desktop_window_created", surface="desktop", window="loading")
 
-    def _start_after_shown():
+    def _shown():
         mark_startup("desktop_window_shown", surface="desktop", window="loading")
-        threading.Thread(
-            target=_run_startup,
-            kwargs={
-                "window": window,
-                "port": port,
-                "log_level": log_level,
-                "state_path": state_path,
-                "child_ref": child_ref,
-                "closed": closed,
-            },
-            daemon=True,
-            name="desktop-server-startup",
-        ).start()
 
-    window.events.shown += _start_after_shown
+    window.events.shown += _shown
 
     def _closed():
         closed.set()
@@ -292,6 +279,19 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
             pass
 
     window.events.closed += _closed
+    threading.Thread(
+        target=_run_startup,
+        kwargs={
+            "window": window,
+            "port": port,
+            "log_level": log_level,
+            "state_path": state_path,
+            "child_ref": child_ref,
+            "closed": closed,
+        },
+        daemon=True,
+        name="desktop-server-startup",
+    ).start()
 
     if sys.platform == "darwin":
         webview.start(gui="cocoa")

--- a/src/kohakuterrarium/serving/desktop_server.py
+++ b/src/kohakuterrarium/serving/desktop_server.py
@@ -1,0 +1,169 @@
+"""Desktop server child entry point."""
+
+import argparse
+import ctypes
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from kohakuterrarium.api.app import create_app
+from kohakuterrarium.serving.web import (
+    WEB_DIST_DIR,
+    _resolve_config_dirs,
+    start_uvicorn_with_port_fallback,
+)
+from kohakuterrarium.utils.logging import (
+    configure_utf8_stdio,
+    enable_file_logging,
+    enable_stderr_logging,
+    get_logger,
+    set_level,
+)
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
+
+logger = get_logger(__name__)
+
+
+def _publish_state(path: Path, **fields) -> None:
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(fields, stream, ensure_ascii=False)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    if sys.platform == "win32":
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(0x00100000, False, pid)
+        if not handle:
+            return False
+        try:
+            return kernel32.WaitForSingleObject(handle, 0) == 0x00000102
+        finally:
+            kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _join_server(server, timeout: float = 5.0) -> None:
+    thread = getattr(server, "_kt_thread", None)
+    if thread is not None:
+        thread.join(timeout)
+
+
+def start_desktop_server(port: int, log_level: str):
+    """Start the desktop FastAPI server and return its server and bound port."""
+    configure_utf8_stdio(log=True)
+    os.environ["KT_STARTUP_SURFACE"] = "desktop"
+    enable_file_logging()
+    set_level(log_level)
+    enable_stderr_logging(log_level)
+    if not WEB_DIST_DIR.is_dir():
+        raise RuntimeError(
+            "web_dist not found — run 'npm run build --prefix "
+            "src/kohakuterrarium-frontend' first"
+        )
+    creatures_dirs, terrariums_dirs = _resolve_config_dirs()
+    mark_startup(
+        "desktop_config_dirs_resolved",
+        surface="desktop",
+        creatures=len(creatures_dirs),
+        terrariums=len(terrariums_dirs),
+    )
+    app = create_app(
+        creatures_dirs=creatures_dirs,
+        terrariums_dirs=terrariums_dirs,
+        static_dir=WEB_DIST_DIR,
+    )
+    mark_startup("desktop_app_created", surface="desktop")
+    return start_uvicorn_with_port_fallback(
+        app,
+        requested_port=port,
+        host="127.0.0.1",
+        log_level="warning",
+    )
+
+
+def run_server_child(
+    port: int, log_level: str, state_path: Path, parent_pid: int = 0
+) -> int:
+    """Start a desktop server child and publish its ready or error state."""
+    try:
+        server, actual_port = start_desktop_server(port, log_level)
+        _publish_state(state_path, status="ready", port=actual_port)
+        mark_startup("desktop_server_ready", surface="desktop", port=actual_port)
+        while not server.should_exit:
+            if parent_pid and not _pid_alive(parent_pid):
+                server.should_exit = True
+                break
+            thread = getattr(server, "_kt_thread", None)
+            if thread is not None and not thread.is_alive():
+                _publish_state(
+                    state_path,
+                    status="error",
+                    error="Desktop server stopped unexpectedly.",
+                )
+                return 1
+            try:
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+            except (FileNotFoundError, json.JSONDecodeError, OSError):
+                state = {}
+            if state.get("status") == "shutdown":
+                server.should_exit = True
+                break
+            time.sleep(0.2)
+        _join_server(server)
+        return 0
+    except Exception as exc:
+        logger.exception("Desktop server startup failed")
+        try:
+            _publish_state(state_path, status="error", error=str(exc))
+        except OSError:
+            pass
+        mark_startup(
+            "desktop_startup_failed",
+            surface="desktop",
+            stage="server",
+            error=str(exc),
+        )
+        return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=8001)
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+    )
+    parser.add_argument("--state-path", type=Path, required=True)
+    parser.add_argument("--parent-pid", type=int, default=0)
+    args = parser.parse_args()
+    return run_server_child(
+        args.port,
+        args.log_level,
+        args.state_path,
+        parent_pid=args.parent_pid,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kohakuterrarium/serving/desktop_server.py
+++ b/src/kohakuterrarium/serving/desktop_server.py
@@ -9,7 +9,6 @@ import tempfile
 import time
 from pathlib import Path
 
-from kohakuterrarium.api.app import create_app
 from kohakuterrarium.serving.web import (
     WEB_DIST_DIR,
     _resolve_config_dirs,
@@ -66,6 +65,12 @@ def _join_server(server, timeout: float = 5.0) -> None:
     thread = getattr(server, "_kt_thread", None)
     if thread is not None:
         thread.join(timeout)
+
+
+def create_app(**kwargs):
+    from kohakuterrarium.api.app import create_app as factory
+
+    return factory(**kwargs)
 
 
 def start_desktop_server(port: int, log_level: str):

--- a/src/kohakuterrarium/serving/web.py
+++ b/src/kohakuterrarium/serving/web.py
@@ -133,6 +133,7 @@ def start_uvicorn_with_port_fallback(
                         actual_port = sockets[0].getsockname()[1]
                 except Exception:
                     pass
+                server._kt_thread = thread
                 return server, actual_port
             if not thread.is_alive():
                 # A dead startup thread indicates that this candidate never bound.
@@ -290,15 +291,13 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
     application stub does not support ``python -m`` execution.
     """
     if _is_briefcase_runtime():
-        # The Briefcase stub is the GUI process and cannot be relaunched with
-        # module arguments, so it must own uvicorn and pywebview directly.
         _run_desktop_app_blocking(port=port, log_level=log_level)
         return
 
     cmd = [
         sys.executable,
         "-m",
-        "kohakuterrarium.serving.web",
+        "kohakuterrarium.serving.desktop",
         "--port",
         str(port),
         "--log-level",

--- a/src/kohakuterrarium/serving/web.py
+++ b/src/kohakuterrarium/serving/web.py
@@ -26,6 +26,7 @@ from kohakuterrarium.utils.logging import (
     get_logger,
     set_level,
 )
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 logger = get_logger(__name__)
 
@@ -227,6 +228,12 @@ def run_web_server(
         logger.info("boot mode: standalone", host=host, port=port)
 
     creatures_dirs, terrariums_dirs = _resolve_config_dirs()
+    mark_startup(
+        "web_config_dirs_resolved",
+        surface="web",
+        creatures=len(creatures_dirs),
+        terrariums=len(terrariums_dirs),
+    )
 
     app = create_app(
         creatures_dirs=creatures_dirs,
@@ -236,6 +243,7 @@ def run_web_server(
         lab_bind=lab_bind,
         lab_token=lab_token,
     )
+    mark_startup("web_app_created", surface="web")
 
     # Probe forward so direct web serving can tolerate a busy requested port.
     try:
@@ -255,6 +263,7 @@ def run_web_server(
     else:
         print(f"KohakuTerrarium web UI: http://{host}:{port}")
 
+    mark_startup("web_server_run", surface="web", host=host, port=port)
     uvicorn.run(app, host=host, port=port)
 
 
@@ -311,7 +320,11 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
     else:
         kwargs["start_new_session"] = True
 
-    subprocess.Popen(cmd, **kwargs)
+    mark_startup("desktop_child_spawn_begin", surface="desktop", port=port)
+    child = subprocess.Popen(cmd, **kwargs)
+    mark_startup(
+        "desktop_child_spawned", surface="desktop", port=port, child_pid=child.pid
+    )
     print(f"KohakuTerrarium desktop app launched (port {port})")
     print(f"  Log: {log_dir / 'app.log'}")
 
@@ -319,6 +332,7 @@ def run_desktop_app(port: int = 8001, log_level: str = "INFO") -> None:
 def _run_desktop_app_blocking(port: int = 8001, log_level: str = "INFO") -> None:
     """Run uvicorn and the native desktop window until the UI closes."""
     configure_utf8_stdio(log=True)
+    os.environ["KT_STARTUP_SURFACE"] = "desktop"
     enable_file_logging()
 
     # A stable application ID lets Windows associate the packaged taskbar icon.
@@ -348,12 +362,19 @@ def _run_desktop_app_blocking(port: int = 8001, log_level: str = "INFO") -> None
         sys.exit(1)
 
     creatures_dirs, terrariums_dirs = _resolve_config_dirs()
+    mark_startup(
+        "desktop_config_dirs_resolved",
+        surface="desktop",
+        creatures=len(creatures_dirs),
+        terrariums=len(terrariums_dirs),
+    )
 
     app = create_app(
         creatures_dirs=creatures_dirs,
         terrariums_dirs=terrariums_dirs,
         static_dir=WEB_DIST_DIR,
     )
+    mark_startup("desktop_app_created", surface="desktop")
 
     # Open webview only after uvicorn reports the actual bound port.
     try:
@@ -367,6 +388,7 @@ def _run_desktop_app_blocking(port: int = 8001, log_level: str = "INFO") -> None
         logger.error("Failed to start uvicorn", error=str(e))
         sys.exit(1)
     logger.info("desktop: uvicorn listening at http://127.0.0.1:%d", port)
+    mark_startup("desktop_server_ready", surface="desktop", port=port)
 
     icons_dir = Path(__file__).parent.parent / "app_icons"
     icon_ico = icons_dir / "window.ico"
@@ -383,6 +405,7 @@ def _run_desktop_app_blocking(port: int = 8001, log_level: str = "INFO") -> None
         confirm_close=True,
         background_color="#1a1a2e",
     )
+    mark_startup("desktop_window_created", surface="desktop", port=port)
 
     def _set_icon_windows():
         try:
@@ -419,6 +442,7 @@ def _run_desktop_app_blocking(port: int = 8001, log_level: str = "INFO") -> None
     if sys.platform == "win32":
 
         def _on_shown():
+            mark_startup("desktop_window_shown", surface="desktop", port=port)
             _set_icon_windows()
 
         window.events.shown += _on_shown
@@ -426,6 +450,7 @@ def _run_desktop_app_blocking(port: int = 8001, log_level: str = "INFO") -> None
     elif sys.platform == "darwin":
 
         def _on_shown():
+            mark_startup("desktop_window_shown", surface="desktop", port=port)
             _set_icon_macos()
 
         window.events.shown += _on_shown

--- a/src/kohakuterrarium/serving/web.py
+++ b/src/kohakuterrarium/serving/web.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 import uvicorn
 
-from kohakuterrarium.api.app import create_app
 from kohakuterrarium.packages.locations import get_package_root, packages_dir
 from kohakuterrarium.packages.walk import list_packages
 from kohakuterrarium.utils.logging import (
@@ -29,6 +28,13 @@ from kohakuterrarium.utils.logging import (
 from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 logger = get_logger(__name__)
+
+
+def create_app(**kwargs):
+    from kohakuterrarium.api.app import create_app
+
+    return create_app(**kwargs)
+
 
 # Vite places the packaged frontend beside the Python application modules.
 WEB_DIST_DIR = Path(__file__).resolve().parent.parent / "web_dist"

--- a/src/kohakuterrarium/session/__init__.py
+++ b/src/kohakuterrarium/session/__init__.py
@@ -1,5 +1,17 @@
-"""Persist, resume, and search session history."""
+"""Session persistence public facade."""
 
-from kohakuterrarium.session.store import SessionStore
+import importlib
 
 __all__ = ["SessionStore"]
+
+
+def __getattr__(name: str):
+    if name != "SessionStore":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module("kohakuterrarium.session.store"), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/kohakuterrarium/studio/__init__.py
+++ b/src/kohakuterrarium/studio/__init__.py
@@ -1,58 +1,30 @@
-"""Studio tier — programmatic façade over the studio sub-packages.
+"""Studio management facade and optional Terrarium integrations."""
 
-The :class:`Studio` facade exposes catalog, identity, session, persistence,
-editor, and attachment services over a Terrarium runtime.
+import importlib
 
-Importing the package registers Studio-owned group-tool integrations for session
-attachment, creature naming, workspace discovery, and spawnable catalogs. The
-Terrarium layer consumes these optional hooks without importing Studio, preserving
-the lower layer's independence and graceful behavior when Studio is absent.
-"""
+from kohakuterrarium.studio import hooks as _hooks
 
-from kohakuterrarium.studio.catalog.spawnable import list_spawnable_creatures
-from kohakuterrarium.studio.editors.workspace_fs import LocalWorkspace
-from kohakuterrarium.studio.sessions.find import (
-    apply_creature_name as _apply_creature_name,
-)
-from kohakuterrarium.studio.sessions.lifecycle import (
-    attach_session_store_for_creature,
-)
-from kohakuterrarium.studio.studio import Studio
-from kohakuterrarium.terrarium import group_hooks as _group_hooks
-
-
-def _store_attach_hook(engine, creature, *, config_path="", config_type="agent"):
-    attach_session_store_for_creature(
-        engine, creature, config_path=config_path, config_type=config_type
-    )
-
-
-def _spawnable_hook(workspace):
-    return list_spawnable_creatures(workspace=workspace)
-
-
-def _resolve_workspace_hook(engine, creature):
-    pwd = ""
-    executor = getattr(creature.agent, "executor", None)
-    if executor is not None:
-        pwd = str(getattr(executor, "_working_dir", "") or "")
-    if not pwd:
-        return None
-    try:
-        return LocalWorkspace.open(pwd)
-    except (FileNotFoundError, NotADirectoryError):
-        return None
-
-
-def _wire_group_hooks() -> None:
-    """Bind optional Studio behavior to Terrarium's dependency-inversion hooks."""
-    _group_hooks.register_store_attach(_store_attach_hook)
-    _group_hooks.register_name_apply(_apply_creature_name)
-    _group_hooks.register_spawnable(_spawnable_hook)
-    _group_hooks.register_workspace_resolver(_resolve_workspace_hook)
-
+_name_apply_hook = _hooks.name_apply_hook
+_resolve_workspace_hook = _hooks.resolve_workspace_hook
+_spawnable_hook = _hooks.spawnable_hook
+_store_attach_hook = _hooks.store_attach_hook
+_wire_group_hooks = _hooks.register_group_hooks
 
 _wire_group_hooks()
 
+_EXPORTS = {"Studio": "kohakuterrarium.studio.studio"}
 
 __all__ = ["Studio"]
+
+
+def __getattr__(name: str):
+    module_path = _EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_EXPORTS))

--- a/src/kohakuterrarium/studio/hooks.py
+++ b/src/kohakuterrarium/studio/hooks.py
@@ -1,0 +1,48 @@
+"""Lightweight Studio integrations registered with the Terrarium layer."""
+
+import importlib
+
+
+def store_attach_hook(engine, creature, *, config_path="", config_type="agent"):
+    from kohakuterrarium.studio.sessions.lifecycle import (
+        attach_session_store_for_creature,
+    )
+
+    attach_session_store_for_creature(
+        engine, creature, config_path=config_path, config_type=config_type
+    )
+
+
+def name_apply_hook(creature, name: str) -> None:
+    from kohakuterrarium.terrarium.creature_host import apply_creature_name
+
+    apply_creature_name(creature, name)
+
+
+def spawnable_hook(workspace):
+    from kohakuterrarium.studio.catalog.spawnable import list_spawnable_creatures
+
+    return list_spawnable_creatures(workspace=workspace)
+
+
+def resolve_workspace_hook(engine, creature):
+    from kohakuterrarium.studio.editors.workspace_fs import LocalWorkspace
+
+    pwd = ""
+    executor = getattr(creature.agent, "executor", None)
+    if executor is not None:
+        pwd = str(getattr(executor, "_working_dir", "") or "")
+    if not pwd:
+        return None
+    try:
+        return LocalWorkspace.open(pwd)
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+
+
+def register_group_hooks() -> None:
+    group_hooks = importlib.import_module("kohakuterrarium.terrarium.group_hooks")
+    group_hooks.register_store_attach(store_attach_hook)
+    group_hooks.register_name_apply(name_apply_hook)
+    group_hooks.register_spawnable(spawnable_hook)
+    group_hooks.register_workspace_resolver(resolve_workspace_hook)

--- a/src/kohakuterrarium/studio/studio.py
+++ b/src/kohakuterrarium/studio/studio.py
@@ -45,6 +45,7 @@ from kohakuterrarium.studio.editors import creatures_crud as _editor_creatures
 from kohakuterrarium.studio.editors import modules_crud as _editor_modules
 from kohakuterrarium.studio.facade_persistence import _PersistenceNS
 from kohakuterrarium.studio.facade_sessions import _SessionsNS
+from kohakuterrarium.studio.hooks import register_group_hooks
 from kohakuterrarium.studio.identity import (
     api_keys as _identity_keys,
     codex_oauth as _identity_codex,
@@ -82,6 +83,7 @@ class Studio:
         *,
         service: TerrariumService | None = None,
     ) -> None:
+        register_group_hooks()
         # Service injection and engine injection are mutually exclusive because
         # a service already defines which engine and ownership policy it uses.
         # Explicit ``is not None`` checks preserve empty Terrarium instances,

--- a/src/kohakuterrarium/terrarium/__init__.py
+++ b/src/kohakuterrarium/terrarium/__init__.py
@@ -1,103 +1,47 @@
-"""Terrarium - the unified runtime engine.
+"""Terrarium runtime engine and graph topology public facade."""
 
-The :class:`Terrarium` engine is the single per-process runtime. Every
-running creature lives inside it; a solo ``kt run creature.yaml`` is a
-1-creature graph, a recipe is an N-creature graph applied via
-:meth:`Terrarium.apply_recipe`. Topology can change at runtime via
-``add_creature`` / ``connect`` / ``add_channel`` etc., or via the
-``group_*`` tool surface from a privileged creature.
+import importlib
 
-Privilege is set at creature creation time and immutable after — see
-:class:`Creature.is_privileged` and :meth:`Terrarium.assign_root`. The
-legacy ``TerrariumRuntime`` / ``KohakuManager`` / ``terrarium_*`` tool
-stack has been removed; the engine and the ``group_*`` tool surface
-are the only paths.
-"""
+_EXPORTS = {
+    "ChannelConfig": "kohakuterrarium.terrarium.config",
+    "ChannelInfo": "kohakuterrarium.terrarium.topology",
+    "ChannelObserver": "kohakuterrarium.terrarium.observer",
+    "ConnectionResult": "kohakuterrarium.terrarium.engine",
+    "Creature": "kohakuterrarium.terrarium.creature_host",
+    "CreatureConfig": "kohakuterrarium.terrarium.config",
+    "CreatureInfo": "kohakuterrarium.terrarium.service",
+    "DisconnectionResult": "kohakuterrarium.terrarium.engine",
+    "EngineEvent": "kohakuterrarium.terrarium.events",
+    "EventFilter": "kohakuterrarium.terrarium.events",
+    "EventKind": "kohakuterrarium.terrarium.events",
+    "GraphTopology": "kohakuterrarium.terrarium.topology",
+    "LocalTerrariumService": "kohakuterrarium.terrarium.service",
+    "LogEntry": "kohakuterrarium.terrarium.output_log",
+    "MultiNodeTerrariumService": "kohakuterrarium.terrarium.multi_node_service",
+    "ObservedMessage": "kohakuterrarium.terrarium.observer",
+    "OutputLogCapture": "kohakuterrarium.terrarium.output_log",
+    "RemoteTerrariumService": "kohakuterrarium.terrarium.remote_service",
+    "RootAssignment": "kohakuterrarium.terrarium.events",
+    "Terrarium": "kohakuterrarium.terrarium.engine",
+    "TerrariumConfig": "kohakuterrarium.terrarium.config",
+    "TerrariumService": "kohakuterrarium.terrarium.service",
+    "TopologyDelta": "kohakuterrarium.terrarium.topology",
+    "TopologyState": "kohakuterrarium.terrarium.topology",
+    "build_creature": "kohakuterrarium.terrarium.creature_host",
+    "load_terrarium_config": "kohakuterrarium.terrarium.config",
+}
 
-# Importing the tool module guarantees registration regardless of which engine
-# construction path is used.
-import kohakuterrarium.terrarium.tools_group as _tools_group  # noqa: F401
-from kohakuterrarium.terrarium.config import (
-    ChannelConfig,
-    CreatureConfig,
-    TerrariumConfig,
-    load_terrarium_config,
-)
-from kohakuterrarium.terrarium.creature_host import (
-    Creature,
-    build_creature,
-)
-from kohakuterrarium.terrarium.engine import (
-    ConnectionResult,
-    DisconnectionResult,
-    Terrarium,
-)
-from kohakuterrarium.terrarium.events import (
-    EngineEvent,
-    EventFilter,
-    EventKind,
-    RootAssignment,
-)
-from kohakuterrarium.terrarium.observer import ChannelObserver, ObservedMessage
-from kohakuterrarium.terrarium.output_log import LogEntry, OutputLogCapture
-from kohakuterrarium.terrarium.service import (
-    CreatureInfo,
-    LocalTerrariumService,
-    TerrariumService,
-)
-from kohakuterrarium.terrarium.topology import (
-    ChannelInfo,
-    GraphTopology,
-    TopologyDelta,
-    TopologyState,
-)
+__all__ = list(_EXPORTS)
 
 
-# Multi-node services live in their own submodules so callers that
-# never go remote (single-host mode) don't transitively import the
-# laboratory layer.  Re-exported here at module level for convenience
-# of multi-node callers.
 def __getattr__(name: str):
-    if name == "RemoteTerrariumService":
-        from kohakuterrarium.terrarium.remote_service import (
-            RemoteTerrariumService,
-        )
-
-        return RemoteTerrariumService
-    if name == "MultiNodeTerrariumService":
-        from kohakuterrarium.terrarium.multi_node_service import (
-            MultiNodeTerrariumService,
-        )
-
-        return MultiNodeTerrariumService
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_path = _EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value
+    return value
 
 
-__all__ = [
-    "ChannelConfig",
-    "ChannelInfo",
-    "ChannelObserver",
-    "ConnectionResult",
-    "Creature",
-    "CreatureConfig",
-    "CreatureInfo",
-    "DisconnectionResult",
-    "EngineEvent",
-    "EventFilter",
-    "EventKind",
-    "GraphTopology",
-    "LocalTerrariumService",
-    "LogEntry",
-    "MultiNodeTerrariumService",
-    "ObservedMessage",
-    "OutputLogCapture",
-    "RemoteTerrariumService",
-    "RootAssignment",
-    "Terrarium",
-    "TerrariumConfig",
-    "TerrariumService",
-    "TopologyDelta",
-    "TopologyState",
-    "build_creature",
-    "load_terrarium_config",
-]
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_EXPORTS))

--- a/src/kohakuterrarium/terrarium/creature_host.py
+++ b/src/kohakuterrarium/terrarium/creature_host.py
@@ -29,6 +29,7 @@ from kohakuterrarium.core.environment import Environment
 from kohakuterrarium.core.events import TriggerEvent
 from kohakuterrarium.core.turn import AgentEventStream, TurnResult
 from kohakuterrarium.llm.profiles import _login_provider_for
+from kohakuterrarium.packages.walk import package_snapshot
 from kohakuterrarium.terrarium.config import CreatureConfig
 from kohakuterrarium.terrarium.creature_ids import _safe_creature_id
 from kohakuterrarium.terrarium.output_log import LogEntry, OutputLogCapture
@@ -784,6 +785,34 @@ def build_creature(
     """
     if io not in ("config", "none", "headless"):
         raise ValueError(f"io= must be 'config', 'none', or 'headless' — got {io!r}")
+    with package_snapshot():
+        return _build_creature_from_config(
+            config,
+            creature_id=creature_id,
+            graph_id=graph_id,
+            pwd=pwd,
+            llm=llm,
+            environment=environment,
+            io=io,
+            strict=strict,
+            tools=tools,
+            plugins=plugins,
+        )
+
+
+def _build_creature_from_config(
+    config: CreatureBuildInput,
+    *,
+    creature_id: str | None,
+    graph_id: str,
+    pwd: str | None,
+    llm: Any,
+    environment: Environment | None,
+    io: str,
+    strict: bool,
+    tools: list[Any] | None,
+    plugins: list[Any] | None,
+) -> Creature:
     _io_override = NoneInput() if io in ("none", "headless") else None
     _out_override = NoneOutput() if io == "headless" else None
     if isinstance(config, (str, Path)):

--- a/src/kohakuterrarium/terrarium/engine_cli.py
+++ b/src/kohakuterrarium/terrarium/engine_cli.py
@@ -45,6 +45,7 @@ from kohakuterrarium.terrarium.events import EventFilter, EventKind
 from kohakuterrarium.terrarium.service import LocalTerrariumService
 from kohakuterrarium.utils.async_utils import cancel_tasks
 from kohakuterrarium.utils.logging import get_logger, restore_logging, suppress_logging
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 logger = get_logger(__name__)
 
@@ -280,6 +281,7 @@ async def run_engine_with_tui(
     for creature in engine.list_creatures():
         if creature.graph_id == graph_id and not creature.is_running:
             await engine.start(creature)
+    mark_startup("tui_creatures_started", surface="tui", creature_id=focus_creature_id)
 
     await tui.start()
     # Wire ESC → interrupt AFTER tui.start() creates the AgentTUI.
@@ -290,8 +292,14 @@ async def run_engine_with_tui(
     if tui._app:
         tui._app.on_interrupt = focus.interrupt
     suppress_logging()
+    mark_startup("tui_run_enter", surface="tui", creature_id=focus_creature_id)
     app_task = asyncio.create_task(tui.run_app())
-    await tui.wait_ready()
+    mounted = await tui.wait_ready()
+    mark_startup(
+        "tui_mounted" if mounted else "tui_mount_timeout",
+        surface="tui",
+        creature_id=focus_creature_id,
+    )
 
     _update_session_info(tui, focus, graph_id, store)
     _seed_tab_models(tui, graph_creatures)

--- a/src/kohakuterrarium/terrarium/engine_rich_cli.py
+++ b/src/kohakuterrarium/terrarium/engine_rich_cli.py
@@ -51,6 +51,7 @@ from kohakuterrarium.modules.input.base import InputModule
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.utils.logging import get_logger
+from kohakuterrarium.utils.startup_trace import mark as mark_startup
 
 logger = get_logger(__name__)
 
@@ -140,6 +141,11 @@ async def run_engine_with_rich_cli(
 
     if not focus_creature.is_running:
         await engine.start(focus_creature)
+    mark_startup(
+        "rich_cli_creature_started",
+        surface="cli",
+        creature_id=focus_creature_id,
+    )
 
     if is_multi:
         # Engine subscription starts after the focus creature is up so
@@ -158,6 +164,7 @@ async def run_engine_with_rich_cli(
         agent._pending_resume_events = None
 
     try:
+        mark_startup("rich_cli_run_enter", surface="cli", creature_id=focus_creature_id)
         await app.run()
     except (KeyboardInterrupt, asyncio.CancelledError):
         pass

--- a/src/kohakuterrarium/utils/startup_trace.py
+++ b/src/kohakuterrarium/utils/startup_trace.py
@@ -1,0 +1,59 @@
+"""Opt-in JSONL milestones for profiling process startup."""
+
+import json
+import os
+import time
+from pathlib import Path
+from uuid import uuid4
+
+_TRACE_PATH = os.environ.get("KT_STARTUP_TRACE", "")
+_START_NS = time.perf_counter_ns()
+_RUN_ID = os.environ.get("KT_STARTUP_RUN_ID", "")
+try:
+    _ORIGIN_NS = int(os.environ.get("KT_STARTUP_ORIGIN_NS", "0") or 0)
+except ValueError:
+    _ORIGIN_NS = 0
+try:
+    if _TRACE_PATH:
+        if not _RUN_ID:
+            _RUN_ID = uuid4().hex
+            os.environ["KT_STARTUP_RUN_ID"] = _RUN_ID
+        if not _ORIGIN_NS:
+            _ORIGIN_NS = time.time_ns()
+            os.environ["KT_STARTUP_ORIGIN_NS"] = str(_ORIGIN_NS)
+except Exception:
+    _TRACE_PATH = ""
+
+
+def mark(event: str, **fields: object) -> None:
+    """Append a startup milestone when ``KT_STARTUP_TRACE`` is enabled."""
+    if not _TRACE_PATH:
+        return
+    try:
+        monotonic_ns = time.perf_counter_ns()
+        wall_ns = time.time_ns()
+        record = {
+            "run_id": _RUN_ID,
+            "pid": os.getpid(),
+            "ppid": os.getppid(),
+            "event": event,
+            "elapsed_ms": round((monotonic_ns - _START_NS) / 1_000_000, 3),
+            "monotonic_ns": monotonic_ns,
+            "wall_ns": wall_ns,
+            "startup_ms": round((wall_ns - _ORIGIN_NS) / 1_000_000, 3),
+            **fields,
+        }
+        path = Path(_TRACE_PATH).expanduser()
+        suffix = path.suffix or ".jsonl"
+        shard = path.with_name(f"{path.stem}.{os.getpid()}{suffix}")
+        shard.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(
+            record,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            default=repr,
+        )
+        with shard.open("a", encoding="utf-8") as stream:
+            stream.write(f"{line}\n")
+    except Exception:
+        return

--- a/tests/unit/api/auth/test_engine_pool.py
+++ b/tests/unit/api/auth/test_engine_pool.py
@@ -43,6 +43,25 @@ class TestSessionDirResolution:
 
 
 class TestGetOrCreate:
+    def test_imports_terrarium_only_when_creating_engine(self, fresh_dirs, monkeypatch):
+        import kohakuterrarium
+
+        created = []
+
+        class _Terrarium:
+            def __init__(self, **kwargs):
+                created.append(kwargs)
+
+        monkeypatch.setattr(kohakuterrarium, "Terrarium", _Terrarium)
+        pool = EnginePool(max_active=1, idle_timeout_s=0)
+
+        engine = pool.get_or_create(7)
+
+        assert isinstance(engine, _Terrarium)
+        assert created == [
+            {"session_dir": str(fresh_dirs / "users" / "7" / "sessions")}
+        ]
+
     def test_same_user_returns_same_engine(self, fresh_dirs):
         pool = EnginePool(max_active=4, idle_timeout_s=0)
         e1 = pool.get_or_create(1)

--- a/tests/unit/api/test_deps.py
+++ b/tests/unit/api/test_deps.py
@@ -93,8 +93,11 @@ class TestServiceSingleton:
             def set_runtime_graph_meta_lookup(self, fn):
                 self.lookup_set = True
 
-        monkeypatch.setattr(mod, "Terrarium", fake_terrarium)
-        monkeypatch.setattr(mod, "LocalTerrariumService", _Local)
+        monkeypatch.setattr(
+            mod,
+            "_runtime_types",
+            lambda: (_Local, fake_terrarium, lambda *_args: {}),
+        )
         svc = get_service()
         assert isinstance(svc, _Local)
         assert svc.lookup_set is True

--- a/tests/unit/api/test_metrics_route.py
+++ b/tests/unit/api/test_metrics_route.py
@@ -39,21 +39,21 @@ class _FakeEngine:
         return self._creatures[cid]
 
 
+def _session_lifecycle(monkeypatch, sessions=None, session_map=None):
+    lifecycle = SimpleNamespace(
+        list_sessions=lambda svc: list(sessions or []),
+        get_session=lambda svc, sid: (session_map or {}).get(sid)
+        or Session(session_id=sid, name=sid),
+    )
+    monkeypatch.setattr(metrics_mod, "_session_lifecycle", lambda: lifecycle)
+    return lifecycle
+
+
 def _client(engine, monkeypatch, *, aggregator=None, sessions=None, session_map=None):
     monkeypatch.setattr(
         metrics_mod, "get_aggregator", lambda: aggregator or _FakeAggregator()
     )
-    monkeypatch.setattr(
-        metrics_mod.sessions_lifecycle,
-        "list_sessions",
-        lambda svc: list(sessions or []),
-    )
-    monkeypatch.setattr(
-        metrics_mod.sessions_lifecycle,
-        "get_session",
-        lambda svc, sid: (session_map or {}).get(sid)
-        or Session(session_id=sid, name=sid),
-    )
+    _session_lifecycle(monkeypatch, sessions, session_map)
     app = FastAPI()
     app.dependency_overrides[get_service] = lambda: engine
     app.include_router(metrics_mod.router, prefix="/metrics")
@@ -125,16 +125,15 @@ class TestMetricsSnapshot:
     def test_get_session_failure_swallowed(self, monkeypatch):
         eng = _FakeEngine()
         # ``get_session`` raises — the gauge computation tolerates it.
-        monkeypatch.setattr(
-            metrics_mod.sessions_lifecycle,
-            "list_sessions",
-            lambda eng: [SessionListing(session_id="g1", name="x", creatures=1)],
+        lifecycle = _session_lifecycle(
+            monkeypatch,
+            [SessionListing(session_id="g1", name="x", creatures=1)],
         )
 
         def boom(svc, sid):
             raise RuntimeError("dead")
 
-        monkeypatch.setattr(metrics_mod.sessions_lifecycle, "get_session", boom)
+        lifecycle.get_session = boom
         monkeypatch.setattr(metrics_mod, "get_aggregator", lambda: _FakeAggregator())
         app = FastAPI()
         app.dependency_overrides[get_service] = lambda: eng
@@ -158,19 +157,16 @@ class TestMetricsSnapshot:
 class TestBuildGauges:
     def test_handles_missing_creature_id(self, monkeypatch):
         eng = _FakeEngine()
-        monkeypatch.setattr(
-            metrics_mod.sessions_lifecycle,
-            "list_sessions",
-            lambda svc: [SessionListing(session_id="g1", name="x", creatures=1)],
-        )
-        monkeypatch.setattr(
-            metrics_mod.sessions_lifecycle,
-            "get_session",
-            lambda svc, sid: Session(
-                session_id=sid,
-                name=sid,
-                creatures=[{"name": "noid-creature"}],  # no creature_id
-            ),
+        _session_lifecycle(
+            monkeypatch,
+            [SessionListing(session_id="g1", name="x", creatures=1)],
+            {
+                "g1": Session(
+                    session_id="g1",
+                    name="g1",
+                    creatures=[{"name": "noid-creature"}],  # no creature_id
+                )
+            },
         )
         gauges = metrics_mod._build_gauges(eng)
         # creature_id missing → no MCP lookup attempted.

--- a/tests/unit/bootstrap/test_agent_init.py
+++ b/tests/unit/bootstrap/test_agent_init.py
@@ -653,7 +653,9 @@ class TestEnsureSkillToolFallback:
         def boom():
             raise RuntimeError("skill tool broken")
 
-        monkeypatch.setattr(ai_mod, "SkillTool", boom)
+        import kohakuterrarium.builtins.tools.skill as skill_mod
+
+        monkeypatch.setattr(skill_mod, "SkillTool", boom)
         registry = Registry()
         fake = SimpleNamespace(registry=registry, executor=None)
         # The exception is caught + logged — no crash, no registration.

--- a/tests/unit/bootstrap/test_llm.py
+++ b/tests/unit/bootstrap/test_llm.py
@@ -120,7 +120,9 @@ class TestCreateLLMProviderProfilePath:
             def __init__(self, **kw):
                 pass
 
-        monkeypatch.setattr(llm_mod, "CodexOAuthProvider", _StubProvider)
+        import kohakuterrarium.llm.codex_provider as codex_provider
+
+        monkeypatch.setattr(codex_provider, "CodexOAuthProvider", _StubProvider)
         cfg = AgentConfig(name="a", model="m")
         out = create_llm_provider(cfg)
         assert isinstance(out, _StubProvider)

--- a/tests/unit/builtins/test_tool_catalog_mobile.py
+++ b/tests/unit/builtins/test_tool_catalog_mobile.py
@@ -6,6 +6,8 @@ monkeypatched ``_MOBILE_HIDDEN_TOOLS`` so they don't depend on the
 real catalog's content (which can grow / shrink over time).
 """
 
+import threading
+
 import pytest
 
 from kohakuterrarium.builtins import tool_catalog
@@ -32,6 +34,61 @@ def with_fake_tools(monkeypatch):
     monkeypatch.setitem(tool_catalog._BUILTIN_TOOLS, "_test_hidden", _FakeTool)
     yield
     # monkeypatch.setitem cleans up automatically.
+
+
+class TestDeferredBuiltinCatalog:
+    def test_first_builtin_lookup_loads_tool_modules(self):
+        assert tool_catalog.get_builtin_tool("bash") is not None
+        assert tool_catalog.get_builtin_tool("image_gen") is not None
+
+    def test_listing_loads_builtin_names(self):
+        names = tool_catalog.list_builtin_tools()
+        assert "bash" in names
+        assert "web_fetch" in names
+
+    def test_failed_default_import_can_retry(self, monkeypatch):
+        real_import = tool_catalog.importlib.import_module
+        calls = []
+
+        def import_module(name):
+            calls.append(name)
+            if len(calls) == 1:
+                raise ImportError("transient")
+            return real_import(name)
+
+        monkeypatch.setattr(tool_catalog.importlib, "import_module", import_module)
+        monkeypatch.setattr(tool_catalog, "_DEFAULT_TOOLS_LOADED", False)
+
+        with pytest.raises(ImportError, match="transient"):
+            tool_catalog._ensure_default_tools_loaded()
+        tool_catalog._ensure_default_tools_loaded()
+
+        assert len(calls) == 2
+
+    def test_concurrent_default_import_waits_for_completion(self, monkeypatch):
+        entered = threading.Event()
+        release = threading.Event()
+        real_import = tool_catalog.importlib.import_module
+
+        def import_module(name):
+            entered.set()
+            release.wait(timeout=2)
+            return real_import(name)
+
+        monkeypatch.setattr(tool_catalog.importlib, "import_module", import_module)
+        monkeypatch.setattr(tool_catalog, "_DEFAULT_TOOLS_LOADED", False)
+        workers = [
+            threading.Thread(target=tool_catalog._ensure_default_tools_loaded)
+            for _ in range(2)
+        ]
+        workers[0].start()
+        entered.wait(timeout=2)
+        workers[1].start()
+        release.set()
+        for worker in workers:
+            worker.join(timeout=2)
+
+        assert tool_catalog._DEFAULT_TOOLS_LOADED is True
 
 
 class TestNoMobileProfile:

--- a/tests/unit/builtins/test_tui_io_lazy.py
+++ b/tests/unit/builtins/test_tui_io_lazy.py
@@ -1,0 +1,94 @@
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import kohakuterrarium.builtins.inputs as builtin_inputs
+import kohakuterrarium.builtins.outputs as builtin_outputs
+from kohakuterrarium.builtins.inputs import create_builtin_input, list_builtin_inputs
+from kohakuterrarium.builtins.outputs import create_builtin_output, list_builtin_outputs
+from kohakuterrarium.builtins.tui.input import TUIInput
+from kohakuterrarium.builtins.tui.output import TUIOutput
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "src"
+
+
+def test_builtin_io_catalog_import_defers_textual():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import json, sys; import kohakuterrarium.builtins.inputs; "
+            "import kohakuterrarium.builtins.outputs; "
+            "print(json.dumps(sorted(sys.modules)))",
+        ],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    loaded = set(json.loads(result.stdout))
+    assert not any(name.startswith("textual") for name in loaded)
+
+
+def test_tui_resolution_does_not_overwrite_concurrent_registration(monkeypatch):
+    entered = threading.Event()
+    release = threading.Event()
+    real_import = builtin_inputs.importlib.import_module
+
+    class OverrideInput:
+        pass
+
+    def import_module(name):
+        entered.set()
+        release.wait(timeout=2)
+        return real_import(name)
+
+    monkeypatch.delitem(builtin_inputs._BUILTIN_INPUTS, "tui", raising=False)
+    monkeypatch.setattr(builtin_inputs.importlib, "import_module", import_module)
+    result = []
+    worker = threading.Thread(
+        target=lambda: result.append(builtin_inputs.get_builtin_input("tui"))
+    )
+    worker.start()
+    entered.wait(timeout=2)
+    builtin_inputs.register_builtin_input("tui", OverrideInput)
+    release.set()
+    worker.join(timeout=2)
+
+    assert builtin_inputs.get_builtin_input("tui") is OverrideInput
+    builtin_inputs._BUILTIN_INPUTS.pop("tui", None)
+
+
+def test_registered_tui_override_does_not_change_public_class(monkeypatch):
+    class OverrideInput:
+        def __init__(self, **_options):
+            pass
+
+    class OverrideOutput:
+        def __init__(self, **_options):
+            pass
+
+    monkeypatch.setitem(builtin_inputs._BUILTIN_INPUTS, "tui", OverrideInput)
+    monkeypatch.setitem(builtin_outputs._BUILTIN_OUTPUTS, "tui", OverrideOutput)
+
+    assert builtin_inputs.TUIInput is TUIInput
+    assert builtin_outputs.TUIOutput is TUIOutput
+    assert isinstance(create_builtin_input("tui"), OverrideInput)
+    assert isinstance(create_builtin_output("tui"), OverrideOutput)
+
+
+def test_tui_io_remains_listed_constructible_and_exported():
+    assert "tui" in list_builtin_inputs()
+    assert "tui" in list_builtin_outputs()
+    assert builtin_inputs.TUIInput is TUIInput
+    assert builtin_outputs.TUIOutput is TUIOutput
+    assert isinstance(create_builtin_input("tui"), TUIInput)
+    assert isinstance(create_builtin_output("tui"), TUIOutput)

--- a/tests/unit/builtins/tools/test_web_fetch_imports.py
+++ b/tests/unit/builtins/tools/test_web_fetch_imports.py
@@ -1,0 +1,30 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SRC = ROOT / "src"
+
+
+def test_web_fetch_import_does_not_load_optional_extractors():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import json, sys; import kohakuterrarium.builtins.tools.web_fetch; "
+            "print(json.dumps(sorted(sys.modules)))",
+        ],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    loaded = set(json.loads(result.stdout))
+
+    assert "crawl4ai" not in loaded
+    assert "trafilatura" not in loaded

--- a/tests/unit/cli/test_cli_parser.py
+++ b/tests/unit/cli/test_cli_parser.py
@@ -4,7 +4,8 @@ import argparse
 
 import pytest
 
-from kohakuterrarium import cli
+from kohakuterrarium.cli import _build_surface_parser
+from kohakuterrarium.cli import _main as cli
 
 
 class TestRunParser:
@@ -19,6 +20,29 @@ class TestRunParser:
                 ["run", "agent", "--session", "run.kohakutr", "--no-session"]
             )
         assert exc_info.value.code == 2
+
+
+def test_fast_surface_parsers_match_full_parser_contract():
+    parser = cli._build_parser()
+    commands = next(
+        action for action in parser._actions if action.dest == "command"
+    ).choices
+
+    def signature(surface_parser):
+        return [
+            (
+                tuple(action.option_strings),
+                action.dest,
+                action.default,
+                action.required,
+                action.choices,
+                action.nargs,
+            )
+            for action in surface_parser._actions
+        ]
+
+    for command in ("web", "app", "cli", "tui"):
+        assert signature(_build_surface_parser(command)) == signature(commands[command])
 
 
 class TestMainStartup:

--- a/tests/unit/cli/test_cli_parser.py
+++ b/tests/unit/cli/test_cli_parser.py
@@ -45,3 +45,26 @@ class TestMainStartup:
         assert cli.main() == 0
         assert capsys.readouterr().out == "version\n"
         assert events == [("utf8", {"log": False}), ("parser", {})]
+
+    def test_records_parser_and_dispatch_milestones(self, monkeypatch):
+        milestones = []
+
+        class _Parser:
+            def parse_args(self):
+                return argparse.Namespace(version=True, verbose=False)
+
+        monkeypatch.setattr(cli, "configure_utf8_stdio", lambda **_kwargs: None)
+        monkeypatch.setattr(cli, "_build_parser", lambda: _Parser())
+        monkeypatch.setattr(cli, "format_version_report", lambda **_kwargs: "version")
+        monkeypatch.setattr(
+            cli,
+            "mark_startup",
+            lambda event, **fields: milestones.append((event, fields)),
+            raising=False,
+        )
+
+        assert cli.main() == 0
+        assert milestones == [
+            ("parser_ready", {"surface": "cli"}),
+            ("dispatch_selected", {"surface": "cli", "command": "version"}),
+        ]

--- a/tests/unit/cli/test_import_contract.py
+++ b/tests/unit/cli/test_import_contract.py
@@ -50,6 +50,20 @@ def test_version_dispatch_does_not_load_command_runtimes():
     assert not any(name.startswith("textual") for name in loaded)
 
 
+def test_default_desktop_dispatch_does_not_load_web_runtime(monkeypatch):
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.serving.desktop as desktop; "
+        "desktop.launch_desktop_app = lambda **kwargs: None; "
+        "from kohakuterrarium import cli; sys.argv = ['kt']; cli.main(); "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.serving.web" not in loaded
+    assert "kohakuterrarium.api.app" not in loaded
+    assert not any(name.startswith("fastapi") for name in loaded)
+    assert not any(name.startswith("uvicorn") for name in loaded)
+
+
 def test_web_help_does_not_load_terminal_surfaces():
     loaded = _loaded_modules(
         "import contextlib, io, json, sys; from kohakuterrarium import cli; "

--- a/tests/unit/cli/test_import_contract.py
+++ b/tests/unit/cli/test_import_contract.py
@@ -1,0 +1,87 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "src"
+
+
+def _loaded_modules(code: str) -> set[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return set(json.loads(result.stdout))
+
+
+def test_cli_package_import_does_not_load_command_runtimes():
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.cli; "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.serving.web" not in loaded
+    assert "kohakuterrarium.cli.run" not in loaded
+    assert "kohakuterrarium.cli.admin" not in loaded
+    assert not any(name.startswith("fastapi") for name in loaded)
+    assert not any(name.startswith("textual") for name in loaded)
+    assert not any(name.startswith("prompt_toolkit") for name in loaded)
+
+
+def test_version_dispatch_does_not_load_command_runtimes():
+    loaded = _loaded_modules(
+        "import contextlib, io, json, sys; from kohakuterrarium import cli; "
+        "sys.argv = ['kt', '--version']; "
+        "\nwith contextlib.redirect_stdout(io.StringIO()):\n  cli.main()"
+        "\nprint(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.cli._main" not in loaded
+    assert "kohakuterrarium.serving.web" not in loaded
+    assert not any(name.startswith("fastapi") for name in loaded)
+    assert not any(name.startswith("textual") for name in loaded)
+
+
+def test_web_help_does_not_load_terminal_surfaces():
+    loaded = _loaded_modules(
+        "import contextlib, io, json, sys; from kohakuterrarium import cli; "
+        "sys.argv = ['kt', 'web', '--help']; "
+        "\ntry:\n  with contextlib.redirect_stdout(io.StringIO()): cli.main()"
+        "\nexcept SystemExit: pass\nprint(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.cli._main" not in loaded
+    assert "kohakuterrarium.terrarium.engine_cli" not in loaded
+    assert "kohakuterrarium.terrarium.engine_rich_cli" not in loaded
+    assert not any(name.startswith("textual") for name in loaded)
+    assert not any(name.startswith("prompt_toolkit") for name in loaded)
+
+
+def test_standalone_cli_import_does_not_load_tui_or_web():
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.cli.entry_cli; "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.terrarium.engine_cli" not in loaded
+    assert "kohakuterrarium.serving.web" not in loaded
+    assert not any(name.startswith("textual") for name in loaded)
+
+
+def test_standalone_tui_import_does_not_load_rich_cli_or_web():
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.cli.entry_tui; "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.terrarium.engine_rich_cli" not in loaded
+    assert "kohakuterrarium.serving.web" not in loaded
+    assert not any(name.startswith("prompt_toolkit") for name in loaded)

--- a/tests/unit/cli/test_picker.py
+++ b/tests/unit/cli/test_picker.py
@@ -11,8 +11,10 @@ def test_picker_records_catalog_ready(monkeypatch):
             terrariums=(Runnable("b", "b", "terrarium", "local"),),
         )
     ]
+    from kohakuterrarium.cli import select_cli
+
     monkeypatch.setattr(picker, "enumerate_runnables", lambda: groups)
-    monkeypatch.setattr(picker, "run_cli_picker", lambda _groups: "a")
+    monkeypatch.setattr(select_cli, "run_cli_picker", lambda _groups: "a")
     monkeypatch.setattr(
         picker,
         "mark_startup",

--- a/tests/unit/cli/test_picker.py
+++ b/tests/unit/cli/test_picker.py
@@ -1,0 +1,28 @@
+from kohakuterrarium.cli import picker
+from kohakuterrarium.cli.select import Runnable, RunnableGroup
+
+
+def test_picker_records_catalog_ready(monkeypatch):
+    milestones = []
+    groups = [
+        RunnableGroup(
+            "local",
+            creatures=(Runnable("a", "a", "creature", "local"),),
+            terrariums=(Runnable("b", "b", "terrarium", "local"),),
+        )
+    ]
+    monkeypatch.setattr(picker, "enumerate_runnables", lambda: groups)
+    monkeypatch.setattr(picker, "run_cli_picker", lambda _groups: "a")
+    monkeypatch.setattr(
+        picker,
+        "mark_startup",
+        lambda event, **fields: milestones.append((event, fields)),
+    )
+
+    assert picker.pick_runnable("cli") == "a"
+    assert milestones == [
+        (
+            "picker_catalog_scanned",
+            {"surface": "cli", "groups": 1, "entries": 2},
+        )
+    ]

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -1,5 +1,7 @@
 """Tests for CLI run and session-selection helpers."""
 
+import pytest
+
 from kohakuterrarium.cli import run
 
 
@@ -23,6 +25,69 @@ class TestSessionPreview:
 
         assert run._session_preview(tmp_path / "broken.kohakutr") == ""
         assert store.closed is True
+
+
+class TestRunStartupTrace:
+    @pytest.mark.asyncio
+    async def test_records_engine_and_surface_milestones(self, monkeypatch, tmp_path):
+        milestones = []
+        creature = type("Creature", (), {"creature_id": "focus", "graph_id": "graph"})()
+
+        class _Engine:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def add_creature(self, *_args, **_kwargs):
+                return creature
+
+        async def _run_cli(_engine, creature_id, _store):
+            assert creature_id == "focus"
+
+        monkeypatch.setattr(run._drive_settings, "resolve_drive_kwargs", lambda: {})
+        monkeypatch.setattr(run, "Terrarium", lambda **_kwargs: _Engine())
+        monkeypatch.setattr(run, "_looks_like_recipe", lambda _path: False)
+        monkeypatch.setattr(
+            run, "_attach_session_store", lambda *_args, **_kwargs: None
+        )
+        monkeypatch.setattr(
+            run, "_apply_cli_topology", lambda *_args, **_kwargs: _async_none()
+        )
+        monkeypatch.setattr(run, "run_engine_with_rich_cli", _run_cli)
+        monkeypatch.setattr(
+            run,
+            "mark_startup",
+            lambda event, **fields: milestones.append((event, fields)),
+            raising=False,
+        )
+        monkeypatch.chdir(tmp_path)
+
+        assert (
+            await run._run(
+                str(tmp_path),
+                session=None,
+                llm=None,
+                io_mode="cli",
+                extra_creatures=[],
+                extra_channels=[],
+            )
+            == 0
+        )
+        assert milestones == [
+            ("engine_create_begin", {"surface": "cli"}),
+            ("engine_entered", {"surface": "cli"}),
+            (
+                "creature_added",
+                {"surface": "cli", "creature_id": "focus", "graph_id": "graph"},
+            ),
+            ("surface_run_begin", {"surface": "cli", "creature_id": "focus"}),
+        ]
+
+
+async def _async_none():
+    return None
 
 
 class TestSessionDir:

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -31,6 +31,7 @@ class TestRunStartupTrace:
     @pytest.mark.asyncio
     async def test_records_engine_and_surface_milestones(self, monkeypatch, tmp_path):
         milestones = []
+        registrations = []
         creature = type("Creature", (), {"creature_id": "focus", "graph_id": "graph"})()
 
         class _Engine:
@@ -47,6 +48,12 @@ class TestRunStartupTrace:
             assert creature_id == "focus"
 
         monkeypatch.setattr(run._drive_settings, "resolve_drive_kwargs", lambda: {})
+        monkeypatch.setattr(
+            run,
+            "register_group_hooks",
+            lambda: registrations.append("registered"),
+            raising=False,
+        )
         monkeypatch.setattr(run, "Terrarium", lambda **_kwargs: _Engine())
         monkeypatch.setattr(run, "_looks_like_recipe", lambda _path: False)
         monkeypatch.setattr(
@@ -55,7 +62,9 @@ class TestRunStartupTrace:
         monkeypatch.setattr(
             run, "_apply_cli_topology", lambda *_args, **_kwargs: _async_none()
         )
-        monkeypatch.setattr(run, "run_engine_with_rich_cli", _run_cli)
+        from kohakuterrarium.terrarium import engine_rich_cli
+
+        monkeypatch.setattr(engine_rich_cli, "run_engine_with_rich_cli", _run_cli)
         monkeypatch.setattr(
             run,
             "mark_startup",
@@ -75,6 +84,7 @@ class TestRunStartupTrace:
             )
             == 0
         )
+        assert registrations == ["registered"]
         assert milestones == [
             ("engine_create_begin", {"surface": "cli"}),
             ("engine_entered", {"surface": "cli"}),

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -20,11 +20,70 @@ class TestSessionPreview:
     def test_store_closes_when_metadata_loading_fails(
         self, monkeypatch, tmp_path
     ) -> None:
+        from kohakuterrarium.session import store as store_module
+
         store = _FailingPreviewStore()
-        monkeypatch.setattr(run.SessionStore, "open_readonly", lambda _path: store)
+        monkeypatch.setattr(
+            store_module.SessionStore, "open_readonly", lambda _path: store
+        )
 
         assert run._session_preview(tmp_path / "broken.kohakutr") == ""
         assert store.closed is True
+
+
+class TestCliTopology:
+    @pytest.mark.asyncio
+    async def test_channel_updates_creature_channel_lists(self, monkeypatch):
+        creature = type(
+            "Creature",
+            (),
+            {
+                "name": "focus",
+                "creature_id": "c1",
+                "agent": object(),
+                "listen_channels": [],
+                "send_channels": [],
+            },
+        )()
+        graph = type("Graph", (), {"creature_ids": {"c1"}})()
+        registry = object()
+        environment = type("Environment", (), {"shared_channels": registry})()
+        engine = type(
+            "Engine",
+            (),
+            {
+                "_topology": object(),
+                "_environments": {"g1": environment},
+                "add_channel": lambda self, *_args: _async_none(),
+                "get_graph": lambda self, _graph_id: graph,
+                "get_creature": lambda self, _creature_id: creature,
+            },
+        )()
+
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.channels.inject_channel_trigger",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.topology.set_listen",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "kohakuterrarium.terrarium.topology.set_send",
+            lambda *_args, **_kwargs: None,
+        )
+
+        await run._apply_cli_topology(
+            engine,
+            graph_id="g1",
+            pwd=".",
+            llm=None,
+            extra_creatures=[],
+            extra_channels=["reviews"],
+        )
+
+        assert creature.listen_channels == ["reviews"]
+        assert creature.send_channels == ["reviews"]
 
 
 class TestRunStartupTrace:
@@ -47,14 +106,17 @@ class TestRunStartupTrace:
         async def _run_cli(_engine, creature_id, _store):
             assert creature_id == "focus"
 
-        monkeypatch.setattr(run._drive_settings, "resolve_drive_kwargs", lambda: {})
+        from kohakuterrarium.studio.identity import drive_settings
+        from kohakuterrarium.terrarium import engine as engine_module
+
+        monkeypatch.setattr(drive_settings, "resolve_drive_kwargs", lambda: {})
         monkeypatch.setattr(
             run,
             "register_group_hooks",
             lambda: registrations.append("registered"),
             raising=False,
         )
-        monkeypatch.setattr(run, "Terrarium", lambda **_kwargs: _Engine())
+        monkeypatch.setattr(engine_module, "Terrarium", lambda **_kwargs: _Engine())
         monkeypatch.setattr(run, "_looks_like_recipe", lambda _path: False)
         monkeypatch.setattr(
             run, "_attach_session_store", lambda *_args, **_kwargs: None

--- a/tests/unit/cli/test_run_drive.py
+++ b/tests/unit/cli/test_run_drive.py
@@ -34,7 +34,9 @@ class _CapturingTerrarium:
 
 
 async def _drive_run(monkeypatch):
-    monkeypatch.setattr(run_mod, "Terrarium", _CapturingTerrarium)
+    from kohakuterrarium.terrarium import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "Terrarium", _CapturingTerrarium)
     _CapturingTerrarium.last_kwargs = None
     with pytest.raises(_Abort):
         await run_mod._run(

--- a/tests/unit/cli/test_run_import_contract.py
+++ b/tests/unit/cli/test_run_import_contract.py
@@ -1,0 +1,45 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "src"
+
+
+def _loaded_modules(code: str) -> set[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return set(json.loads(result.stdout))
+
+
+def test_run_module_import_defers_engine_and_terminal_surfaces():
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.cli.run; "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.terrarium.engine" not in loaded
+    assert "kohakuterrarium.terrarium.engine_rich_cli" not in loaded
+    assert "kohakuterrarium.terrarium.engine_cli" not in loaded
+    assert not any(name.startswith("textual") for name in loaded)
+    assert not any(name.startswith("prompt_toolkit") for name in loaded)
+
+
+def test_rich_cli_runtime_does_not_load_textual():
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.terrarium.engine_rich_cli; "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.terrarium.engine_cli" not in loaded
+    assert not any(name.startswith("textual") for name in loaded)

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -63,6 +63,47 @@ class _EchoTool(BaseTool):
         return ToolResult(output=str(args.get("msg", "")))
 
 
+@pytest.mark.asyncio
+async def test_agent_build_path_reuses_one_package_snapshot(tmp_path, monkeypatch):
+    from kohakuterrarium.packages import walk
+
+    (tmp_path / "config.yaml").write_text(
+        "name: built\ninput:\n  type: none\noutput:\n  type: stdout\n",
+        encoding="utf-8",
+    )
+    calls = 0
+    original = walk._list_packages_uncached
+
+    def counted():
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(walk, "_list_packages_uncached", counted)
+
+    await Agent.build(tmp_path, llm=ScriptedLLM(["ok"]))
+
+    assert calls == 1
+
+
+def test_agent_build_reuses_one_package_snapshot(make_agent, monkeypatch):
+    from kohakuterrarium.packages import walk
+
+    calls = 0
+    original = walk._list_packages_uncached
+
+    def counted():
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(walk, "_list_packages_uncached", counted)
+
+    make_agent()
+
+    assert calls == 1
+
+
 # ── fixtures ─────────────────────────────────────────────────────
 
 

--- a/tests/unit/packages/test_walk.py
+++ b/tests/unit/packages/test_walk.py
@@ -5,10 +5,16 @@ builds a real directory layout (plain dirs, ``.link`` pointer files)
 and asserts the enumerated shape reflects what is on disk.
 """
 
+import asyncio
+
 import pytest
 
 from kohakuterrarium.packages import locations as loc_mod
-from kohakuterrarium.packages.walk import get_package_modules, list_packages
+from kohakuterrarium.packages.walk import (
+    get_package_modules,
+    list_packages,
+    package_snapshot,
+)
 
 
 @pytest.fixture
@@ -97,6 +103,80 @@ class TestListPackages:
         (pkg_dir / "README.txt").write_text("hi")
         _make_pkg(pkg_dir, "real", "")
         assert [p["name"] for p in list_packages()] == ["real"]
+
+
+class TestPackageSnapshot:
+    def test_reuses_one_walk_and_refreshes_after_scope(self, pkg_dir, monkeypatch):
+        _make_pkg(pkg_dir, "alpha", "version: '1.0'")
+        from kohakuterrarium.packages import walk
+
+        calls = 0
+        original = walk._list_packages_uncached
+
+        def counted():
+            nonlocal calls
+            calls += 1
+            return original()
+
+        monkeypatch.setattr(walk, "_list_packages_uncached", counted)
+
+        with package_snapshot():
+            assert list_packages()[0]["version"] == "1.0"
+            (pkg_dir / "alpha" / "kohaku.yaml").write_text(
+                "name: alpha\nversion: '2.0'"
+            )
+            assert list_packages()[0]["version"] == "1.0"
+
+        assert list_packages()[0]["version"] == "2.0"
+        assert calls == 2
+
+    def test_copy_mutation_does_not_change_later_reads(self, pkg_dir):
+        _make_pkg(pkg_dir, "alpha", "version: '1.0'")
+
+        with package_snapshot():
+            first = list_packages()
+            first[0]["version"] = "changed"
+            first.clear()
+            assert list_packages()[0]["version"] == "1.0"
+
+    @pytest.mark.asyncio
+    async def test_child_task_does_not_inherit_snapshot(self, pkg_dir):
+        _make_pkg(pkg_dir, "alpha", "version: '1.0'")
+        release = asyncio.Event()
+
+        async def read_after_scope():
+            await release.wait()
+            return list_packages()[0]["version"]
+
+        with package_snapshot():
+            task = asyncio.create_task(read_after_scope())
+            (pkg_dir / "alpha" / "kohaku.yaml").write_text(
+                "name: alpha\nversion: '2.0'"
+            )
+
+        release.set()
+        assert await task == "2.0"
+
+    def test_nested_scopes_share_the_outer_snapshot(self, pkg_dir, monkeypatch):
+        _make_pkg(pkg_dir, "alpha", "version: '1.0'")
+        from kohakuterrarium.packages import walk
+
+        calls = 0
+        original = walk._list_packages_uncached
+
+        def counted():
+            nonlocal calls
+            calls += 1
+            return original()
+
+        monkeypatch.setattr(walk, "_list_packages_uncached", counted)
+
+        with package_snapshot():
+            list_packages()
+            with package_snapshot():
+                list_packages()
+
+        assert calls == 1
 
 
 class TestGetPackageModules:

--- a/tests/unit/serving/test_desktop_bootstrap.py
+++ b/tests/unit/serving/test_desktop_bootstrap.py
@@ -131,7 +131,7 @@ def test_briefcase_uses_in_process_server(monkeypatch):
     )
 
 
-def test_loading_window_is_shown_before_server_start(monkeypatch):
+def test_server_start_overlaps_loading_window_startup(monkeypatch):
     order = []
     messages = [{"status": "ready", "port": 8123}]
     webview = _Webview(messages)
@@ -152,7 +152,7 @@ def test_loading_window_is_shown_before_server_start(monkeypatch):
 
     desktop.run_desktop_app(port=8001, log_level="ERROR")
 
-    assert order[:2] == ["shown", "server"]
+    assert order[:2] == ["server", "shown"]
     assert webview.window.loaded == ["http://127.0.0.1:8123"]
     assert webview.created[0][1]["html"] == desktop.LOADING_HTML
 

--- a/tests/unit/serving/test_desktop_bootstrap.py
+++ b/tests/unit/serving/test_desktop_bootstrap.py
@@ -1,0 +1,376 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kohakuterrarium.serving import desktop
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "src"
+
+
+class _Events:
+    def __init__(self):
+        self.shown = _Event()
+        self.closed = _Event()
+
+
+class _Event:
+    def __init__(self):
+        self.handlers = []
+
+    def __iadd__(self, handler):
+        self.handlers.append(handler)
+        return self
+
+    def fire(self):
+        for handler in self.handlers:
+            handler()
+
+
+class _ImmediateThread:
+    def __init__(self, *, target, kwargs, **_ignored):
+        self.target = target
+        self.kwargs = kwargs
+
+    def start(self):
+        self.target(**self.kwargs)
+
+
+class _Window:
+    def __init__(self):
+        self.events = _Events()
+        self.loaded = []
+        self.html = []
+
+    def load_url(self, url):
+        self.loaded.append(url)
+
+    def load_html(self, html):
+        self.html.append(html)
+
+
+class _Webview:
+    def __init__(self, messages):
+        self.messages = messages
+        self.window = _Window()
+        self.created = []
+
+    def create_window(self, *args, **kwargs):
+        self.created.append((args, kwargs))
+        return self.window
+
+    def start(self, func=None, args=None, **_kwargs):
+        if func:
+            func(*(args or ()))
+        self.window.events.shown.fire()
+        self.window.events.closed.fire()
+
+
+def test_desktop_module_import_stays_lightweight():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import json, sys; import kohakuterrarium.serving.desktop; "
+            "print(json.dumps(sorted(sys.modules)))",
+        ],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    loaded = set(json.loads(result.stdout))
+
+    assert "kohakuterrarium.serving.web" not in loaded
+    assert "kohakuterrarium.api.app" not in loaded
+    assert not any(name.startswith("fastapi") for name in loaded)
+    assert not any(name.startswith("uvicorn") for name in loaded)
+
+
+def test_launcher_detaches_lightweight_desktop_process(monkeypatch, tmp_path):
+    calls = []
+    child = SimpleNamespace(pid=73)
+    monkeypatch.setattr(desktop, "_is_briefcase_runtime", lambda: False)
+    monkeypatch.setattr(
+        desktop.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: calls.append((cmd, kwargs)) or child,
+    )
+    monkeypatch.setattr(desktop.Path, "home", lambda: tmp_path)
+
+    result = desktop.launch_desktop_app(port=8123, log_level="ERROR")
+
+    assert result is child
+    assert calls[0][0][:3] == [sys.executable, "-m", "kohakuterrarium.serving.desktop"]
+    assert "8123" in calls[0][0]
+
+
+def test_briefcase_uses_in_process_server(monkeypatch):
+    in_process = object()
+    monkeypatch.setattr(desktop, "_is_briefcase_runtime", lambda: True)
+    monkeypatch.setattr(
+        desktop, "_start_in_process_server", lambda **_kwargs: in_process
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_start_subprocess_server",
+        lambda **_kwargs: pytest.fail("subprocess used"),
+    )
+
+    assert (
+        desktop._start_server(port=8001, log_level="ERROR", state_path=Path("state"))
+        is in_process
+    )
+
+
+def test_loading_window_is_shown_before_server_start(monkeypatch):
+    order = []
+    messages = [{"status": "ready", "port": 8123}]
+    webview = _Webview(messages)
+    webview.window.events.shown += lambda: order.append("shown")
+
+    monkeypatch.setattr(desktop, "configure_utf8_stdio", lambda **_kwargs: None)
+    monkeypatch.setattr(desktop.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(desktop, "_load_webview", lambda: webview)
+    monkeypatch.setattr(
+        desktop,
+        "_start_server",
+        lambda **_kwargs: order.append("server") or SimpleNamespace(pid=42),
+    )
+    monkeypatch.setattr(
+        desktop, "_wait_for_server", lambda *_args, **_kwargs: messages[0]
+    )
+    monkeypatch.setattr(desktop, "_stop_server_child", lambda *_args, **_kwargs: None)
+
+    desktop.run_desktop_app(port=8001, log_level="ERROR")
+
+    assert order[:2] == ["shown", "server"]
+    assert webview.window.loaded == ["http://127.0.0.1:8123"]
+    assert webview.created[0][1]["html"] == desktop.LOADING_HTML
+
+
+def test_server_fallback_port_drives_navigation(monkeypatch):
+    webview = _Webview([])
+    monkeypatch.setattr(desktop, "configure_utf8_stdio", lambda **_kwargs: None)
+    monkeypatch.setattr(desktop.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(desktop, "_load_webview", lambda: webview)
+    monkeypatch.setattr(
+        desktop, "_start_server", lambda **_kwargs: SimpleNamespace(pid=42)
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_server",
+        lambda *_args, **_kwargs: {"status": "ready", "port": 8002},
+    )
+    monkeypatch.setattr(desktop, "_stop_server_child", lambda *_args, **_kwargs: None)
+
+    desktop.run_desktop_app(port=8001, log_level="ERROR")
+
+    assert webview.window.loaded == ["http://127.0.0.1:8002"]
+
+
+def test_server_error_replaces_loading_shell(monkeypatch):
+    webview = _Webview([])
+    monkeypatch.setattr(desktop, "configure_utf8_stdio", lambda **_kwargs: None)
+    monkeypatch.setattr(desktop.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(desktop, "_load_webview", lambda: webview)
+    monkeypatch.setattr(
+        desktop, "_start_server", lambda **_kwargs: SimpleNamespace(pid=42)
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_server",
+        lambda *_args, **_kwargs: {"status": "error", "error": "bind failed"},
+    )
+    monkeypatch.setattr(desktop, "_stop_server_child", lambda *_args, **_kwargs: None)
+
+    desktop.run_desktop_app(port=8001, log_level="ERROR")
+
+    assert not webview.window.loaded
+    assert "bind failed" in webview.window.html[-1]
+
+
+def test_close_during_start_stops_late_server(monkeypatch):
+    stopped = []
+    webview = _Webview([])
+    child = SimpleNamespace(pid=42)
+    monkeypatch.setattr(desktop, "configure_utf8_stdio", lambda **_kwargs: None)
+    monkeypatch.setattr(desktop.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(desktop, "_load_webview", lambda: webview)
+
+    def start_then_close(**_kwargs):
+        webview.window.events.closed.fire()
+        return child
+
+    monkeypatch.setattr(desktop, "_start_server", start_then_close)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_server",
+        lambda *_args, **_kwargs: {"status": "ready", "port": 8123},
+    )
+    monkeypatch.setattr(
+        desktop, "_stop_server_child", lambda value, *_args: stopped.append(value)
+    )
+
+    desktop.run_desktop_app(port=8001, log_level="ERROR")
+
+    assert stopped
+    assert all(value is child for value in stopped)
+    assert not webview.window.loaded
+
+
+def test_window_close_stops_server_child(monkeypatch):
+    stopped = []
+    webview = _Webview([])
+    monkeypatch.setattr(desktop, "configure_utf8_stdio", lambda **_kwargs: None)
+    monkeypatch.setattr(desktop.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(desktop, "_load_webview", lambda: webview)
+    child = SimpleNamespace(pid=42)
+    monkeypatch.setattr(desktop, "_start_server", lambda **_kwargs: child)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_server",
+        lambda *_args, **_kwargs: {"status": "ready", "port": 8123},
+    )
+    monkeypatch.setattr(
+        desktop, "_stop_server_child", lambda value, *_args: stopped.append(value)
+    )
+
+    desktop.run_desktop_app(port=8001, log_level="ERROR")
+
+    assert stopped == [child]
+
+
+def test_server_child_publishes_ready_state(monkeypatch, tmp_path):
+    from kohakuterrarium.serving import desktop_server
+
+    state = tmp_path / "state.json"
+    server = SimpleNamespace(should_exit=True)
+    monkeypatch.setattr(
+        desktop_server,
+        "start_desktop_server",
+        lambda _port, _level: (server, 8002),
+    )
+
+    assert desktop_server.run_server_child(8001, "ERROR", state) == 0
+    assert json.loads(state.read_text()) == {"status": "ready", "port": 8002}
+
+
+def test_server_child_publishes_startup_error(monkeypatch, tmp_path):
+    from kohakuterrarium.serving import desktop_server
+
+    state = tmp_path / "state.json"
+    monkeypatch.setattr(
+        desktop_server,
+        "start_desktop_server",
+        lambda _port, _level: (_ for _ in ()).throw(RuntimeError("bind failed")),
+    )
+
+    assert desktop_server.run_server_child(8001, "ERROR", state) == 1
+    assert json.loads(state.read_text()) == {
+        "status": "error",
+        "error": "bind failed",
+    }
+
+
+def test_in_process_server_waits_for_uvicorn_thread():
+    joined = []
+    thread = SimpleNamespace(join=lambda timeout: joined.append(timeout))
+    server = SimpleNamespace(should_exit=False, _kt_thread=thread)
+
+    child = desktop._InProcessServer(server)
+    child.terminate()
+    child.wait(timeout=3)
+
+    assert server.should_exit is True
+    assert joined == [3]
+
+
+def test_server_child_reports_runtime_exit(monkeypatch, tmp_path):
+    from kohakuterrarium.serving import desktop_server
+
+    state = tmp_path / "state.json"
+    thread = SimpleNamespace(is_alive=lambda: False)
+    server = SimpleNamespace(should_exit=False, _kt_thread=thread)
+    monkeypatch.setattr(
+        desktop_server,
+        "start_desktop_server",
+        lambda _port, _level: (server, 8002),
+    )
+
+    assert desktop_server.run_server_child(8001, "ERROR", state) == 1
+    assert json.loads(state.read_text()) == {
+        "status": "error",
+        "error": "Desktop server stopped unexpectedly.",
+    }
+
+
+def test_windows_pid_probe_uses_process_handle(monkeypatch):
+    from kohakuterrarium.serving import desktop_server
+
+    calls = []
+    kernel32 = SimpleNamespace(
+        OpenProcess=lambda access, inherit, pid: calls.append((access, inherit, pid))
+        or 99,
+        WaitForSingleObject=lambda handle, timeout: 0x00000102,
+        CloseHandle=lambda handle: calls.append(("close", handle)),
+    )
+    monkeypatch.setattr(desktop_server.sys, "platform", "win32")
+    monkeypatch.setattr(
+        desktop_server.ctypes,
+        "windll",
+        SimpleNamespace(kernel32=kernel32),
+        raising=False,
+    )
+
+    assert desktop_server._pid_alive(42) is True
+    assert calls[-1] == ("close", 99)
+
+
+def test_server_child_exits_when_ui_parent_dies(monkeypatch, tmp_path):
+    from kohakuterrarium.serving import desktop_server
+
+    state = tmp_path / "state.json"
+    joined = []
+    thread = SimpleNamespace(
+        is_alive=lambda: True, join=lambda timeout: joined.append(timeout)
+    )
+    server = SimpleNamespace(should_exit=False, _kt_thread=thread)
+    monkeypatch.setattr(
+        desktop_server,
+        "start_desktop_server",
+        lambda _port, _level: (server, 8002),
+    )
+    monkeypatch.setattr(desktop_server, "_pid_alive", lambda _pid: False)
+
+    assert desktop_server.run_server_child(8001, "ERROR", state, parent_pid=42) == 0
+    assert server.should_exit is True
+    assert joined == [5]
+
+
+def test_server_child_honors_shutdown_state(monkeypatch, tmp_path):
+    from kohakuterrarium.serving import desktop_server
+
+    state = tmp_path / "state.json"
+    server = SimpleNamespace(should_exit=False)
+    monkeypatch.setattr(
+        desktop_server,
+        "start_desktop_server",
+        lambda _port, _level: (server, 8002),
+    )
+
+    def request_shutdown(_seconds):
+        state.write_text(json.dumps({"status": "shutdown"}))
+
+    monkeypatch.setattr(desktop_server.time, "sleep", request_shutdown)
+
+    assert desktop_server.run_server_child(8001, "ERROR", state) == 0
+    assert server.should_exit is True

--- a/tests/unit/serving/test_desktop_bootstrap.py
+++ b/tests/unit/serving/test_desktop_bootstrap.py
@@ -1,4 +1,5 @@
 import json
+import ctypes
 import os
 import subprocess
 import sys
@@ -129,6 +130,72 @@ def test_briefcase_uses_in_process_server(monkeypatch):
         desktop._start_server(port=8001, log_level="ERROR", state_path=Path("state"))
         is in_process
     )
+
+
+def test_windows_desktop_restores_native_app_and_window_icons(monkeypatch):
+    calls = []
+    shell32 = SimpleNamespace(
+        SetCurrentProcessExplicitAppUserModelID=lambda app_id: calls.append(
+            ("app-id", app_id)
+        )
+    )
+    user32 = SimpleNamespace(
+        LoadImageW=lambda *_args: 73,
+        FindWindowW=lambda *_args: 91,
+        SendMessageW=lambda *args: calls.append(("window-icon", *args)),
+    )
+    webview = _Webview([])
+    monkeypatch.setattr(desktop.sys, "platform", "win32")
+    monkeypatch.setattr(
+        ctypes,
+        "windll",
+        SimpleNamespace(shell32=shell32, user32=user32),
+        raising=False,
+    )
+    monkeypatch.setattr(desktop, "configure_utf8_stdio", lambda **_kwargs: None)
+    monkeypatch.setattr(desktop.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(desktop, "_load_webview", lambda: webview)
+    monkeypatch.setattr(
+        desktop, "_start_server", lambda **_kwargs: SimpleNamespace(pid=42)
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_server",
+        lambda *_args, **_kwargs: {"status": "ready", "port": 8123},
+    )
+    monkeypatch.setattr(desktop, "_stop_server_child", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(desktop.Path, "exists", lambda _self: True)
+
+    desktop.run_desktop_app(port=8001, log_level="ERROR")
+
+    assert ("app-id", "KohakuLab.KohakuTerrarium") in calls
+    assert ("window-icon", 91, 0x0080, 0, 73) in calls
+    assert ("window-icon", 91, 0x0080, 1, 73) in calls
+
+
+def test_macos_desktop_restores_native_dock_icon(monkeypatch):
+    applied = []
+    webview = _Webview([])
+    monkeypatch.setattr(desktop.sys, "platform", "darwin")
+    monkeypatch.setattr(desktop, "configure_utf8_stdio", lambda **_kwargs: None)
+    monkeypatch.setattr(desktop.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(desktop, "_load_webview", lambda: webview)
+    monkeypatch.setattr(
+        desktop, "_start_server", lambda **_kwargs: SimpleNamespace(pid=42)
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_server",
+        lambda *_args, **_kwargs: {"status": "ready", "port": 8123},
+    )
+    monkeypatch.setattr(desktop, "_stop_server_child", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        desktop, "_set_icon_macos", lambda _path: applied.append("dock-icon")
+    )
+
+    desktop.run_desktop_app(port=8001, log_level="ERROR")
+
+    assert applied == ["dock-icon"]
 
 
 def test_server_start_overlaps_loading_window_startup(monkeypatch):

--- a/tests/unit/serving/test_web.py
+++ b/tests/unit/serving/test_web.py
@@ -20,6 +20,79 @@ from kohakuterrarium.serving.web import (
     find_free_port,
 )
 
+# ── startup trace ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_lifespan_records_ready_boundary(monkeypatch):
+    from kohakuterrarium.api import app as api_app
+
+    milestones = []
+
+    async def _shutdown():
+        return None
+
+    engine = type(
+        "Engine",
+        (),
+        {
+            "_runtime_prompt": type(
+                "Prompt", (), {"attach": lambda self: None, "detach": lambda self: None}
+            )(),
+            "shutdown": staticmethod(_shutdown),
+        },
+    )()
+    monkeypatch.setattr(api_app, "get_aggregator", lambda: None)
+    monkeypatch.setattr(api_app, "ensure_auth_migrated", lambda: None)
+    monkeypatch.setattr(api_app, "get_engine", lambda: engine)
+    monkeypatch.setattr(api_app, "close_session_index", lambda: None)
+    monkeypatch.delenv("KT_STARTUP_SURFACE", raising=False)
+    monkeypatch.setattr(
+        api_app,
+        "mark_startup",
+        lambda event, **fields: milestones.append((event, fields)),
+        raising=False,
+    )
+    app = type(
+        "App",
+        (),
+        {"state": type("State", (), {"lab_mode": "standalone", "engine_pool": None})()},
+    )()
+
+    async with api_app.lifespan(app):
+        assert milestones == [("api_lifespan_ready", {"surface": "web"})]
+
+
+def test_web_server_records_ready_boundary(monkeypatch):
+    milestones = []
+    app = object()
+    monkeypatch.setattr(web_mod, "configure_utf8_stdio", lambda **_kwargs: None)
+    monkeypatch.setattr(web_mod, "set_level", lambda _level: None)
+    monkeypatch.setattr(web_mod, "enable_stderr_logging", lambda _level: None)
+    monkeypatch.setattr(web_mod, "_resolve_config_dirs", lambda: (["c"], ["t"]))
+    monkeypatch.setattr(web_mod, "create_app", lambda **_kwargs: app)
+    monkeypatch.setattr(web_mod, "find_free_port", lambda **_kwargs: 8123)
+    monkeypatch.setattr(web_mod, "_publish_actual_port", lambda *_args: None)
+    monkeypatch.setattr(web_mod.uvicorn, "run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        web_mod,
+        "mark_startup",
+        lambda event, **fields: milestones.append((event, fields)),
+        raising=False,
+    )
+
+    web_mod.run_web_server(port=8001, dev=True, log_level="ERROR")
+
+    assert milestones == [
+        (
+            "web_config_dirs_resolved",
+            {"surface": "web", "creatures": 1, "terrariums": 1},
+        ),
+        ("web_app_created", {"surface": "web"}),
+        ("web_server_run", {"surface": "web", "host": "127.0.0.1", "port": 8123}),
+    ]
+
+
 # ── desktop logging ─────────────────────────────────────────────
 
 

--- a/tests/unit/serving/test_web_import_contract.py
+++ b/tests/unit/serving/test_web_import_contract.py
@@ -1,0 +1,57 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "src"
+
+
+def _loaded_modules(code: str) -> set[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return set(json.loads(result.stdout))
+
+
+def test_web_module_import_defers_api_application_graph():
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.serving.web; "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.api.app" not in loaded
+    assert "kohakuterrarium.terrarium.engine" not in loaded
+    assert "kohakuterrarium.llm.anthropic_provider" not in loaded
+    assert "kohakuterrarium.builtins.tools.web_fetch" not in loaded
+
+
+def test_engine_pool_import_defers_terrarium_runtime():
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.api.auth.engine_pool; "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.terrarium.engine" not in loaded
+    assert "kohakuterrarium.core.agent" not in loaded
+    assert "kohakuterrarium.llm.anthropic_provider" not in loaded
+
+
+def test_api_app_import_defers_provider_and_tool_implementations():
+    loaded = _loaded_modules(
+        "import json, sys; import kohakuterrarium.api.app; "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+
+    assert "kohakuterrarium.llm.anthropic_provider" not in loaded
+    assert "kohakuterrarium.llm.openai" not in loaded
+    assert "kohakuterrarium.builtins.tools.web_fetch" not in loaded
+    assert "kohakuterrarium.builtins.tools.web_search" not in loaded

--- a/tests/unit/studio/test_studio_init.py
+++ b/tests/unit/studio/test_studio_init.py
@@ -8,6 +8,24 @@ from kohakuterrarium import studio as studio_pkg
 
 
 class TestStudioInitHooks:
+    def test_import_registers_group_hooks(self):
+        from kohakuterrarium.terrarium import group_hooks
+
+        assert group_hooks._store_attach is not None
+        assert group_hooks._spawnable is not None
+        assert group_hooks._workspace_resolver is not None
+
+    def test_studio_constructor_registers_group_hooks(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "kohakuterrarium.studio.studio.register_group_hooks",
+            lambda: calls.append("registered"),
+        )
+
+        studio_pkg.Studio()
+
+        assert calls == ["registered"]
+
     async def test_store_attach_hook_attaches_a_session_store(
         self, tmp_path, monkeypatch
     ):

--- a/tests/unit/terrarium/test_creature_host.py
+++ b/tests/unit/terrarium/test_creature_host.py
@@ -25,6 +25,28 @@ def _creature(*, name="alice", agent=None, **kw):
 # ── build_creature: llm= instance injection (E5) ───────────────
 
 
+def test_build_creature_reuses_one_package_snapshot(tmp_path, monkeypatch):
+    from kohakuterrarium.packages import walk
+
+    (tmp_path / "config.yaml").write_text(
+        "name: scripted\ninput:\n  type: none\noutput:\n  type: stdout\n",
+        encoding="utf-8",
+    )
+    calls = 0
+    original = walk._list_packages_uncached
+
+    def counted():
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(walk, "_list_packages_uncached", counted)
+
+    build_creature(str(tmp_path), llm=ScriptedLLM(["hi"]), io="none")
+
+    assert calls == 1
+
+
 class TestBuildCreatureLLMInjection:
     def test_provider_instance_flows_to_agent(self, tmp_path):
         # ``engine.add_creature(path, llm=ScriptedLLM(...))`` must bind

--- a/tests/unit/terrarium/test_engine_rich_cli.py
+++ b/tests/unit/terrarium/test_engine_rich_cli.py
@@ -121,11 +121,22 @@ class TestRunEngineWithRichCli:
             def __init__(self, app) -> None:
                 pass
 
+        milestones = []
         monkeypatch.setattr(engine_rich_cli.RichCLIApp, "run", _immediate_run)
         monkeypatch.setattr(engine_rich_cli, "RichCLIOutput", _PassthroughOutput)
+        monkeypatch.setattr(
+            engine_rich_cli,
+            "mark_startup",
+            lambda event, **fields: milestones.append((event, fields)),
+            raising=False,
+        )
 
         await run_engine_with_rich_cli(engine, creature.creature_id)
 
+        assert milestones == [
+            ("rich_cli_creature_started", {"surface": "cli", "creature_id": "focus"}),
+            ("rich_cli_run_enter", {"surface": "cli", "creature_id": "focus"}),
+        ]
         assert during_run["input_type"] is RichCLIInput
         assert "clear" in during_run["commands"]
         assert "help" in during_run["commands"]

--- a/tests/unit/test_file_sizes.py
+++ b/tests/unit/test_file_sizes.py
@@ -213,7 +213,7 @@ ALLOWLIST_600 = {
     # always extends this file; the actual handler bodies live in
     # ``cli/<verb>.py``.  Splitting the parser build would scatter
     # subcommands across files for no readability win.
-    "cli/__init__.py",
+    "cli/_main.py",
     # Marketplace resolver — single cohesive surface (source-list mgmt
     # + disk + in-memory cache + ETag-conditional fetch + parse +
     # dedup + framework-compat check + spec parsing + resolve + sync

--- a/tests/unit/test_root_facade.py
+++ b/tests/unit/test_root_facade.py
@@ -1,0 +1,72 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import kohakuterrarium as kt
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def _fresh_python(code: str) -> dict:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_root_import_defers_public_implementation_modules():
+    loaded = _fresh_python(
+        "import json, sys; import kohakuterrarium; "
+        "print(json.dumps(sorted(name for name in sys.modules "
+        "if name.startswith('kohakuterrarium'))))"
+    )
+
+    assert "kohakuterrarium.studio" not in loaded
+    assert "kohakuterrarium.terrarium" not in loaded
+    assert "kohakuterrarium.core.agent" not in loaded
+    assert "kohakuterrarium.validate" not in loaded
+    assert "kohakuterrarium.session.store" not in loaded
+
+
+def test_public_terrarium_access_registers_group_hooks():
+    state = _fresh_python(
+        "import json; from kohakuterrarium import Terrarium; "
+        "from kohakuterrarium.terrarium import group_hooks; "
+        "print(json.dumps([group_hooks._store_attach is not None, "
+        "group_hooks._spawnable is not None, "
+        "group_hooks._workspace_resolver is not None]))"
+    )
+
+    assert state == [True, True, True]
+
+
+def test_root_exports_resolve_to_real_objects_and_cache():
+    from kohakuterrarium.core.agent import Agent
+    from kohakuterrarium.session.store import SessionStore
+    from kohakuterrarium.studio.studio import Studio
+    from kohakuterrarium.terrarium.engine import Terrarium
+
+    assert kt.Agent is Agent
+    assert kt.Studio is Studio
+    assert kt.Terrarium is Terrarium
+    assert kt.SessionStore is SessionStore
+    assert kt.__dict__["Agent"] is Agent
+
+
+def test_root_dir_and_unknown_attribute():
+    assert "Agent" in dir(kt)
+    assert "Studio" in dir(kt)
+    with pytest.raises(AttributeError, match="no attribute 'missing'"):
+        kt.missing

--- a/tests/unit/utils/test_startup_trace.py
+++ b/tests/unit/utils/test_startup_trace.py
@@ -1,0 +1,99 @@
+import importlib
+import json
+import os
+import sys
+
+
+def _reload_trace_module():
+    sys.modules.pop("kohakuterrarium.utils.startup_trace", None)
+    return importlib.import_module("kohakuterrarium.utils.startup_trace")
+
+
+def test_startup_trace_is_silent_when_disabled(monkeypatch, tmp_path):
+    trace_path = tmp_path / "startup.jsonl"
+    monkeypatch.delenv("KT_STARTUP_TRACE", raising=False)
+
+    trace = _reload_trace_module()
+    trace.mark("parser_ready", surface="cli")
+
+    assert not trace_path.exists()
+
+
+def test_startup_trace_writes_process_correlated_jsonl(monkeypatch, tmp_path):
+    trace_path = tmp_path / "nested" / "startup.jsonl"
+    monkeypatch.setenv("KT_STARTUP_TRACE", str(trace_path))
+    monkeypatch.setenv("KT_STARTUP_RUN_ID", "startup-test")
+
+    trace = _reload_trace_module()
+    trace.mark("parser_ready", surface="cli", command="version")
+    trace.mark("dispatch_selected", surface="cli", command="version")
+
+    shard = trace_path.with_name(f"{trace_path.stem}.{os.getpid()}{trace_path.suffix}")
+    records = [json.loads(line) for line in shard.read_text().splitlines()]
+    assert [record["event"] for record in records] == [
+        "parser_ready",
+        "dispatch_selected",
+    ]
+    assert all(record["run_id"] == "startup-test" for record in records)
+    assert all(record["pid"] == os.getpid() for record in records)
+    assert all(record["ppid"] == os.getppid() for record in records)
+    assert all(record["surface"] == "cli" for record in records)
+    assert records[0]["command"] == "version"
+    assert records[0]["elapsed_ms"] <= records[1]["elapsed_ms"]
+    assert records[0]["monotonic_ns"] <= records[1]["monotonic_ns"]
+    assert records[0]["wall_ns"] <= records[1]["wall_ns"]
+
+
+def test_startup_trace_uses_external_wall_clock_origin(monkeypatch, tmp_path):
+    trace_path = tmp_path / "startup.jsonl"
+    monkeypatch.setenv("KT_STARTUP_TRACE", str(trace_path))
+    monkeypatch.setenv("KT_STARTUP_ORIGIN_NS", "1000000000")
+
+    trace = _reload_trace_module()
+    trace.mark("process_enter", surface="web")
+
+    shard = trace_path.with_name(f"{trace_path.stem}.{os.getpid()}{trace_path.suffix}")
+    record = json.loads(shard.read_text())
+    assert record["startup_ms"] > 0
+
+
+def test_startup_trace_never_breaks_startup_for_bad_metadata(monkeypatch, tmp_path):
+    trace_path = tmp_path / "startup.jsonl"
+    monkeypatch.setenv("KT_STARTUP_TRACE", str(trace_path))
+    monkeypatch.setenv(
+        "KT_STARTUP_ORIGIN_NS", "9999999999999999999999999999999999999999"
+    )
+
+    trace = _reload_trace_module()
+    trace.mark("process_enter", metadata=object())
+
+    shard = trace_path.with_name(f"{trace_path.stem}.{os.getpid()}{trace_path.suffix}")
+    record = json.loads(shard.read_text())
+    assert record["event"] == "process_enter"
+    assert record["metadata"].startswith("<object object at")
+
+
+def test_startup_trace_uses_process_shards(monkeypatch, tmp_path):
+    trace_path = tmp_path / "startup.jsonl"
+    monkeypatch.setenv("KT_STARTUP_TRACE", str(trace_path))
+
+    trace = _reload_trace_module()
+    trace.mark("process_enter")
+
+    shard = trace_path.with_name(f"{trace_path.stem}.{os.getpid()}{trace_path.suffix}")
+    assert shard.exists()
+    assert not trace_path.exists()
+
+
+def test_startup_trace_generates_and_exports_run_id(monkeypatch, tmp_path):
+    trace_path = tmp_path / "startup.jsonl"
+    monkeypatch.setenv("KT_STARTUP_TRACE", str(trace_path))
+    monkeypatch.delenv("KT_STARTUP_RUN_ID", raising=False)
+
+    trace = _reload_trace_module()
+    trace.mark("process_enter", surface="web")
+
+    shard = trace_path.with_name(f"{trace_path.stem}.{os.getpid()}{trace_path.suffix}")
+    record = json.loads(shard.read_text())
+    assert record["run_id"]
+    assert os.environ["KT_STARTUP_RUN_ID"] == record["run_id"]


### PR DESCRIPTION
## Summary

Reduce cold startup latency across the public facade, CLI/TUI, Web/API, Desktop shell, and Agent construction without changing public APIs or readiness semantics. The changes keep heavy imports behind the selected runtime path, overlap independent Desktop initialization, and reuse package metadata only within one bounded build.

## PR Type

- [ ] Bug fix
- [ ] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Cold startup imported most of the runtime graph even for lightweight commands and initialized the Desktop loading window and backend sequentially. One Agent build also enumerated and parsed installed package manifests repeatedly.

Fresh-process profiling on Windows 11 / Python 3.14.2 showed pre-change p50 startup times of about 5.88 s for `kt --version`, 5.22 s for Web health, 8.08 s for CLI ready, 8.16 s for TUI mounted, 10.75 s for the Desktop window, and 10.16 s for the Desktop backend.

This PR is intentionally bounded: it does not add a permanent package cache, defer route registration to first request, weaken Desktop process isolation, or report readiness before required initialization.

## Changes

- Add opt-in, failure-silent, per-process startup trace shards and profiling documentation.
- Keep root/public facades and CLI command dispatch lazy so lightweight paths avoid unrelated runtime imports.
- Defer runtime-only Web/API and terminal UI imports until their surfaces are selected.
- Display the native Desktop loading shell before importing the heavy server graph.
- Start the isolated Desktop backend in parallel with native window initialization while preserving fallback navigation and close-time cleanup.
- Reuse one package enumeration across config loading and Agent initialization, then release it so later builds observe package install/remove and editable manifest changes.
- Add import-contract, startup-order, snapshot lifetime, nested scope, and child-task regression tests.
- Remove the superseded dependency-graph allowlist entry for the old Desktop/Web import path.

Measured p50 after the bounded pass:

| Surface | Before | After |
|---|---:|---:|
| `kt --version` | 5881 ms | 329 ms |
| Web `/healthz` | 5219 ms | 1987 ms |
| CLI ready | 8076 ms | about 1.21 s |
| TUI mounted | 8161 ms | about 1.40 s |
| Desktop window shown | 10751 ms | about 1.16 s |
| Desktop backend ready | 10163 ms | about 2.63 s |

For the final Desktop overlap slice specifically, window shown changed from 1127 ms to 1155 ms (+28 ms / 2.5%) while backend ready improved from 3211 ms to 2633 ms (-577 ms / 18%).

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
PYTHONPATH="$PWD/src" python -m pytest \
  tests/unit/test_dep_graph_lint.py \
  tests/unit/test_file_sizes.py -q --tb=short
PYTHONPATH="$PWD/src" python -m pytest \
  tests/unit/serving/test_desktop_bootstrap.py \
  tests/unit/packages/test_walk.py \
  tests/unit/core/test_agent_real.py \
  tests/unit/terrarium/test_creature_host.py -q --tb=short
PYTHONPATH="$PWD/src" python -m pytest \
  tests/integration/test_core.py \
  tests/integration/test_bootstrap.py \
  tests/integration/test_packages.py \
  tests/integration/test_terrarium.py \
  tests/integration/test_serving.py -q --tb=short
```

Results after rebasing onto the latest `main`:

- Ruff: passed
- Black: passed (`1570 files would be left unchanged`)
- File-size + dependency-graph guards: `1738 passed`
- Affected unit tests: `306 passed`
- Affected integration workflows: `33 passed`
- Five-run fresh-process startup benchmarks completed for the optimized surfaces

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #249

## Notes for Reviewers

Please focus review on:

- import boundaries and whether every lazy import preserves the selected surface's initialization semantics;
- Desktop close-during-start cleanup and backend/window ordering;
- package snapshot lifetime, especially nested construction and visibility of later editable manifest changes;
- readiness markers remaining after required initialization rather than moving work to the first request.

No public API was added or removed. The package snapshot is build-scoped rather than process-global to avoid stale discovery state.

## Screenshots / Logs (if applicable)

Not applicable. Benchmark results are included above; the Desktop loading shell keeps the existing UI.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The complete unit tier was attempted locally but exceeded 600 seconds on Windows/Python 3.14. The independently runnable failures observed before timeout were environment-specific: six Dulwich tests assume a local `master` default branch, and one WebSocket refusal test inherited a SOCKS proxy; the WebSocket test passed after clearing proxy variables. The affected unit files and CI guard suites listed above pass.
- The full OS × Python matrix was not reproduced locally. This machine is Windows/Python 3.14, a combination explicitly excluded from CI because pythonnet has no matching wheel.
- The fork's `ci.yml` only triggers for pushes to `main` and pull requests, so pushing this feature branch did not create a fork CI run. This PR's GitHub Actions run is the authoritative full matrix.
- No frontend source files changed, so frontend format/build checks were not rerun for this backend-only change.
- The full e2e tier was not run. It is intentionally excluded from CI and is volatile on this local Windows/Python 3.14 environment; Desktop behavior was validated with real-window fresh-process benchmarks plus focused serving tests.
