### PR TITLE
fix(subagent): bound tool output before model injection

### DIFF
--- a/src/kohakuterrarium/modules/subagent/base.py
+++ b/src/kohakuterrarium/modules/subagent/base.py
@@ -11,6 +11,10 @@ from kohakuterrarium.core.budget import (
 from kohakuterrarium.core.conversation import Conversation
 from kohakuterrarium.core.executor import Executor
 from kohakuterrarium.core.registry import Registry
+from kohakuterrarium.core.tool_output import (
+    discard_raw_output_file,
+    normalize_tool_output,
+)
 from kohakuterrarium.llm.base import LLMProvider
 from kohakuterrarium.llm.tools import build_tool_schemas
 from kohakuterrarium.modules.plugin.base import (
@@ -26,6 +30,7 @@ from kohakuterrarium.modules.subagent.result import (  # noqa: F401
     SubAgentResult,
     build_subagent_framework_hints,
 )
+from kohakuterrarium.modules.tool.base import BaseTool
 from kohakuterrarium.parsing import ParserConfig, StreamParser, TextEvent, ToolCallEvent
 from kohakuterrarium.parsing.format import BRACKET_FORMAT, XML_FORMAT, ToolCallFormat
 from kohakuterrarium.prompt.aggregator import aggregate_system_prompt
@@ -663,10 +668,32 @@ class SubAgent:
                     continue
                 # Preserve compatibility with tools predating the ToolResult contract.
                 if isinstance(result, str):
-                    results.append(f"[{tool_call.name}]\n{result}")
+                    max_output = (
+                        tool.config.max_output if isinstance(tool, BaseTool) else 0
+                    )
+                    normalized = normalize_tool_output(
+                        result,
+                        max_output=max_output,
+                        tool_name=tool_call.name,
+                    )
+                    results.append(f"[{tool_call.name}]\n{normalized.text}")
                     continue
+                max_output = tool.config.max_output if isinstance(tool, BaseTool) else 0
+                result_metadata = (
+                    result.metadata if isinstance(result.metadata, dict) else {}
+                )
+                normalized = normalize_tool_output(
+                    result.output,
+                    max_output=max_output,
+                    tool_name=tool_call.name,
+                    saved_to=result_metadata.get("raw_output_path"),
+                )
+                if tool_call.name == "bash" and (
+                    not result.success or not normalized.metadata.get("truncated")
+                ):
+                    discard_raw_output_file(result_metadata)
                 if result.success:
-                    text_output = result.get_text_output()
+                    text_output = normalized.text
                     output = text_output if text_output else "(no output)"
                     results.append(f"[{tool_call.name}]\n{output}")
                     logger.debug(

--- a/tests/unit/modules/subagent/test_base.py
+++ b/tests/unit/modules/subagent/test_base.py
@@ -13,7 +13,7 @@ from kohakuterrarium.modules.plugin.base import BasePlugin, ToolVisibility
 from kohakuterrarium.modules.plugin.manager import PluginManager
 from kohakuterrarium.modules.subagent.base import SubAgent
 from kohakuterrarium.modules.subagent.config import SubAgentConfig
-from kohakuterrarium.modules.tool.base import BaseTool, ToolResult
+from kohakuterrarium.modules.tool.base import BaseTool, ToolConfig, ToolResult
 from kohakuterrarium.testing.llm import ScriptedLLM
 
 
@@ -303,6 +303,218 @@ class TestNativeMode:
         # Token usage from last_usage is accumulated across turns.
         assert result.total_tokens == 30  # 15 per turn × 2 turns
         assert result.cached_tokens == 6
+
+    async def test_native_tool_output_honors_configured_byte_cap(self):
+        class _LargeOutputTool(BaseTool):
+            def __init__(self):
+                super().__init__(ToolConfig(max_output=32))
+
+            @property
+            def tool_name(self):
+                return "large"
+
+            @property
+            def description(self):
+                return "return a large result"
+
+            async def _execute(self, args, **kwargs):
+                return ToolResult(output="x" * 100)
+
+        class _LargeOutputLLM(_NativeLLM):
+            async def chat(self, messages, *, stream=True, tools=None, **kwargs):
+                self._turn += 1
+                if self._turn == 1:
+                    self.last_tool_calls = [
+                        _NativeToolCall("call-large", "large", "{}")
+                    ]
+                    yield ""
+                else:
+                    self.last_tool_calls = []
+                    yield "done"
+
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["large"], max_turns=5),
+            _registry(_LargeOutputTool()),
+            _LargeOutputLLM(),
+            tool_format="native",
+        )
+
+        result = await sa.run("get the large output")
+
+        assert result.success is True
+        tool_message = next(
+            message
+            for message in sa.conversation.to_messages()
+            if message.get("role") == "tool"
+        )
+        assert tool_message["content"].startswith("[large]\n" + "x" * 32)
+        assert "tool output truncated to 32 bytes" in tool_message["content"]
+        assert "68 bytes omitted" in tool_message["content"]
+        assert "x" * 100 not in tool_message["content"]
+
+    async def test_text_tool_output_honors_configured_byte_cap(self):
+        class _LargeOutputTool(BaseTool):
+            def __init__(self):
+                super().__init__(ToolConfig(max_output=32))
+
+            @property
+            def tool_name(self):
+                return "large"
+
+            @property
+            def description(self):
+                return "return a large result"
+
+            async def _execute(self, args, **kwargs):
+                return ToolResult(output="x" * 100)
+
+        llm = ScriptedLLM([_bracket_call("large"), "done"])
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["large"], max_turns=5),
+            _registry(_LargeOutputTool()),
+            llm,
+            tool_format="bracket",
+        )
+
+        result = await sa.run("get the large output")
+
+        assert result.success is True
+        user_message = sa.conversation.to_messages()[-2]
+        assert user_message["role"] == "user"
+        assert user_message["content"].startswith("[large]\n" + "x" * 32)
+        assert "tool output truncated to 32 bytes" in user_message["content"]
+        assert "68 bytes omitted" in user_message["content"]
+        assert "x" * 100 not in user_message["content"]
+
+    async def test_bash_raw_output_cleanup_matches_truncation(self, tmp_path):
+        class _BashLikeTool(BaseTool):
+            def __init__(self, output, raw_path, error=None):
+                super().__init__(ToolConfig(max_output=32))
+                self._output = output
+                self._raw_path = raw_path
+                self._error = error
+
+            @property
+            def tool_name(self):
+                return "bash"
+
+            @property
+            def description(self):
+                return "return shell output"
+
+            async def _execute(self, args, **kwargs):
+                return ToolResult(
+                    output=self._output,
+                    error=self._error,
+                    metadata={"raw_output_path": str(self._raw_path)},
+                )
+
+        class _BashOutputLLM(_NativeLLM):
+            async def chat(self, messages, *, stream=True, tools=None, **kwargs):
+                self._turn += 1
+                if self._turn == 1:
+                    self.last_tool_calls = [
+                        _NativeToolCall("call-bash", "bash", '{"command": "x"}')
+                    ]
+                    yield ""
+                else:
+                    self.last_tool_calls = []
+                    yield "done"
+
+        raw_path = tmp_path / "full-output.log"
+        raw_path.write_text("small", encoding="utf-8")
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["bash"], max_turns=5),
+            _registry(_BashLikeTool("small", raw_path)),
+            _BashOutputLLM(),
+            tool_format="native",
+        )
+        result = await sa.run("run a small command")
+        assert result.success is True
+        assert raw_path.exists() is False
+
+        raw_path.write_text("x" * 100, encoding="utf-8")
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["bash"], max_turns=5),
+            _registry(_BashLikeTool("x" * 100, raw_path)),
+            _BashOutputLLM(),
+            tool_format="native",
+        )
+        result = await sa.run("run a large command")
+        assert result.success is True
+        assert raw_path.exists() is True
+        tool_message = next(
+            message
+            for message in sa.conversation.to_messages()
+            if message.get("role") == "tool"
+        )
+        assert f"Full output saved to {raw_path}" in tool_message["content"]
+
+        raw_path.write_text("failed", encoding="utf-8")
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["bash"], max_turns=5),
+            _registry(_BashLikeTool("failed", raw_path, error="boom")),
+            _BashOutputLLM(),
+            tool_format="native",
+        )
+        result = await sa.run("run a failing command")
+        assert result.success is True
+        assert raw_path.exists() is False
+        tool_message = next(
+            message
+            for message in sa.conversation.to_messages()
+            if message.get("role") == "tool"
+        )
+        assert tool_message["content"] == "[bash] Error: boom"
+
+        raw_path.write_text("x" * 100, encoding="utf-8")
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["bash"], max_turns=5),
+            _registry(_BashLikeTool("x" * 100, raw_path, error="boom")),
+            _BashOutputLLM(),
+            tool_format="native",
+        )
+        result = await sa.run("run a large failing command")
+        assert result.success is True
+        assert raw_path.exists() is False
+        tool_message = next(
+            message
+            for message in sa.conversation.to_messages()
+            if message.get("role") == "tool"
+        )
+        assert tool_message["content"] == "[bash] Error: boom"
+
+    async def test_legacy_string_tool_output_honors_configured_byte_cap(self):
+        class _LegacyStringTool(BaseTool):
+            def __init__(self):
+                super().__init__(ToolConfig(max_output=32))
+
+            @property
+            def tool_name(self):
+                return "legacy"
+
+            @property
+            def description(self):
+                return "return a legacy string result"
+
+            async def execute(self, args, context=None):
+                return "x" * 100
+
+        llm = ScriptedLLM([_bracket_call("legacy"), "done"])
+        sa = SubAgent(
+            SubAgentConfig(name="x", tools=["legacy"], max_turns=5),
+            _registry(_LegacyStringTool()),
+            llm,
+            tool_format="bracket",
+        )
+
+        result = await sa.run("get the legacy output")
+
+        assert result.success is True
+        user_message = sa.conversation.to_messages()[-2]
+        assert user_message["content"].startswith("[legacy]\n" + "x" * 32)
+        assert "tool output truncated to 32 bytes" in user_message["content"]
+        assert "x" * 100 not in user_message["content"]
 
     async def test_native_turn_applies_plugin_tool_visibility(self):
         class _CaptureLLM(_NativeLLM):


### PR DESCRIPTION
Sub-agents now apply the same tool-output normalization boundary as main-agent execution before injecting results into child model context. This prevents broad Bash/read/search results from overflowing the model context window or Responses API per-field limits.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

`SubAgent._execute_tools()` called tools directly and appended their complete output to the child conversation, bypassing `BaseTool.config.max_output` and `normalize_tool_output()`. Real sessions captured 7.2 MiB and 13.1 MiB Bash results; the latter matched the provider-rejected `function_call_output.output` length exactly after the `[bash]\n` wrapper.

This is a focused bug fix with no public API or architectural change.

## Changes

- Normalize `ToolResult` output using each `BaseTool`'s configured byte cap before child conversation injection.
- Apply the same cap to native tool messages, bracket/text feedback, and legacy tools that return plain strings.
- Preserve successful truncated Bash output files for recovery, while deleting untruncated or failed-output temporary files.
- Add regression coverage for output caps and Bash raw-output lifecycle.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
python -m pytest tests/unit/modules/subagent/test_base.py tests/unit/core/test_tool_output.py tests/unit/core/test_executor.py -q --tb=short
python -m pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q --tb=short
python -m pytest tests/integration/test_bootstrap.py tests/integration/test_api.py -q --tb=short
```

Results:

- Ruff passed.
- Black passed; 1,587 files unchanged.
- Affected unit tests: 137 passed.
- File-size and dependency-graph guards: 1,752 passed.
- Related integration tests: 15 passed.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [ ] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #269

## Notes for Reviewers

The key boundary is `SubAgent._execute_tools()`. The main `Executor` already normalizes output; this PR reuses the same helper for the child-only direct execution path without routing child tools through the parent executor.

For the captured 13 MiB incident, the raw Bash file had 13,069,430 characters and the provider reported 13,069,437 characters, exactly accounting for the `[bash]\n` prefix. This supports unbounded direct injection rather than replay or serialization amplification.

## Screenshots / Logs (if applicable)

```text
Invalid 'input[114].output': string too long. Expected a string with maximum length 10485760, but got a string with length 13069437 instead.

Your input exceeds the context window of this model. Please adjust your input and try again.
```

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The complete local unit suite was attempted. With proxy variables enabled, a WebSocket refusal test failed because the local `WS_PROXY` / `WSS_PROXY` configuration requires `python-socks`; the test passes when those variables are cleared.
- With proxies cleared, the suite reached 6,137 passed / 5 skipped before the first failure in `tests/unit/packages/test_git_backend_dulwich_integration.py`. All six tests in that file assume a temporary `master` branch, while this machine has `init.defaultBranch=main`. This is unrelated to the sub-agent change.
- A subsequent full run reached 88% before the local 600-second execution limit.
- Full integration, frontend, wheel, and cross-platform matrix checks were left to GitHub Actions because this change only touches Python sub-agent execution and tests.
- Fork Actions are enabled, but this workflow triggers only for pushes or pull requests targeting `main`; therefore there was no pre-PR branch-push run to wait for.
