### PR TITLE
feat(tools): add Codex subscription web search

### DIFF
--- a/docs/en/guides/configuration.md
+++ b/docs/en/guides/configuration.md
@@ -97,14 +97,17 @@ With options:
 tools:
   - name: web_search
     backend: duckduckgo
+    codex_model: gpt-5.6-luna
     deepseek_model: deepseek-v4-flash
     fallback: none
 ```
 
-`web_search` keeps DuckDuckGo as its no-key default. To opt into DeepSeek,
-run `kt config key set deepseek`, then either set `backend: deepseek` in the
-creature config or switch the live creature with
-`/module set web_search backend deepseek`.
+`web_search` keeps DuckDuckGo as its no-key default. To explicitly use hosted
+Codex subscription search, run `kt login codex`, then set `backend: codex` or
+use `/module set web_search backend codex`; this is independent of the
+creature's active LLM. To use DeepSeek, run `kt config key set deepseek`, then
+select `backend: deepseek`. Set `fallback: duckduckgo` when a transient failure
+of an explicitly selected Codex or DeepSeek backend should fall back.
 
 Custom (local module):
 

--- a/docs/en/reference/builtins.md
+++ b/docs/en/reference/builtins.md
@@ -107,9 +107,12 @@ timeout. Direct.
 
 - Args: `url`.
 
-**`web_search`**: Web search with a DuckDuckGo default and an optional
-DeepSeek Responses backend. DeepSeek requires `kt config key set deepseek`;
-switch per creature with `/module set web_search backend deepseek`. Direct.
+**`web_search`**: Web search with a DuckDuckGo default plus optional Codex
+subscription and DeepSeek Responses backends. After `kt login codex`, select
+`backend: codex`; this works independently of the creature's active LLM.
+DeepSeek requires `kt config key set deepseek` and `backend: deepseek`. Either
+explicit provider backend can use `fallback: duckduckgo` for transient
+failures. Direct.
 
 - Args: `query`, `max_results` (int), `region` (str).
 

--- a/docs/zh-CN/guides/configuration.md
+++ b/docs/zh-CN/guides/configuration.md
@@ -91,14 +91,17 @@ tools:
 tools:
   - name: web_search
     backend: duckduckgo
+    codex_model: gpt-5.6-luna
     deepseek_model: deepseek-v4-flash
     fallback: none
 ```
 
-`web_search` 默认使用无需 Key 的 DuckDuckGo。若要启用 DeepSeek，先执行
-`kt config key set deepseek`，再在 Creature 配置中设置
-`backend: deepseek`，或通过 `/module set web_search backend deepseek`
-切换当前 Creature。
+`web_search` 默认仍使用无需 Key 的 DuckDuckGo。若要明确使用 Codex
+订阅托管搜索，先执行 `kt login codex`，再设置 `backend: codex`，或通过
+`/module set web_search backend codex` 切换；此后端独立于当前 Creature
+的主模型。若要使用 DeepSeek，先执行 `kt config key set deepseek`，再选择
+`backend: deepseek`。为明确选择的 Codex 或 DeepSeek 后端设置
+`fallback: duckduckgo`，可在临时故障时回退。
 
 本地 custom 模块：
 

--- a/docs/zh-CN/reference/builtins.md
+++ b/docs/zh-CN/reference/builtins.md
@@ -88,9 +88,11 @@ KohakuTerrarium 随附的所有内置工具、子代理、输入、输出、用�
 
 - 参数：`url`。
 
- **`web_search`**：默认使用 DuckDuckGo，也可选择 DeepSeek Responses
-搜索后端。DeepSeek 需要先执行 `kt config key set deepseek`，再通过
-`/module set web_search backend deepseek` 为当前 Creature 启用。直接执行。
+**`web_search`**：默认使用 DuckDuckGo，也可明确选择 Codex 订阅或
+DeepSeek Responses 后端。执行 `kt login codex` 后可设置
+`backend: codex`；此后端与当前 Creature 主模型无关。DeepSeek 需要先执行
+`kt config key set deepseek`，再设置 `backend: deepseek`。两个明确选择的
+Provider 后端均可配置 `fallback: duckduckgo` 处理临时故障。直接执行。
 
 - 参数：`query`、`max_results`（int）、`region`（str）。
 

--- a/docs/zh-TW/guides/configuration.md
+++ b/docs/zh-TW/guides/configuration.md
@@ -91,14 +91,17 @@ tools:
 tools:
   - name: web_search
     backend: duckduckgo
+    codex_model: gpt-5.6-luna
     deepseek_model: deepseek-v4-flash
     fallback: none
 ```
 
-`web_search` 預設使用不需 Key 的 DuckDuckGo。若要啟用 DeepSeek，先執行
-`kt config key set deepseek`，再於 Creature 設定中指定
-`backend: deepseek`，或透過 `/module set web_search backend deepseek`
-切換目前的 Creature。
+`web_search` 預設仍使用不需 Key 的 DuckDuckGo。若要明確使用 Codex
+訂閱託管搜尋，先執行 `kt login codex`，再設定 `backend: codex`，或透過
+`/module set web_search backend codex` 切換；此後端獨立於目前 Creature
+的主模型。若要使用 DeepSeek，先執行 `kt config key set deepseek`，再選擇
+`backend: deepseek`。為明確選擇的 Codex 或 DeepSeek 後端設定
+`fallback: duckduckgo`，可在暫時故障時回退。
 
 本地 custom 模組：
 

--- a/docs/zh-TW/reference/builtins.md
+++ b/docs/zh-TW/reference/builtins.md
@@ -91,9 +91,11 @@ KohakuTerrarium 隨附的所有內建工具、子代理、輸入、輸出、使�
 
 - 參數：`url`。
 
-**`web_search`**：預設使用 DuckDuckGo，也可選擇 DeepSeek Responses
-搜尋後端。DeepSeek 需先執行 `kt config key set deepseek`，再透過
-`/module set web_search backend deepseek` 為目前 Creature 啟用。直接執行。
+**`web_search`**：預設使用 DuckDuckGo，也可明確選擇 Codex 訂閱或
+DeepSeek Responses 後端。執行 `kt login codex` 後可設定
+`backend: codex`；此後端與目前 Creature 主模型無關。DeepSeek 需先執行
+`kt config key set deepseek`，再設定 `backend: deepseek`。兩個明確選擇的
+Provider 後端均可設定 `fallback: duckduckgo` 處理暫時故障。直接執行。
 
 - 參數：`query`、`max_results`（int）、`region`（str）。
 

--- a/src/kohakuterrarium/builtins/tools/README.md
+++ b/src/kohakuterrarium/builtins/tools/README.md
@@ -30,7 +30,7 @@ the public API from `builtins.tool_catalog`.
 | `stop_task.py`                          | `stop_task`: cancel a running background tool, sub-agent, or trigger by id                                        |
 | `search_memory.py`                      | `search_memory`: FTS5 + semantic search over the current session's event log                                      |
 | `web_fetch.py`                          | `web_fetch`: clean-read a URL (crawl4ai → trafilatura → jina → naive fallback)                                    |
-| `web_search.py`                         | `web_search`: DuckDuckGo search (optional `duckduckgo-search` dep)                                                |
+| `web_search.py`                         | `web_search`: DuckDuckGo search with optional Codex subscription and DeepSeek backends                           |
 | `skill.py`                              | `skill`: load a named skill's full documentation                                                                  |
 | `image_gen.py`                          | `image_gen`: provider-backed image generation                                                                     |
 | `canvas_preview.py` / `show_card.py`    | UI surfaces: canvas preview + structured cards                                                                    |

--- a/src/kohakuterrarium/builtins/tools/web_search.py
+++ b/src/kohakuterrarium/builtins/tools/web_search.py
@@ -1,17 +1,30 @@
-"""Web search with selectable DuckDuckGo and DeepSeek backends."""
+"""Web search with Codex-subscription, DuckDuckGo, and DeepSeek backends."""
 
-import asyncio
-import html as _html
 import re
 import time
 from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 
 import httpx
 
 from kohakuterrarium.builtins.tools.registry import register_builtin
+from kohakuterrarium.builtins.tools.web_search_duckduckgo import (
+    DDGS,
+    _parse_ddg_html as _parse_ddg_html,
+    _search_ddg,
+    _search_httpx_ddg,
+    _unwrap_ddg_redirect as _unwrap_ddg_redirect,
+)
 from kohakuterrarium.llm.api_keys import get_api_key, has_api_key
+from kohakuterrarium.llm.codex_web_search import (
+    CODEX_SEARCH_MODELS,
+    DEFAULT_CODEX_SEARCH_MODEL,
+    CodexSearchOperationalError,
+    CodexSearchUnavailable,
+    CodexSubscriptionSearchBackend,
+    codex_search_available,
+)
 from kohakuterrarium.modules.tool.base import BaseTool, ExecutionMode, ToolResult
 from kohakuterrarium.utils.logging import get_logger
 
@@ -21,18 +34,6 @@ MAX_RESULTS = 10
 DEEPSEEK_RESPONSES_URL = "https://api.deepseek.com/responses"
 DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-flash"
 DEEPSEEK_MODELS = ("deepseek-v4-flash", "deepseek-v4-pro")
-
-
-# Prefer the current optional package, then its legacy predecessor; ``None``
-# selects the HTTP backend on installations without either dependency.
-DDGS: Any = None
-try:
-    from ddgs import DDGS  # type: ignore[no-redef]
-except ImportError:
-    try:
-        from duckduckgo_search import DDGS  # type: ignore[no-redef]
-    except ImportError:
-        pass
 
 
 def _has_ddg() -> bool:
@@ -61,7 +62,7 @@ class SearchResponse:
 
 
 class DuckDuckGoSearchBackend:
-    """Run the existing DDGS-to-HTML fallback chain."""
+    """Use the optional DDGS package, then the HTTP endpoint as fallback."""
 
     async def search(self, query: str, max_results: int, region: str) -> SearchResponse:
         results: list[dict] = []
@@ -75,7 +76,6 @@ class DuckDuckGoSearchBackend:
                     "ddgs search failed, falling back to httpx scraper",
                     error=str(exc),
                 )
-
         if not results:
             try:
                 results = await _search_httpx_ddg(query, max_results, region)
@@ -84,7 +84,6 @@ class DuckDuckGoSearchBackend:
                 raise SearchBackendOperationalError(
                     f"DuckDuckGo search failed: {detail}"
                 ) from exc
-
         if not results:
             return SearchResponse(
                 output="No results found.", metadata={"backend": "duckduckgo"}
@@ -185,6 +184,7 @@ class WebSearchTool(BaseTool):
     def __init__(self, config=None):
         super().__init__(config=config)
         self.backend = "duckduckgo"
+        self.codex_model = DEFAULT_CODEX_SEARCH_MODEL
         self.deepseek_model = DEFAULT_DEEPSEEK_MODEL
         self.fallback = "none"
         self.refresh_runtime_options(dict(self.config.extra))
@@ -195,6 +195,11 @@ class WebSearchTool(BaseTool):
 
     @property
     def description(self) -> str:
+        if self.backend == "codex":
+            return (
+                "Search the web once per question; retry only if incomplete "
+                "or conflicting"
+            )
         return "Search the web and return results with titles, URLs, and snippets"
 
     @property
@@ -207,13 +212,23 @@ class WebSearchTool(BaseTool):
             disabled["deepseek"] = (
                 "DeepSeek API key is not configured. Run: " "kt config key set deepseek"
             )
+        if not codex_search_available():
+            disabled["codex"] = (
+                "Codex subscription is not connected. Run: kt login codex"
+            )
         return {
             "backend": {
                 "type": "enum",
-                "values": ["duckduckgo", "deepseek"],
+                "values": ["duckduckgo", "codex", "deepseek"],
                 "default": "duckduckgo",
                 "disabled_values": disabled,
                 "doc": "Search implementation used by this creature.",
+            },
+            "codex_model": {
+                "type": "enum",
+                "values": list(CODEX_SEARCH_MODELS),
+                "default": DEFAULT_CODEX_SEARCH_MODEL,
+                "doc": "Codex subscription model used for standalone web search.",
             },
             "deepseek_model": {
                 "type": "enum",
@@ -225,12 +240,13 @@ class WebSearchTool(BaseTool):
                 "type": "enum",
                 "values": ["none", "duckduckgo"],
                 "default": "none",
-                "doc": "Fallback for transient DeepSeek failures only.",
+                "doc": "Fallback for transient explicitly selected backend failures.",
             },
         }
 
     def refresh_runtime_options(self, options: dict[str, Any]) -> None:
         self.backend = str(options.get("backend", "duckduckgo"))
+        self.codex_model = str(options.get("codex_model", DEFAULT_CODEX_SEARCH_MODEL))
         self.deepseek_model = str(options.get("deepseek_model", DEFAULT_DEEPSEEK_MODEL))
         self.fallback = str(options.get("fallback", "none"))
 
@@ -243,29 +259,32 @@ class WebSearchTool(BaseTool):
         region = args.get("region", "")
 
         started_at = time.monotonic()
+        selected_backend = self.backend
         try:
-            search_backend = self._backend()
+            search_backend = self._backend(selected_backend)
             response = await search_backend.search(query, max_results, region)
+        except CodexSearchOperationalError as exc:
+            response = await self._fallback_or_error(
+                query, max_results, region, selected_backend, exc
+            )
+            if isinstance(response, ToolResult):
+                return response
+        except CodexSearchUnavailable as exc:
+            return ToolResult(error=str(exc))
         except SearchBackendOperationalError as exc:
-            if self.backend == "deepseek" and self.fallback == "duckduckgo":
-                logger.warning("DeepSeek search failed, using configured fallback")
-                try:
-                    response = await DuckDuckGoSearchBackend().search(
-                        query, max_results, region
-                    )
-                except SearchBackendError as fallback_exc:
-                    return ToolResult(error=str(fallback_exc))
-                response.metadata["fallback_from"] = "deepseek"
-                response.metadata["fallback_reason"] = str(exc)
-            else:
-                return ToolResult(error=str(exc))
+            response = await self._fallback_or_error(
+                query, max_results, region, selected_backend, exc
+            )
+            if isinstance(response, ToolResult):
+                return response
         except SearchBackendError as exc:
             return ToolResult(error=str(exc))
 
+        response.metadata["requested_backend"] = self.backend
         response.metadata["duration_ms"] = round(
             (time.monotonic() - started_at) * 1000.0, 1
         )
-        response.metadata["source_count"] = len(response.sources)
+        response.metadata.setdefault("source_count", len(response.sources))
         response.metadata["session_metadata"] = _search_session_metadata(
             response.metadata
         )
@@ -280,12 +299,41 @@ class WebSearchTool(BaseTool):
             metadata=response.metadata,
         )
 
-    def _backend(self):
-        if self.backend == "duckduckgo":
+    def _backend(self, selected: str | None = None):
+        selected = selected or self.backend
+        if selected == "codex":
+            return CodexSubscriptionSearchBackend(self.codex_model)
+        if selected == "duckduckgo":
             return DuckDuckGoSearchBackend()
-        if self.backend == "deepseek":
+        if selected == "deepseek":
             return DeepSeekSearchBackend(self.deepseek_model)
-        raise SearchBackendUnavailable(f"Unknown web search backend: {self.backend!r}")
+        raise SearchBackendUnavailable(f"Unknown web search backend: {selected!r}")
+
+    async def _fallback_or_error(
+        self,
+        query: str,
+        max_results: int,
+        region: str,
+        selected: str,
+        error: Exception,
+    ) -> SearchResponse | ToolResult:
+        fallback_enabled = self.fallback == "duckduckgo"
+        if not fallback_enabled or selected == "duckduckgo":
+            return ToolResult(error=str(error))
+        logger.warning(
+            "Primary web search failed, using DuckDuckGo fallback",
+            backend=selected,
+            error=str(error),
+        )
+        try:
+            response = await DuckDuckGoSearchBackend().search(
+                query, max_results, region
+            )
+        except SearchBackendError as fallback_exc:
+            return ToolResult(error=str(fallback_exc))
+        response.metadata["fallback_from"] = selected
+        response.metadata["fallback_reason"] = str(error)
+        return response
 
 
 def _render_ddg_results(query: str, results: list[dict]) -> str:
@@ -389,26 +437,30 @@ def _search_session_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     """Select non-secret search diagnostics for session persistence."""
     keys = (
         "backend",
+        "requested_backend",
         "model",
         "response_status",
         "citation_status",
         "annotation_count",
         "source_count",
+        "verified_source_count",
+        "action_source_count",
         "result_count",
         "fallback_from",
         "fallback_reason",
         "duration_ms",
     )
     result = {key: metadata[key] for key in keys if key in metadata}
-    sources = metadata.get("verified_sources")
-    if isinstance(sources, list):
-        result["verified_sources"] = [
-            {"title": source["title"], "url": source["url"]}
-            for source in sources
-            if isinstance(source, dict)
-            and isinstance(source.get("title"), str)
-            and isinstance(source.get("url"), str)
-        ]
+    for key in ("verified_sources", "consulted_sources"):
+        sources = metadata.get(key)
+        if isinstance(sources, list):
+            result[key] = [
+                {"title": source["title"], "url": source["url"]}
+                for source in sources
+                if isinstance(source, dict)
+                and isinstance(source.get("title"), str)
+                and isinstance(source.get("url"), str)
+            ]
     usage = metadata.get("usage")
     if isinstance(usage, dict):
         result["usage"] = {
@@ -416,6 +468,17 @@ def _search_session_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
             for key, value in usage.items()
             if isinstance(value, (int, float)) and not isinstance(value, bool)
         }
+    actions = metadata.get("actions")
+    if isinstance(actions, list):
+        result["actions"] = [
+            {
+                str(key): value
+                for key, value in action.items()
+                if key in {"type", "query", "queries", "url", "pattern"}
+            }
+            for action in actions[:20]
+            if isinstance(action, dict)
+        ]
     return result
 
 
@@ -501,86 +564,3 @@ def _source_from_annotation(annotation: Any) -> dict[str, str] | None:
         return None
     title = str(source.get("title") or parsed.netloc)
     return {"title": title, "url": url}
-
-
-async def _search_ddg(query: str, max_results: int, region: str) -> list[dict]:
-    """Run the synchronous ``ddgs`` client without blocking the event loop."""
-
-    def _do_search():
-        kwargs: dict[str, Any] = {"max_results": max_results}
-        if region:
-            kwargs["region"] = region
-        with DDGS() as ddgs:
-            return list(ddgs.text(query, **kwargs))
-
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, _do_search)
-
-
-# Title and snippet patterns intentionally tolerate extra attributes and
-# whitespace but remain coupled to DuckDuckGo's HTML result class names.
-_RE_DDG_TITLE = re.compile(
-    r'<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>',
-    re.DOTALL,
-)
-_RE_DDG_SNIPPET = re.compile(
-    r'class="result__snippet"[^>]*>(.*?)</a>',
-    re.DOTALL,
-)
-_RE_DDG_HTML_TAG = re.compile(r"<[^>]+>")
-_RE_DDG_REDIRECT = re.compile(r"^//duckduckgo\.com/l/\?(?:.*&)?uddg=([^&]+)")
-
-
-def _strip_html(text: str) -> str:
-    return _html.unescape(_RE_DDG_HTML_TAG.sub("", text)).strip()
-
-
-def _unwrap_ddg_redirect(href: str) -> str:
-    """Extract the target from DuckDuckGo redirect URLs when present."""
-    m = _RE_DDG_REDIRECT.match(href)
-    if m:
-        return unquote(m.group(1))
-    return href
-
-
-def _parse_ddg_html(body: str, max_results: int) -> list[dict]:
-    """Parse HTML results into the same mapping shape as ``ddgs``."""
-    results: list[dict] = []
-    for m in _RE_DDG_TITLE.finditer(body):
-        href = _unwrap_ddg_redirect(_html.unescape(m.group(1)))
-        title = _strip_html(m.group(2))
-        results.append({"href": href, "title": title, "body": ""})
-        if len(results) >= max_results:
-            break
-    snippets = [_strip_html(m.group(1)) for m in _RE_DDG_SNIPPET.finditer(body)]
-    for i, snip in enumerate(snippets[: len(results)]):
-        results[i]["body"] = snip
-    return results
-
-
-async def _search_httpx_ddg(
-    query: str,
-    max_results: int,
-    region: str,
-) -> list[dict]:
-    """Search DuckDuckGo's HTML endpoint without native dependencies."""
-    url = "https://html.duckduckgo.com/html/"
-    headers = {
-        # The HTML endpoint challenges obvious bot user agents.
-        "User-Agent": (
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/120.0 Safari/537.36"
-        ),
-        "Accept": "text/html,application/xhtml+xml",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
-    payload: dict[str, str] = {"q": query, "b": "", "df": ""}
-    if region:
-        payload["kl"] = region
-
-    async with httpx.AsyncClient(
-        headers=headers, follow_redirects=True, timeout=15.0
-    ) as client:
-        resp = await client.post(url, data=payload)
-        resp.raise_for_status()
-        return _parse_ddg_html(resp.text, max_results)

--- a/src/kohakuterrarium/builtins/tools/web_search_duckduckgo.py
+++ b/src/kohakuterrarium/builtins/tools/web_search_duckduckgo.py
@@ -1,0 +1,95 @@
+"""DuckDuckGo SDK/HTML implementation for the built-in web-search tool."""
+
+import asyncio
+import html as _html
+import re
+from typing import Any
+from urllib.parse import unquote
+
+import httpx
+
+DDGS: Any = None
+try:
+    from ddgs import DDGS  # type: ignore[no-redef]
+except ImportError:
+    try:
+        from duckduckgo_search import DDGS  # type: ignore[no-redef]
+    except ImportError:
+        pass
+
+
+async def _search_ddg(query: str, max_results: int, region: str) -> list[dict]:
+    """Run the synchronous ``ddgs`` client without blocking the event loop."""
+
+    def _do_search():
+        kwargs: dict[str, Any] = {"max_results": max_results}
+        if region:
+            kwargs["region"] = region
+        with DDGS() as ddgs:
+            return list(ddgs.text(query, **kwargs))
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _do_search)
+
+
+_RE_DDG_TITLE = re.compile(
+    r'<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>',
+    re.DOTALL,
+)
+_RE_DDG_SNIPPET = re.compile(
+    r'class="result__snippet"[^>]*>(.*?)</a>',
+    re.DOTALL,
+)
+_RE_DDG_HTML_TAG = re.compile(r"<[^>]+>")
+_RE_DDG_REDIRECT = re.compile(r"^//duckduckgo\.com/l/\?(?:.*&)?uddg=([^&]+)")
+
+
+def _strip_html(text: str) -> str:
+    return _html.unescape(_RE_DDG_HTML_TAG.sub("", text)).strip()
+
+
+def _unwrap_ddg_redirect(href: str) -> str:
+    match = _RE_DDG_REDIRECT.match(href)
+    if match:
+        return unquote(match.group(1))
+    return href
+
+
+def _parse_ddg_html(body: str, max_results: int) -> list[dict]:
+    results: list[dict] = []
+    for match in _RE_DDG_TITLE.finditer(body):
+        href = _unwrap_ddg_redirect(_html.unescape(match.group(1)))
+        title = _strip_html(match.group(2))
+        results.append({"href": href, "title": title, "body": ""})
+        if len(results) >= max_results:
+            break
+    snippets = [_strip_html(match.group(1)) for match in _RE_DDG_SNIPPET.finditer(body)]
+    for index, snippet in enumerate(snippets[: len(results)]):
+        results[index]["body"] = snippet
+    return results
+
+
+async def _search_httpx_ddg(
+    query: str,
+    max_results: int,
+    region: str,
+) -> list[dict]:
+    url = "https://html.duckduckgo.com/html/"
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    payload: dict[str, str] = {"q": query, "b": "", "df": ""}
+    if region:
+        payload["kl"] = region
+
+    async with httpx.AsyncClient(
+        headers=headers, follow_redirects=True, timeout=15.0
+    ) as client:
+        response = await client.post(url, data=payload)
+        response.raise_for_status()
+        return _parse_ddg_html(response.text, max_results)

--- a/src/kohakuterrarium/llm/codex_web_search.py
+++ b/src/kohakuterrarium/llm/codex_web_search.py
@@ -6,10 +6,12 @@ can therefore call the ordinary ``web_search`` function while this helper
 uses cached ``kt login codex`` credentials for the hosted search request.
 """
 
+import asyncio
 import hashlib
+import re
 from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 import httpx
 
@@ -34,6 +36,9 @@ CODEX_SEARCH_MODELS = (
     "gpt-5.4",
     "gpt-5.4-mini",
 )
+_TOKEN_REFRESH_LOCK = asyncio.Lock()
+_TRACKING_QUERY_KEYS = frozenset({"fbclid", "gclid", "mc_cid", "mc_eid", "msclkid"})
+_TEXT_URL_PATTERN = re.compile(r"https?://[^\s<>\[\]{}]+")
 
 
 class CodexSearchError(RuntimeError):
@@ -127,12 +132,22 @@ async def _load_valid_tokens() -> CodexTokens:
             "Codex subscription is not connected. Run: kt login codex"
         )
     if tokens.is_expired():
-        try:
-            tokens = await refresh_tokens(tokens)
-        except Exception as exc:
-            raise CodexSearchUnavailable(
-                "Codex subscription login expired. Run: kt login codex"
-            ) from exc
+        async with _TOKEN_REFRESH_LOCK:
+            tokens = CodexTokens.load()
+            if tokens is None:
+                raise CodexSearchUnavailable(
+                    "Codex subscription is not connected. Run: kt login codex"
+                )
+            if tokens.is_expired():
+                try:
+                    tokens = await refresh_tokens(tokens)
+                except Exception as exc:
+                    recovered = CodexTokens.load()
+                    if recovered is not None and not recovered.is_expired():
+                        return recovered
+                    raise CodexSearchUnavailable(
+                        "Codex subscription login expired. Run: kt login codex"
+                    ) from exc
     return tokens
 
 
@@ -202,7 +217,41 @@ def _action(value: Any) -> dict[str, Any]:
 
 
 def _has_source_url(sources: list[dict[str, str]], candidate: dict[str, str]) -> bool:
-    return any(source["url"] == candidate["url"] for source in sources)
+    candidate_key = _source_url_key(candidate["url"])
+    return any(_source_url_key(source["url"]) == candidate_key for source in sources)
+
+
+def _source_url_key(url: str) -> str:
+    """Normalize non-content URL differences used by source tracking."""
+    parsed = urlparse(url)
+    query = urlencode(
+        [
+            (key, value)
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+            if not key.lower().startswith("utm_")
+            and key.lower() not in _TRACKING_QUERY_KEYS
+        ]
+    )
+    return parsed._replace(
+        scheme=parsed.scheme.lower(),
+        netloc=parsed.netloc.lower(),
+        query=query,
+        fragment="",
+    ).geturl()
+
+
+def _text_url_keys(text: str) -> set[str]:
+    return {
+        _source_url_key(_clean_text_url(match.group(0)))
+        for match in _TEXT_URL_PATTERN.finditer(text)
+    }
+
+
+def _clean_text_url(url: str) -> str:
+    cleaned = url.rstrip(".,;:!?\"'")
+    while cleaned.endswith(")") and cleaned.count(")") > cleaned.count("("):
+        cleaned = cleaned[:-1]
+    return cleaned
 
 
 @dataclass
@@ -296,18 +345,24 @@ class _SearchCollector:
             if not _has_source_url(ordered_sources, source):
                 ordered_sources.append(source)
         sources = ordered_sources[:max_results]
-        selected_urls = {source["url"] for source in sources}
+        selected_url_keys = {_source_url_key(source["url"]) for source in sources}
         citation_sources = [
-            source for source in self.citation_sources if source["url"] in selected_urls
+            source
+            for source in self.citation_sources
+            if _source_url_key(source["url"]) in selected_url_keys
         ]
         action_sources = [
-            source for source in self.action_sources if source["url"] in selected_urls
+            source
+            for source in self.action_sources
+            if _source_url_key(source["url"]) in selected_url_keys
         ]
         body = "".join(self.text).strip() or "No results found."
         if self.response_status == "incomplete":
             body = f"Incomplete Codex search response.\n\n{body}"
         output = f"Search results for: {self.query}\n\n{body}"
-        has_text_links = "http://" in body or "https://" in body
+        text_url_keys = _text_url_keys(body)
+        has_text_links = bool(text_url_keys)
+        unverified_text_links = text_url_keys - selected_url_keys
         citation_status = (
             "verified"
             if citation_sources
@@ -317,11 +372,18 @@ class _SearchCollector:
                 else "unverified_text" if has_text_links else "none"
             )
         )
-        if has_text_links and not sources:
-            output += (
-                "\n\nCitation note: Links in the answer text are unverified "
-                "provider text because no structured citations were returned."
-            )
+        if unverified_text_links:
+            if sources:
+                output += (
+                    "\n\nCitation note: Only links in the Sources list below were "
+                    "returned as structured citations; other links in the answer "
+                    "text are unverified provider text."
+                )
+            else:
+                output += (
+                    "\n\nCitation note: Links in the answer text are unverified "
+                    "provider text because no structured citations were returned."
+                )
         if action_sources and not citation_sources:
             output += (
                 "\n\nGrounding note: The Sources list contains structured URLs "

--- a/src/kohakuterrarium/llm/codex_web_search.py
+++ b/src/kohakuterrarium/llm/codex_web_search.py
@@ -1,0 +1,366 @@
+"""Standalone Codex-subscription web search for non-Codex controllers.
+
+This module deliberately treats search as an account-backed KT capability,
+not as a provider-native tool of the creature's active LLM.  Any controller
+can therefore call the ordinary ``web_search`` function while this helper
+uses cached ``kt login codex`` credentials for the hosted search request.
+"""
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from kohakuterrarium.llm.codex_auth import CodexTokens, refresh_tokens
+from kohakuterrarium.llm.codex_provider import CODEX_BASE_URL
+
+try:
+    from openai import AsyncOpenAI
+
+    HAS_OPENAI = True
+except ImportError:  # pragma: no cover - optional dependency boundary
+    AsyncOpenAI = None  # type: ignore[misc, assignment]
+    HAS_OPENAI = False
+
+
+DEFAULT_CODEX_SEARCH_MODEL = "gpt-5.6-luna"
+CODEX_SEARCH_MODELS = (
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "gpt-5.6-sol",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+)
+
+
+class CodexSearchError(RuntimeError):
+    """Base error for the account-backed Codex search client."""
+
+
+class CodexSearchUnavailable(CodexSearchError):
+    """The subscription credential or requested capability is unavailable."""
+
+
+class CodexSearchOperationalError(CodexSearchError):
+    """A transient remote failure made this search attempt unusable."""
+
+
+@dataclass
+class CodexSearchResult:
+    """Normalized result returned to the ordinary KT web-search tool."""
+
+    output: str
+    sources: list[dict[str, str]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def codex_search_available() -> bool:
+    """Return whether a cached Codex subscription credential can be loaded."""
+    return HAS_OPENAI and CodexTokens.load() is not None
+
+
+class CodexSubscriptionSearchBackend:
+    """Run one hosted web-search request using cached Codex OAuth credentials."""
+
+    def __init__(self, model: str = DEFAULT_CODEX_SEARCH_MODEL) -> None:
+        self.model = model
+
+    async def search(
+        self, query: str, max_results: int, region: str
+    ) -> CodexSearchResult:
+        tokens = await _load_valid_tokens()
+        prompt = _search_prompt(query, max_results, region)
+        cache_key = hashlib.sha256(
+            f"kt-codex-search:{self.model}".encode()
+        ).hexdigest()[:32]
+        client = AsyncOpenAI(
+            api_key=tokens.access_token,
+            base_url=CODEX_BASE_URL,
+            timeout=60.0,
+            max_retries=1,
+            http_client=httpx.AsyncClient(timeout=60.0),
+        )
+        collector = _SearchCollector(query=query, model=self.model)
+        try:
+            stream = await client.responses.create(
+                model=self.model,
+                instructions=(
+                    "Use web search to answer the request. Prefer primary sources, "
+                    "keep the answer concise, and preserve source citations."
+                ),
+                input=[
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": prompt}],
+                    }
+                ],
+                tools=[{"type": "web_search", "external_web_access": True}],
+                tool_choice={"type": "web_search"},
+                include=["web_search_call.action.sources"],
+                store=False,
+                stream=True,
+                prompt_cache_key=cache_key,
+                extra_headers={"session_id": cache_key},
+            )
+            async for event in stream:
+                collector.observe(event)
+        except CodexSearchError:
+            raise
+        except Exception as exc:
+            raise _map_request_error(exc) from exc
+        finally:
+            await client.close()
+        return collector.result(max_results)
+
+
+async def _load_valid_tokens() -> CodexTokens:
+    if not HAS_OPENAI:
+        raise CodexSearchUnavailable(
+            "Codex search requires the OpenAI SDK; install the standard KT dependencies"
+        )
+    tokens = CodexTokens.load()
+    if tokens is None:
+        raise CodexSearchUnavailable(
+            "Codex subscription is not connected. Run: kt login codex"
+        )
+    if tokens.is_expired():
+        try:
+            tokens = await refresh_tokens(tokens)
+        except Exception as exc:
+            raise CodexSearchUnavailable(
+                "Codex subscription login expired. Run: kt login codex"
+            ) from exc
+    return tokens
+
+
+def _search_prompt(query: str, max_results: int, region: str) -> str:
+    region_hint = f" Prefer sources relevant to region {region}." if region else ""
+    return (
+        f"Search the live web for: {query}.{region_hint} "
+        f"Answer using no more than {max_results} distinct sources."
+    )
+
+
+def _map_request_error(exc: Exception) -> CodexSearchError:
+    status = getattr(exc, "status_code", None)
+    response = getattr(exc, "response", None)
+    status = status or getattr(response, "status_code", None)
+    if status in {401, 403}:
+        return CodexSearchUnavailable(
+            "Codex subscription authentication failed. Run: kt login codex"
+        )
+    if status in {408, 409, 429} or (isinstance(status, int) and status >= 500):
+        return CodexSearchOperationalError(
+            f"Codex search temporarily failed with HTTP {status}"
+        )
+    if isinstance(exc, (httpx.TimeoutException, httpx.TransportError)):
+        return CodexSearchOperationalError("Codex search is temporarily unavailable")
+    if isinstance(status, int) and status >= 400:
+        return CodexSearchUnavailable(
+            f"Codex search request was rejected with HTTP {status}"
+        )
+    return CodexSearchOperationalError(f"Codex search failed: {exc}")
+
+
+def _value(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _source(value: Any) -> dict[str, str] | None:
+    citation = _value(value, "url_citation")
+    raw = citation if citation is not None else value
+    url = str(_value(raw, "url", "") or "")
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    title = str(_value(raw, "title", "") or parsed.netloc)
+    return {"title": title, "url": url}
+
+
+def _citation_source(value: Any) -> dict[str, str] | None:
+    """Accept only Responses URL-citation annotations as cited sources."""
+    nested = _value(value, "url_citation")
+    if nested is not None:
+        return _source(nested)
+    if _value(value, "type") != "url_citation":
+        return None
+    return _source(value)
+
+
+def _action(value: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key in ("type", "query", "queries", "url", "pattern"):
+        item = _value(value, key)
+        if item not in (None, "", []):
+            result[key] = item
+    return result
+
+
+def _has_source_url(sources: list[dict[str, str]], candidate: dict[str, str]) -> bool:
+    return any(source["url"] == candidate["url"] for source in sources)
+
+
+@dataclass
+class _SearchCollector:
+    query: str
+    model: str
+    text: list[str] = field(default_factory=list)
+    sources: list[dict[str, str]] = field(default_factory=list)
+    citation_sources: list[dict[str, str]] = field(default_factory=list)
+    action_sources: list[dict[str, str]] = field(default_factory=list)
+    actions: list[dict[str, Any]] = field(default_factory=list)
+    usage: dict[str, int] = field(default_factory=dict)
+    response_status: str = "not_reported"
+    annotation_count: int = 0
+
+    def observe(self, event: Any) -> None:
+        event_type = str(_value(event, "type", "") or "")
+        if event_type == "response.output_text.delta":
+            delta = _value(event, "delta", "")
+            if isinstance(delta, str):
+                self.text.append(delta)
+            return
+        if event_type == "response.output_item.done":
+            self._observe_item(_value(event, "item"))
+            return
+        if event_type == "response.completed":
+            response = _value(event, "response")
+            self._observe_final_search_calls(response)
+            self.response_status = str(_value(response, "status", "completed"))
+            self.usage = _usage(_value(response, "usage"))
+            return
+        if event_type in {"response.failed", "response.incomplete"}:
+            response = _value(event, "response")
+            self._observe_final_search_calls(response)
+            self.response_status = str(
+                _value(response, "status", event_type.removeprefix("response."))
+            )
+            error = _value(response, "error") or _value(event, "error")
+            message = _value(error, "message", "") or self.response_status
+            if event_type == "response.failed":
+                raise CodexSearchOperationalError(f"Codex search {message}")
+            if not self.text and not self.sources:
+                raise CodexSearchOperationalError(f"Codex search {message}")
+
+    def _observe_final_search_calls(self, response: Any) -> None:
+        """Collect included action sources even if the stream omitted item events."""
+        for item in _value(response, "output", []) or []:
+            if _value(item, "type", "") == "web_search_call":
+                self._observe_item(item)
+
+    def _observe_item(self, item: Any) -> None:
+        item_type = _value(item, "type", "")
+        if item_type == "web_search_call":
+            action = _action(_value(item, "action"))
+            if action and action not in self.actions:
+                self.actions.append(action)
+            for raw in _value(_value(item, "action"), "sources", []) or []:
+                self._add_source(raw, origin=self.action_sources)
+            return
+        if item_type != "message":
+            return
+        for part in _value(item, "content", []) or []:
+            for annotation in _value(part, "annotations", []) or []:
+                self.annotation_count += 1
+                normalized = _citation_source(annotation)
+                if normalized is not None:
+                    self._add_normalized_source(
+                        normalized, origin=self.citation_sources
+                    )
+
+    def _add_source(self, raw: Any, *, origin: list[dict[str, str]]) -> None:
+        normalized = _source(raw)
+        if normalized is None:
+            return
+        self._add_normalized_source(normalized, origin=origin)
+
+    def _add_normalized_source(
+        self, normalized: dict[str, str], *, origin: list[dict[str, str]]
+    ) -> None:
+        if not _has_source_url(origin, normalized):
+            origin.append(normalized)
+        if not _has_source_url(self.sources, normalized):
+            self.sources.append(normalized)
+
+    def result(self, max_results: int) -> CodexSearchResult:
+        # The search-call item normally arrives before the cited message. Put
+        # inline citations first so a source limit cannot hide the answer's
+        # most relevant references behind the larger consulted-source list.
+        ordered_sources: list[dict[str, str]] = []
+        for source in [*self.citation_sources, *self.action_sources]:
+            if not _has_source_url(ordered_sources, source):
+                ordered_sources.append(source)
+        sources = ordered_sources[:max_results]
+        selected_urls = {source["url"] for source in sources}
+        citation_sources = [
+            source for source in self.citation_sources if source["url"] in selected_urls
+        ]
+        action_sources = [
+            source for source in self.action_sources if source["url"] in selected_urls
+        ]
+        body = "".join(self.text).strip() or "No results found."
+        if self.response_status == "incomplete":
+            body = f"Incomplete Codex search response.\n\n{body}"
+        output = f"Search results for: {self.query}\n\n{body}"
+        has_text_links = "http://" in body or "https://" in body
+        citation_status = (
+            "verified"
+            if citation_sources
+            else (
+                "grounded"
+                if action_sources
+                else "unverified_text" if has_text_links else "none"
+            )
+        )
+        if has_text_links and not sources:
+            output += (
+                "\n\nCitation note: Links in the answer text are unverified "
+                "provider text because no structured citations were returned."
+            )
+        if action_sources and not citation_sources:
+            output += (
+                "\n\nGrounding note: The Sources list contains structured URLs "
+                "reported as consulted by OpenAI web search; the answer did not "
+                "include inline URL citations."
+            )
+        if sources:
+            output += "\n\nSources:\n" + "\n".join(
+                f"{index}. [{source['title']}]({source['url']})"
+                for index, source in enumerate(sources, 1)
+            )
+        return CodexSearchResult(
+            output=output,
+            sources=sources,
+            metadata={
+                "backend": "codex",
+                "model": self.model,
+                "response_status": self.response_status,
+                "citation_status": citation_status,
+                "annotation_count": self.annotation_count,
+                "source_count": len(sources),
+                "verified_source_count": len(citation_sources),
+                "action_source_count": len(action_sources),
+                "sources": sources,
+                "verified_sources": citation_sources,
+                "consulted_sources": action_sources,
+                "actions": self.actions,
+                "usage": self.usage,
+            },
+        )
+
+
+def _usage(value: Any) -> dict[str, int]:
+    if value is None:
+        return {}
+    details = _value(value, "input_tokens_details")
+    return {
+        "prompt_tokens": int(_value(value, "input_tokens", 0) or 0),
+        "completion_tokens": int(_value(value, "output_tokens", 0) or 0),
+        "total_tokens": int(_value(value, "total_tokens", 0) or 0),
+        "cached_tokens": int(_value(details, "cached_tokens", 0) or 0),
+    }

--- a/tests/unit/builtins/tools/test_web_search.py
+++ b/tests/unit/builtins/tools/test_web_search.py
@@ -1,9 +1,6 @@
-"""Unit tests for the web_search tool's parser + fallback path.
+"""Unit tests for web-search parsing, backend selection, and fallback.
 
-The real DDG endpoint is NOT hit — these tests pin the HTML parser
-against fixed snippets and the backend-selection logic against
-monkey-patched search functions.  Live-network behaviour is the
-integration tier's concern.
+Network calls are replaced with fixed HTML or deterministic fakes.
 """
 
 import pytest
@@ -11,11 +8,13 @@ import pytest
 from kohakuterrarium.builtins.tools import web_search
 from kohakuterrarium.builtins.tools.web_search import (
     DeepSeekSearchBackend,
+    DuckDuckGoSearchBackend,
     SearchBackendOperationalError,
     SearchBackendUnavailable,
     WebSearchTool,
     _normalize_deepseek_response,
     _parse_ddg_html,
+    _search_session_metadata,
     _unwrap_ddg_redirect,
 )
 from kohakuterrarium.modules.tool.base import ToolConfig
@@ -38,6 +37,43 @@ _DDG_SAMPLE_HTML = """
 </div>
 </body></html>
 """
+
+
+def test_session_metadata_preserves_codex_grounding_sources():
+    source = {"title": "Weather", "url": "https://example.com/weather"}
+    metadata = _search_session_metadata(
+        {
+            "backend": "codex",
+            "citation_status": "grounded",
+            "source_count": 1,
+            "verified_source_count": 0,
+            "action_source_count": 1,
+            "verified_sources": [],
+            "consulted_sources": [source],
+        }
+    )
+
+    assert metadata["citation_status"] == "grounded"
+    assert metadata["source_count"] == 1
+    assert metadata["consulted_sources"] == [source]
+
+
+def test_description_discourages_repeated_search_only_for_explicit_codex():
+    codex_tool = WebSearchTool(ToolConfig(extra={"backend": "codex"}))
+
+    assert "once per question" in codex_tool.description
+    for backend in ("duckduckgo", "deepseek"):
+        tool = WebSearchTool(ToolConfig(extra={"backend": backend}))
+        assert "once per question" not in tool.description
+
+
+def test_codex_login_does_not_change_the_default_backend(monkeypatch):
+    monkeypatch.setattr(web_search, "codex_search_available", lambda: True)
+
+    tool = WebSearchTool()
+
+    assert tool.backend == "duckduckgo"
+    assert isinstance(tool._backend(), DuckDuckGoSearchBackend)
 
 
 class TestParseDdgHtml:
@@ -400,7 +436,11 @@ class TestDeepSeekSearch:
         class _FailingBackend:
             search = staticmethod(fail_search)
 
-        monkeypatch.setattr(WebSearchTool, "_backend", lambda self: _FailingBackend())
+        monkeypatch.setattr(
+            WebSearchTool,
+            "_backend",
+            lambda self, selected=None: _FailingBackend(),
+        )
         monkeypatch.setattr(web_search, "_has_ddg", lambda: False)
         monkeypatch.setattr(web_search, "_search_httpx_ddg", fallback_search)
         tool = WebSearchTool(
@@ -414,11 +454,80 @@ class TestDeepSeekSearch:
 
     def test_schema_marks_deepseek_unavailable_without_key(self, monkeypatch):
         monkeypatch.setattr(web_search, "has_api_key", lambda provider: False)
+        monkeypatch.setattr(web_search, "codex_search_available", lambda: False)
 
         schema = WebSearchTool().runtime_option_schema()
 
         assert "deepseek" in schema["backend"]["disabled_values"]
+        assert "codex" in schema["backend"]["disabled_values"]
         assert schema["backend"]["default"] == "duckduckgo"
+        assert schema["backend"]["values"] == ["duckduckgo", "codex", "deepseek"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_codex_backend_uses_subscription_search(self, monkeypatch):
+        class _CodexBackend:
+            def __init__(self, model):
+                self.model = model
+
+            async def search(self, query, max_results, region):
+                return web_search.SearchResponse(
+                    output="codex result",
+                    metadata={"backend": "codex", "model": self.model},
+                )
+
+        monkeypatch.setattr(web_search, "CodexSubscriptionSearchBackend", _CodexBackend)
+
+        tool = WebSearchTool(ToolConfig(extra={"backend": "codex"}))
+        result = await tool._execute({"query": "anything"})
+
+        assert result.output == "codex result"
+        assert result.metadata["backend"] == "codex"
+        assert result.metadata["requested_backend"] == "codex"
+
+    @pytest.mark.asyncio
+    async def test_explicit_codex_operational_failure_uses_configured_fallback(
+        self, monkeypatch
+    ):
+        async def fail_search(*args):
+            raise web_search.CodexSearchOperationalError("rate limited")
+
+        async def fallback_search(*args):
+            return [{"href": "https://fallback", "title": "fallback", "body": ""}]
+
+        class _CodexBackend:
+            def __init__(self, model):
+                self.search = fail_search
+
+        monkeypatch.setattr(web_search, "CodexSubscriptionSearchBackend", _CodexBackend)
+        monkeypatch.setattr(web_search, "_has_ddg", lambda: False)
+        monkeypatch.setattr(web_search, "_search_httpx_ddg", fallback_search)
+
+        tool = WebSearchTool(
+            ToolConfig(extra={"backend": "codex", "fallback": "duckduckgo"})
+        )
+        result = await tool._execute({"query": "anything"})
+
+        assert "fallback" in result.output
+        assert result.metadata["fallback_from"] == "codex"
+
+    @pytest.mark.asyncio
+    async def test_codex_failure_without_configured_fallback_is_an_error(
+        self, monkeypatch
+    ):
+        async def fail_search(*args):
+            raise web_search.CodexSearchOperationalError("rate limited")
+
+        class _CodexBackend:
+            def __init__(self, model):
+                self.search = fail_search
+
+        monkeypatch.setattr(web_search, "CodexSubscriptionSearchBackend", _CodexBackend)
+        tool = WebSearchTool(ToolConfig(extra={"backend": "codex"}))
+
+        result = await tool._execute({"query": "anything"})
+
+        assert result.error == "rate limited"
+        assert result.output == ""
 
     def test_untrusted_annotation_url_is_not_exposed(self):
         response = _normalize_deepseek_response(

--- a/tests/unit/llm/test_codex_web_search.py
+++ b/tests/unit/llm/test_codex_web_search.py
@@ -1,6 +1,8 @@
 """Unit contract for standalone Codex-subscription web search."""
 
+import asyncio
 import json
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -189,6 +191,62 @@ class TestSearchCollector:
         assert result.metadata["verified_source_count"] == 1
         assert result.metadata["action_source_count"] == 1
 
+    def test_tracking_variants_share_one_source_slot_and_keep_both_roles(self):
+        collector = _SearchCollector(query="q", model="m")
+        collector._add_source(
+            {"title": "Consulted", "url": "https://example.com/doc?utm_source=openai"},
+            origin=collector.action_sources,
+        )
+        collector._add_source(
+            {"title": "Cited", "url": "https://example.com/doc"},
+            origin=collector.citation_sources,
+        )
+
+        result = collector.result(1)
+
+        assert result.metadata["source_count"] == 1
+        assert result.metadata["verified_source_count"] == 1
+        assert result.metadata["action_source_count"] == 1
+
+    def test_semantic_query_parameters_remain_distinct_sources(self):
+        collector = _SearchCollector(query="q", model="m")
+        for page in (1, 2):
+            collector._add_source(
+                {
+                    "title": f"Page {page}",
+                    "url": f"https://example.com/doc?page={page}",
+                },
+                origin=collector.action_sources,
+            )
+
+        result = collector.result(5)
+
+        assert result.metadata["source_count"] == 2
+
+    def test_only_unstructured_body_links_receive_a_warning(self):
+        collector = _SearchCollector(query="q", model="m")
+        collector.text.append(
+            "Verified https://example.com/cited and raw https://other.example/page"
+        )
+        collector._add_source(
+            {"title": "Cited", "url": "https://example.com/cited"},
+            origin=collector.citation_sources,
+        )
+
+        result = collector.result(5)
+
+        assert result.metadata["citation_status"] == "verified"
+        assert "other links in the answer text are unverified" in result.output
+
+        matching = _SearchCollector(query="q", model="m")
+        matching.text.append("Verified https://example.com/cited")
+        matching._add_source(
+            {"title": "Cited", "url": "https://example.com/cited?utm_source=openai"},
+            origin=matching.citation_sources,
+        )
+
+        assert "unverified provider text" not in matching.result(5).output
+
     def test_non_url_annotation_is_not_promoted_to_verified_source(self):
         collector = _SearchCollector(query="q", model="m")
         collector.observe(
@@ -341,6 +399,64 @@ class TestSearchCollector:
 
 
 class TestCodexSubscriptionSearchBackend:
+    @pytest.mark.asyncio
+    async def test_valid_credentials_do_not_enter_refresh_lock(self, monkeypatch):
+        valid = CodexTokens(
+            access_token="valid",
+            refresh_token="refresh",
+            expires_at=time.time() + 3600,
+        )
+
+        class UnexpectedLock:
+            async def __aenter__(self):
+                raise AssertionError("refresh lock entered for a valid token")
+
+            async def __aexit__(self, *_args):
+                return None
+
+        monkeypatch.setattr(search_mod, "HAS_OPENAI", True)
+        monkeypatch.setattr(search_mod.CodexTokens, "load", lambda: valid)
+        monkeypatch.setattr(search_mod, "_TOKEN_REFRESH_LOCK", UnexpectedLock())
+
+        assert await search_mod._load_valid_tokens() is valid
+
+    @pytest.mark.asyncio
+    async def test_parallel_expired_credentials_refresh_once(self, monkeypatch):
+        expired = CodexTokens(
+            access_token="expired",
+            refresh_token="refresh",
+            expires_at=time.time() - 60,
+        )
+        refreshed = CodexTokens(
+            access_token="fresh",
+            refresh_token="rotated",
+            expires_at=time.time() + 3600,
+        )
+        current = expired
+        refresh_calls = 0
+
+        def load_tokens():
+            return current
+
+        async def refresh(_tokens):
+            nonlocal current, refresh_calls
+            refresh_calls += 1
+            await asyncio.sleep(0)
+            current = refreshed
+            return refreshed
+
+        monkeypatch.setattr(search_mod, "HAS_OPENAI", True)
+        monkeypatch.setattr(search_mod.CodexTokens, "load", load_tokens)
+        monkeypatch.setattr(search_mod, "refresh_tokens", refresh)
+        monkeypatch.setattr(search_mod, "_TOKEN_REFRESH_LOCK", asyncio.Lock())
+
+        results = await asyncio.gather(
+            search_mod._load_valid_tokens(), search_mod._load_valid_tokens()
+        )
+
+        assert results == [refreshed, refreshed]
+        assert refresh_calls == 1
+
     @pytest.mark.asyncio
     async def test_sends_forced_live_search_with_cached_subscription(self, monkeypatch):
         captured = {}

--- a/tests/unit/llm/test_codex_web_search.py
+++ b/tests/unit/llm/test_codex_web_search.py
@@ -1,0 +1,417 @@
+"""Unit contract for standalone Codex-subscription web search."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from kohakuterrarium.llm import codex_web_search as search_mod
+from kohakuterrarium.llm.codex_auth import CodexTokens
+from kohakuterrarium.llm.codex_web_search import (
+    CodexSearchOperationalError,
+    CodexSearchUnavailable,
+    CodexSubscriptionSearchBackend,
+    _SearchCollector,
+    _map_request_error,
+)
+
+
+def _event(event_type: str, **values):
+    return SimpleNamespace(type=event_type, **values)
+
+
+class TestSearchCollector:
+    def test_collects_text_actions_sources_and_usage(self):
+        collector = _SearchCollector(query="KT latest", model="gpt-5.6-luna")
+        collector.observe(_event("response.output_text.delta", delta="Current answer"))
+        collector.observe(
+            _event(
+                "response.output_item.done",
+                item=SimpleNamespace(
+                    type="web_search_call",
+                    action=SimpleNamespace(
+                        type="search",
+                        query="KT latest",
+                        sources=[
+                            SimpleNamespace(
+                                type="api",
+                                title="Primary source",
+                                url="https://example.com/source",
+                            )
+                        ],
+                    ),
+                ),
+            )
+        )
+        collector.observe(
+            _event(
+                "response.completed",
+                response=SimpleNamespace(
+                    status="completed",
+                    usage=SimpleNamespace(
+                        input_tokens=11,
+                        output_tokens=7,
+                        total_tokens=18,
+                        input_tokens_details=SimpleNamespace(cached_tokens=3),
+                    ),
+                ),
+            )
+        )
+
+        result = collector.result(5)
+
+        assert "Current answer" in result.output
+        assert result.sources == [
+            {"title": "Primary source", "url": "https://example.com/source"}
+        ]
+        assert result.metadata["actions"] == [{"type": "search", "query": "KT latest"}]
+        assert result.metadata["citation_status"] == "grounded"
+        assert result.metadata["action_source_count"] == 1
+        assert result.metadata["verified_source_count"] == 0
+        assert result.metadata["consulted_sources"] == result.sources
+        assert result.metadata["usage"]["cached_tokens"] == 3
+        json.dumps(result.metadata)
+
+    def test_message_annotations_are_normalized_and_deduplicated(self):
+        annotation = {
+            "type": "url_citation",
+            "url": "https://example.org/doc",
+            "title": "Doc",
+        }
+        collector = _SearchCollector(query="q", model="m")
+        collector.observe(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "content": [{"annotations": [annotation, annotation]}],
+                },
+            }
+        )
+
+        result = collector.result(10)
+
+        assert result.sources == [{"title": "Doc", "url": "https://example.org/doc"}]
+        assert result.metadata["annotation_count"] == 2
+        assert result.metadata["citation_status"] == "verified"
+        assert result.metadata["verified_sources"] == result.sources
+
+    def test_inline_citations_take_priority_over_consulted_source_limit(self):
+        collector = _SearchCollector(query="q", model="m")
+        collector.observe(
+            _event(
+                "response.output_item.done",
+                item=SimpleNamespace(
+                    type="web_search_call",
+                    action=SimpleNamespace(
+                        type="search",
+                        sources=[
+                            SimpleNamespace(
+                                type="url", url="https://example.com/consulted"
+                            )
+                        ],
+                    ),
+                ),
+            )
+        )
+        collector.observe(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "content": [
+                        {
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "url": "https://example.com/cited",
+                                    "title": "Cited",
+                                }
+                            ]
+                        }
+                    ],
+                },
+            }
+        )
+
+        result = collector.result(1)
+
+        assert result.sources == [
+            {"title": "Cited", "url": "https://example.com/cited"}
+        ]
+        assert result.metadata["source_count"] == 1
+        assert result.metadata["citation_status"] == "verified"
+
+    def test_same_url_is_one_source_but_keeps_both_grounding_roles(self):
+        collector = _SearchCollector(query="q", model="m")
+        collector.observe(
+            _event(
+                "response.output_item.done",
+                item=SimpleNamespace(
+                    type="web_search_call",
+                    action=SimpleNamespace(
+                        type="search",
+                        sources=[
+                            SimpleNamespace(
+                                type="url", url="https://example.com/source"
+                            )
+                        ],
+                    ),
+                ),
+            )
+        )
+        collector.observe(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "content": [
+                        {
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "url": "https://example.com/source",
+                                    "title": "Specific article",
+                                }
+                            ]
+                        }
+                    ],
+                },
+            }
+        )
+
+        result = collector.result(5)
+
+        assert result.sources == [
+            {"title": "Specific article", "url": "https://example.com/source"}
+        ]
+        assert result.metadata["source_count"] == 1
+        assert result.metadata["verified_source_count"] == 1
+        assert result.metadata["action_source_count"] == 1
+
+    def test_non_url_annotation_is_not_promoted_to_verified_source(self):
+        collector = _SearchCollector(query="q", model="m")
+        collector.observe(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "content": [
+                        {
+                            "annotations": [
+                                {
+                                    "type": "file_reference",
+                                    "url": "https://example.com/not-a-citation",
+                                    "title": "Not a citation",
+                                }
+                            ]
+                        }
+                    ],
+                },
+            }
+        )
+
+        result = collector.result(5)
+
+        assert result.sources == []
+        assert result.metadata["annotation_count"] == 1
+        assert result.metadata["citation_status"] == "none"
+
+    def test_weather_action_source_is_grounded_without_inline_citation(self):
+        collector = _SearchCollector(query="Shanghai weather", model="m")
+        collector.observe(
+            _event(
+                "response.output_text.delta",
+                delta="Seven-day forecast from the live weather feed.",
+            )
+        )
+        collector.observe(
+            _event(
+                "response.output_item.done",
+                item=SimpleNamespace(
+                    type="web_search_call",
+                    action=SimpleNamespace(
+                        type="search",
+                        query="weather: China, Shanghai, Shanghai",
+                        sources=[
+                            SimpleNamespace(
+                                type="url", url="https://weather.example/forecast"
+                            )
+                        ],
+                    ),
+                ),
+            )
+        )
+
+        result = collector.result(5)
+
+        assert result.metadata["citation_status"] == "grounded"
+        assert result.metadata["annotation_count"] == 0
+        assert result.metadata["action_source_count"] == 1
+        assert result.metadata["verified_source_count"] == 0
+        assert result.metadata["consulted_sources"] == [
+            {
+                "title": "weather.example",
+                "url": "https://weather.example/forecast",
+            }
+        ]
+        assert "structured URLs reported as consulted" in result.output
+
+    def test_completed_response_is_a_fallback_source_for_included_actions(self):
+        collector = _SearchCollector(query="q", model="m")
+        collector.observe(
+            _event(
+                "response.completed",
+                response=SimpleNamespace(
+                    status="completed",
+                    usage=None,
+                    output=[
+                        SimpleNamespace(
+                            type="web_search_call",
+                            action=SimpleNamespace(
+                                type="search",
+                                sources=[
+                                    SimpleNamespace(
+                                        type="url", url="https://example.com/source"
+                                    )
+                                ],
+                            ),
+                        )
+                    ],
+                ),
+            )
+        )
+
+        result = collector.result(5)
+
+        assert result.metadata["citation_status"] == "grounded"
+        assert result.metadata["source_count"] == 1
+        assert result.metadata["consulted_sources"] == [
+            {"title": "example.com", "url": "https://example.com/source"}
+        ]
+
+    def test_failed_response_without_partial_output_is_error(self):
+        collector = _SearchCollector(query="q", model="m")
+
+        with pytest.raises(CodexSearchOperationalError, match="backend unavailable"):
+            collector.observe(
+                _event(
+                    "response.failed",
+                    response=SimpleNamespace(
+                        status="failed",
+                        error=SimpleNamespace(message="backend unavailable"),
+                    ),
+                )
+            )
+
+    def test_failed_response_with_partial_output_is_still_error(self):
+        collector = _SearchCollector(query="q", model="m")
+        collector.observe(_event("response.output_text.delta", delta="partial"))
+
+        with pytest.raises(CodexSearchOperationalError, match="backend unavailable"):
+            collector.observe(
+                _event(
+                    "response.failed",
+                    response=SimpleNamespace(
+                        status="failed",
+                        error=SimpleNamespace(message="backend unavailable"),
+                    ),
+                )
+            )
+
+    def test_incomplete_response_with_partial_output_is_explicit(self):
+        collector = _SearchCollector(query="q", model="m")
+        collector.observe(_event("response.output_text.delta", delta="partial"))
+        collector.observe(
+            _event(
+                "response.incomplete",
+                response=SimpleNamespace(
+                    status="incomplete",
+                    error=None,
+                    output=[],
+                ),
+            )
+        )
+
+        result = collector.result(5)
+
+        assert result.metadata["response_status"] == "incomplete"
+        assert "Incomplete Codex search response" in result.output
+        assert "partial" in result.output
+
+
+class TestCodexSubscriptionSearchBackend:
+    @pytest.mark.asyncio
+    async def test_sends_forced_live_search_with_cached_subscription(self, monkeypatch):
+        captured = {}
+
+        async def valid_tokens():
+            return CodexTokens(access_token="token", refresh_token="refresh")
+
+        async def events():
+            yield _event("response.output_text.delta", delta="Answer")
+            yield _event(
+                "response.output_item.done",
+                item=SimpleNamespace(
+                    type="web_search_call",
+                    action=SimpleNamespace(
+                        type="search",
+                        query="query",
+                        sources=[
+                            SimpleNamespace(
+                                title="Source", url="https://example.com", type="api"
+                            )
+                        ],
+                    ),
+                ),
+            )
+            yield _event(
+                "response.completed",
+                response=SimpleNamespace(status="completed", usage=None),
+            )
+
+        class _Responses:
+            async def create(self, **kwargs):
+                captured.update(kwargs)
+                return events()
+
+        class _Client:
+            responses = _Responses()
+
+            async def close(self):
+                captured["closed"] = True
+
+        monkeypatch.setattr(search_mod, "_load_valid_tokens", valid_tokens)
+        monkeypatch.setattr(search_mod, "AsyncOpenAI", lambda **kwargs: _Client())
+
+        result = await CodexSubscriptionSearchBackend().search("query", 3, "CN")
+
+        assert captured["tools"] == [
+            {"type": "web_search", "external_web_access": True}
+        ]
+        assert captured["tool_choice"] == {"type": "web_search"}
+        assert captured["include"] == ["web_search_call.action.sources"]
+        assert captured["model"] == "gpt-5.6-luna"
+        assert captured["closed"] is True
+        assert result.metadata["backend"] == "codex"
+        assert result.sources[0]["url"] == "https://example.com"
+
+    @pytest.mark.asyncio
+    async def test_missing_cached_login_does_not_open_interactive_oauth(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(search_mod, "HAS_OPENAI", True)
+        monkeypatch.setattr(search_mod.CodexTokens, "load", lambda: None)
+
+        with pytest.raises(CodexSearchUnavailable, match="kt login codex"):
+            await search_mod._load_valid_tokens()
+
+
+class TestRequestErrorMapping:
+    def test_auth_error_is_unavailable(self):
+        error = SimpleNamespace(status_code=401, response=None)
+        assert isinstance(_map_request_error(error), CodexSearchUnavailable)
+
+    def test_rate_limit_is_operational(self):
+        error = SimpleNamespace(status_code=429, response=None)
+        assert isinstance(_map_request_error(error), CodexSearchOperationalError)


### PR DESCRIPTION
## Summary

Add an explicitly selectable Codex subscription-backed web-search backend for any controller while preserving DuckDuckGo as the default. The implementation keeps account-backed search independent from the controller model and records structured citation diagnostics without persisting credentials.

## PR Type

- [ ] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Users with an existing Codex subscription should be able to opt into hosted Codex web search without changing the creature controller model or affecting users who keep the default search configuration.

## Changes

- Add `codex` as an explicit `web_search` backend with selectable Codex models.
- Keep DuckDuckGo as the default and require explicit transient-failure fallback configuration.
- Preserve structured citations, consulted sources, usage, and sanitized session diagnostics.
- Coalesce concurrent expired-token refreshes without locking normal searches.
- Deduplicate known tracking URL variants without merging semantic query parameters.
- Warn only about answer-text links not covered by structured sources.
- Add English, Simplified Chinese, and Traditional Chinese documentation.

## Validation

```bash
.venv/Scripts/ruff.exe check src/kohakuterrarium/llm/codex_web_search.py tests/unit/llm/test_codex_web_search.py
.venv/Scripts/pytest.exe tests/unit/llm/test_codex_web_search.py tests/unit/builtins/tools/test_web_search.py -q --basetemp .pytest-review-light-5 -p no:cacheprovider
# 49 passed
git diff --check
```

Manual desktop validation also completed successfully, including the final lightweight hardening changes.

Fork CI preflight (green): https://github.com/WilliamQin7/KohakuTerrarium/pull/7
Upstream CI (green): https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/33624459649

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/` (not applicable; no frontend files changed)
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #273
- Issue opened: 2026-09-01
- Maintainer approval received in the project QQ group: 2026-09-02
- Approval record: https://github.com/Kohaku-Lab/KohakuTerrarium/issues/273#issuecomment-5508759636
- The implementation matches the approved scope: opt-in Codex subscription search with behavior analogous to the existing selectable search backend.

## Notes for Reviewers

The backend is never selected automatically. Users without Codex credentials remain on the existing DuckDuckGo default, and controller-model selection is unchanged.

## Exceptions / Not Run

None. The focused suite passed locally, and both fork preflight CI and the upstream cross-platform CI matrix completed successfully.
