### PR TITLE
fix(triggers): persist resumable-trigger snapshot on removal

### DIFF
--- a/src/kohakuterrarium/core/trigger_manager.py
+++ b/src/kohakuterrarium/core/trigger_manager.py
@@ -116,6 +116,12 @@ class TriggerManager:
         if trigger is None:
             return False
 
+        # Removal was decided above, so converge the persisted snapshot
+        # BEFORE any cancellable await: if the caller is cancelled while
+        # joining the run-loop task or stopping the trigger, memory and
+        # disk must already agree or resume resurrects this trigger.
+        self._persist_resumable_triggers()
+
         task = self._tasks.pop(trigger_id, None)
         if task and not task.done():
             task.cancel()
@@ -129,8 +135,8 @@ class TriggerManager:
                 )
 
         # Removal was already decided; the stop hook is best-effort so a
-        # failing custom trigger cannot leave memory and the persisted
-        # snapshot out of sync.
+        # failing custom trigger cannot leave runtime bookkeeping out of
+        # sync with the (already rewritten) snapshot.
         try:
             await trigger.stop()
         except Exception as e:
@@ -142,8 +148,6 @@ class TriggerManager:
             )
         self._created_at.pop(trigger_id, None)
         logger.info("Trigger removed", trigger_id=trigger_id)
-        # Rewrite the snapshot so a later resume cannot restore this trigger.
-        self._persist_resumable_triggers()
         return True
 
     def get(self, trigger_id: str) -> TriggerInfo | None:

--- a/src/kohakuterrarium/core/trigger_manager.py
+++ b/src/kohakuterrarium/core/trigger_manager.py
@@ -79,24 +79,7 @@ class TriggerManager:
             )
 
         if getattr(trigger, "resumable", False) and self._session_store:
-            try:
-                self._session_store.save_state(
-                    self._agent_name,
-                    triggers=[
-                        {
-                            "trigger_id": tid,
-                            "type": type(t).__name__,
-                            "module": type(t).__module__,
-                            "data": t.to_resume_dict(),
-                        }
-                        for tid, t in self._triggers.items()
-                        if getattr(t, "resumable", False)
-                    ],
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to save trigger state", error=str(e), exc_info=True
-                )
+            self._persist_resumable_triggers()
         else:
             logger.debug(
                 "Trigger registered (not started)",
@@ -105,6 +88,27 @@ class TriggerManager:
             )
 
         return trigger_id
+
+    def _persist_resumable_triggers(self) -> None:
+        """Snapshot every resumable trigger into the session store."""
+        if self._session_store is None:
+            return
+        try:
+            self._session_store.save_state(
+                self._agent_name,
+                triggers=[
+                    {
+                        "trigger_id": tid,
+                        "type": type(t).__name__,
+                        "module": type(t).__module__,
+                        "data": t.to_resume_dict(),
+                    }
+                    for tid, t in self._triggers.items()
+                    if getattr(t, "resumable", False)
+                ],
+            )
+        except Exception as e:
+            logger.warning("Failed to save trigger state", error=str(e), exc_info=True)
 
     async def remove(self, trigger_id: str) -> bool:
         """Stop and remove a trigger, reporting whether it existed."""
@@ -124,9 +128,22 @@ class TriggerManager:
                     "Trigger task cleanup error", error=str(e), exc_info=True
                 )
 
-        await trigger.stop()
+        # Removal was already decided; the stop hook is best-effort so a
+        # failing custom trigger cannot leave memory and the persisted
+        # snapshot out of sync.
+        try:
+            await trigger.stop()
+        except Exception as e:
+            logger.warning(
+                "Trigger stop failed during removal",
+                trigger_id=trigger_id,
+                error=str(e),
+                exc_info=True,
+            )
         self._created_at.pop(trigger_id, None)
         logger.info("Trigger removed", trigger_id=trigger_id)
+        # Rewrite the snapshot so a later resume cannot restore this trigger.
+        self._persist_resumable_triggers()
         return True
 
     def get(self, trigger_id: str) -> TriggerInfo | None:

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -28,6 +28,7 @@ from kohakuterrarium.bootstrap import llm as _bootstrap_llm
 from kohakuterrarium.core.agent import Agent
 from kohakuterrarium.core.events import create_user_input_event
 from kohakuterrarium.modules.tool.base import BaseTool, ExecutionMode, ToolResult
+from kohakuterrarium.modules.trigger.timer import TimerTrigger
 from kohakuterrarium.session.attachment_service import get_attach_state
 from kohakuterrarium.session.embedding import BaseEmbedder
 from kohakuterrarium.session.errors import (
@@ -411,17 +412,17 @@ class TestSessionIntegration:
         assert "scribe:subagent:research:0" in loops
         assert loops["scribe:subagent:research:0"]["completion_tokens"] == 5
 
-        # Persist resumable triggers the way the runtime does on stop —
-        # save_state writes the triggers list, load_triggers reads it
-        # back, and resume hands it to the rebuilt agent.
-        store.save_state(
-            "scribe",
-            triggers=[
-                {"trigger_id": "hb", "type": "timer", "prompt": "tick", "interval": 99}
-            ],
-        )
-        assert store.load_triggers("scribe")[0]["trigger_id"] == "hb"
+        # Resumable triggers ride this same store through runtime
+        # mutations. Install two timers through the live agent's public
+        # API and delete one: TriggerManager.remove must converge the
+        # persisted snapshot on disk, or resume resurrects the deleted id.
+        hb_id = await agent.add_trigger(TimerTrigger(interval=3600, prompt="tick"))
+        t2_id = await agent.add_trigger(TimerTrigger(interval=3600, prompt="tock"))
+        installed = {t["trigger_id"] for t in store.load_triggers("scribe")}
+        assert {hb_id, t2_id} <= installed
         assert store.load_triggers("nobody") == []
+        assert await agent.remove_trigger(hb_id) is True
+        assert [t["trigger_id"] for t in store.load_triggers("scribe")] == [t2_id]
         store.close()
 
         # ---- version probe + session-type detection on the closed file ----
@@ -450,6 +451,11 @@ class TestSessionIntegration:
             # Two research runs were saved (run 0 via SessionOutput, run 1
             # explicitly) — the counter restored to the next free index.
             assert reopened.next_subagent_run("scribe", "research") == 2
+            # The trigger deletion converged across processes: a fresh
+            # handle sees only the survivor, never the deleted id.
+            assert [t["trigger_id"] for t in reopened.load_triggers("scribe")] == [
+                t2_id
+            ]
             # Job records round-tripped through the jobs table.
             job = reopened.load_job("job-echo-1")
             assert job["status"] == "completed"
@@ -505,9 +511,10 @@ class TestSessionIntegration:
             assert resumed_store.load_meta()["status"] == "running"
             assert resumed_store.load_meta()["format_version"] == FORMAT_VERSION
             # The saved resumable triggers were staged onto the agent for
-            # the trigger manager to pick up.
+            # the trigger manager to pick up — including the delete: only
+            # the surviving timer is staged, never the removed one.
             staged = getattr(resumed_agent, "_pending_resume_triggers", None)
-            assert staged and staged[0]["trigger_id"] == "hb"
+            assert staged and staged[0]["trigger_id"] == t2_id
         finally:
             await resumed_agent.stop()
             resumed_store.close()

--- a/tests/unit/core/test_trigger_manager.py
+++ b/tests/unit/core/test_trigger_manager.py
@@ -368,6 +368,81 @@ class TestResumablePersistence:
         assert store.state_calls == []
         await mgr.stop_all()
 
+    async def test_removed_resumable_not_persisted(self, mgr):
+        """Removing a resumable trigger must rewrite the saved snapshot
+        empty; otherwise resume restores a stale snapshot and the deleted
+        trigger comes back to life."""
+        store = _StubStore()
+        mgr._session_store = store
+        mgr._agent_name = "a1"
+        tid = await mgr.add(_ResumableTrigger(), trigger_id="r1")
+        removed = await mgr.remove(tid)
+        assert removed is True
+        last = store.state_calls[-1]
+        assert (
+            last["triggers"] == []
+        ), "deleted trigger must not survive in the persisted snapshot"
+
+    async def test_remove_one_of_two_keeps_survivor_persisted(self, mgr):
+        store = _StubStore()
+        mgr._session_store = store
+        mgr._agent_name = "a1"
+        await mgr.add(_ResumableTrigger(), trigger_id="r1")
+        await mgr.add(_ResumableTrigger(), trigger_id="r2")
+        await mgr.remove("r1")
+        last = store.state_calls[-1]
+        ids = [entry["trigger_id"] for entry in last["triggers"]]
+        assert ids == ["r2"]
+
+    async def test_remove_unknown_id_skips_rewrite(self, mgr):
+        # A failed lookup must not touch the persisted snapshot.
+        store = _StubStore()
+        mgr._session_store = store
+        mgr._agent_name = "a1"
+        tid = await mgr.add(_ResumableTrigger(), trigger_id="r1")
+        writes_before = len(store.state_calls)
+        removed = await mgr.remove("ghost")
+        assert removed is False
+        assert len(store.state_calls) == writes_before
+        await mgr.remove(tid)
+
+    async def test_remove_without_store_no_crash(self, mgr):
+        tid = await mgr.add(_ResumableTrigger(), trigger_id="r1")
+        removed = await mgr.remove(tid)
+        assert removed is True
+
+    async def test_remove_survives_failing_stop_hook(self, mgr):
+        """A trigger whose stop hook raises must still be forgotten from
+        memory AND vanish from the persisted snapshot — removal was
+        already decided, so a half-stopped trigger must not come back
+        to life on resume."""
+        store = _StubStore()
+        mgr._session_store = store
+        mgr._agent_name = "a1"
+
+        class _BrokenStop(_ResumableTrigger):
+            async def _on_stop(self):
+                raise RuntimeError("stop boom")
+
+        tid = await mgr.add(_BrokenStop(), trigger_id="bad")
+        removed = await mgr.remove(tid)
+        assert removed is True
+        assert tid not in mgr._triggers
+        last = store.state_calls[-1]
+        assert last["triggers"] == []
+
+    async def test_stop_all_keeps_persisted_snapshot(self, mgr):
+        """Teardown is not deletion: stopping the agent clears memory but
+        keeps the saved triggers so a later resume restores them."""
+        store = _StubStore()
+        mgr._session_store = store
+        mgr._agent_name = "a1"
+        await mgr.add(_ResumableTrigger(), trigger_id="r1")
+        await mgr.stop_all()
+        assert "r1" not in mgr._triggers
+        ids = [entry["trigger_id"] for entry in store.state_calls[-1]["triggers"]]
+        assert ids == ["r1"]
+
 
 # ── schedule_drift observability ──────────────────────────────────
 
@@ -470,6 +545,22 @@ class TestResumablePersistFailure:
         # Trigger still registered.
         assert "r1" in mgr._triggers
         await mgr.remove("r1")
+
+    async def test_save_state_failure_on_remove_swallowed(self, mgr):
+        """Exception inside save_state during a resumable trigger removal
+        is logged but doesn't break the in-memory removal."""
+        store = _StubStore()
+
+        def boom(*a, **kw):
+            raise RuntimeError("disk")
+
+        store.save_state = boom
+        mgr._session_store = store
+        mgr._agent_name = "a1"
+        await mgr.add(_ResumableTrigger(), trigger_id="r1")
+        ok = await mgr.remove("r1")
+        assert ok is True
+        assert "r1" not in mgr._triggers
 
 
 class TestRemoveCancellationError:

--- a/tests/unit/core/test_trigger_manager.py
+++ b/tests/unit/core/test_trigger_manager.py
@@ -443,6 +443,46 @@ class TestResumablePersistence:
         ids = [entry["trigger_id"] for entry in store.state_calls[-1]["triggers"]]
         assert ids == ["r1"]
 
+    async def test_remove_converges_snapshot_when_cancelled_mid_teardown(self, mgr):
+        """External cancellation between the memory pop and the snapshot
+        write must not leave the deleted trigger on disk — removal was
+        decided, so persistence may not depend on teardown completing."""
+
+        class _SlowStop(_StubTrigger):
+            resumable = True
+
+            def __init__(self):
+                super().__init__()
+                self.release = asyncio.Event()
+                self.stop_entered = False
+
+            async def _on_stop(self):
+                self.stop_entered = True
+                await self.release.wait()
+
+            def to_resume_dict(self):
+                return {"saved": True}
+
+        store = _StubStore()
+        mgr._session_store = store
+        mgr._agent_name = "a1"
+        slow = _SlowStop()
+        tid = await mgr.add(slow, trigger_id="slow")
+        remover = asyncio.create_task(mgr.remove(tid))
+        for _ in range(200):
+            if slow.stop_entered:
+                break
+            await asyncio.sleep(0)
+        assert slow.stop_entered
+        remover.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await remover
+        # Deletion was decided -> disk must reflect it even though
+        # teardown never completed.
+        assert tid not in mgr._triggers
+        last = store.state_calls[-1]
+        assert last["triggers"] == []
+
 
 # ── schedule_drift observability ──────────────────────────────────
 


### PR DESCRIPTION
## Summary

Deleting a runtime-installed trigger did not survive a restart: `TriggerManager.remove()` dropped the in-memory entry but never rewrote the persistent `{agent}:triggers` snapshot, so every session resume reinstalled deleted timers. This makes removal converge to disk and pins the teardown/deletion contract with regression tests.

## PR Type

- [x] Bug fix

## Motivation / Context

Fixes #258 (with reproduction, session evidence, and root cause). The `{agent}:triggers` snapshot had exactly one writer — `TriggerManager.add()` — so any successful `delete_trigger` left a stale snapshot behind, and `_restore_triggers()` resurrected deleted timers on the next `kt resume`, engine creature restart, or Studio restart.

## Changes

- extract `_persist_resumable_triggers()` and call it from both mutation paths; removing a trigger now rewrites the saved snapshot (empty list included) before returning
- make the stop hook best-effort during removal so a failing custom trigger cannot leave memory and disk out of sync; stop-task-cleanup precedent in the same function already followed this pattern
- `stop_all()` intentionally still does not touch the snapshot: teardown is not deletion, and resume-after-crash must keep the last known set
- unit regressions for the new contracts (delete converges snapshot; survivor kept among multiple; unknown id writes nothing; missing store OK; failing stop hook tolerated; stop_all retains snapshot)
- extend the canonical session-resume integration workflow (`tests/integration/test_session.py`) to install/remove real timers through the live agent's public API and verify deletion convergence from a fresh store handle; verified this workflow fails on unfixed source (mutation check)

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/core/test_trigger_manager.py tests/integration/test_session.py tests/unit/session -q   # 760 passed
pytest tests/integration/ -q                                   # 173 passed
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
```

Unit tier for all touched areas plus the full integration tier pass; `black`/`ruff` clean tree-wide (1570 files). The two new manager-level regression tests were confirmed RED before the fix and GREEN after.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it (N/A - bug fix)
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (existing `delete_trigger` skill doc already implies removal permanence; implementation now matches it)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/` (no frontend files changed)
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #258

## Notes for Reviewers

- The persisted-snapshot write stays best-effort (`try/except` + warning) matching the existing save-on-add semantics; removal never fails because persistence fails.
- Deliberately out of scope: `group_stop_node` → same-process `group_start_node` rebuilds an empty `TriggerManager` without replaying persisted triggers; only file-level resume replays them. Flagging here in case a follow-up should make engine-level start reuse the restore path.

## Breaking Changes (if applicable)

None. Trigger installation/resume output shapes are unchanged.

## Exceptions / Not Run

- **Full unit matrix locally**: the whole tier runs ~16 min and contains baseline-red environment-dependent cases on this host (real-network dulwich clones, real WebSocket port binds) that fail identically without this patch. Covered instead by: touched areas (core/session/modules.trigger) + full integration tier (173 passed) + tree-wide lint/format + both guard suites.
- **Fork CI**: branch was pushed immediately before opening this PR, so hosted runs are still in flight; results will land on this PR's checks. Note `test-format-guards` is currently red on `main` itself — `terrarium/engine_cli.py` is 607 lines vs the 600 limit — which will surface here independently of this change.
- **E2E tier**: not run; this change touches neither multi-node nor Studio/serving paths.
