### PR TITLE
perf(frontend): eliminate conversation long tasks

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.test.js
@@ -1,9 +1,10 @@
 import { flushPromises, mount } from "@vue/test-utils"
 import { createPinia, setActivePinia } from "pinia"
 import { ElMessageBox } from "element-plus"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import ChatPanel from "./ChatPanel.vue"
+import { createChatScrollScheduler } from "./chatScrollScheduler"
 import { useChatStore } from "@/stores/chat"
 import { terrariumAPI } from "@/utils/api"
 
@@ -17,12 +18,127 @@ beforeEach(() => {
   setActivePinia(createPinia())
 })
 
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("ChatPanel scroll scheduling", () => {
+  function setupScheduler({ nearBottom = true } = {}) {
+    const frames = new Map()
+    let nextFrame = 1
+    const scroll = vi.fn()
+    const scheduler = createChatScrollScheduler({
+      afterDomCommit: (callback) => callback(),
+      requestFrame: (callback) => {
+        const id = nextFrame++
+        frames.set(id, callback)
+        return id
+      },
+      cancelFrame: (id) => frames.delete(id),
+      shouldScroll: () => nearBottom,
+      scroll,
+    })
+    return {
+      frames,
+      scroll,
+      scheduler,
+      runFrame() {
+        const [[id, callback]] = frames
+        frames.delete(id)
+        callback()
+      },
+    }
+  }
+
+  it("coalesces repeated requests into one scroll per frame", () => {
+    const { frames, scroll, scheduler, runFrame } = setupScheduler()
+
+    scheduler.schedule()
+    scheduler.schedule()
+    scheduler.schedule()
+
+    expect(frames.size).toBe(1)
+    runFrame()
+    expect(scroll).toHaveBeenCalledOnce()
+  })
+
+  it("upgrades a pending normal request when a force request arrives", () => {
+    const { scroll, scheduler, runFrame } = setupScheduler({ nearBottom: false })
+
+    scheduler.schedule()
+    scheduler.schedule(true)
+    runFrame()
+
+    expect(scroll).toHaveBeenCalledOnce()
+  })
+
+  it("does not scroll for a normal request after leaving the bottom", () => {
+    const { scroll, scheduler, runFrame } = setupScheduler({ nearBottom: false })
+
+    scheduler.schedule()
+    runFrame()
+
+    expect(scroll).not.toHaveBeenCalled()
+  })
+
+  it("cancels the pending frame when disposed", () => {
+    const { frames, scroll, scheduler } = setupScheduler()
+
+    scheduler.schedule()
+    scheduler.dispose()
+
+    expect(frames.size).toBe(0)
+    expect(scroll).not.toHaveBeenCalled()
+  })
+
+  it("does not run a forced frame after its scope is invalidated", () => {
+    const { frames, scroll, scheduler } = setupScheduler({ nearBottom: false })
+
+    scheduler.schedule(true, "instance:A")
+    scheduler.invalidate()
+
+    expect(frames.size).toBe(0)
+    expect(scroll).not.toHaveBeenCalled()
+  })
+
+  it("does not create a frame from an invalidated DOM commit", () => {
+    const commits = []
+    const frames = new Map()
+    const scheduler = createChatScrollScheduler({
+      afterDomCommit: (callback) => commits.push(callback),
+      requestFrame: (callback) => {
+        frames.set(1, callback)
+        return 1
+      },
+      cancelFrame: (id) => frames.delete(id),
+      shouldScroll: () => true,
+      scroll: vi.fn(),
+    })
+
+    scheduler.schedule(true, "instance:A")
+    scheduler.invalidate()
+    commits[0]()
+
+    expect(frames.size).toBe(0)
+  })
+
+  it("does not merge force state across scopes", () => {
+    const { scroll, scheduler, runFrame } = setupScheduler({ nearBottom: false })
+
+    scheduler.schedule(true, "instance:A")
+    scheduler.schedule(false, "instance:B")
+    runFrame()
+
+    expect(scroll).not.toHaveBeenCalled()
+  })
+})
+
 describe("ChatPanel render window", () => {
-  function mountPanel(chat) {
+  function mountPanel(chat, { groupId = null } = {}) {
     chat._instanceId = "graph_1"
     chat._instanceGraphId = "graph_1"
-    chat.activeTab = "kohaku"
-    chat.tabs = ["kohaku"]
+    if (!chat.activeTab) chat.activeTab = "kohaku"
+    if (!chat.tabs.length) chat.tabs = ["kohaku"]
     chat.commandInventoryByTab = { kohaku: { commands: [], skills: [] } }
     chat._commandInventoryFetchedAtByTab = { kohaku: Date.now() }
     return mount(ChatPanel, {
@@ -32,6 +148,7 @@ describe("ChatPanel render window", () => {
           graph_id: "graph_1",
           creatures: [{ name: "kohaku", status: "idle" }],
         },
+        groupId,
       },
       global: {
         provide: { chatStore: chat },
@@ -124,6 +241,40 @@ describe("ChatPanel render window", () => {
     expect(renderedIds(wrapper).length).toBe(400)
     expect(renderedIds(wrapper).at(-1)).toBe("m_420")
     expect(renderedIds(wrapper)).not.toContain("m_0")
+  })
+
+  it("does not let a pending frame from the previous tab overwrite the new tab position", async () => {
+    const frames = new Map()
+    let nextFrame = 1
+    vi.stubGlobal("requestAnimationFrame", (callback) => {
+      const id = nextFrame++
+      frames.set(id, callback)
+      return id
+    })
+    vi.stubGlobal("cancelAnimationFrame", (id) => frames.delete(id))
+
+    const chat = useChatStore("graph_1")
+    chat.activeTab = "kohaku"
+    chat.tabs = ["kohaku", "reviewer"]
+    chat.messagesByTab = { kohaku: [], reviewer: [] }
+    const groupId = chat.enableGroups()
+    const wrapper = mountPanel(chat, { groupId })
+    await flushPromises()
+
+    chat.messagesByTab.kohaku.push({ id: "m_1", role: "user", content: "force scroll" })
+    await flushPromises()
+    const pendingFrame = [...frames.values()][0]
+    expect(pendingFrame).toBeTypeOf("function")
+
+    chat.setGroupActiveTab(groupId, "reviewer")
+    await flushPromises()
+    const viewport = wrapper.find(".chat-messages-viewport").element
+    viewport.scrollTop = 73
+
+    pendingFrame()
+    expect(viewport.scrollTop).toBe(73)
+    expect(frames.size).toBe(0)
+    wrapper.unmount()
   })
 })
 

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -192,6 +192,7 @@ import { inject } from "vue"
 
 import StatusDot from "@/components/common/StatusDot.vue"
 import ChatMessage from "@/components/chat/ChatMessage.vue"
+import { createChatScrollScheduler } from "@/components/chat/chatScrollScheduler"
 import SlashCommandMenu from "@/components/chat/SlashCommandMenu.vue"
 import ModelSwitcher from "@/components/chrome/ModelSwitcher.vue"
 import SiteChip from "@/components/cluster/SiteChip.vue"
@@ -234,6 +235,8 @@ let dragDepth = 0
 const viewGroup = computed(() => (props.groupId ? chat.groups?.[props.groupId] || null : null))
 const viewTabs = computed(() => (viewGroup.value ? viewGroup.value.tabs : chat.tabs))
 const viewActiveTab = computed(() => (viewGroup.value ? viewGroup.value.activeTab : chat.activeTab))
+const viewInstanceId = computed(() => props.instance?.id || chat._instanceId || null)
+const scrollScope = computed(() => ({ instanceId: viewInstanceId.value, tab: viewActiveTab.value }))
 const viewMessages = computed(() => {
   const t = viewActiveTab.value
   return t ? chat.messagesByTab[t] || [] : []
@@ -595,6 +598,15 @@ function scrollToBottom() {
   saveScrollPosition()
 }
 
+const scrollScheduler = createChatScrollScheduler({
+  afterDomCommit: nextTick,
+  requestFrame: (callback) => requestAnimationFrame(callback),
+  cancelFrame: (id) => cancelAnimationFrame(id),
+  shouldScroll: () => isNearBottom.value,
+  scroll: scrollToBottom,
+})
+const scheduleScrollToBottom = (force = false) => scrollScheduler.schedule(force, scrollScope.value)
+
 const messageTailSignature = computed(() => {
   const messages = viewMessages.value
   const last = messages[messages.length - 1]
@@ -611,32 +623,36 @@ const messageTailSignature = computed(() => {
   return `${messages.length}:${last.id}:${last.role}:${contentLen}:${parts}`
 })
 
-watch(messageTailSignature, (nextSig, prevSig) => {
-  if (!prevSig || nextSig === prevSig) return
-  if (forceScrollOnNextMessageUpdate.value || isNearBottom.value) {
-    forceScrollOnNextMessageUpdate.value = false
-    nextTick(scrollToBottom)
-  }
-})
-
 watch(
-  () => viewProcessing.value,
-  (val) => {
-    if (val && isNearBottom.value) {
-      nextTick(scrollToBottom)
-    }
+  () => [scrollScope.value, messageTailSignature.value],
+  ([scope, nextSig], previous) => {
+    const [previousScope, prevSig] = previous || []
+    if (scope !== previousScope || !prevSig || nextSig === prevSig) return
+    const force = forceScrollOnNextMessageUpdate.value
+    forceScrollOnNextMessageUpdate.value = false
+    scheduleScrollToBottom(force)
   },
 )
 
 watch(
-  () => [props.instance?.id, viewActiveTab.value],
-  ([instanceId, tab], previous) => {
-    const [prevInstanceId, prevTab] = previous || []
-    if (prevInstanceId && prevTab) saveScrollPosition(prevInstanceId, prevTab)
+  () => [scrollScope.value, viewProcessing.value],
+  ([scope, val], previous) => {
+    if (scope === previous?.[0] && val) scheduleScrollToBottom()
+  },
+)
+
+watch(
+  scrollScope,
+  (scope, previousScope) => {
+    scrollScheduler.invalidate()
+    if (previousScope?.instanceId && previousScope.tab) {
+      saveScrollPosition(previousScope.instanceId, previousScope.tab)
+    }
     windowStartIndex.value = null
     restoreDraft()
     nextTick(() => {
-      const hadSavedScroll = restoreScrollPosition(instanceId, tab)
+      if (scope !== scrollScope.value) return
+      const hadSavedScroll = restoreScrollPosition(scope.instanceId, scope.tab)
       forceScrollOnNextMessageUpdate.value = !hadSavedScroll
     })
   },
@@ -822,8 +838,8 @@ async function send() {
   isNearBottom.value = true // force scroll after send
   nextTick(() => {
     if (inputEl.value) inputEl.value.style.height = "auto"
-    scrollToBottom()
   })
+  scheduleScrollToBottom(true)
   try {
     const outcome = await outcomePromise
     if (outcome?.handled === "command") {
@@ -850,7 +866,7 @@ async function send() {
         },
         commandTarget.resultContext,
       )
-      if (viewActiveTab.value === commandTarget.tabKey) nextTick(scrollToBottom)
+      if (viewActiveTab.value === commandTarget.tabKey) scheduleScrollToBottom(true)
     } else {
       ElMessage.error(`Command failed: ${err?.message || err}`)
     }
@@ -875,7 +891,7 @@ async function surfaceCommandResult(response, target = null) {
   if (!response) return
   if (target?.inline) {
     chat.addCommandResult(target.tabKey, target.commandText, response, target.resultContext)
-    if (viewActiveTab.value === target.tabKey) nextTick(scrollToBottom)
+    if (viewActiveTab.value === target.tabKey) scheduleScrollToBottom(true)
     return
   }
   if (response.error) {
@@ -954,7 +970,10 @@ function onGlobalKeydown(e) {
   }
 }
 onMounted(() => window.addEventListener("keydown", onGlobalKeydown))
-onUnmounted(() => window.removeEventListener("keydown", onGlobalKeydown))
+onUnmounted(() => {
+  window.removeEventListener("keydown", onGlobalKeydown)
+  scrollScheduler.dispose()
+})
 </script>
 
 <style scoped src="./chat-panel.css"></style>

--- a/src/kohakuterrarium-frontend/src/components/chat/chatScrollScheduler.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatScrollScheduler.js
@@ -1,0 +1,56 @@
+export function createChatScrollScheduler({
+  afterDomCommit,
+  requestFrame,
+  cancelFrame,
+  shouldScroll,
+  scroll,
+}) {
+  let commitPending = false
+  let frameId = null
+  let forcePending = false
+  let pendingScope
+  let generation = 0
+  let disposed = false
+
+  function invalidate() {
+    generation++
+    commitPending = false
+    forcePending = false
+    pendingScope = undefined
+    if (frameId !== null) {
+      cancelFrame(frameId)
+      frameId = null
+    }
+  }
+
+  function schedule(force = false, scope) {
+    if (disposed) return
+    if ((commitPending || frameId !== null) && pendingScope !== scope) invalidate()
+
+    pendingScope = scope
+    forcePending ||= force
+    if (commitPending || frameId !== null) return
+
+    const scheduledGeneration = generation
+    commitPending = true
+    afterDomCommit(() => {
+      if (disposed || generation !== scheduledGeneration) return
+      commitPending = false
+      frameId = requestFrame(() => {
+        if (disposed || generation !== scheduledGeneration) return
+        frameId = null
+        const forceScroll = forcePending
+        forcePending = false
+        pendingScope = undefined
+        if (forceScroll || shouldScroll()) scroll()
+      })
+    })
+  }
+
+  function dispose() {
+    disposed = true
+    invalidate()
+  }
+
+  return { schedule, invalidate, dispose }
+}

--- a/src/kohakuterrarium-frontend/src/components/common/MarkdownRenderer.test.js
+++ b/src/kohakuterrarium-frontend/src/components/common/MarkdownRenderer.test.js
@@ -43,7 +43,7 @@ describe("MarkdownRenderer streaming", () => {
     await vi.advanceTimersByTimeAsync(200)
 
     const after = renderedHtml(wrapper)
-    expect(after).toContain("const b = 2;")
+    expect(wrapper.find("pre.hljs code").text()).toContain("const b = 2;")
     expect(after).toContain("outro")
     // The untouched leading paragraph must survive byte-for-byte across the
     // stream — that stability is what keeps incremental rendering correct.
@@ -67,6 +67,90 @@ describe("MarkdownRenderer streaming", () => {
     expect(block.find(".code-header").exists()).toBe(true)
     expect(block.find("pre.hljs").exists()).toBe(true)
     expect(block.find("pre.hljs code").text()).toContain("const answer = 42")
+    expect(block.find("code").classes()).toContain("language-js")
+  })
+
+  it.each([
+    ["list", "- item\n  ```js\n  const inside = 1\noutside"],
+    ["blockquote", "> ```js\n> const inside = 1\noutside"],
+    ["four-space relative indent", "- item\n     ~~~~js\n     const inside = 1\noutside"],
+  ])("does not let an open fence in a %s consume outside content", (_name, content) => {
+    const wrapper = mount(MarkdownRenderer, { props: { content } })
+
+    expect(wrapper.find("pre.hljs code").text()).toContain("const inside = 1")
+    expect(wrapper.find("pre.hljs code").html()).not.toContain("hljs-")
+    expect(wrapper.find(".md-content > p").text()).toBe("outside")
+  })
+
+  it.each([
+    ["a relative four-space marker", "- item\n\n  ```javascript\n  const inside = 1\n      ```"],
+    ["a nested list marker", "- item\n\n  ```javascript\n  const inside = 1\n  - ```"],
+    ["a marker with an NBSP tail", "```javascript\nconst inside = 1\n```\u00a0"],
+  ])("does not mistake %s for a closing fence", (_name, content) => {
+    const wrapper = mount(MarkdownRenderer, { props: { content } })
+
+    const code = wrapper.find("pre.hljs code")
+    expect(code.html()).not.toContain("hljs-")
+    expect(code.text()).toContain("const inside = 1")
+  })
+
+  it("closes a list fence at its valid relative indent without consuming outside content", () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: "- item\n\n  ```javascript\n  const inside = 1\n    ```\n\noutside",
+      },
+    })
+
+    expect(wrapper.find("pre.hljs code").html()).toContain("hljs-keyword")
+    expect(wrapper.find("pre.hljs code").text()).toContain("const inside = 1")
+    expect(wrapper.find("pre.hljs code").text()).not.toContain("outside")
+    expect(wrapper.find(".md-content > p").text()).toBe("outside")
+  })
+
+  it("preserves a fence inside nested list structure as one code block", () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: { content: "- - ```javascript\n    const inside = 1\n    const nested = 2\n    ```" },
+    })
+
+    expect(wrapper.findAll(".code-block")).toHaveLength(1)
+    expect(wrapper.find("pre.hljs code").text()).toContain("const nested = 2")
+    expect(wrapper.find("pre.hljs code").html()).toContain("hljs-keyword")
+  })
+
+  it("does not infer a close from a top-level opening marker at EOF", () => {
+    const wrapper = mount(MarkdownRenderer, { props: { content: "```" } })
+
+    expect(wrapper.findAll(".code-block")).toHaveLength(1)
+    expect(wrapper.find("pre.hljs code").html()).not.toContain("hljs-")
+  })
+
+  it("keeps an unterminated streaming fence plain, then highlights it when closed", async () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: { content: "~~~javascript\nconst answer = 42 < 100" },
+    })
+
+    expect(wrapper.find("pre.hljs code").text()).toBe("const answer = 42 < 100")
+    expect(wrapper.find("pre.hljs code").html()).not.toContain("hljs-")
+
+    await wrapper.setProps({ content: "~~~javascript\nconst answer = 42 < 100\n~~~" })
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(wrapper.find("pre.hljs code").html()).toContain("hljs-keyword")
+    expect(wrapper.find("pre.hljs code").text()).toBe("const answer = 42 < 100")
+  })
+
+  it("copies fenced source from code text without duplicating it in data-copy", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } })
+    const source = 'const tag = "<button>"\nconsole.log(tag)'
+    const wrapper = mount(MarkdownRenderer, { props: { content: `\`\`\`js\n${source}\n\`\`\`` } })
+    const button = wrapper.find(".code-copy-btn")
+
+    expect(button.attributes("data-copy")).toBeUndefined()
+    expect(renderedHtml(wrapper)).not.toContain("data-copy=")
+    await button.trigger("click")
+
+    expect(writeText).toHaveBeenCalledWith(`${source}\n`)
   })
 
   it("renders empty for empty content", () => {

--- a/src/kohakuterrarium-frontend/src/components/common/MarkdownRenderer.vue
+++ b/src/kohakuterrarium-frontend/src/components/common/MarkdownRenderer.vue
@@ -23,13 +23,18 @@ const props = defineProps({
 
 const rootEl = ref(null)
 
+function codeBlockHtml(lang, fenceHtml) {
+  const displayLang = md.utils.escapeHtml(lang || "text")
+  const styledFenceHtml = fenceHtml.replace("<pre>", '<pre class="hljs">')
+  return `<div class="code-block">` + `<div class="code-header">` + `<span class="code-lang">${displayLang}</span>` + `<button class="code-copy-btn" title="Copy">Copy</button>` + `</div>` + styledFenceHtml + `</div>`
+}
+
 const md = new MarkdownIt({
   html: false,
   linkify: true,
   typographer: false,
   breaks: props.breaks,
   highlight(str, lang) {
-    const displayLang = lang || "text"
     const langClass = lang && hljs.getLanguage(lang) ? lang : ""
     let highlighted
     if (langClass) {
@@ -41,10 +46,88 @@ const md = new MarkdownIt({
     } else {
       highlighted = md.utils.escapeHtml(str)
     }
-    // Wrap with header (language label + copy button)
-    return `<div class="code-block">` + `<div class="code-header">` + `<span class="code-lang">${displayLang}</span>` + `<button class="code-copy-btn" data-copy="${md.utils.escapeHtml(str).replace(/"/g, "&quot;")}" title="Copy">Copy</button>` + `</div>` + `<pre class="hljs"><code>${highlighted}</code></pre>` + `</div>`
+    return highlighted
   },
 })
+
+// Keep this scan in lockstep with markdown-it 14.3's rules_block/fence.mjs.
+// It deliberately uses StateBlock's container-relative offsets and indentation;
+// raw source regexes cannot distinguish real closers inside nested containers.
+function fenceHasEndMarker(state, startLine, endLine) {
+  let pos = state.bMarks[startLine] + state.tShift[startLine]
+  let max = state.eMarks[startLine]
+
+  if (state.sCount[startLine] - state.blkIndent >= 4 || pos + 3 > max) return false
+
+  const marker = state.src.charCodeAt(pos)
+  if (marker !== 0x7e && marker !== 0x60) return false
+
+  const markerStart = pos
+  pos = state.skipChars(pos, marker)
+  const markerLength = pos - markerStart
+  if (markerLength < 3) return false
+
+  const params = state.src.slice(pos, max)
+  if (marker === 0x60 && params.indexOf(String.fromCharCode(marker)) >= 0) return false
+
+  let nextLine = startLine
+  for (;;) {
+    nextLine++
+    if (nextLine >= endLine) return false
+
+    pos = state.bMarks[nextLine] + state.tShift[nextLine]
+    const lineStart = pos
+    max = state.eMarks[nextLine]
+
+    if (pos < max && state.sCount[nextLine] < state.blkIndent) return false
+    if (state.src.charCodeAt(pos) !== marker) continue
+    if (state.sCount[nextLine] - state.blkIndent >= 4) continue
+
+    pos = state.skipChars(pos, marker)
+    if (pos - lineStart < markerLength) continue
+
+    pos = state.skipSpaces(pos)
+    if (pos < max) continue
+
+    return true
+  }
+}
+
+const fenceBlockRule = md.block.ruler.__rules__.find((rule) => rule.name === "fence")
+if (!fenceBlockRule) throw new Error("markdown-it fence block rule not found")
+const originalFenceBlock = fenceBlockRule.fn
+const fenceBlockAlt = [...fenceBlockRule.alt]
+md.block.ruler.at(
+  "fence",
+  (state, startLine, endLine, silent) => {
+    const closed = !silent && fenceHasEndMarker(state, startLine, endLine)
+    const tokenCount = state.tokens.length
+    const matched = originalFenceBlock(state, startLine, endLine, silent)
+    if (matched && !silent) {
+      const token = state.tokens[tokenCount]
+      token.meta = { ...token.meta, unclosedFence: !closed }
+    }
+    return matched
+  },
+  { alt: fenceBlockAlt },
+)
+
+const originalFenceRule = md.renderer.rules.fence
+md.renderer.rules.fence = (tokens, idx, options, env, renderer) => {
+  const token = tokens[idx]
+  const lang =
+    md.utils
+      .unescapeAll(token.info || "")
+      .trim()
+      .split(/[ \t]+/, 1)[0] || ""
+  let fenceHtml
+  if (token.meta?.unclosedFence) {
+    fenceHtml = originalFenceRule(tokens, idx, { ...options, highlight: null }, env, renderer)
+  } else {
+    fenceHtml = originalFenceRule(tokens, idx, options, env, renderer)
+  }
+  return codeBlockHtml(lang, fenceHtml)
+}
 
 const katexPlugin = typeof markdownItKatex === "function" ? markdownItKatex : markdownItKatex?.default
 if (typeof katexPlugin === "function") {
@@ -57,10 +140,8 @@ applyExternalLinkRule(md)
 function onClick(e) {
   const btn = e.target.closest(".code-copy-btn")
   if (!btn) return
-  const raw = btn.getAttribute("data-copy") || ""
-  // Decode HTML entities
-  const decoded = new DOMParser().parseFromString(raw, "text/html").body.textContent
-  navigator.clipboard.writeText(decoded || "").then(() => {
+  const code = btn.closest(".code-block")?.querySelector("pre code")
+  navigator.clipboard.writeText(code?.textContent || "").then(() => {
     const orig = btn.textContent
     btn.textContent = "Copied!"
     btn.classList.add("copied")

--- a/src/kohakuterrarium-frontend/src/stores/chat.branch.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.branch.test.js
@@ -171,6 +171,41 @@ describe("chat store — duplicate backend-event compatibility", () => {
   })
 })
 
+describe("chat store — parent branch path compatibility", () => {
+  const parentPathEvents = (parentBranchPath) => {
+    const child = {
+      type: "user_input",
+      content: "child",
+      event_id: 3,
+      turn_index: 2,
+      branch_id: 1,
+    }
+    if (parentBranchPath !== undefined) child.parent_branch_path = parentBranchPath
+    return [
+      { type: "user_input", content: "one", event_id: 1, turn_index: 1, branch_id: 1 },
+      { type: "user_input", content: "two", event_id: 2, turn_index: 1, branch_id: 2 },
+      child,
+    ]
+  }
+
+  it("treats an explicit empty parent path as authoritative", () => {
+    const { messages } = _replayEvents([], parentPathEvents([]), { 1: 1 })
+    expect(
+      messages.filter((message) => message.role === "user").map((message) => message.content),
+    ).toEqual(["one", "child"])
+  })
+
+  it.each([undefined, null])(
+    "derives the legacy parent path when the field is %s",
+    (parentBranchPath) => {
+      const { messages } = _replayEvents([], parentPathEvents(parentBranchPath), { 1: 1 })
+      expect(
+        messages.filter((message) => message.role === "user").map((message) => message.content),
+      ).toEqual(["one"])
+    },
+  )
+})
+
 describe("chat store — branch-switch keeps consistent follow-ups", () => {
   it("default view shows turn 1 branch 2 + follow-up turn 2", () => {
     const { messages } = _replayEvents([], makeEvents())

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -381,9 +381,10 @@ function _indexParentPaths(events) {
     const ti = evt?.turn_index
     const bi = evt?.branch_id
     const eid = evt?.event_id
+    const hasExplicitPath = Array.isArray(evt?.parent_branch_path)
     const explicit = _coercePath(evt?.parent_branch_path)
     if (typeof eid === "number") {
-      if (explicit.length) {
+      if (hasExplicitPath) {
         paths.set(eid, explicit)
       } else if (typeof ti === "number") {
         const snap = []
@@ -402,9 +403,9 @@ function _indexParentPaths(events) {
   return paths
 }
 
-function _pathMatches(path, selected) {
+function _pathMatches(path, selected, beforeTurn = Infinity) {
   for (const [t, b] of path) {
-    if (selected.has(t) && selected.get(t) !== b) return false
+    if (t < beforeTurn && selected.has(t) && selected.get(t) !== b) return false
   }
   return true
 }
@@ -470,9 +471,7 @@ export function _collectBranchMetadata(events, branchView = null) {
     const eid = evt?.event_id
     if (typeof ti !== "number" || typeof bi !== "number") continue
     const path = typeof eid === "number" ? parentPaths.get(eid) || [] : []
-    const priorSelected = new Map()
-    for (const [t, b] of branchSelection) if (t < ti) priorSelected.set(t, b)
-    if (!_pathMatches(path, priorSelected)) continue
+    if (!_pathMatches(path, branchSelection, ti)) continue
     let bucket = byTurn.get(ti)
     if (!bucket) {
       bucket = { branches: [], latestBranch: 0, eventIdsByBranch: new Map() }
@@ -499,9 +498,7 @@ export function _collectBranchMetadata(events, branchView = null) {
     }
     if (branchSelection.get(ti) !== bi) continue
     const path = parentPaths.get(eid) || []
-    const priorSelected = new Map()
-    for (const [t, b] of branchSelection) if (t < ti) priorSelected.set(t, b)
-    if (!_pathMatches(path, priorSelected)) continue
+    if (!_pathMatches(path, branchSelection, ti)) continue
     liveIds.add(eid)
   }
   return { byTurn, liveIds, branchSelection }
@@ -538,7 +535,19 @@ function _dedupeAdjacentDuplicateEvents(events) {
   return out
 }
 
+export function _prepareReplayEvents(events, branchView = null) {
+  const dedupedEvents = _dedupeAdjacentDuplicateEvents(events)
+  return {
+    events: dedupedEvents,
+    branchMetadata: _collectBranchMetadata(dedupedEvents, branchView),
+  }
+}
+
 export function _replayEvents(messages, events, branchView = null, tab = "") {
+  return _replayPreparedEvents(messages, _prepareReplayEvents(events, branchView), tab)
+}
+
+function _replayPreparedEvents(messages, prepared, tab = "") {
   // A terminal event is authoritative: liveness comes from the backend,
   // which withholds a job's terminal (``normalize_resumable_events`` with
   // ``live_job_ids``) for as long as it sees the job running. A job with
@@ -547,10 +556,17 @@ export function _replayEvents(messages, events, branchView = null, tab = "") {
   // a job that is genuinely dead and renders "interrupted"/"error"/"done"
   // — dead work resumed from a saved session reads as interrupted, never
   // stuck "running" forever (UXI-04).
-  if (!events?.length) return { messages: _convertHistory(messages), pendingJobs: {} }
+  if (!prepared?.events?.length) {
+    return {
+      messages: _convertHistory(messages),
+      pendingJobs: {},
+      events: prepared?.events || [],
+      branchMetadata: prepared?.branchMetadata || null,
+    }
+  }
 
-  events = _dedupeAdjacentDuplicateEvents(events)
-  const { byTurn, liveIds, branchSelection } = _collectBranchMetadata(events, branchView)
+  const events = prepared.events
+  const { byTurn, liveIds, branchSelection } = prepared.branchMetadata
 
   // Pre-pass: compact_replace ranges hide every event whose event_id
   // falls inside the replaced range. Mirrors Python replay_conversation
@@ -1468,7 +1484,13 @@ export function _replayEvents(messages, events, branchView = null, tab = "") {
     }
   }
 
-  return { messages: result, pendingJobs, branchMeta: { byTurn, branchSelection } }
+  return {
+    messages: result,
+    pendingJobs,
+    events,
+    branchMetadata: prepared.branchMetadata,
+    branchMeta: { byTurn, branchSelection },
+  }
 }
 
 function _parseArgs(args) {
@@ -2705,13 +2727,14 @@ const _chatStoreOptions = {
     },
 
     /** Restore token usage from event log (for page refresh) */
-    _restoreTokenUsage(source, events) {
+    _restoreTokenUsage(source, events, alreadyDeduped = false) {
       // Canonical history is authoritative — rebuild this source's total
       // from scratch so a reconnect (which re-runs _loadHistory on the
       // same generation) does not add the persisted token_usage rows a
       // second time and double the count.
       this.tokenUsage[source] = { prompt: 0, completion: 0, total: 0, cached: 0, lastPrompt: 0 }
-      for (const evt of _dedupeAdjacentDuplicateEvents(events)) {
+      const normalizedEvents = alreadyDeduped ? events : _dedupeAdjacentDuplicateEvents(events)
+      for (const evt of normalizedEvents) {
         const isTokenEvt =
           (evt.type === "activity" && evt.activity_type === "token_usage") ||
           evt.type === "token_usage"
@@ -4473,10 +4496,11 @@ const _chatStoreOptions = {
         // wiping ``branchViewByTab`` here was the historical source of
         // "I switched to branch 1 of turn 2, did an unrelated action,
         // and was yanked back to the latest branch."
-        this.eventsByTab[tab] = _dedupeAdjacentDuplicateEvents(data.events)
         if (!this.branchViewByTab[tab]) this.branchViewByTab[tab] = {}
-        this._restoreTokenUsage(tab, this.eventsByTab[tab])
-        this._rebuildMessages(tab, fetchedAt)
+        const prepared = _prepareReplayEvents(data.events, this.branchViewByTab[tab])
+        this.eventsByTab[tab] = prepared.events
+        this._restoreTokenUsage(tab, prepared.events, true)
+        this._rebuildMessages(tab, fetchedAt, prepared)
         const scope = scopeOfStoreId(this.$id) || "default"
         this.attentionByTab[tab] = restoreAttentionFromHistory(
           this.eventsByTab[tab],
@@ -4502,15 +4526,18 @@ const _chatStoreOptions = {
      * Rebuild ``messagesByTab[tab]`` from the cached event log,
      * applying the current ``branchViewByTab[tab]`` override.
      */
-    _rebuildMessages(tab, fetchedAt = null) {
+    _rebuildMessages(tab, fetchedAt = null, prepared = null) {
       const events = this.eventsByTab[tab]
       if (!events) return
       const branchView = this.branchViewByTab[tab] || null
       // Canonical history is the liveness authority (see _loadHistory):
       // the backend withholds synthetic terminals for still-live jobs,
       // so a terminal in the cached log means the job is dead.
-      const { messages, pendingJobs } = _replayEvents([], events, branchView, tab)
-      const branchSelection = _commandResultBranchSelection(events, branchView)
+      const replay = prepared
+        ? _replayPreparedEvents([], prepared, tab)
+        : _replayEvents([], events, branchView, tab)
+      const { messages, pendingJobs } = replay
+      const branchSelection = replay.branchMetadata.branchSelection
       adoptLocalCommandResultSelections(
         this._pendingCommandResultContextsByTab[tab],
         this._localCommandResultsByTab[tab],

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from "pinia"
-import { computed, isReactive } from "vue"
+import { computed, isReactive, toRaw } from "vue"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { _parseSlashCommand, _replayEvents, useChatStore } from "./chat.js"
@@ -528,6 +528,31 @@ describe("chat store — slash commands", () => {
       "older history",
       "Goals",
     ])
+    getHistory.mockRestore()
+  })
+
+  it("passes one prepared history projection through the real Pinia resync path", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session_1"
+    chat._instanceGraphId = "graph_1"
+    chat.messagesByTab = { kohaku: [] }
+    const events = [
+      { type: "user_input", content: "hello", event_id: 1, turn_index: 1, branch_id: 1 },
+      { type: "user_input", content: "hello", event_id: 2, turn_index: 1, branch_id: 1 },
+    ]
+    const importActual = await vi.importActual("@/utils/api")
+    const getHistory = vi
+      .spyOn(importActual.terrariumAPI, "getHistory")
+      .mockResolvedValue({ events, messages: [], is_processing: false })
+    const rebuild = vi.spyOn(chat, "_rebuildMessages")
+
+    await expect(chat._resyncHistory("kohaku")).resolves.toBe(true)
+
+    const prepared = rebuild.mock.calls[0][2]
+    expect(prepared.events).toBe(toRaw(chat.eventsByTab.kohaku))
+    expect(prepared.events).toHaveLength(1)
+    expect(prepared.branchMetadata.branchSelection).toEqual(new Map([[1, 1]]))
+    rebuild.mockRestore()
     getHistory.mockRestore()
   })
 
@@ -2337,7 +2362,7 @@ describe("chat store — multimodal edit + branch resync", () => {
 
     // Second poll: branch=2 events landed. Rebuild now safe; pending cleared.
     await expect(chat._resyncHistory("main")).resolves.toBe(true)
-    expect(rebuildSpy).toHaveBeenCalledWith("main", expect.any(Number))
+    expect(rebuildSpy).toHaveBeenCalledWith("main", expect.any(Number), expect.any(Object))
     expect(chat._branchResyncPendingByTab.main).toBeUndefined()
 
     rebuildSpy.mockRestore()
@@ -2397,7 +2422,7 @@ describe("chat store — multimodal edit + branch resync", () => {
     await chat._resyncHistory("main")
 
     expect(chat.branchViewByTab.main).toEqual({ 2: 1 })
-    expect(rebuildSpy).toHaveBeenCalledWith("main", expect.any(Number))
+    expect(rebuildSpy).toHaveBeenCalledWith("main", expect.any(Number), expect.any(Object))
 
     rebuildSpy.mockRestore()
     getHistory.mockRestore()

--- a/src/kohakuterrarium-frontend/src/utils/markdownIncremental.js
+++ b/src/kohakuterrarium-frontend/src/utils/markdownIncremental.js
@@ -23,15 +23,17 @@
  *     CommonMark and are therefore NOT merged.
  *
  * Reference-style link definitions (``[ref]: url``) can be referenced from
- * any later block, so content containing them is not safe to split:
- * ``splitMarkdownBlocks`` returns ``null`` and callers fall back to a
- * full-document render.
+ * any later block. Fence indentation is also container-relative in lists and
+ * blockquotes. Content containing either unsafe case returns ``null`` so
+ * callers fall back to a full-document render.
  */
 
 const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/
 const FENCE_CLOSE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 const MATH_DELIM_RE = /^\s*\$\$\s*$/
 const REF_DEF_RE = /^ {0,3}\[[^\]]*\]:/
+const LIST_START_RE = /^ {0,3}(?:[-*+]|[0-9]{1,9}[.)])(?:[ \t]+|$)/
+const QUOTE_START_RE = /^ {0,3}>/
 
 function firstLine(block) {
   return block.split("\n", 1)[0] || ""
@@ -58,12 +60,26 @@ function mergeableLists(a, b) {
 
 /**
  * Split preprocessed markdown into independently renderable blocks.
- * Returns ``[]`` for empty input and ``null`` when the content is not
- * safe to split (reference-style link definitions).
+ * Returns ``[]`` for empty input and ``null`` when the content cannot be
+ * proven safe to split.
  */
 export function splitMarkdownBlocks(text) {
   if (!text) return []
   const lines = text.split("\n")
+
+  // Container-relative fence indentation cannot be inferred safely with the
+  // top-level regexes below. Be deliberately conservative: markdown-it gets
+  // the whole document whenever a fence may belong to a list/blockquote, or
+  // when its raw indentation already rules out a top-level fence.
+  let sawListOrQuote = false
+  let sawAnyFenceMarker = false
+  for (const line of lines) {
+    if (LIST_START_RE.test(line) || QUOTE_START_RE.test(line)) sawListOrQuote = true
+    if (/`{3,}|~{3,}/.test(line)) sawAnyFenceMarker = true
+    if (/^(?: {4,}| {0,3}\t)(?:`{3,}|~{3,})/.test(line)) return null
+  }
+  if (sawListOrQuote && sawAnyFenceMarker) return null
+
   const raw = []
   let cur = []
   let fenceChar = null

--- a/src/kohakuterrarium-frontend/src/utils/markdownIncremental.test.js
+++ b/src/kohakuterrarium-frontend/src/utils/markdownIncremental.test.js
@@ -73,6 +73,31 @@ describe("splitMarkdownBlocks", () => {
     const text = "```\n[not]: a ref\n```\n\npara"
     expect(splitMarkdownBlocks(text)).toEqual(["```\n[not]: a ref\n```", "para"])
   })
+
+  it.each([
+    ["a list-relative close", "- item\n\n  ```javascript\n  const a = 1\n    ```\n\noutside"],
+    ["a blockquote fence", "> ```javascript\n> const a = 1\n> ```\n\noutside"],
+    [
+      "a nested-list fence",
+      "- outer\n  - inner\n\n    ```javascript\n    const a = 1\n      ```\n\noutside",
+    ],
+  ])("falls back for %s", (_name, text) => {
+    expect(splitMarkdownBlocks(text)).toBeNull()
+    assertRenderEquivalence(text)
+  })
+
+  it.each(["\t", " \t", "  \t"])(
+    "falls back when tab-expanded indentation precedes a fence marker (%j)",
+    (indent) => {
+      const text = `${indent}\`\`\`javascript\n${indent}const a = 1\n\n${indent}const b = 2\n${indent}\`\`\``
+      expect(splitMarkdownBlocks(text)).toBeNull()
+      assertRenderEquivalence(text)
+    },
+  )
+
+  it("falls back for a deeply indented fence marker", () => {
+    expect(splitMarkdownBlocks("    ```javascript\n    const a = 1\n    ```")).toBeNull()
+  })
 })
 
 describe("IncrementalMarkdownRenderer equivalence", () => {


### PR DESCRIPTION
This fixes the two browser-main-thread performance failures described in #267: superlinear canonical history rebuilds after a turn completes, and repeated syntax highlighting / DOM replacement while a streamed fenced code block is still open. It also coalesces high-frequency auto-scroll work without changing the public API.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Long conversations could freeze the entire web dashboard or desktop app when a turn completed. A separate periodic stall occurred while streaming a large code fence before its closing marker arrived.

Chromium/CDP profiling showed that the completion freeze was dominated by repeated, superlinear branch metadata and history replay work before Vue patched the DOM. The streaming freeze was dominated by Highlight.js processing the full accumulated fence, Vue replacing `innerHTML`, browser HTML parsing/layout, and per-update auto-scroll work.

This is a bug fix with no public API or schema change. Known branching behavior problems are outside this PR and are being handled separately.

## Changes

- Prepare canonical events and branch metadata once per history resync.
- Remove per-event construction of prior-turn selection maps and reuse normalized events during token restoration and message replay.
- Preserve legacy parent-path inference only where canonical path metadata is unavailable.
- Detect genuinely unclosed Markdown fence tokens using markdown-it's block parsing state and render them without syntax highlighting while streaming.
- Restore normal Highlight.js output as soon as a real closing fence arrives.
- Use conservative full-document Markdown rendering where list, blockquote, tab-expanded indentation, or container-relative fence semantics cannot be proven safe by the incremental splitter.
- Copy code from rendered DOM text rather than duplicating the complete source in a `data-copy` attribute.
- Coalesce high-frequency bottom scrolling into one animation-frame request.
- Isolate pending scroll requests by instance/tab identity and cancel stale requests when the active scope changes or the component unmounts.
- Add regression tests for normalization reuse, explicit/legacy parent-path handling, open/closed fence behavior, Markdown container equivalence, code copying, scroll coalescing, and cross-tab scroll races.

### Performance comparison

The same synthetic event and streaming shapes were run before and after the changes with the real Pinia store, Vue components, Playwright, local Chrome, CDP tracing, and a 1440×1000 viewport.

#### Turn completion: 1,000 turns / 4,000 canonical events

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| `_resyncHistory()` through two animation frames | 657.5 ms | 38.1 ms | 94.2% lower |
| Maximum renderer-main-thread `RunTask` | 625.8 ms | 35.3 ms | 94.4% lower |

The profiled post-turn rebuild no longer crosses the 50 ms Long Task threshold.

Synthetic scaling of the complete Pinia resync:

| Turns | Events | Before | After |
|---:|---:|---:|---:|
| 500 | 2,000 | 298.2 ms | 32.7 ms |
| 1,000 | 4,000 | 959.1 ms | 56.9 ms |
| 2,000 | 8,000 | 3,338.1 ms | 91.7 ms |

#### Streaming an unclosed JavaScript fence: 80 updates / 166,414 final characters

| Metric | Before | After |
|---|---:|---:|
| Average interval with an 85 ms nominal cadence | 112.1 ms | 91.4 ms |
| Median | 111.2 ms | 92.7 ms |
| P95 | 148.5 ms | 98.9 ms |
| Maximum | 164.1 ms | 101.2 ms |
| Updates over 100 ms | 56 / 80 | 3 / 80 |
| Maximum renderer-main-thread `RunTask` | ~94.5 ms | 0.9 ms |

Highlight.js is not called while the fence is genuinely unclosed. Closed fences continue to receive normal syntax highlighting.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -v --tb=short

cd src/kohakuterrarium-frontend
npm test -- --run \
  src/stores/chat.test.js \
  src/stores/chat.branch.test.js \
  src/stores/chat.branchOperations.test.js \
  src/stores/attention.test.js \
  src/utils/markdownIncremental.test.js \
  src/components/common/MarkdownRenderer.test.js \
  src/components/chat/ChatPanel.test.js
npm run lint -- --quiet
npm run format:check
npm run build
```

Results:

- `ruff`: passed
- `black --check`: passed; 1,587 files unchanged
- file-size and dependency-graph guards: 1,752 tests passed
- affected frontend suite: 275 tests passed
- frontend lint and format checks: passed
- production frontend build: passed
- `src/kohakuterrarium/web_dist/index.html`: produced successfully
- Chrome/CDP before/after profiling: results shown above

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #267

## Notes for Reviewers

Suggested review order:

1. `03b8b298` — history normalization and replay reuse
2. `d953f751` — open-fence highlighting and Markdown equivalence safeguards
3. `2b87815e` — animation-frame scroll scheduler and scope invalidation

Please focus on:

- whether prepared history projections remain single-use and branch-view-specific;
- equivalence between incremental and full-document Markdown rendering around fenced blocks;
- stale animation-frame work during instance/tab switches.

## Screenshots / Logs (if applicable)

No visual layout change is intended. Browser profiling results are included in the performance tables above. The issue contains the full symptom and root-cause analysis.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The full Python unit and integration suites were not run locally because this is a frontend-only performance patch and the requested local pre-flight was limited to checks that can run quickly. The CI-specific file-size and dependency-graph guards did run successfully.
- Fork CI did not start on the pushed topic branch because `.github/workflows/ci.yml` only triggers `push` for `main` and `pull_request` targeting `main`. The upstream PR will trigger the complete CI matrix.
- Wheel build/install smoke tests were not run. The local environment does not have the optional `build` module installed, and this PR does not change Python code, package metadata, or CLI entry points.
- Full OS/Python matrices, Android, Briefcase, nightly, and release workflows were not run locally.
- Black emitted a local Python 3.14 versus Python 3.15 AST-safety advisory, but completed successfully and reported every file unchanged.
