### PR TITLE
fix(llm): send valid model ID for GLM 5.2 1M preset

### DIFF
--- a/src/kohakuterrarium/llm/presets.py
+++ b/src/kohakuterrarium/llm/presets.py
@@ -678,8 +678,8 @@ PRESETS: dict[str, dict[str, Any]] = {
     # ═══════════════════════════════════════════════════════
     #  GLM Coding Plan Direct API (Anthropic-compatible).
     #  GLM's Anthropic-compatible endpoint uses Bearer-token auth.
-    #  GLM-5.2 ids are lowercase; the 1M-context variant is a
-    #  SEPARATE model id with a literal ``[1m]`` suffix.
+    #  GLM-5.2 ids are lowercase. The 1M-context selector changes the
+    #  local context budget, while the API model id remains ``glm-5.2``.
     # ═══════════════════════════════════════════════════════
     "glm-5.2": {
         "provider": "glm-coding",
@@ -690,7 +690,7 @@ PRESETS: dict[str, dict[str, Any]] = {
     },
     "glm-5.2-1m": {
         "provider": "glm-coding",
-        "model": "glm-5.2[1m]",
+        "model": "glm-5.2",
         "max_context": 1000000,
         "max_output": 131072,
         "extra_body": {"auth_as_bearer": True},

--- a/tests/unit/llm/test_presets.py
+++ b/tests/unit/llm/test_presets.py
@@ -314,10 +314,10 @@ class TestPresetsDataIntegrity:
         assert preset["max_context"] == 262144
         assert preset["max_output"] == 32768
 
-    def test_glm_coding_direct_presets_use_bearer_auth(self):
+    def test_glm_coding_direct_presets_use_supported_model_id_and_bearer_auth(self):
         expected = {
             "glm-5.2": ("glm-5.2", 262144, 131072),
-            "glm-5.2-1m": ("glm-5.2[1m]", 1000000, 131072),
+            "glm-5.2-1m": ("glm-5.2", 1000000, 131072),
         }
         for name, (model, max_context, max_output) in expected.items():
             preset = PRESETS[name]


### PR DESCRIPTION
## Summary

Fix the built-in `glm-coding/glm-5.2-1m` preset so it sends the supported `glm-5.2` API model ID while retaining its 1,000,000-token local context budget.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The preset currently sends `glm-5.2[1m]` verbatim to the GLM Anthropic-compatible endpoint. The endpoint rejects that value because `[1m]` is a client-side context selector rather than part of the API model ID.

Authenticated reproduction before this change returned HTTP 400 with provider code `1214` (`modelCode` does not exist). The standard `glm-5.2` preset succeeded with the same provider and credential.

## Changes

- Send `glm-5.2` for the `glm-5.2-1m` preset.
- Keep `max_context=1000000`, `max_output=131072`, Bearer authentication, and existing aliases unchanged.
- Update the preset regression test to pin the supported wire model ID and distinct context budgets.

## Validation

```bash
.venv/bin/pytest tests/unit/llm/test_presets.py -q
.venv/bin/pytest tests/unit/llm -q
.venv/bin/black --check src/ tests/
.venv/bin/ruff check src/ tests/
.venv/bin/kt config llm show glm-coding/glm-5.2-1m
.venv/bin/kt doctor --llm glm-coding/glm-5.2-1m --ping
```

Results:

- Preset tests: 36 passed.
- LLM unit tests: 770 passed.
- Black and Ruff: passed.
- Authenticated GLM Coding Plan ping: `pong`; resolved model `glm-5.2`, context 1,000,000.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [ ] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Closes #73

## Notes for Reviewers

The public preset selector remains `glm-coding/glm-5.2-1m`. Only the model ID sent to the provider changes; context budgeting remains 1M.

## Screenshots / Logs (if applicable)

Not applicable; this is a provider request configuration fix.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The complete unit and integration suites are deferred to PR CI as requested; the full affected LLM unit directory passed locally.
- Fork CI is pull-request-triggered and did not run on the branch push, so the upstream PR CI is the authoritative matrix.
- No documentation update is needed because the public selector and documented behavior are unchanged.
- No frontend files changed, so frontend validation was not applicable.
