### PR TITLE
fix(llm): refresh GLM Coding Plan model catalog

### DIFF
--- a/src/kohakuterrarium/llm/presets.py
+++ b/src/kohakuterrarium/llm/presets.py
@@ -678,8 +678,8 @@ PRESETS: dict[str, dict[str, Any]] = {
     # ═══════════════════════════════════════════════════════
     #  GLM Coding Plan Direct API (Anthropic-compatible).
     #  GLM's Anthropic-compatible endpoint uses Bearer-token auth.
-    #  GLM-5.2 ids are lowercase; the 1M-context variant is a
-    #  SEPARATE model id with a literal ``[1m]`` suffix.
+    #  Model ids are lowercase. The 1M selectors change the local
+    #  context budget while keeping the supported base API model ids.
     # ═══════════════════════════════════════════════════════
     "glm-5.2": {
         "provider": "glm-coding",
@@ -690,7 +690,35 @@ PRESETS: dict[str, dict[str, Any]] = {
     },
     "glm-5.2-1m": {
         "provider": "glm-coding",
-        "model": "glm-5.2[1m]",
+        "model": "glm-5.2",
+        "max_context": 1000000,
+        "max_output": 131072,
+        "extra_body": {"auth_as_bearer": True},
+    },
+    "glm-5.3": {
+        "provider": "glm-coding",
+        "model": "glm-5.3",
+        "max_context": 262144,
+        "max_output": 131072,
+        "extra_body": {"auth_as_bearer": True},
+    },
+    "glm-5.3-1m": {
+        "provider": "glm-coding",
+        "model": "glm-5.3",
+        "max_context": 1000000,
+        "max_output": 131072,
+        "extra_body": {"auth_as_bearer": True},
+    },
+    "glm-5.3-flash": {
+        "provider": "glm-coding",
+        "model": "glm-5.3-flash",
+        "max_context": 262144,
+        "max_output": 131072,
+        "extra_body": {"auth_as_bearer": True},
+    },
+    "glm-5.3-flash-1m": {
+        "provider": "glm-coding",
+        "model": "glm-5.3-flash",
         "max_context": 1000000,
         "max_output": 131072,
         "extra_body": {"auth_as_bearer": True},

--- a/tests/unit/llm/test_presets.py
+++ b/tests/unit/llm/test_presets.py
@@ -314,10 +314,14 @@ class TestPresetsDataIntegrity:
         assert preset["max_context"] == 262144
         assert preset["max_output"] == 32768
 
-    def test_glm_coding_direct_presets_use_bearer_auth(self):
+    def test_glm_coding_direct_presets_use_supported_model_id_and_bearer_auth(self):
         expected = {
             "glm-5.2": ("glm-5.2", 262144, 131072),
-            "glm-5.2-1m": ("glm-5.2[1m]", 1000000, 131072),
+            "glm-5.2-1m": ("glm-5.2", 1000000, 131072),
+            "glm-5.3": ("glm-5.3", 262144, 131072),
+            "glm-5.3-1m": ("glm-5.3", 1000000, 131072),
+            "glm-5.3-flash": ("glm-5.3-flash", 262144, 131072),
+            "glm-5.3-flash-1m": ("glm-5.3-flash", 1000000, 131072),
         }
         for name, (model, max_context, max_output) in expected.items():
             preset = PRESETS[name]


### PR DESCRIPTION
## Summary

Correct the existing GLM-5.2 1M selector and refresh the GLM Coding Plan provider catalog with GLM-5.3 and GLM-5.3-Flash. Every 1M selector uses a live-verified base wire model ID and a 1,000,000-token local context budget.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The existing `glm-5.2-1m` preset sends the unsupported `glm-5.2[1m]` wire ID, and the built-in `glm-coding` catalog does not expose current GLM-5.3 models. Live probing confirmed that the endpoint accepts the base GLM-5.2/5.3 model IDs but rejects synthetic `[1m]` suffixes with error code 1214.

## Changes

- Correct `glm-5.2-1m` to send the supported `glm-5.2` wire model ID.
- Add `glm-5.3` and `glm-5.3-1m` presets.
- Add `glm-5.3-flash` and `glm-5.3-flash-1m` presets.
- Keep the 1M selectors on the verified base wire IDs while raising the local context budget to 1,000,000.
- Extend the existing preset integrity test to pin provider, wire model, context/output limits, and Bearer authentication.
- Preserve the current implicit default and existing aliases.

## Validation

```bash
/Users/williamqin/KohakuTerrarium/.venv/bin/python -m pytest tests/unit/llm tests/integration/test_llm.py -q
/Users/williamqin/KohakuTerrarium/.venv/bin/python -m black --check src tests
/Users/williamqin/KohakuTerrarium/.venv/bin/python -m ruff check src tests

PYTHONPATH=/tmp/kt-glm53/src /Users/williamqin/KohakuTerrarium/.venv/bin/kt doctor --llm glm-coding/glm-5.3 --ping
PYTHONPATH=/tmp/kt-glm53/src /Users/williamqin/KohakuTerrarium/.venv/bin/kt doctor --llm glm-coding/glm-5.2-1m --ping
PYTHONPATH=/tmp/kt-glm53/src /Users/williamqin/KohakuTerrarium/.venv/bin/kt doctor --llm glm-coding/glm-5.3-1m --ping
PYTHONPATH=/tmp/kt-glm53/src /Users/williamqin/KohakuTerrarium/.venv/bin/kt doctor --llm glm-coding/glm-5.3-flash --ping
PYTHONPATH=/tmp/kt-glm53/src /Users/williamqin/KohakuTerrarium/.venv/bin/kt doctor --llm glm-coding/glm-5.3-flash-1m --ping
```

Results:

- LLM unit + integration: 775 passed.
- Black and Ruff: passed across `src/` and `tests/`.
- All five maintained/added profile paths resolved and returned `pong` from the live Coding Plan endpoint.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Closes #73

Closes #254

Supersedes #253

## Notes for Reviewers

The `-1m` names are catalog selectors, not API model IDs. The current Coding Plan endpoint accepts `glm-5.2`, `glm-5.3`, and `glm-5.3-flash`, while the tested literal `[1m]` wire IDs return error code 1214 (`modelCode` does not exist).

No documentation syntax, default model, or alias changed. The GUI/CLI model catalog is populated dynamically from these presets.

## Screenshots / Logs (if applicable)

Live `kt doctor --ping` result for each maintained/added selector: `pong`.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The full unit suite was not repeated locally; the affected LLM unit and integration suites passed (775 tests), and the PR CI matrix is the authoritative full-suite validation.
- Fork CI was not awaited before opening the PR; the upstream PR CI matrix is the authoritative validation for this maintenance update.
- Frontend checks were not run because no frontend files changed.
- No standalone docs were changed because the GUI/CLI catalog is generated from the preset table and no configuration syntax changed.
