### PR TITLE
fix(llm): detect installed Grok CLI version

### DIFF
--- a/src/kohakuterrarium/llm/grok_auth.py
+++ b/src/kohakuterrarium/llm/grok_auth.py
@@ -10,6 +10,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -28,6 +29,7 @@ _EXPIRY_SKEW_SECONDS = 30
 _GROK_CLI_REFRESH_WINDOW_SECONDS = 30 * 60
 _GROK_CLI_REFRESH_TIMEOUT_SECONDS = 20.0
 _refresh_tasks: dict[asyncio.AbstractEventLoop, asyncio.Task["GrokToken | None"]] = {}
+_grok_version_cache: dict[tuple[str, int], str] = {}
 _GROK_VERSION_PATTERN = re.compile(
     r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)*(?: \([0-9A-Fa-f]+\))?$"
 )
@@ -188,9 +190,11 @@ def _grok_cli_executable() -> str | None:
     executable = shutil.which("grok")
     if executable:
         return executable
-    bundled = _grok_home() / "bin" / "grok"
-    if bundled.is_file() and os.access(bundled, os.X_OK):
-        return str(bundled)
+    bin_dir = _grok_home() / "bin"
+    for name in ("grok", "grok.exe"):
+        bundled = bin_dir / name
+        if bundled.is_file() and os.access(bundled, os.X_OK):
+            return str(bundled)
     return None
 
 
@@ -208,6 +212,10 @@ def _grok_cli_headers() -> dict[str, str]:
 
 
 def _read_grok_cli_version() -> str:
+    executable_version = _read_grok_cli_executable_version()
+    if executable_version:
+        return executable_version
+
     path = _grok_home() / ".metadata_version"
     try:
         version = path.read_text(encoding="utf-8").strip()
@@ -224,6 +232,49 @@ def _read_grok_cli_version() -> str:
         logger.warning("Ignoring invalid Grok CLI version metadata", path=str(path))
         return ""
     return version
+
+
+def _read_grok_cli_executable_version() -> str:
+    """Return the installed CLI version without trusting mutable auth data."""
+    executable = _grok_cli_executable()
+    if executable is None:
+        return ""
+    try:
+        stamp = Path(executable).stat().st_mtime_ns
+    except OSError:
+        return ""
+    cache_key = (executable, stamp)
+    cached = _grok_version_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5.0,
+            check=False,
+            creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        result = None
+    match = (
+        re.search(
+            r"(?:^|\s)grok\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)*)",
+            result.stdout,
+        )
+        if result is not None and result.returncode == 0
+        else None
+    )
+    version = match.group(1) if match else ""
+    _grok_version_cache.clear()
+    _grok_version_cache[cache_key] = version
+    if version and _GROK_VERSION_PATTERN.fullmatch(version):
+        return version
+    return ""
 
 
 def _load_opencode_token() -> GrokToken | None:

--- a/tests/unit/llm/test_grok_auth.py
+++ b/tests/unit/llm/test_grok_auth.py
@@ -1,12 +1,14 @@
 """Behavior tests for read-only Grok subscription credential discovery."""
 
+import asyncio
 import json
 import time
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
-import asyncio
 import pytest
 
+from kohakuterrarium.llm import grok_auth
 from kohakuterrarium.llm.grok_auth import (
     GROK_CLI_BASE_URL,
     GROK_CLI_SOURCE,
@@ -98,11 +100,88 @@ class TestGrokTokens:
         )
         monkeypatch.setenv("GROK_HOME", str(grok_home))
         monkeypatch.setenv("OPENCODE_AUTH_FILE", str(tmp_path / "missing"))
+        monkeypatch.setattr(
+            "kohakuterrarium.llm.grok_auth._grok_cli_executable", lambda: None
+        )
 
         candidates = GrokTokens.load_candidates()
 
         assert len(candidates) == 1
         assert "x-grok-client-version" not in candidates[0].extra_headers
+
+    def test_cli_binary_version_is_used_when_metadata_is_missing(
+        self, tmp_path, monkeypatch
+    ):
+        grok_home = tmp_path / "grok"
+        grok_home.mkdir()
+        (grok_home / "auth.json").write_text(
+            json.dumps({"key": "usable"}), encoding="utf-8"
+        )
+        executable = grok_home / "bin" / "grok.exe"
+        executable.parent.mkdir()
+        executable.write_bytes(b"test executable placeholder")
+        monkeypatch.setenv("GROK_HOME", str(grok_home))
+        monkeypatch.setenv("OPENCODE_AUTH_FILE", str(tmp_path / "missing"))
+        monkeypatch.setattr(
+            "kohakuterrarium.llm.grok_auth._grok_cli_executable",
+            lambda: str(executable),
+        )
+        monkeypatch.setattr(
+            "kohakuterrarium.llm.grok_auth.subprocess.run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0,
+                stdout="grok 1.0.13 (5e9a58528b76)\n",
+                stderr="",
+            ),
+        )
+
+        candidates = GrokTokens.load_candidates()
+
+        assert candidates[0].extra_headers["x-grok-client-version"] == "1.0.13"
+
+    def test_bundled_windows_cli_is_discovered(self, tmp_path, monkeypatch):
+        grok_home = tmp_path / "grok"
+        executable = grok_home / "bin" / "grok.exe"
+        executable.parent.mkdir(parents=True)
+        executable.write_bytes(b"test executable placeholder")
+        monkeypatch.setenv("GROK_HOME", str(grok_home))
+        monkeypatch.setattr(grok_auth.shutil, "which", lambda name: None)
+        monkeypatch.setattr(grok_auth.os, "access", lambda path, mode: True)
+
+        assert grok_auth._grok_cli_executable() == str(executable)
+
+    def test_failed_binary_version_probe_is_cached(self, tmp_path, monkeypatch):
+        grok_home = tmp_path / "grok"
+        grok_home.mkdir()
+        (grok_home / "auth.json").write_text(
+            json.dumps({"key": "usable"}), encoding="utf-8"
+        )
+        (grok_home / ".metadata_version").write_text("1.0.5\n", encoding="utf-8")
+        executable = grok_home / "bin" / "grok.exe"
+        executable.parent.mkdir()
+        executable.write_bytes(b"test executable placeholder")
+        monkeypatch.setenv("GROK_HOME", str(grok_home))
+        monkeypatch.setenv("OPENCODE_AUTH_FILE", str(tmp_path / "missing"))
+        monkeypatch.setattr(
+            "kohakuterrarium.llm.grok_auth._grok_cli_executable",
+            lambda: str(executable),
+        )
+        calls = []
+
+        def failed_version(*args, **kwargs):
+            calls.append(args)
+            return SimpleNamespace(returncode=1, stdout="grok 9.9.9\n", stderr="")
+
+        monkeypatch.setattr(
+            "kohakuterrarium.llm.grok_auth.subprocess.run", failed_version
+        )
+
+        first = GrokTokens.load_candidates()
+        second = GrokTokens.load_candidates()
+
+        assert first[0].extra_headers["x-grok-client-version"] == "1.0.5"
+        assert second[0].extra_headers["x-grok-client-version"] == "1.0.5"
+        assert len(calls) == 1
 
     def test_expired_and_malformed_sources_are_skipped(self, tmp_path, monkeypatch):
         grok_home = tmp_path / "grok"


### PR DESCRIPTION
## Summary

Detect the installed Grok CLI version from the executable before falling back to `.metadata_version`. This prevents subscription requests from omitting `x-grok-client-version` on recent Windows CLI installations.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Current Grok CLI installations can have valid cached subscription credentials without a `.metadata_version` file. KT then sends no client-version header and the Grok service rejects the request with HTTP 426, reporting version `(none)`.

## Changes

- Discover both PATH-installed and bundled `grok` / `grok.exe` executables.
- Parse and cache the successful `grok --version` result by executable path and mtime.
- Ignore failed probes and fall back to validated metadata.
- Add regression coverage for executable discovery, version precedence, failed probes, and cache behavior.

## Validation

```bash
ruff check src/kohakuterrarium/llm/grok_auth.py tests/unit/llm/test_grok_auth.py
black --check src/kohakuterrarium/llm/grok_auth.py tests/unit/llm/test_grok_auth.py
pytest tests/unit/llm/test_grok_auth.py -q
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
pytest tests/integration/ -q
```

Results:

- Grok regression: 13 passed.
- Full lint/format: passed.
- File-size/dependency guards: 1756 passed.
- Integration: 173 passed.
- Full unit run: 12414 passed, 14 skipped, with four environment/baseline failures documented below.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #274

## Notes for Reviewers

The CLI probe is synchronous but capped at five seconds and cached by executable path plus mtime. Credential refresh already invokes the CLI through the same auth module.

## Screenshots / Logs (if applicable)

Observed before this fix:

```text
APIStatusError: Error code: 426 - {'error': 'Your Grok CLI version (none) is outdated. Please update to version 0.1.202 or later...'}
```

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The fork has Actions enabled, but `.github/workflows/ci.yml` only listens to pushes on `main` and pull requests. A feature-branch push therefore produced no fork workflow run. This Draft PR is expected to trigger the upstream PR matrix and will not be marked ready until CI is green.
- The full unit run had four unrelated local-environment failures: one path-boundary test because the first run placed `--basetemp` inside the repository (it passed when rerun in the system temp directory), two pre-existing Drive settings log-capture assertions that still fail in isolation on this Windows logging setup, and the real-config pollution guard observing the already-running desktop app update `~/.kohakuterrarium/app.log`. No affected test imports or exercises this Grok change.
- No frontend files changed, so frontend install/build was not applicable.
- E2E was not run because this change does not touch multi-node, Studio, or serving behavior.