### PR TITLE
fix(session): preserve native tool pairs during edit replay

### DIFF
--- a/src/kohakuterrarium/core/agent_message_history.py
+++ b/src/kohakuterrarium/core/agent_message_history.py
@@ -12,6 +12,7 @@ from kohakuterrarium.core.message_locator import (
     user_message_indices_for_turn,
 )
 from kohakuterrarium.session.history import (
+    normalize_tool_call_events,
     replay_conversation,
     resolve_branch_view_strict,
     select_live_event_ids,
@@ -213,7 +214,17 @@ def reload_conversation_under_branch_view(
         return
 
     selected = resolve_branch_view_strict(events, branch_view)
-    messages = replay(events, branch_view=branch_view)
+    live_event_ids = select_live_event_ids(events, branch_view=branch_view)
+    replay_events = [
+        event
+        for event in events
+        if not isinstance(event.get("event_id"), int)
+        or event["event_id"] in live_event_ids
+    ]
+    messages = replay(
+        normalize_tool_call_events(replay_events),
+        branch_view=branch_view,
+    )
     metadata_by_turn = {
         int(event["turn_index"]): {
             "event_id": event.get("event_id"),

--- a/src/kohakuterrarium/core/agent_raw_history.py
+++ b/src/kohakuterrarium/core/agent_raw_history.py
@@ -6,6 +6,7 @@ from kohakuterrarium.core.conversation import Conversation
 from kohakuterrarium.llm.message import dicts_to_messages
 from kohakuterrarium.session.history import (
     compact_path_from_event,
+    normalize_tool_call_events,
     replay_conversation,
 )
 from kohakuterrarium.session.raw_history import (
@@ -115,7 +116,7 @@ def reload_raw_prefix_for_target(
     # pending-summary flush/drop logic assumes one).
     raw_events.sort(key=lambda evt: evt.get("event_id", 0))
     messages = replay_conversation(
-        raw_events,
+        normalize_tool_call_events(raw_events),
         branch_view=prefix.branch_view,
         include_metadata=True,
     )

--- a/src/kohakuterrarium/session/history.py
+++ b/src/kohakuterrarium/session/history.py
@@ -887,6 +887,18 @@ def _inject_synthetic_announcements(
     return result
 
 
+def normalize_tool_call_events(
+    events: Iterable[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Copy events and restore missing assistant tool-call announcements.
+
+    Unlike resume normalization, live history replay must not finalize an
+    unfinished background job as interrupted. It only repairs the declaration
+    required to pair persisted tool results with their assistant call.
+    """
+    return _inject_synthetic_announcements([dict(evt) for evt in events])
+
+
 def normalize_resumable_events(
     events: list[dict[str, Any]],
     *,
@@ -966,4 +978,4 @@ def normalize_resumable_events(
         )
 
     full = normalized + synthetic_events
-    return _inject_synthetic_announcements(full)
+    return normalize_tool_call_events(full)

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -1320,6 +1320,27 @@ class TestCoreIntegration:
             assert agent._turn_index == 1
             assert agent._branch_id == 1
 
+            # Persist the native-tool event shape produced by a background
+            # completion. The event log records the call and result, while
+            # the assistant announcement is reconstructed for replay.
+            replay_call_id = "bash_history_replay_1"
+            store.append_event(
+                agent.config.name,
+                "tool_call",
+                {"name": "bash", "call_id": replay_call_id, "args": {"cmd": "pwd"}},
+                turn_index=1,
+                branch_id=1,
+                parent_branch_path=[],
+            )
+            store.append_event(
+                agent.config.name,
+                "tool_result",
+                {"name": "bash", "call_id": replay_call_id, "output": "/work"},
+                turn_index=1,
+                branch_id=1,
+                parent_branch_path=[],
+            )
+
             # --- regenerate: same user msg, new branch -----------------
             await agent.regenerate_last_response()
             assert "regenerated reply" in _assistant_text(agent)
@@ -1498,6 +1519,17 @@ class TestCoreIntegration:
             )
             assert "first question" in replayed
             assert "original reply" in replayed
+            replay_messages = agent.controller.conversation.get_messages()
+            replay_tool_index = next(
+                i
+                for i, message in enumerate(replay_messages)
+                if message.role == "tool" and message.tool_call_id == replay_call_id
+            )
+            replay_announcement = replay_messages[replay_tool_index - 1]
+            assert replay_announcement.role == "assistant"
+            assert replay_call_id in {
+                call["id"] for call in replay_announcement.tool_calls
+            }
 
     async def test_inject_event_and_unified_trigger_model(self, make_creature):
         """The unified ``TriggerEvent`` model: a non-user-input event

--- a/tests/unit/core/test_agent_messages.py
+++ b/tests/unit/core/test_agent_messages.py
@@ -494,6 +494,102 @@ class TestReloadConversationUnderBranchView:
         roles = [m.role for m in msgs]
         assert "user" in roles
 
+    async def test_restores_native_tool_announcement_before_result(self, agent):
+        agent._apply_user_input("run it")
+        agent.session_store.append_event(
+            "alice",
+            "tool_call",
+            {"name": "bash", "call_id": "bash_replay_1", "args": {"cmd": "pwd"}},
+            turn_index=1,
+            branch_id=1,
+        )
+        agent.session_store.append_event(
+            "alice",
+            "tool_result",
+            {"name": "bash", "call_id": "bash_replay_1", "output": "/work"},
+            turn_index=1,
+            branch_id=1,
+        )
+
+        agent._reload_conversation_under_branch_view({1: 1})
+
+        messages = agent.controller.conversation.get_messages()
+        tool_index = next(
+            i for i, message in enumerate(messages) if message.role == "tool"
+        )
+        announcement = messages[tool_index - 1]
+        assert announcement.role == "assistant"
+        assert [call["id"] for call in announcement.tool_calls] == ["bash_replay_1"]
+        assert messages[tool_index].tool_call_id == "bash_replay_1"
+
+    async def test_does_not_restore_tool_announcement_from_sibling_branch(self, agent):
+        agent._apply_user_input("branch one")
+        for event_type, payload in (
+            (
+                "tool_call",
+                {"name": "bash", "call_id": "branch_1_call", "args": {}},
+            ),
+            (
+                "tool_result",
+                {"name": "bash", "call_id": "branch_1_call", "output": "one"},
+            ),
+        ):
+            agent.session_store.append_event(
+                "alice", event_type, payload, turn_index=1, branch_id=1
+            )
+        for event_type, payload in (
+            (
+                "tool_call",
+                {"name": "bash", "call_id": "branch_2_call", "args": {}},
+            ),
+            (
+                "tool_result",
+                {"name": "bash", "call_id": "branch_2_call", "output": "two"},
+            ),
+        ):
+            agent.session_store.append_event(
+                "alice", event_type, payload, turn_index=1, branch_id=2
+            )
+
+        agent._reload_conversation_under_branch_view({1: 1})
+
+        messages = agent.controller.conversation.get_messages()
+        announced_ids = {
+            call["id"]
+            for message in messages
+            if message.role == "assistant"
+            for call in message.tool_calls
+        }
+        result_ids = {
+            message.tool_call_id for message in messages if message.role == "tool"
+        }
+        assert announced_ids == {"branch_1_call"}
+        assert result_ids == {"branch_1_call"}
+
+    async def test_does_not_mark_unfinished_tool_interrupted_during_live_replay(
+        self, agent
+    ):
+        agent._apply_user_input("keep running")
+        agent.session_store.append_event(
+            "alice",
+            "tool_call",
+            {"name": "bash", "call_id": "still_running", "args": {}},
+            turn_index=1,
+            branch_id=1,
+        )
+
+        agent._reload_conversation_under_branch_view({1: 1})
+
+        messages = agent.controller.conversation.get_messages()
+        announced_ids = {
+            call["id"]
+            for message in messages
+            if message.role == "assistant"
+            for call in message.tool_calls
+        }
+        assert announced_ids == {"still_running"}
+        assert all(message.role != "tool" for message in messages)
+
     async def test_no_events_rejects_nonempty_view(self, agent):
         agent._turn_index = 5
         agent._branch_id = 7

--- a/tests/unit/core/test_agent_raw_history.py
+++ b/tests/unit/core/test_agent_raw_history.py
@@ -84,6 +84,46 @@ def test_reload_restores_missing_system_prompt_and_canonical_user_metadata():
     assert agent._parent_branch_path == [(1, 1)]
 
 
+def test_reload_restores_native_tool_announcement_before_result():
+    events = [
+        _event(1, "user_message", turn=1, content="run it"),
+        {
+            "event_id": 2,
+            "type": "tool_call",
+            "name": "bash",
+            "call_id": "bash_replay_1",
+            "args": {"cmd": "pwd"},
+            "turn_index": 1,
+            "branch_id": 1,
+            "parent_branch_path": [],
+        },
+        {
+            "event_id": 3,
+            "type": "tool_result",
+            "name": "bash",
+            "call_id": "bash_replay_1",
+            "output": "/work",
+            "turn_index": 1,
+            "branch_id": 1,
+            "parent_branch_path": [],
+        },
+        _event(4, "user_message", turn=2, content="change this", path=[[1, 1]]),
+    ]
+    agent = _agent(events)
+
+    reload_raw_prefix_for_target(
+        agent,
+        UserMessageSelector(event_id=4, turn_index=2, branch_id=1),
+    )
+
+    messages = agent.controller.conversation.get_messages()
+    tool_index = next(i for i, message in enumerate(messages) if message.role == "tool")
+    announcement = messages[tool_index - 1]
+    assert announcement.role == "assistant"
+    assert [call["id"] for call in announcement.tool_calls] == ["bash_replay_1"]
+    assert messages[tool_index].tool_call_id == "bash_replay_1"
+
+
 def test_reload_does_not_duplicate_a_persisted_system_prompt():
     events = [
         _event(1, "system_prompt_set", content="persisted prompt"),

--- a/tests/unit/session/test_history.py
+++ b/tests/unit/session/test_history.py
@@ -12,6 +12,7 @@ from kohakuterrarium.session.history import (
     collect_user_groups,
     dedupe_adjacent_duplicate_events,
     normalize_resumable_events,
+    normalize_tool_call_events,
     project_branch_metadata,
     replay_conversation,
     resolve_branch_view_strict,
@@ -1103,7 +1104,23 @@ class TestDedupe:
         assert len(out) == 1
 
 
-# ── normalize_resumable_events ────────────────────────────────────
+# ── normalize_tool_call_events / normalize_resumable_events ──────
+
+
+class TestNormalizeToolCallEvents:
+    def test_restores_announcement_without_finalizing_unfinished_call(self):
+        events = [{"type": "tool_call", "call_id": "c1", "name": "bash", "ts": 1.0}]
+
+        out = normalize_tool_call_events(events)
+
+        assert events == [
+            {"type": "tool_call", "call_id": "c1", "name": "bash", "ts": 1.0}
+        ]
+        assert [event["type"] for event in out] == [
+            "tool_call",
+            "assistant_tool_calls",
+        ]
+        assert all(event.get("_synthetic_resume") is not True for event in out)
 
 
 class TestNormalizeResumable:


### PR DESCRIPTION
## Summary

Preserve persisted native tool-call/result pairs when editing, regenerating, or replaying a selected branch. Live history replay now restores missing assistant tool-call announcements without incorrectly finalizing unfinished background jobs.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Normal session resume repairs persisted `tool_call` / `tool_result` events before replay, but the two live edit/branch reconstruction paths replayed raw events directly. A persisted tool result could therefore appear without its assistant declaration, be dropped as orphaned, and trigger repeated cleanup warnings after later edits or requests.

The live edit path must only restore the missing declaration. It must not reuse resume-only interrupted-job synthesis because a promoted background job may still be running.

## Changes

- Add announcement-only tool event normalization shared with resume normalization.
- Normalize the selected live branch before branch-view replay.
- Normalize the canonical raw prefix before edit/regenerate replay.
- Cover paired results, sibling-branch isolation, unfinished background calls, and the existing integrated history workflow.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/core/test_agent_messages.py tests/unit/core/test_agent_raw_history.py tests/unit/session/test_history.py tests/integration/test_core.py -q
```

Results:

- Ruff: passed
- Black: passed
- Focused unit + integration coverage: 168 passed
- `git diff --check`: passed

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #256

## Notes for Reviewers

The branch-view path filters to the selected live event IDs before injecting synthetic announcements. This prevents announcement-only synthetic events from leaking across sibling branches.

The new helper intentionally does not synthesize interrupted tool results. That behavior remains exclusive to `normalize_resumable_events()` for actual process resume.

## Screenshots / Logs (if applicable)

Not applicable; no UI changes.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The full local unit run reached 12,296 passed / 1 skipped, with 12 failures and 5 errors caused by the sandbox denying localhost socket binds. PR CI is the authoritative full matrix.
- The full local integration run reached 172 passed, with one localhost bind failure caused by the same sandbox restriction.
- The file-size guard has one unrelated `origin/main` baseline failure: `terrarium/engine_cli.py` is 607 lines against the 600-line limit; 1,735 file checks passed.
- E2E was not run because this change does not touch multi-node, Studio, or serving behavior.
- Frontend checks were not run because no frontend files changed.
- Fork CI was not awaited; PR CI is used as the authoritative validation for this collaboration workflow.
