### PR TITLE
fix(logging): stop KTLogger mutating caller extra; type structured fields

### DIFF
--- a/src/kohakuterrarium/utils/README.md
+++ b/src/kohakuterrarium/utils/README.md
@@ -11,6 +11,7 @@ for timeouts, retries, concurrency limiting, and thread offloading.
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `__init__.py`    | Re-exports logging and async utility functions                                                                                    |
 | `logging.py`     | `get_logger`, `set_level`, `disable_colors`: colored structured logging with ANSI codes                                           |
+| `kt_logger.py`   | `KTLogger`: `Logger` subclass whose level methods take structured fields as keyword arguments                                     |
 | `async_utils.py` | `run_with_timeout`, `gather_with_concurrency`, `retry_async`, `collect_async_iterator`, `first_result`, `AsyncQueue`, `to_thread` |
 
 ## Dependencies

--- a/src/kohakuterrarium/utils/kt_logger.py
+++ b/src/kohakuterrarium/utils/kt_logger.py
@@ -23,7 +23,7 @@ class KTLogger(logging.Logger):
         self,
         level: int,
         msg: object,
-        args: tuple[Any, ...],
+        args: tuple[object, ...] | Mapping[str, object],
         exc_info: Any = None,
         extra: Mapping[str, Any] | None = None,
         stack_info: bool = False,

--- a/src/kohakuterrarium/utils/kt_logger.py
+++ b/src/kohakuterrarium/utils/kt_logger.py
@@ -1,0 +1,197 @@
+"""KTLogger: a ``logging.Logger`` whose level methods take structured fields.
+
+Split out of :mod:`kohakuterrarium.utils.logging` so the explicit level-method
+overrides stay under the file-size cap. The overrides exist so type checkers
+accept the project's ``logger.info("msg", field=value)`` convention; the merge
+itself happens once, in :meth:`KTLogger._log`.
+
+Each override adds one frame between the caller and ``Logger._log``.
+``findCaller`` only skips frames belonging to the stdlib logging module, so both
+the level methods and ``_log`` compensate with ``stacklevel + 1`` to keep
+``filename`` / ``lineno`` / ``funcName`` pointing at the real call site.
+"""
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+
+class KTLogger(logging.Logger):
+    """Extended logger accepting extra record fields as keyword arguments."""
+
+    def _log(
+        self,
+        level: int,
+        msg: object,
+        args: tuple[Any, ...],
+        exc_info: Any = None,
+        extra: Mapping[str, Any] | None = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        **kwargs: Any,
+    ) -> None:
+        # Build a fresh mapping: callers may reuse the dict they passed as extra.
+        merged: dict[str, Any] | None = None
+        if extra is not None or kwargs:
+            merged = dict(extra) if extra else {}
+            merged.update(kwargs)
+        super()._log(level, msg, args, exc_info, merged, stack_info, stacklevel + 1)
+
+    def debug(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: Any = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if self.isEnabledFor(logging.DEBUG):
+            self._log(
+                logging.DEBUG,
+                msg,
+                args,
+                exc_info=exc_info,
+                extra=extra,
+                stack_info=stack_info,
+                stacklevel=stacklevel + 1,
+                **kwargs,
+            )
+
+    def info(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: Any = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if self.isEnabledFor(logging.INFO):
+            self._log(
+                logging.INFO,
+                msg,
+                args,
+                exc_info=exc_info,
+                extra=extra,
+                stack_info=stack_info,
+                stacklevel=stacklevel + 1,
+                **kwargs,
+            )
+
+    def warning(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: Any = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if self.isEnabledFor(logging.WARNING):
+            self._log(
+                logging.WARNING,
+                msg,
+                args,
+                exc_info=exc_info,
+                extra=extra,
+                stack_info=stack_info,
+                stacklevel=stacklevel + 1,
+                **kwargs,
+            )
+
+    def error(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: Any = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if self.isEnabledFor(logging.ERROR):
+            self._log(
+                logging.ERROR,
+                msg,
+                args,
+                exc_info=exc_info,
+                extra=extra,
+                stack_info=stack_info,
+                stacklevel=stacklevel + 1,
+                **kwargs,
+            )
+
+    def critical(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: Any = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if self.isEnabledFor(logging.CRITICAL):
+            self._log(
+                logging.CRITICAL,
+                msg,
+                args,
+                exc_info=exc_info,
+                extra=extra,
+                stack_info=stack_info,
+                stacklevel=stacklevel + 1,
+                **kwargs,
+            )
+
+    def exception(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: Any = True,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if self.isEnabledFor(logging.ERROR):
+            self._log(
+                logging.ERROR,
+                msg,
+                args,
+                exc_info=exc_info,
+                extra=extra,
+                stack_info=stack_info,
+                stacklevel=stacklevel + 1,
+                **kwargs,
+            )
+
+    def log(
+        self,
+        level: int,
+        msg: object,
+        *args: object,
+        exc_info: Any = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if not isinstance(level, int):
+            if logging.raiseExceptions:
+                raise TypeError("level must be an integer")
+            return
+        if self.isEnabledFor(level):
+            self._log(
+                level,
+                msg,
+                args,
+                exc_info=exc_info,
+                extra=extra,
+                stack_info=stack_info,
+                stacklevel=stacklevel + 1,
+                **kwargs,
+            )

--- a/src/kohakuterrarium/utils/logging.py
+++ b/src/kohakuterrarium/utils/logging.py
@@ -20,9 +20,10 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from kohakuterrarium.utils.config_dir import config_dir
+from kohakuterrarium.utils.kt_logger import KTLogger
 
 try:
     import ctypes
@@ -175,28 +176,6 @@ class ColoredFormatter(logging.Formatter):
         if self.use_color:
             return f"{COLORS['ERROR']}{result}{COLORS['RESET']}"
         return result
-
-
-class KTLogger(logging.Logger):
-    """Extended logger with extra field support."""
-
-    def _log(
-        self,
-        level: int,
-        msg: object,
-        args: tuple[Any, ...],
-        exc_info: Any = None,
-        extra: dict[str, Any] | None = None,
-        stack_info: bool = False,
-        stacklevel: int = 1,
-        **kwargs: Any,
-    ) -> None:
-        # Build a fresh mapping: callers may reuse the dict they passed as extra.
-        merged: dict[str, Any] | None = None
-        if extra is not None or kwargs:
-            merged = dict(extra) if extra else {}
-            merged.update(kwargs)
-        super()._log(level, msg, args, exc_info, merged, stack_info, stacklevel + 1)
 
 
 # Set custom logger class
@@ -360,7 +339,7 @@ def enable_file_logging() -> None:
     root_logger.addHandler(_handler)
 
 
-def get_logger(name: str, level: int | str = logging.INFO) -> logging.Logger:
+def get_logger(name: str, level: int | str = logging.INFO) -> KTLogger:
     """
     Get a configured logger for a module.
 
@@ -372,7 +351,7 @@ def get_logger(name: str, level: int | str = logging.INFO) -> logging.Logger:
         level: Logging level (default: INFO)
 
     Returns:
-        Configured Logger instance
+        Configured KTLogger instance
     """
     global _handler
 
@@ -401,7 +380,7 @@ def get_logger(name: str, level: int | str = logging.INFO) -> logging.Logger:
         root_logger.setLevel(logging.INFO)
         root_logger.propagate = False
 
-    return logger
+    return cast(KTLogger, logger)
 
 
 def set_level(level: int | str) -> None:

--- a/src/kohakuterrarium/utils/logging.py
+++ b/src/kohakuterrarium/utils/logging.py
@@ -191,13 +191,12 @@ class KTLogger(logging.Logger):
         stacklevel: int = 1,
         **kwargs: Any,
     ) -> None:
-        # Merge kwargs into extra for convenience
-        # This allows: logger.info("message", field1=value1, field2=value2)
-        if kwargs:
-            if extra is None:
-                extra = {}
-            extra.update(kwargs)
-        super()._log(level, msg, args, exc_info, extra, stack_info, stacklevel + 1)
+        # Build a fresh mapping: callers may reuse the dict they passed as extra.
+        merged: dict[str, Any] | None = None
+        if extra is not None or kwargs:
+            merged = dict(extra) if extra else {}
+            merged.update(kwargs)
+        super()._log(level, msg, args, exc_info, merged, stack_info, stacklevel + 1)
 
 
 # Set custom logger class

--- a/src/kohakuterrarium/utils/logging.py
+++ b/src/kohakuterrarium/utils/logging.py
@@ -280,7 +280,7 @@ def configure_utf8_stdio(*, log: bool = False) -> None:
             pass
 
     if log:
-        logger = logging.getLogger("kohakuterrarium.startup")
+        logger = cast(KTLogger, logging.getLogger("kohakuterrarium.startup"))
         logger.info(
             "stdio encoding configured",
             stdout_encoding=getattr(sys.stdout, "encoding", None),

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -299,6 +299,45 @@ class TestKTLogger:
         assert captured[0].custom_field == "x"
         assert captured[0].number == 42
 
+    def test_caller_extra_dict_is_not_mutated(self):
+        # Merging kwargs must not write back into the caller's dict.
+        captured: list[logging.LogRecord] = []
+
+        class _Cap(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        log = get_logger("kohakuterrarium.kt_test_extra")
+        cap = _Cap(level=logging.DEBUG)
+        log.addHandler(cap)
+
+        caller_extra = {"request_id": "r1"}
+        log.info("hi", extra=caller_extra, trace_id="t1")
+
+        assert caller_extra == {"request_id": "r1"}
+        assert captured[0].request_id == "r1"
+        assert captured[0].trace_id == "t1"
+
+    def test_reused_extra_does_not_leak_fields_across_calls(self):
+        # A base `extra` reused by a caller must not accumulate earlier kwargs.
+        captured: list[logging.LogRecord] = []
+
+        class _Cap(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        log = get_logger("kohakuterrarium.kt_test_extra_reuse")
+        cap = _Cap(level=logging.DEBUG)
+        log.addHandler(cap)
+
+        base = {"agent": "a1"}
+        log.info("first", extra=base, tool_name="read")
+        log.info("second", extra=base)
+
+        assert len(captured) == 2
+        assert captured[1].agent == "a1"
+        assert not hasattr(captured[1], "tool_name")
+
     def test_logger_is_KTLogger_instance(self):
         log = get_logger("kohakuterrarium.kt_test2")
         assert isinstance(log, KTLogger)

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -338,6 +338,58 @@ class TestKTLogger:
         assert captured[1].agent == "a1"
         assert not hasattr(captured[1], "tool_name")
 
+    def test_every_level_method_attributes_the_real_caller(self):
+        # The overrides add frames; findCaller only skips stdlib logging ones,
+        # so filename/lineno/funcName must still land on this test.
+        captured: list[logging.LogRecord] = []
+
+        class _Cap(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        log = get_logger("kohakuterrarium.kt_test_caller", logging.DEBUG)
+        cap = _Cap(level=logging.DEBUG)
+        log.addHandler(cap)
+
+        log.debug("d", field="x")
+        log.info("i", field="x")
+        log.warning("w", field="x")
+        log.error("e", field="x")
+        log.critical("c", field="x")
+        log.log(logging.INFO, "l", field="x")
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            log.exception("x", field="x")
+
+        assert len(captured) == 7
+        for rec in captured:
+            assert rec.filename == os.path.basename(__file__)
+            assert rec.funcName == "test_every_level_method_attributes_the_real_caller"
+            assert rec.field == "x"
+        assert captured[-1].exc_info is not None
+
+    def test_explicit_stacklevel_still_walks_up(self):
+        # stacklevel=2 must attribute to the caller's caller, not the override.
+        captured: list[logging.LogRecord] = []
+
+        class _Cap(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        log = get_logger("kohakuterrarium.kt_test_stacklevel", logging.DEBUG)
+        cap = _Cap(level=logging.DEBUG)
+        log.addHandler(cap)
+
+        def _helper():
+            log.info("via helper", stacklevel=2, field="x")
+
+        _helper()
+
+        assert len(captured) == 1
+        assert captured[0].funcName == "test_explicit_stacklevel_still_walks_up"
+        assert captured[0].field == "x"
+
     def test_logger_is_KTLogger_instance(self):
         log = get_logger("kohakuterrarium.kt_test2")
         assert isinstance(log, KTLogger)

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -390,6 +390,28 @@ class TestKTLogger:
         assert captured[0].funcName == "test_explicit_stacklevel_still_walks_up"
         assert captured[0].field == "x"
 
+    def test_percent_style_args_survive_the_override(self):
+        # `args` must reach Logger._log untouched in both stdlib forms:
+        # a positional tuple, and a single mapping for %(name)s formatting.
+        captured: list[logging.LogRecord] = []
+
+        class _Cap(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        log = get_logger("kohakuterrarium.kt_test_args", logging.DEBUG)
+        cap = _Cap(level=logging.DEBUG)
+        log.addHandler(cap)
+
+        log.info("hello %s, you are %d", "amy", 30, field="x")
+        log.info("hello %(who)s", {"who": "bob"}, field="y")
+
+        assert len(captured) == 2
+        assert captured[0].getMessage() == "hello amy, you are 30"
+        assert captured[0].field == "x"
+        assert captured[1].getMessage() == "hello bob"
+        assert captured[1].field == "y"
+
     def test_logger_is_KTLogger_instance(self):
         log = get_logger("kohakuterrarium.kt_test2")
         assert isinstance(log, KTLogger)


### PR DESCRIPTION
## Summary

`KTLogger._log` merged keyword fields into the dict the caller passed as `extra`, so a reused base dict accumulated fields and leaked them into later records. This fixes that, and gives `KTLogger` explicit level-method overrides so type checkers stop flagging the project's own structured-logging style.

Four files, no call sites touched. The bug fix is a separate commit and stands alone if the typing half isn't wanted.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

**The bug (commit 1).** `_log` did `extra.update(kwargs)` on the caller's own dict:

```python
base = {"agent": "a1"}
log.info("start", extra=base, tool_name="read")
log.info("done",  extra=base)          # this record still carries tool_name="read"
```

Any caller that reuses an `extra` dict across calls silently accumulates fields from earlier calls. `test_kwargs_merged_into_extra` only covered the kwargs-only path, so nothing caught it.

**The typing gap (commits 2–3, #74).** `get_logger` was annotated `-> logging.Logger`, so checkers resolved `.info()` against the stdlib signature and the `KTLogger._log` override was invisible to them:

```
mypy    → Unexpected keyword argument "tool_name" for "debug" of "Logger"  [call-arg]
pyright → No parameter named "tool_name"  (reportCallIssue)
```

That flags 1054 structured-logging call sites across 275 files — every one of which is correct as written, and none of which this PR touches. `CLAUDE.md` explicitly prescribes this logging style, so the annotation was what was wrong, not the calls.

Changing only the return type isn't enough: `info`/`debug`/… stay inherited from `logging.Logger`, so the explicit overrides are required too.

## Changes

- **`utils/kt_logger.py` (new)**: `KTLogger` with explicit `debug` / `info` / `warning` / `error` / `critical` / `exception` / `log` overrides accepting `**kwargs` as record fields.
  - The merge itself stays in `_log`, as a single merge point, so stdlib paths that bypass the overrides (e.g. `Logger.fatal` → `critical`) keep working.
  - `_log` now builds a fresh mapping (`dict(extra)`) rather than mutating the caller's.
  - `_log` keeps the supertype's `args` type (`tuple[object, ...] | Mapping[str, object]`) so the override stays substitutable and the mapping form for `%(name)s` formatting still passes through.
  - Each override adds a stack frame that `findCaller` does not skip, so both layers bump `stacklevel` to keep `filename` / `lineno` / `funcName` on the real call site.
- **`utils/logging.py`**: `KTLogger` moved out and re-exported; `get_logger` now returns `KTLogger`. `configure_utf8_stdio` builds its logger via `logging.getLogger` (typed `Logger` by typeshed) and now casts to `KTLogger` the way `get_logger` does. No call site or import changes.
  - The overrides would have pushed this file to ~645 lines, past the 600-line soft cap in `tests/unit/test_file_sizes.py` (it is not in `ALLOWLIST_600`). The split also matches the one-responsibility-per-module convention. Happy to use a `TYPE_CHECKING` overload stub in one file instead if that's preferred.
- **`tests/unit/utils/test_logging.py`**: 5 tests — caller `extra` not mutated; no cross-call field leak; all 7 level methods attribute the real caller; explicit `stacklevel=` still walks up; `%`-style `args` survive the override in both tuple and mapping forms.
- **`utils/README.md`**: one row for the new module.

No logging output format change. No behavior change beyond the mutation fix.

## Validation

```bash
ruff check src/ tests/                     # clean
black --check src/ tests/                  # clean
pytest tests/unit/ -q                      # 14164 passed, 1 skipped
pytest tests/integration/ -q               # 173 passed
pytest tests/unit/test_file_sizes.py -q    # clean (logging.py 497, kt_logger.py 197)
```

Type checkers were run with `MYPYPATH=<src>` so they resolve the source tree the way an in-tree contributor's editor does (the package ships no `py.typed`, so an installed copy resolves as `Any` and shows nothing either way). Sample: four `get_logger(...)` calls carrying five structured fields. mypy follows imports, so this also picks up real in-tree call sites:

| | `main` | this PR |
|---|---|---|
| sample file (5 structured fields) | 5 | **0** |
| `utils/logging.py` | 4 | **0** |
| `utils/async_utils.py` — structured-logging `[call-arg]` | 9 | **0** |
| `utils/async_utils.py` — pre-existing, unrelated (TypeVar / missing annotations) | 6 | 6 |
| **mypy total** | **24** | **6** |
| **pyright on the sample** | **5** | **0** |

The 6 that remain are `async_utils.py` TypeVar and missing-annotation issues that predate this PR and are out of its scope.

Mutation-checked the new tests: injecting an off-by-one into `info()`'s `stacklevel` makes both attribution tests fail, and reverting the `dict(extra)` copy makes both leak tests fail.

Frontend untouched, so `npm` checks were not run.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` — no frontend files changed
- [x] CI on my fork is green — all 13 checks, including the full 3.12/3.13/3.14 × Linux/Windows/macOS matrix: [run 33535948941](https://github.com/treeleaves30760/KohakuTerrarium/actions/runs/33535948941)

## Related Issues / Discussions

- Fixes #74
- The `extra` mutation bug was found while writing the regression test for #74; it has no prior issue.

## Notes for Reviewers

**The commits are deliberately separable.**

- `244b133d fix(logging): copy caller-supplied extra instead of mutating it` — a runtime correctness fix, independent of any position on type checking.
- `7e3b84a0 feat(logging): type structured fields on KTLogger level methods` — the #74 work.
- `eef7e8f8 fix(logging): keep KTLogger._log substitutable for Logger._log` — follow-up to the above, kept separate because it records something worth knowing (below).

If you'd rather not take the typing half, drop the last two commits; the first stands on its own with its own tests.

Three places worth focused review:

1. **`stacklevel` bookkeeping.** Adding override methods inserts frames that `logging.Logger.findCaller` does not skip (it only skips frames in `logging`'s own `_srcfile`). Both the override and `_log` bump `stacklevel + 1` to compensate. `test_every_level_method_attributes_the_real_caller` and `test_explicit_stacklevel_still_walks_up` pin this; both fail on an off-by-one.

2. **Worth flagging honestly:** commit 3 exists because running a type checker over the finished module found two defects that a full green unit run could not — the `_log` signature was not substitutable for its supertype, and one internal call site in `logging.py` was still untyped. Annotations aren't enforced at runtime, so no pytest test can catch that class of defect. The suite has no type checker and this PR doesn't add one, so the same blind spot remains for future changes to this module. If you'd want a guard there, that's a separate discussion; I didn't want to smuggle a new CI dependency into a PR arguing it adds no CI surface.

3. **The module split**, if you'd prefer `KTLogger` stay in `logging.py` behind a `TYPE_CHECKING` overload stub. Either shape works for me; the split was chosen to stay under the file-size guard.

One pre-existing behavior I checked and did **not** change: `log.exception(...)` prints no traceback, because `ColoredFormatter.format` builds its own string and never appends `formatException` output. `record.exc_info` is preserved correctly; verified against `main` that this is not a regression from this PR.

## Exceptions / Not Run

- **Maintainer approval checkbox left unchecked.** #74 predates this PR (opened 2026-07-10, labeled `enhancement`), but no maintainer has weighed in on it, so I can't honestly claim explicit approval. Commit 2 is labeled `feat` and adds public typing surface, though it changes no runtime behavior. If you consider that a feature change requiring prior sign-off, drop commits 2–3 and the bug fix in commit 1 still applies cleanly.
- **e2e tier not run** — per `tests/README.md`, e2e is for the multi-node / Studio / serving stack; this PR touches neither.
- **Frontend checks not run** — no frontend files changed.
