### PR TITLE
fix(session): skip tool feedback during metadata backfill

### DIFF
--- a/src/kohakuterrarium/session/resume_branch.py
+++ b/src/kohakuterrarium/session/resume_branch.py
@@ -7,6 +7,7 @@ agent resumes onto, or must be rebuilt from the event log.
 
 from typing import Any
 
+from kohakuterrarium.core.conversation_elide import TOOL_FEEDBACK_KIND
 from kohakuterrarium.session.history import (
     normalize_resumable_events,
     replay_conversation,
@@ -34,6 +35,10 @@ def snapshot_has_turn_metadata(snapshot: list[dict]) -> bool:
         isinstance(m, dict)
         and (
             m.get("role") != "user"
+            or (
+                isinstance(m.get("metadata"), dict)
+                and m["metadata"].get("kind") == TOOL_FEEDBACK_KIND
+            )
             or (
                 isinstance(m.get("metadata"), dict)
                 and isinstance(m["metadata"].get("turn_index"), int)
@@ -97,7 +102,14 @@ def backfill_turn_metadata(snapshot: list[dict], events: list[dict]) -> list[dic
         pos_by_key[key] = len(meta_by_pos)
         meta_by_pos.append(meta)
     user_messages = [
-        m for m in snapshot if isinstance(m, dict) and m.get("role") == "user"
+        m
+        for m in snapshot
+        if isinstance(m, dict)
+        and m.get("role") == "user"
+        and not (
+            isinstance(m.get("metadata"), dict)
+            and m["metadata"].get("kind") == TOOL_FEEDBACK_KIND
+        )
     ]
     tail_meta = meta_by_pos[-len(user_messages) :] if user_messages else []
     out: list[dict] = []
@@ -109,8 +121,13 @@ def backfill_turn_metadata(snapshot: list[dict], events: list[dict]) -> list[dic
             out.append(msg)
             continue
         m = dict(msg)
-        if m.get("role") == "user" and tail_meta:
-            meta = dict(m.get("metadata") or {})
+        raw_metadata = m.get("metadata")
+        metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+        is_canonical_user = (
+            m.get("role") == "user" and metadata.get("kind") != TOOL_FEEDBACK_KIND
+        )
+        if is_canonical_user and tail_meta:
+            meta = dict(metadata)
             # Position-aligned: every user message consumes one tail slot so
             # later messages keep their correct turn. Replace the canonical
             # identity fields whenever turn or branch is not a positive int

--- a/tests/unit/session/test_resume.py
+++ b/tests/unit/session/test_resume.py
@@ -975,6 +975,116 @@ class TestBackfillDedupeAndPathResilience:
         # duplicate event 3 is dropped, so event 2's id is attached.
         assert out[1]["metadata"]["event_id"] == 2
 
+    def test_backfill_skips_synthetic_tool_feedback_user_messages(self):
+        from kohakuterrarium.session.resume_branch import backfill_turn_metadata
+
+        snapshot = [
+            {"role": "user", "content": "U1"},
+            {
+                "role": "user",
+                "content": "tool feedback",
+                "metadata": {"kind": "tool_results"},
+            },
+            {"role": "user", "content": "U2"},
+        ]
+        events = [
+            {
+                "event_id": 1,
+                "type": "user_message",
+                "content": "U1",
+                "turn_index": 1,
+                "branch_id": 1,
+                "parent_branch_path": [],
+            },
+            {
+                "event_id": 2,
+                "type": "user_message",
+                "content": "U2",
+                "turn_index": 2,
+                "branch_id": 1,
+                "parent_branch_path": [(1, 1)],
+            },
+        ]
+
+        out = backfill_turn_metadata(snapshot, events)
+
+        assert out[0]["metadata"] == {
+            "event_id": 1,
+            "turn_index": 1,
+            "branch_id": 1,
+        }
+        assert out[1]["metadata"] == {"kind": "tool_results"}
+        assert out[2]["metadata"] == {
+            "event_id": 2,
+            "turn_index": 2,
+            "branch_id": 1,
+        }
+
+    def test_backfill_skips_multiple_tool_feedback_messages_without_rewriting_them(
+        self,
+    ):
+        from kohakuterrarium.session.resume_branch import backfill_turn_metadata
+
+        feedback = [
+            {
+                "role": "user",
+                "content": f"tool feedback {index}",
+                "metadata": {"kind": "tool_results", "batch": index},
+            }
+            for index in range(2)
+        ]
+        snapshot = [
+            {"role": "user", "content": "U1"},
+            *feedback,
+            {"role": "user", "content": "U2"},
+        ]
+        events = [
+            {
+                "event_id": index,
+                "type": "user_message",
+                "content": f"U{index}",
+                "turn_index": index,
+                "branch_id": 1,
+                "parent_branch_path": [],
+            }
+            for index in (1, 2)
+        ]
+
+        out = backfill_turn_metadata(snapshot, events)
+
+        assert [out[0]["metadata"]["event_id"], out[-1]["metadata"]["event_id"]] == [
+            1,
+            2,
+        ]
+        assert [message["metadata"] for message in out[1:-1]] == [
+            {"kind": "tool_results", "batch": 0},
+            {"kind": "tool_results", "batch": 1},
+        ]
+        assert [message["content"] for message in out] == [
+            "U1",
+            "tool feedback 0",
+            "tool feedback 1",
+            "U2",
+        ]
+
+    def test_tool_feedback_does_not_make_snapshot_metadata_incomplete(self):
+        from kohakuterrarium.session.resume_branch import snapshot_has_turn_metadata
+
+        snapshot = [
+            {
+                "role": "user",
+                "content": "U1",
+                "metadata": {"turn_index": 1, "branch_id": 1},
+            },
+            {
+                "role": "user",
+                "content": "tool feedback",
+                "metadata": {"kind": "tool_results"},
+            },
+        ]
+
+        assert snapshot_has_turn_metadata(snapshot) is True
+
     def test_backfill_metadata_matches_replay_metadata(self):
         # Cross-path consistency guard: backfilled legacy snapshots and
         # replay(include_metadata=True) must attach IDENTICAL user message


### PR DESCRIPTION
## Summary

Fix legacy session metadata backfill so synthetic bracket-mode tool feedback is not treated as a canonical user turn. This preserves positional turn metadata alignment while retaining the existing snapshot corruption defenses.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Bracket-mode tool feedback is represented as `role=user` with `metadata.kind == "tool_results"`, but it is internal tool-result feedback rather than a user-authored turn. Counting these messages during resume backfill shifts later canonical `event_id`, `turn_index`, and `branch_id` metadata onto the wrong message.

The same classification also caused `snapshot_has_turn_metadata()` to reject otherwise complete snapshots solely because synthetic feedback did not carry canonical turn coordinates.

## Changes

- Skip synthetic `tool_results` feedback when assigning positional canonical user-turn metadata.
- Ignore synthetic feedback when checking whether a snapshot already has complete turn metadata.
- Preserve feedback content, order, and existing metadata unchanged.
- Keep malformed non-dict metadata classified as incomplete.
- Add regression coverage for single and consecutive feedback messages, completeness detection, metadata preservation, and corrupt metadata.

## Validation

```bash
ruff check src/ tests/
black --check --fast src/ tests/
pytest tests/unit/session/ -q
pytest tests/integration/session/ -q
pytest tests/unit/test_file_sizes.py -q
pytest tests/unit/test_dep_graph_lint.py -q
git diff --check
```

Results:

- Ruff: passed
- Black: 1,579 files unchanged locally; standard `black --check` also passed in fork CI
- Session unit tier: 720 passed
- Session integration tier: 5 passed
- File-size guard: 1,742 passed
- Dependency-graph guard: 2 passed
- Fork CI: lint, format guards, dependency graph, frontend, package build, and all non-Windows/Python 3.12 test matrix jobs passed

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Closes #260

## Notes for Reviewers

The classification intentionally remains narrow: only `role=user` messages whose dict metadata has `kind == "tool_results"` are excluded from canonical user-turn positions. Other user messages retain the existing behavior, and malformed metadata still triggers the defensive incomplete-snapshot path.

## Screenshots / Logs (if applicable)

Not applicable.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The full repository unit suite was not run locally. The complete session unit tier and session integration tier were run locally, and the fork CI exercised the full unit/integration matrix.
- The fork's Windows/Python 3.12 matrix is subject to a known timeout/flaky build issue. Its attempts failed in unrelated time-sensitive Studio persistence and TUI scrollbar tests; the changed session tests passed. Per the known CI limitation, it was not rerun again.
- No frontend files changed. The frontend checklist item is marked complete because the fork CI ran and passed both frontend formatting and build checks.
