### PR TITLE
perf(chat): auto-expand history on continuous upward scroll

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.scrollBehavior.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.scrollBehavior.test.js
@@ -493,7 +493,11 @@ describe("ChatPanel long-session performance", () => {
 
     expect(renderedIds(wrapper)).toHaveLength(300)
     expect(renderedIds(wrapper)[0]).toBe("m_700")
-    expect(viewport.scrollTop).toBe(210)
+    // jsdom rects are all zero, so the anchor delta reads 0: the panel
+    // pins "no spurious jump" (e.g. an absolute write to the bottom),
+    // while the compensation math itself is pinned with real rects in
+    // chatHistoryExpand.test.js.
+    expect(viewport.scrollTop).toBe(10)
     expect(idleCallbacks).toHaveLength(1)
 
     idleCallbacks[0]()
@@ -501,7 +505,7 @@ describe("ChatPanel long-session performance", () => {
 
     expect(renderedIds(wrapper)).toHaveLength(400)
     expect(renderedIds(wrapper)[0]).toBe("m_600")
-    expect(viewport.scrollTop).toBe(410)
+    expect(viewport.scrollTop).toBe(10)
     expect(idleCallbacks).toHaveLength(1)
     wrapper.unmount()
   })

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.scrollBehavior.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.scrollBehavior.test.js
@@ -458,7 +458,13 @@ describe("ChatPanel long-session performance", () => {
     frames.clear()
 
     const viewport = wrapper.find(".chat-messages-viewport").element
-    Object.defineProperty(viewport, "scrollHeight", { configurable: true, value: 1000 })
+    // Height tracks the mounted window (200 messages -> 1000px), so the
+    // prepended content of each expansion really grows the scroll area
+    // and the compensation assertions below are meaningful.
+    Object.defineProperty(viewport, "scrollHeight", {
+      configurable: true,
+      get: () => 600 + wrapper.findAll(".chat-message-stub").length * 2,
+    })
     Object.defineProperty(viewport, "clientHeight", { configurable: true, value: 200 })
 
     viewport.scrollTop = 800
@@ -487,7 +493,7 @@ describe("ChatPanel long-session performance", () => {
 
     expect(renderedIds(wrapper)).toHaveLength(300)
     expect(renderedIds(wrapper)[0]).toBe("m_700")
-    expect(viewport.scrollTop).toBe(10)
+    expect(viewport.scrollTop).toBe(210)
     expect(idleCallbacks).toHaveLength(1)
 
     idleCallbacks[0]()
@@ -495,6 +501,7 @@ describe("ChatPanel long-session performance", () => {
 
     expect(renderedIds(wrapper)).toHaveLength(400)
     expect(renderedIds(wrapper)[0]).toBe("m_600")
+    expect(viewport.scrollTop).toBe(410)
     expect(idleCallbacks).toHaveLength(1)
     wrapper.unmount()
   })

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.scrollBehavior.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.scrollBehavior.test.js
@@ -428,4 +428,137 @@ describe("ChatPanel long-session performance", () => {
     expect(frames.size).toBe(0)
     wrapper.unmount()
   })
+
+  function stubIdleExpansion() {
+    const idleCallbacks = []
+    const idleCancelled = new Set()
+    vi.stubGlobal("requestIdleCallback", (callback) => {
+      idleCallbacks.push(callback)
+      return idleCallbacks.length
+    })
+    vi.stubGlobal("cancelIdleCallback", (id) => idleCancelled.add(id))
+    return { idleCallbacks, idleCancelled }
+  }
+
+  it("auto-expands the history window when scrolling reaches the top", async () => {
+    const frames = new Map()
+    let nextFrame = 1
+    vi.stubGlobal("requestAnimationFrame", (callback) => {
+      const id = nextFrame++
+      frames.set(id, callback)
+      return id
+    })
+    vi.stubGlobal("cancelAnimationFrame", (id) => frames.delete(id))
+    const { idleCallbacks } = stubIdleExpansion()
+
+    const chat = useChatStore("graph_1")
+    seedMessages(chat, 1000)
+    const wrapper = mountPanel(chat)
+    await flushPromises()
+    frames.clear()
+
+    const viewport = wrapper.find(".chat-messages-viewport").element
+    Object.defineProperty(viewport, "scrollHeight", { configurable: true, value: 1000 })
+    Object.defineProperty(viewport, "clientHeight", { configurable: true, value: 200 })
+
+    viewport.scrollTop = 800
+    viewport.dispatchEvent(new Event("scroll"))
+    let [id, frame] = [...frames][0]
+    frames.delete(id)
+    frame()
+
+    // Upward but away from the top: history mode pins the window,
+    // no automatic expansion yet.
+    viewport.scrollTop = 300
+    viewport.dispatchEvent(new Event("scroll"))
+    ;[id, frame] = [...frames][0]
+    frames.delete(id)
+    frame()
+    expect(renderedIds(wrapper)).toHaveLength(200)
+
+    // Reaching the top expands one small step, then the idle lookahead
+    // pre-mounts the next step exactly once.
+    viewport.scrollTop = 10
+    viewport.dispatchEvent(new Event("scroll"))
+    ;[id, frame] = [...frames][0]
+    frames.delete(id)
+    frame()
+    await flushPromises()
+
+    expect(renderedIds(wrapper)).toHaveLength(300)
+    expect(renderedIds(wrapper)[0]).toBe("m_700")
+    expect(viewport.scrollTop).toBe(10)
+    expect(idleCallbacks).toHaveLength(1)
+
+    idleCallbacks[0]()
+    await flushPromises()
+
+    expect(renderedIds(wrapper)).toHaveLength(400)
+    expect(renderedIds(wrapper)[0]).toBe("m_600")
+    expect(idleCallbacks).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it("cancels the pending idle expansion when the active tab changes", async () => {
+    const frames = new Map()
+    let nextFrame = 1
+    vi.stubGlobal("requestAnimationFrame", (callback) => {
+      const id = nextFrame++
+      frames.set(id, callback)
+      return id
+    })
+    vi.stubGlobal("cancelAnimationFrame", (id) => frames.delete(id))
+    const { idleCallbacks, idleCancelled } = stubIdleExpansion()
+
+    const chat = useChatStore("graph_1")
+    chat.activeTab = "kohaku"
+    chat.tabs = ["kohaku", "reviewer"]
+    seedMessages(chat, 1000)
+    chat.messagesByTab.reviewer = Array.from({ length: 20 }, (_, index) => ({
+      id: `r_${index}`,
+      role: index % 2 ? "assistant" : "user",
+      content: `review ${index}`,
+    }))
+    chat.commandInventoryByTab.reviewer = { commands: [], skills: [] }
+    chat._commandInventoryFetchedAtByTab.reviewer = Date.now()
+    const groupId = chat.enableGroups()
+    const wrapper = mountPanel(chat, { groupId })
+    await flushPromises()
+    frames.clear()
+
+    const viewport = wrapper.find(".chat-messages-viewport").element
+    Object.defineProperty(viewport, "scrollHeight", { configurable: true, value: 1000 })
+    Object.defineProperty(viewport, "clientHeight", { configurable: true, value: 200 })
+
+    viewport.scrollTop = 800
+    viewport.dispatchEvent(new Event("scroll"))
+    let [id, frame] = [...frames][0]
+    frames.delete(id)
+    frame()
+
+    viewport.scrollTop = 300
+    viewport.dispatchEvent(new Event("scroll"))
+    ;[id, frame] = [...frames][0]
+    frames.delete(id)
+    frame()
+
+    viewport.scrollTop = 10
+    viewport.dispatchEvent(new Event("scroll"))
+    ;[id, frame] = [...frames][0]
+    frames.delete(id)
+    frame()
+    await flushPromises()
+
+    expect(renderedIds(wrapper)).toHaveLength(300)
+    expect(idleCallbacks).toHaveLength(1)
+
+    chat.setGroupActiveTab(groupId, "reviewer")
+    await flushPromises()
+    expect(idleCancelled.size).toBe(1)
+
+    idleCallbacks[0]()
+    await flushPromises()
+    expect(renderedIds(wrapper)).toHaveLength(20)
+    wrapper.unmount()
+  })
 })

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -195,7 +195,7 @@ import { inject } from "vue"
 import StatusDot from "@/components/common/StatusDot.vue"
 import ChatMessage from "@/components/chat/ChatMessage.vue"
 import { useChatRenderWindow, CHAT_RENDER_EXPAND_MESSAGE_LIMIT, CHAT_RENDER_EXPAND_UNIT_BUDGET } from "@/components/chat/chatRenderWindow"
-import { createChatHistoryExpander } from "@/components/chat/chatHistoryExpand"
+import { createChatHistoryExpander, captureViewportAnchor, restoreViewportAnchor } from "@/components/chat/chatHistoryExpand"
 import { createChatScrollScheduler } from "@/components/chat/chatScrollScheduler"
 import SlashCommandMenu from "@/components/chat/SlashCommandMenu.vue"
 import ModelSwitcher from "@/components/chrome/ModelSwitcher.vue"
@@ -551,11 +551,10 @@ const historyExpander = createChatHistoryExpander({
 })
 
 async function loadEarlierMessages() {
-  const el = messagesEl.value
-  const prevHeight = el ? el.scrollHeight : 0
+  const anchor = captureViewportAnchor(() => messagesEl.value)
   expandHistory()
   await nextTick()
-  if (el && prevHeight) el.scrollTop += el.scrollHeight - prevHeight
+  restoreViewportAnchor(() => messagesEl.value, anchor)
 }
 
 let lastObservedScrollTop = 0

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -194,7 +194,8 @@ import { inject } from "vue"
 
 import StatusDot from "@/components/common/StatusDot.vue"
 import ChatMessage from "@/components/chat/ChatMessage.vue"
-import { useChatRenderWindow } from "@/components/chat/chatRenderWindow"
+import { useChatRenderWindow, CHAT_RENDER_EXPAND_MESSAGE_LIMIT, CHAT_RENDER_EXPAND_UNIT_BUDGET } from "@/components/chat/chatRenderWindow"
+import { createChatHistoryExpander } from "@/components/chat/chatHistoryExpand"
 import { createChatScrollScheduler } from "@/components/chat/chatScrollScheduler"
 import SlashCommandMenu from "@/components/chat/SlashCommandMenu.vue"
 import ModelSwitcher from "@/components/chrome/ModelSwitcher.vue"
@@ -539,6 +540,16 @@ function getScrollKey(instanceId = props.instance?.id || chat._instanceId, tab =
 // end keeps newly arriving messages reachable.
 const { enterHistoryAt, expandHistory, isHistoryMode, leaveHistory, restoreHistory, windowMessages, windowStart } = useChatRenderWindow(viewMessages, () => getScrollKey())
 
+// Continuous upward scrolling: reaching the top of the rendered window
+// expands it one small step, and an idle lookahead pre-mounts the next
+// step so back-to-back expansions never stall the scroll interaction.
+const historyExpander = createChatHistoryExpander({
+  canExpand: () => isHistoryMode.value && windowStart.value > 0,
+  expand: () => expandHistory({ unitBudget: CHAT_RENDER_EXPAND_UNIT_BUDGET, messageLimit: CHAT_RENDER_EXPAND_MESSAGE_LIMIT }),
+  getViewportEl: () => messagesEl.value,
+  getContext: () => getScrollKey(),
+})
+
 async function loadEarlierMessages() {
   const el = messagesEl.value
   const prevHeight = el ? el.scrollHeight : 0
@@ -593,6 +604,8 @@ function onMessagesScroll() {
     if (isNearBottom.value) {
       leaveHistory()
       scrollScheduler.resume()
+    } else if (el) {
+      historyExpander.maybeExpandAtTop(el.scrollTop)
     }
     saveScrollPosition()
   })
@@ -656,6 +669,7 @@ watch(
   (scope, previousScope) => {
     scrollScheduler.invalidate()
     scrollScheduler.resume()
+    historyExpander.cancelIdleExpand()
     if (scrollStateFrame !== null) {
       cancelAnimationFrame(scrollStateFrame)
       scrollStateFrame = null
@@ -990,6 +1004,7 @@ onMounted(() => window.addEventListener("keydown", onGlobalKeydown))
 onUnmounted(() => {
   window.removeEventListener("keydown", onGlobalKeydown)
   scrollScheduler.dispose()
+  historyExpander.dispose()
   if (scrollStateFrame !== null) cancelAnimationFrame(scrollStateFrame)
 })
 </script>

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
@@ -5,6 +5,33 @@ import { nextTick } from "vue"
 // "show earlier".
 export const CHAT_AUTO_EXPAND_TOP_PX = 48
 
+// Reading-position anchor for prepending content. The first message
+// wrapper visible at the viewport top is captured before the DOM
+// changes; after the commit its viewport-relative position is restored
+// via an absolute delta on its live rect. Unlike a scrollHeight delta
+// this is self-correcting when the browser's native scroll anchoring
+// already adjusted scrollTop for the insertion (the anchor delta then
+// reads ~0, so no double compensation).
+export function captureViewportAnchor(getViewportEl) {
+  const el = getViewportEl()
+  if (!el) return null
+  const viewportTop = el.getBoundingClientRect().top
+  for (const wrapper of el.querySelectorAll("[data-message-id]")) {
+    if (wrapper.getBoundingClientRect().bottom > viewportTop) {
+      return { element: wrapper, offset: wrapper.getBoundingClientRect().top - viewportTop }
+    }
+  }
+  return null
+}
+
+export function restoreViewportAnchor(getViewportEl, anchor) {
+  if (!anchor || !anchor.element.isConnected) return
+  const el = getViewportEl()
+  if (!el) return
+  const viewportTop = el.getBoundingClientRect().top
+  el.scrollTop += anchor.element.getBoundingClientRect().top - viewportTop - anchor.offset
+}
+
 function defaultScheduleIdle(callback) {
   if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
     return window.requestIdleCallback(callback, { timeout: 400 })
@@ -41,16 +68,14 @@ export function createChatHistoryExpander({
 
   async function expandAndCompensate() {
     const context = getContext?.()
-    const el = getViewportEl()
-    const prevHeight = el ? el.scrollHeight : 0
+    const anchor = captureViewportAnchor(getViewportEl)
     expand()
     await nextTick()
     // A scope switch during the DOM commit means the prepended content
     // no longer belongs to the mounted list — don't shift the new
     // scope's restored scroll position by a stale delta.
     if (getContext && getContext() !== context) return
-    const after = getViewportEl()
-    if (after && prevHeight) after.scrollTop += after.scrollHeight - prevHeight
+    restoreViewportAnchor(getViewportEl, anchor)
   }
 
   async function runExpand() {

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
@@ -1,0 +1,95 @@
+import { nextTick } from "vue"
+
+// Distance (px) from the top of the viewport at which continuous
+// upward scrolling expands the render window without a click on
+// "show earlier".
+export const CHAT_AUTO_EXPAND_TOP_PX = 48
+
+function defaultScheduleIdle(callback) {
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+    return window.requestIdleCallback(callback, { timeout: 400 })
+  }
+  return setTimeout(callback, 120)
+}
+
+function defaultCancelIdle(handle) {
+  if (typeof window !== "undefined" && typeof window.cancelIdleCallback === "function") {
+    window.cancelIdleCallback(handle)
+  } else {
+    clearTimeout(handle)
+  }
+}
+
+// Drives automatic history expansion on top of useChatRenderWindow:
+// - ``maybeExpandAtTop`` grows the window one small step when scrolling
+//   reaches the top of the rendered range, compensating scrollTop after
+//   the DOM commit so reading position never jumps.
+// - ``scheduleIdleExpand`` pre-mounts the next step off the interaction
+//   path. It never chains: at most one batch lives ahead of the
+//   viewport, so idle expansion cannot walk the whole history.
+export function createChatHistoryExpander({
+  canExpand,
+  expand,
+  getViewportEl,
+  getContext,
+  scheduleIdle = defaultScheduleIdle,
+  cancelIdle = defaultCancelIdle,
+}) {
+  let idleHandle = null
+  let expanding = false
+
+  async function expandAndCompensate() {
+    const context = getContext?.()
+    const el = getViewportEl()
+    const prevHeight = el ? el.scrollHeight : 0
+    expand()
+    await nextTick()
+    // A scope switch during the DOM commit means the prepended content
+    // no longer belongs to the mounted list — don't shift the new
+    // scope's restored scroll position by a stale delta.
+    if (getContext && getContext() !== context) return
+    const after = getViewportEl()
+    if (after && prevHeight) after.scrollTop += after.scrollHeight - prevHeight
+  }
+
+  async function runExpand() {
+    expanding = true
+    try {
+      await expandAndCompensate()
+    } finally {
+      expanding = false
+    }
+  }
+
+  function maybeExpandAtTop(scrollTop) {
+    if (expanding || !canExpand() || scrollTop > CHAT_AUTO_EXPAND_TOP_PX) return false
+    runExpand().then(scheduleIdleExpand)
+    return true
+  }
+
+  function scheduleIdleExpand() {
+    if (idleHandle !== null || expanding || !canExpand()) return
+    idleHandle = scheduleIdle(() => {
+      idleHandle = null
+      if (!canExpand()) return
+      runExpand()
+    })
+  }
+
+  function cancelIdleExpand() {
+    if (idleHandle === null) return
+    cancelIdle(idleHandle)
+    idleHandle = null
+  }
+
+  function dispose() {
+    cancelIdleExpand()
+  }
+
+  return {
+    cancelIdleExpand,
+    dispose,
+    maybeExpandAtTop,
+    scheduleIdleExpand,
+  }
+}

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
@@ -93,6 +93,11 @@ export function createChatHistoryExpander({
 
   function maybeExpandAtTop(scrollTop) {
     if (disposed || expanding || !canExpand() || scrollTop > CHAT_AUTO_EXPAND_TOP_PX) return false
+    // The interactive step mounts the batch a pending lookahead was
+    // going to pre-mount, so supersede it: keeps at most one batch
+    // ahead of the reading position, and keeps the setTimeout fallback
+    // from firing a stale expansion mid-gesture.
+    cancelIdleExpand()
     const context = getContext?.()
     runExpand().then(() => {
       // A scope switch or disposal during the in-flight expansion

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
@@ -37,6 +37,7 @@ export function createChatHistoryExpander({
 }) {
   let idleHandle = null
   let expanding = false
+  let disposed = false
 
   async function expandAndCompensate() {
     const context = getContext?.()
@@ -56,22 +57,33 @@ export function createChatHistoryExpander({
     expanding = true
     try {
       await expandAndCompensate()
+    } catch (error) {
+      // Scroll-handler-originated work must never surface as an
+      // unhandled rejection.
+      console.warn("[chat] history expansion failed", error)
     } finally {
       expanding = false
     }
   }
 
   function maybeExpandAtTop(scrollTop) {
-    if (expanding || !canExpand() || scrollTop > CHAT_AUTO_EXPAND_TOP_PX) return false
-    runExpand().then(scheduleIdleExpand)
+    if (disposed || expanding || !canExpand() || scrollTop > CHAT_AUTO_EXPAND_TOP_PX) return false
+    const context = getContext?.()
+    runExpand().then(() => {
+      // A scope switch or disposal during the in-flight expansion
+      // invalidates the continuation: never re-arm the lookahead for a
+      // scope the user did not scroll in.
+      if (disposed || (getContext && getContext() !== context)) return
+      scheduleIdleExpand()
+    })
     return true
   }
 
   function scheduleIdleExpand() {
-    if (idleHandle !== null || expanding || !canExpand()) return
+    if (disposed || idleHandle !== null || expanding || !canExpand()) return
     idleHandle = scheduleIdle(() => {
       idleHandle = null
-      if (!canExpand()) return
+      if (disposed || !canExpand()) return
       runExpand()
     })
   }
@@ -83,6 +95,7 @@ export function createChatHistoryExpander({
   }
 
   function dispose() {
+    disposed = true
     cancelIdleExpand()
   }
 

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
@@ -206,4 +206,72 @@ describe("chat history auto expansion", () => {
     expect(expand).toHaveBeenCalledOnce()
     expect(el.scrollTop).toBe(10)
   })
+
+  it("does not rearm idle work for a new scope after a mid-expansion switch", async () => {
+    const idle = createIdleHarness()
+    const el = createViewport()
+    let context = "tab-a"
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => el,
+      getContext: () => context,
+      ...idle,
+    })
+
+    expander.maybeExpandAtTop(0)
+    // Scope flips while the expansion is still awaiting its DOM commit.
+    context = "tab-b"
+    await flushPromises()
+
+    expect(expand).toHaveBeenCalledOnce()
+    expect(idle.scheduled).toHaveLength(0)
+  })
+
+  it("does not rearm or expand anything after dispose", async () => {
+    const idle = createIdleHarness()
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...idle,
+    })
+
+    expander.maybeExpandAtTop(0)
+    // Unmount lands while the expansion is still in flight, so the
+    // continuation (not just a pending handle) must be fenced off.
+    expander.dispose()
+    await flushPromises()
+
+    expect(expand).toHaveBeenCalledOnce()
+    expect(idle.scheduled).toHaveLength(0)
+    expect(expander.maybeExpandAtTop(0)).toBe(false)
+    expect(expander.scheduleIdleExpand()).toBeUndefined()
+    expect(idle.scheduled).toHaveLength(0)
+  })
+
+  it("warns instead of rejecting when the expand callback throws", async () => {
+    const idle = createIdleHarness()
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const expand = vi.fn(() => {
+      throw new Error("boom")
+    })
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...idle,
+    })
+
+    expect(expander.maybeExpandAtTop(0)).toBe(true)
+    await flushPromises()
+
+    expect(warn).toHaveBeenCalledOnce()
+    expect(expander.maybeExpandAtTop(0)).toBe(true)
+    warn.mockRestore()
+  })
 })

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
@@ -16,6 +16,9 @@ describe("chat history auto expansion", () => {
         return id
       },
       cancelIdle: (id) => cancelled.add(id),
+      pendingCount() {
+        return scheduled.filter((entry) => !cancelled.has(entry.id)).length
+      },
       runNext() {
         const entry = scheduled.find((candidate) => !cancelled.has(candidate.id))
         if (!entry) return false
@@ -199,6 +202,31 @@ describe("chat history auto expansion", () => {
     await flushPromises()
 
     expect(el.scrollTop).toBe(10)
+  })
+
+  it("supersedes a stale lookahead when a new scroll-triggered expansion starts", async () => {
+    const expand = vi.fn()
+    const { idle, expander } = createExpander({ expand })
+
+    expander.maybeExpandAtTop(0)
+    await flushPromises()
+    expect(idle.pendingCount()).toBe(1)
+
+    // The user reaches the top again before the lookahead fires. The
+    // stale handle must be cancelled, not left to fire an extra
+    // expansion on top of the fresh one.
+    expect(expander.maybeExpandAtTop(0)).toBe(true)
+    expect(idle.cancelled).toContain(idle.scheduled[0].id)
+    await flushPromises()
+
+    expect(expand).toHaveBeenCalledTimes(2)
+    expect(idle.pendingCount()).toBe(1)
+
+    // The replacement lookahead fires once and never chains.
+    expect(idle.runNext()).toBe(true)
+    await flushPromises()
+    expect(expand).toHaveBeenCalledTimes(3)
+    expect(idle.pendingCount()).toBe(0)
   })
 
   it("does not rearm idle work for a new scope after a mid-expansion switch", async () => {

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
@@ -1,0 +1,209 @@
+import { flushPromises } from "@vue/test-utils"
+import { describe, expect, it, vi } from "vitest"
+
+import { CHAT_AUTO_EXPAND_TOP_PX, createChatHistoryExpander } from "./chatHistoryExpand"
+
+describe("chat history auto expansion", () => {
+  function createIdleHarness() {
+    const scheduled = []
+    const cancelled = new Set()
+    return {
+      scheduled,
+      cancelled,
+      scheduleIdle: (callback) => {
+        const id = scheduled.length + 1
+        scheduled.push({ id, callback })
+        return id
+      },
+      cancelIdle: (id) => cancelled.add(id),
+      runNext() {
+        const entry = scheduled.find((candidate) => !cancelled.has(candidate.id))
+        if (!entry) return false
+        scheduled.splice(scheduled.indexOf(entry), 1)
+        entry.callback()
+        return true
+      },
+    }
+  }
+
+  function createViewport({ scrollTop = 0, height = 1000 } = {}) {
+    const el = { scrollTop }
+    let viewportHeight = height
+    Object.defineProperty(el, "scrollHeight", {
+      configurable: true,
+      get: () => viewportHeight,
+      set: (value) => {
+        viewportHeight = value
+      },
+    })
+    return el
+  }
+
+  it("expands one step at the top and compensates the reading position", async () => {
+    const idle = createIdleHarness()
+    const el = createViewport({ scrollTop: 10 })
+    const expand = vi.fn(() => {
+      // Simulate the prepended content growing the scroll area.
+      el.scrollHeight = 3000
+    })
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => el,
+      getContext: () => "tab",
+      ...idle,
+    })
+
+    expect(expander.maybeExpandAtTop(10)).toBe(true)
+    await flushPromises()
+
+    expect(expand).toHaveBeenCalledOnce()
+    expect(el.scrollTop).toBe(2010)
+  })
+
+  it("still expands exactly at the threshold", () => {
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...createIdleHarness(),
+    })
+
+    expect(expander.maybeExpandAtTop(CHAT_AUTO_EXPAND_TOP_PX)).toBe(true)
+    expect(expand).toHaveBeenCalledOnce()
+  })
+
+  it("does not expand while the viewport is away from the top", () => {
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...createIdleHarness(),
+    })
+
+    expect(expander.maybeExpandAtTop(CHAT_AUTO_EXPAND_TOP_PX + 1)).toBe(false)
+    expect(expand).not.toHaveBeenCalled()
+  })
+
+  it("does not expand when the window has nothing earlier to show", () => {
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => false,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...createIdleHarness(),
+    })
+
+    expect(expander.maybeExpandAtTop(0)).toBe(false)
+    expect(expand).not.toHaveBeenCalled()
+  })
+
+  it("does not stack expansions while one is in flight", () => {
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...createIdleHarness(),
+    })
+
+    expect(expander.maybeExpandAtTop(0)).toBe(true)
+    expect(expander.maybeExpandAtTop(0)).toBe(false)
+    expect(expand).toHaveBeenCalledOnce()
+  })
+
+  it("pre-mounts one idle lookahead and never chains further", async () => {
+    const idle = createIdleHarness()
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...idle,
+    })
+
+    expander.maybeExpandAtTop(0)
+    await flushPromises()
+    expect(idle.scheduled).toHaveLength(1)
+
+    expect(idle.runNext()).toBe(true)
+    await flushPromises()
+    expect(expand).toHaveBeenCalledTimes(2)
+    // runNext consumes the fired entry; a chained schedule would push a
+    // new one, so an empty list proves the lookahead never chains.
+    expect(idle.scheduled).toHaveLength(0)
+  })
+
+  it("drops a pending idle lookahead once the window has nothing earlier", async () => {
+    const idle = createIdleHarness()
+    let expandable = true
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => expandable,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...idle,
+    })
+
+    expander.maybeExpandAtTop(0)
+    await flushPromises()
+    expandable = false
+
+    expect(idle.runNext()).toBe(true)
+    await flushPromises()
+    expect(expand).toHaveBeenCalledOnce()
+  })
+
+  it("cancels a pending idle lookahead on demand", async () => {
+    const idle = createIdleHarness()
+    const expand = vi.fn()
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => createViewport(),
+      getContext: () => "tab",
+      ...idle,
+    })
+
+    expander.maybeExpandAtTop(0)
+    await flushPromises()
+    expect(idle.scheduled).toHaveLength(1)
+
+    expander.cancelIdleExpand()
+    expect(idle.cancelled).toContain(idle.scheduled[0].id)
+    expect(idle.runNext()).toBe(false)
+    await flushPromises()
+    expect(expand).toHaveBeenCalledOnce()
+  })
+
+  it("skips the scroll compensation when the scope changed mid-expansion", async () => {
+    const idle = createIdleHarness()
+    const el = createViewport({ scrollTop: 10 })
+    let context = "tab"
+    const expand = vi.fn(() => {
+      el.scrollHeight = 3000
+      context = "other-tab"
+    })
+    const expander = createChatHistoryExpander({
+      canExpand: () => true,
+      expand,
+      getViewportEl: () => el,
+      getContext: () => context,
+      ...idle,
+    })
+
+    expander.maybeExpandAtTop(0)
+    await flushPromises()
+
+    expect(expand).toHaveBeenCalledOnce()
+    expect(el.scrollTop).toBe(10)
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
@@ -26,50 +26,71 @@ describe("chat history auto expansion", () => {
     }
   }
 
-  function createViewport({ scrollTop = 0, height = 1000 } = {}) {
+  // A message wrapper whose viewport-relative top is readable and
+  // mutable, simulating content prepended above it.
+  function createWrapper(top, { connected = true } = {}) {
+    const element = {
+      isConnected: connected,
+      getBoundingClientRect: () => ({ top: element.top, bottom: element.top + 50 }),
+    }
+    element.top = top
+    return element
+  }
+
+  function createViewport({ scrollTop = 0, wrappers = [] } = {}) {
     const el = { scrollTop }
-    let viewportHeight = height
-    Object.defineProperty(el, "scrollHeight", {
-      configurable: true,
-      get: () => viewportHeight,
-      set: (value) => {
-        viewportHeight = value
-      },
-    })
+    el.getBoundingClientRect = () => ({ top: 0, bottom: 0 })
+    el.querySelectorAll = () => wrappers
     return el
   }
 
-  it("expands one step at the top and compensates the reading position", async () => {
-    const idle = createIdleHarness()
-    const el = createViewport({ scrollTop: 10 })
-    const expand = vi.fn(() => {
-      // Simulate the prepended content growing the scroll area.
-      el.scrollHeight = 3000
-    })
+  function createExpander(overrides = {}) {
+    const idle = overrides.idle || createIdleHarness()
     const expander = createChatHistoryExpander({
       canExpand: () => true,
-      expand,
-      getViewportEl: () => el,
+      expand: vi.fn(),
+      getViewportEl: () => createViewport(),
       getContext: () => "tab",
       ...idle,
+      ...overrides,
     })
+    return { idle, expander }
+  }
+
+  it("expands one step at the top and compensates the reading position", async () => {
+    const wrapper = createWrapper(100)
+    const el = createViewport({ scrollTop: 10, wrappers: [wrapper] })
+    const expand = vi.fn(() => {
+      // Prepending content pushes the anchor message down.
+      wrapper.top = 300
+    })
+    const { expander } = createExpander({ expand, getViewportEl: () => el })
 
     expect(expander.maybeExpandAtTop(10)).toBe(true)
     await flushPromises()
 
     expect(expand).toHaveBeenCalledOnce()
-    expect(el.scrollTop).toBe(2010)
+    expect(el.scrollTop).toBe(210)
+  })
+
+  it("does not double-compensate when the browser already restored the position", async () => {
+    const wrapper = createWrapper(100)
+    const el = createViewport({ scrollTop: 10, wrappers: [wrapper] })
+    // Native scroll anchoring keeps the anchor visually stable while the
+    // content above it grows; the anchor delta must then read zero and
+    // scrollTop must not be shifted a second time.
+    const expand = vi.fn()
+    const { expander } = createExpander({ expand, getViewportEl: () => el })
+
+    expander.maybeExpandAtTop(10)
+    await flushPromises()
+
+    expect(el.scrollTop).toBe(10)
   })
 
   it("still expands exactly at the threshold", () => {
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...createIdleHarness(),
-    })
+    const { expander } = createExpander({ expand })
 
     expect(expander.maybeExpandAtTop(CHAT_AUTO_EXPAND_TOP_PX)).toBe(true)
     expect(expand).toHaveBeenCalledOnce()
@@ -77,13 +98,7 @@ describe("chat history auto expansion", () => {
 
   it("does not expand while the viewport is away from the top", () => {
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...createIdleHarness(),
-    })
+    const { expander } = createExpander({ expand })
 
     expect(expander.maybeExpandAtTop(CHAT_AUTO_EXPAND_TOP_PX + 1)).toBe(false)
     expect(expand).not.toHaveBeenCalled()
@@ -91,13 +106,7 @@ describe("chat history auto expansion", () => {
 
   it("does not expand when the window has nothing earlier to show", () => {
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => false,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...createIdleHarness(),
-    })
+    const { expander } = createExpander({ expand, canExpand: () => false })
 
     expect(expander.maybeExpandAtTop(0)).toBe(false)
     expect(expand).not.toHaveBeenCalled()
@@ -105,13 +114,7 @@ describe("chat history auto expansion", () => {
 
   it("does not stack expansions while one is in flight", () => {
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...createIdleHarness(),
-    })
+    const { expander } = createExpander({ expand })
 
     expect(expander.maybeExpandAtTop(0)).toBe(true)
     expect(expander.maybeExpandAtTop(0)).toBe(false)
@@ -119,15 +122,8 @@ describe("chat history auto expansion", () => {
   })
 
   it("pre-mounts one idle lookahead and never chains further", async () => {
-    const idle = createIdleHarness()
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...idle,
-    })
+    const { idle, expander } = createExpander({ expand })
 
     expander.maybeExpandAtTop(0)
     await flushPromises()
@@ -142,16 +138,9 @@ describe("chat history auto expansion", () => {
   })
 
   it("drops a pending idle lookahead once the window has nothing earlier", async () => {
-    const idle = createIdleHarness()
     let expandable = true
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => expandable,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...idle,
-    })
+    const { idle, expander } = createExpander({ expand, canExpand: () => expandable })
 
     expander.maybeExpandAtTop(0)
     await flushPromises()
@@ -163,15 +152,8 @@ describe("chat history auto expansion", () => {
   })
 
   it("cancels a pending idle lookahead on demand", async () => {
-    const idle = createIdleHarness()
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...idle,
-    })
+    const { idle, expander } = createExpander({ expand })
 
     expander.maybeExpandAtTop(0)
     await flushPromises()
@@ -185,19 +167,17 @@ describe("chat history auto expansion", () => {
   })
 
   it("skips the scroll compensation when the scope changed mid-expansion", async () => {
-    const idle = createIdleHarness()
-    const el = createViewport({ scrollTop: 10 })
+    const wrapper = createWrapper(100)
+    const el = createViewport({ scrollTop: 10, wrappers: [wrapper] })
     let context = "tab"
     const expand = vi.fn(() => {
-      el.scrollHeight = 3000
+      wrapper.top = 300
       context = "other-tab"
     })
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
+    const { expander } = createExpander({
       expand,
       getViewportEl: () => el,
       getContext: () => context,
-      ...idle,
     })
 
     expander.maybeExpandAtTop(0)
@@ -207,18 +187,24 @@ describe("chat history auto expansion", () => {
     expect(el.scrollTop).toBe(10)
   })
 
+  it("ignores a detached anchor element", async () => {
+    const wrapper = createWrapper(100, { connected: false })
+    const el = createViewport({ scrollTop: 10, wrappers: [wrapper] })
+    const expand = vi.fn(() => {
+      wrapper.top = 300
+    })
+    const { expander } = createExpander({ expand, getViewportEl: () => el })
+
+    expander.maybeExpandAtTop(0)
+    await flushPromises()
+
+    expect(el.scrollTop).toBe(10)
+  })
+
   it("does not rearm idle work for a new scope after a mid-expansion switch", async () => {
-    const idle = createIdleHarness()
-    const el = createViewport()
     let context = "tab-a"
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
-      expand,
-      getViewportEl: () => el,
-      getContext: () => context,
-      ...idle,
-    })
+    const { idle, expander } = createExpander({ expand, getContext: () => context })
 
     expander.maybeExpandAtTop(0)
     // Scope flips while the expansion is still awaiting its DOM commit.
@@ -230,15 +216,8 @@ describe("chat history auto expansion", () => {
   })
 
   it("does not rearm or expand anything after dispose", async () => {
-    const idle = createIdleHarness()
     const expand = vi.fn()
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...idle,
-    })
+    const { idle, expander } = createExpander({ expand })
 
     expander.maybeExpandAtTop(0)
     // Unmount lands while the expansion is still in flight, so the
@@ -254,18 +233,11 @@ describe("chat history auto expansion", () => {
   })
 
   it("warns instead of rejecting when the expand callback throws", async () => {
-    const idle = createIdleHarness()
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     const expand = vi.fn(() => {
       throw new Error("boom")
     })
-    const expander = createChatHistoryExpander({
-      canExpand: () => true,
-      expand,
-      getViewportEl: () => createViewport(),
-      getContext: () => "tab",
-      ...idle,
-    })
+    const { expander } = createExpander({ expand })
 
     expect(expander.maybeExpandAtTop(0)).toBe(true)
     await flushPromises()

--- a/src/kohakuterrarium-frontend/src/components/chat/chatRenderWindow.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatRenderWindow.js
@@ -3,6 +3,11 @@ import { computed, ref } from "vue"
 export const CHAT_RENDER_UNIT_BUDGET = 1000
 export const CHAT_RENDER_MESSAGE_LIMIT = 200
 export const CHAT_RENDER_MIN_MESSAGES = 2
+// Automatic expansion (scroll-to-top / idle lookahead) grows the window
+// in smaller steps than the explicit "show earlier" button so the mount
+// cost never lands on the interaction path all at once.
+export const CHAT_RENDER_EXPAND_UNIT_BUDGET = 500
+export const CHAT_RENDER_EXPAND_MESSAGE_LIMIT = 100
 
 function directChildCount(items) {
   if (!Array.isArray(items)) return 0
@@ -24,15 +29,19 @@ export function messageRenderUnits(message) {
   return 1 + contentParts.length + toolCalls.length + directChildCount(toolCalls)
 }
 
-export function findRenderWindowStart(messages, end = messages.length) {
+export function findRenderWindowStart(
+  messages,
+  end = messages.length,
+  { unitBudget = CHAT_RENDER_UNIT_BUDGET, messageLimit = CHAT_RENDER_MESSAGE_LIMIT } = {},
+) {
   const boundedEnd = Math.max(0, Math.min(end, messages.length))
   let start = boundedEnd
   let units = 0
   let count = 0
 
-  while (start > 0 && count < CHAT_RENDER_MESSAGE_LIMIT) {
+  while (start > 0 && count < messageLimit) {
     const nextUnits = messageRenderUnits(messages[start - 1])
-    if (count >= CHAT_RENDER_MIN_MESSAGES && units + nextUnits > CHAT_RENDER_UNIT_BUDGET) break
+    if (count >= CHAT_RENDER_MIN_MESSAGES && units + nextUnits > unitBudget) break
     start -= 1
     count += 1
     units += nextUnits
@@ -74,8 +83,8 @@ export function useChatRenderWindow(messages, getScopeKey) {
     if (key) windowStarts.set(key, messageId)
   }
 
-  function expandHistory() {
-    enterHistoryAt(findRenderWindowStart(messages.value, windowStart.value))
+  function expandHistory(step = {}) {
+    enterHistoryAt(findRenderWindowStart(messages.value, windowStart.value, step))
   }
 
   function restoreHistory(key = getScopeKey()) {


### PR DESCRIPTION
## Summary

Follow-up to #278: scrolling to the top of the rendered history window now expands it automatically (no button click), in smaller steps, with an idle-time lookahead that pre-mounts the next step so back-to-back expansions never stall the scroll interaction.

**Opened as a draft** per CONTRIBUTING's feature-PR policy — see the Feature checklist below.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

#278 bounds the chat panel's render load with a tail-anchored window, but history expansion still requires clicking **Show earlier**, one full-budget step per click. Scrolling dead-ends at the window top, and each click mounts up to 1000 render units synchronously. Proposed in #280; this draft implements it as a concrete reference for that discussion.

## Changes

- `chatRenderWindow.js`: `findRenderWindowStart` / `expandHistory` accept an optional step (`unitBudget` / `messageLimit`); new automatic-expansion constants (500 units / 100 messages). Button path keeps the full 1000 / 200 step.
- `chatHistoryExpand.js` (new): `createChatHistoryExpander` — expands one small step when the viewport reaches within 48px of the window top, restores the reading position after the DOM commit by anchoring to the first visible message (self-correcting under the browser's native scroll anchoring, which would otherwise double-apply a scrollHeight delta and fling the viewport toward the bottom), and schedules an idle lookahead that pre-mounts exactly one further step (never chained).
- `ChatPanel.vue`: wires the expander into the rAF-throttled scroll handler; cancels pending idle work on tab/group scope switches and unmount; skips compensation if the scope changed mid-expansion.

## Validation

```bash
# Frontend (in src/kohakuterrarium-frontend)
npx vitest run src/components/chat/        # 13 files, 97 tests pass
npx vitest run                             # see Exceptions below
npm run lint                               # 0 errors
npx prettier --check <changed files>       # clean
npm run build                              # succeeds

# Python (project .venv)
ruff check src/ tests/                     # All checks passed!
black --check src/ tests/                  # 1591 files unchanged
pytest tests/unit/ -q                      # 12422 passed, 10 skipped, 6 failed (pre-existing, see below)
pytest tests/unit/test_file_sizes.py -q    # 1756 passed
```

New tests: `chatHistoryExpand.test.js` (module level: threshold boundary, in-flight de-dup, single non-chained lookahead, cancellation, scope-change compensation skip) and two panel-level cases in `ChatPanel.scrollBehavior.test.js` (auto-expand at top; idle cancellation on tab switch).

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Closes #280

**Feature-PR checklist (per CONTRIBUTING):**

- Issue link: #280
- When opened: 2026-09-02, immediately before this draft PR
- Who approved it: **not yet approved** — no maintainer has signed off on the proposal yet
- Scope match: the diff implements exactly the #280 proposal (auto-expand + smaller automatic steps + one-step idle lookahead); nothing else

Because approval has not landed, this PR stays a **draft** and will be marked ready only after a maintainer signs off on #280 (or asks for changes).

## Notes for Reviewers

- The #278 window/anchor model is untouched; only window growth changed. The riskiest interaction is scroll-position restore across tab/group switches, covered by the existing `ChatPanel.scrollBehavior.test.js` suite plus the new cancellation case.
- The idle lookahead is deliberately bounded to one step (never chained) so it cannot walk the whole history while the user reads.
- `requestIdleCallback` falls back to a `setTimeout` in environments without it.

## Screenshots / Logs (if applicable)

N/A — behavior is a scroll-flow smoothing; happy to record a demo of a 5k-message session scrolling up if useful.

## Breaking Changes (if applicable)

None. No API/config changes; existing manual button behavior is preserved.

## Exceptions / Not Run

- `pytest tests/unit/` shows **6 pre-existing failures**, all in `tests/unit/packages/test_git_backend_dulwich_integration.py` (tests that perform real git clone operations); verified identical on clean `main`. Everything else passes (12422 passed, 10 skipped). The change itself is frontend-only.
- Full `vitest run` shows pre-existing failures in `src/components/shell/`, `src/stores/studio/`, and `src/stores/layoutPanels.test.js`; verified identical on clean `main` before this branch. All chat-panel suites (13 files / 97 tests) pass.
- Fork CI was triggered on push; this PR is opened as draft before it finishes, and will be marked ready once green and once #280 has maintainer sign-off.
