### PR TITLE
fix(launcher): run the first-launch splash on the main thread

### DIFF
--- a/scripts/dep_graph_allowlist.json
+++ b/scripts/dep_graph_allowlist.json
@@ -91,9 +91,9 @@
   },
   {
     "file": "src/kohakuterrarium/launcher/splash_window.py",
-    "function": "_try_tk",
+    "function": "_run_tk",
     "target": "tkinter",
-    "reason": "tkinter is the optional fallback splash backend used only when pywebview is unavailable; deferred so headless / non-Tk environments aren't required to have it"
+    "reason": "tkinter (and tkinter.ttk) is the optional fallback splash backend used only when pywebview is unavailable; deferred so headless / non-Tk environments aren't required to have it"
   },
   {
     "file": "src/kohakuterrarium/mcp/client.py",

--- a/src/kohakuterrarium/launcher/bootloader.py
+++ b/src/kohakuterrarium/launcher/bootloader.py
@@ -23,7 +23,8 @@ from kohakuterrarium.launcher.paths import (
     site_packages_dir,
     version_dir,
 )
-from kohakuterrarium.launcher.splash_window import open_splash
+from kohakuterrarium.launcher.splash_server import SplashServer
+from kohakuterrarium.launcher.splash_window import run_with_splash
 from kohakuterrarium.launcher.tree_ops import read_active_pointer
 from kohakuterrarium.launcher.update_runner import (
     UpdateResult,
@@ -133,41 +134,12 @@ def prepare(argv: list[str] | None = None) -> "PrepareResult":
     if pointer is None:
         # First installation can block on extraction, download, and smoke
         # checks, so keep the shell visibly responsive with progress.
-        srv = open_splash()
-        try:
-            srv.publish("Setting up", percent=5, message="")
-
-            def _progress(phase: str, percent: float, msg: str) -> None:
-                try:
-                    srv.publish(phase, percent=percent, message=msg)
-                except Exception:
-                    pass
-
-            log.info("launcher: no active pointer — first_install")
-            install_result = first_install(_progress)
-            if not install_result.ok:
-                srv.publish(
-                    "Failed",
-                    percent=100,
-                    message=install_result.error or "",
-                    status="failed",
-                )
-                log.error("launcher: first_install failed: %s", install_result.error)
-                time.sleep(2.0)
-                return PrepareResult(exit_code=5, error=install_result.error)
-            log.info("launcher: first_install succeeded at %s", install_result.version)
-            srv.publish(
-                "Ready",
-                percent=100,
-                message=str(install_result.version),
-                status="ok",
-            )
-            time.sleep(0.4)
-        finally:
-            try:
-                srv.stop()
-            except Exception:
-                pass
+        log.info("launcher: no active pointer — first_install")
+        install_result = run_with_splash(_first_install_with_progress)
+        if not install_result.ok:
+            log.error("launcher: first_install failed: %s", install_result.error)
+            return PrepareResult(exit_code=5, error=install_result.error)
+        log.info("launcher: first_install succeeded at %s", install_result.version)
         pointer = read_active_pointer()
         if pointer is None:
             log.error("launcher: first_install reported ok but pointer absent")
@@ -234,28 +206,45 @@ def _build_pythonpath(version_root) -> str:
     return os.pathsep.join([site, existing])
 
 
+def _first_install_with_progress(srv: SplashServer) -> UpdateResult:
+    """Run first_install behind the splash, mirroring progress into it."""
+    srv.publish("Setting up", percent=5, message="")
+
+    def _progress(phase: str, percent: float, msg: str) -> None:
+        srv.publish(phase, percent=percent, message=msg)
+
+    result = first_install(_progress)
+    if result.ok:
+        srv.publish("Ready", percent=100, message=str(result.version), status="ok")
+        time.sleep(0.4)
+    else:
+        srv.publish("Failed", percent=100, message=result.error or "", status="failed")
+        time.sleep(2.0)
+    return result
+
+
 def _run_splash_demo(log) -> int:
     """Run a scripted splash sequence and return a successful exit code."""
     log.info("launcher: --splash-demo running scripted sequence")
-    srv = open_splash()
-    try:
-        srv.publish("Starting…", percent=5, message="")
-        time.sleep(0.8)
-        srv.publish("Resolving feed", percent=20, message="stable.json")
-        time.sleep(0.8)
-        srv.publish(
-            "Downloading",
-            percent=55,
-            message="kohakuterrarium-1.5.1-linux-x64-py3.13.tar.zst",
-        )
-        time.sleep(0.8)
-        srv.publish("Smoke testing", percent=85, message="kt --version")
-        time.sleep(0.4)
-        srv.publish("Ready", percent=100, message="", status="ok")
-        time.sleep(1.0)
-    finally:
-        srv.stop()
+    run_with_splash(_splash_demo_sequence)
     return 0
+
+
+def _splash_demo_sequence(srv: SplashServer) -> None:
+    srv.publish("Starting…", percent=5, message="")
+    time.sleep(0.8)
+    srv.publish("Resolving feed", percent=20, message="stable.json")
+    time.sleep(0.8)
+    srv.publish(
+        "Downloading",
+        percent=55,
+        message="kohakuterrarium-1.5.1-linux-x64-py3.13.tar.zst",
+    )
+    time.sleep(0.8)
+    srv.publish("Smoke testing", percent=85, message="kt --version")
+    time.sleep(0.4)
+    srv.publish("Ready", percent=100, message="", status="ok")
+    time.sleep(1.0)
 
 
 __all__ = ["PrepareResult", "UpdateResult", "main", "prepare"]

--- a/src/kohakuterrarium/launcher/splash.html
+++ b/src/kohakuterrarium/launcher/splash.html
@@ -71,8 +71,9 @@
     <p class="message" id="message"></p>
   </div>
   <script>
-    // SPLASH_ENDPOINT is injected by splash_window.py before the page loads.
-    const endpoint = window.SPLASH_ENDPOINT || "http://127.0.0.1:0/progress";
+    // The page is served by the SplashServer that owns the feed, so the
+    // poll stays same-origin.
+    const endpoint = "/progress";
     let lastSeq = -1;
     async function poll() {
       try {

--- a/src/kohakuterrarium/launcher/splash_server.py
+++ b/src/kohakuterrarium/launcher/splash_server.py
@@ -1,8 +1,12 @@
-"""Serve splash progress frames over an ephemeral loopback endpoint.
+"""Serve the splash page and its progress frames over a loopback endpoint.
 
-The server accepts only progress polling requests. An ephemeral port avoids
-collisions between concurrent launcher instances, and a single request thread
-is sufficient for the splash page's periodic polling.
+The server answers ``/`` with the splash page (when constructed with
+``page_html``) and ``/progress`` with the current frame; anything else is a
+404. Serving the page from the same origin as its feed keeps the poll
+same-origin, so neither CORS nor the browser's private-network gate can
+strand it. An ephemeral port avoids collisions between concurrent launcher
+instances, and a single request thread is sufficient for the splash page's
+periodic polling.
 """
 
 import json
@@ -31,9 +35,10 @@ class ProgressFrame:
 class SplashServer:
     """Manage the splash HTTP endpoint and its current progress frame."""
 
-    def __init__(self) -> None:
+    def __init__(self, page_html: str | None = None) -> None:
         self._lock = threading.Lock()
         self._frame = ProgressFrame()
+        self._page_html = page_html
         self._server: HTTPServer | None = None
         self._thread: threading.Thread | None = None
         # UI backends register teardown here so stopping the progress server
@@ -46,10 +51,14 @@ class SplashServer:
 
     @property
     def endpoint(self) -> str:
+        return self.page_url + "progress"
+
+    @property
+    def page_url(self) -> str:
         if self._server is None:
             raise RuntimeError("SplashServer not started")
         host, port = self._server.server_address[:2]
-        return f"http://{host}:{port}/progress"
+        return f"http://{host}:{port}/"
 
     def publish(
         self,
@@ -89,11 +98,20 @@ class SplashServer:
                 pass
 
             def _emit_cors(self) -> None:
-                # Inline pywebview content has a non-loopback origin, so its
-                # progress fetch requires explicit cross-origin permission.
+                # Harmless for the same-origin page; keeps an embedder that
+                # loads the page from another origin working too.
                 self.send_header("Access-Control-Allow-Origin", "*")
                 self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
                 self.send_header("Access-Control-Allow-Headers", "Content-Type")
+
+            def _send(self, content_type: str, body: bytes) -> None:
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("Cache-Control", "no-store")
+                self._emit_cors()
+                self.end_headers()
+                self.wfile.write(body)
 
             def do_OPTIONS(self):  # noqa: N802
                 self.send_response(204)
@@ -101,20 +119,18 @@ class SplashServer:
                 self.end_headers()
 
             def do_GET(self):  # noqa: N802
-                if not self.path.startswith("/progress"):
-                    self.send_response(404)
-                    self._emit_cors()
-                    self.end_headers()
+                if self.path.startswith("/progress"):
+                    frame = srv_ref.snapshot()
+                    body = json.dumps(asdict(frame)).encode("utf-8")
+                    self._send("application/json", body)
                     return
-                frame = srv_ref.snapshot()
-                body = json.dumps(asdict(frame)).encode("utf-8")
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(body)))
-                self.send_header("Cache-Control", "no-store")
+                page = srv_ref._page_html
+                if page is not None and self.path.split("?", 1)[0] == "/":
+                    self._send("text/html; charset=utf-8", page.encode("utf-8"))
+                    return
+                self.send_response(404)
                 self._emit_cors()
                 self.end_headers()
-                self.wfile.write(body)
 
         self._server = HTTPServer(("127.0.0.1", 0), _Handler)
         self._thread = threading.Thread(

--- a/src/kohakuterrarium/launcher/splash_window.py
+++ b/src/kohakuterrarium/launcher/splash_window.py
@@ -1,150 +1,235 @@
-"""Open a borderless splash with pywebview or a Tk fallback.
+"""Splash window driven from the main thread — pywebview primary, Tk fallback.
 
-Both backends run off the caller's thread and consume progress from a local
-:class:`SplashServer`. When no graphical backend is available, callers still
-receive the server and can follow the same publishing path headlessly.
+Every toolkit pywebview wraps insists on owning the process's main
+thread: ``webview.start()`` raises when called anywhere else. Running
+the install work on the main thread with the splash on a helper thread
+therefore never showed a window — and ``webview.create_window()`` had
+already put the splash into pywebview's process-global window list. The
+framework calls ``webview.start()`` on this same thread once the
+launcher hands off, and that call materialises every registered window:
+the dead splash came back as a frameless, always-on-top page polling a
+progress server that was long gone, with no way for the user to close it.
+
+:func:`run_with_splash` inverts the threading. The caller's ``work``
+runs on a worker thread; the main thread hosts the toolkit's event loop
+until the work finishes; the window is closed and unregistered before
+the function returns, on every exit path. Backends are tried in order:
+pywebview, Tk, headless (progress is only logged). Whichever backend
+runs, ``work`` executes exactly once and its result or exception is
+handed back to the caller.
 """
 
 import threading
 from pathlib import Path
+from typing import Any, Callable, TypeVar
 
 from kohakuterrarium.launcher.log import get_logger
 from kohakuterrarium.launcher.splash_server import SplashServer
 
 _HTML_PATH = Path(__file__).parent / "splash.html"
 
-
-def _render_html(endpoint: str) -> str:
-    """Inject the progress endpoint before the template's polling script."""
-    template = _HTML_PATH.read_text(encoding="utf-8")
-    # The assignment must precede the polling script that reads it.
-    inject = f'<script>window.SPLASH_ENDPOINT = "{endpoint}";</script>'
-    needle = "<script>"
-    if needle not in template:
-        return template
-    head, tail = template.split(needle, 1)
-    return f"{head}{inject}{needle}{tail}"
+T = TypeVar("T")
 
 
-def _try_pywebview(server: SplashServer) -> bool:
-    """Start a pywebview splash when the optional backend is available."""
+class _Outcome:
+    """Slot the worker thread fills in; ``done`` fires once it is final."""
+
+    def __init__(self) -> None:
+        self.done = threading.Event()
+        self.value: Any = None
+        self.error: BaseException | None = None
+
+    def result(self) -> Any:
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
+def _run_work(
+    work: Callable[[SplashServer], Any], server: SplashServer, outcome: _Outcome
+) -> None:
+    try:
+        outcome.value = work(server)
+    except BaseException as e:
+        outcome.error = e
+    finally:
+        outcome.done.set()
+
+
+def _is_main_thread() -> bool:
+    return threading.current_thread() is threading.main_thread()
+
+
+# ── pywebview backend ───────────────────────────────────────────────
+
+
+def _unregister(webview_module: Any, window: Any) -> None:
+    """Drop ``window`` from pywebview's process-global registry.
+
+    pywebview only forgets a window once its toolkit reports it closed.
+    One that never opened (``start()`` failed, or returned before it was
+    shown) stays listed and would be materialised by the next ``start()``
+    in this process — the framework's main window.
+    """
+    try:
+        registry = webview_module.windows
+        while window in registry:
+            registry.remove(window)
+    except Exception:
+        pass
+
+
+def _destroy_when_done(
+    window: Any, outcome: _Outcome, loop_finished: threading.Event
+) -> None:
+    """Close the splash once the work is over, but only if it opened.
+
+    ``destroy()`` blocks until the window has been shown and raises when
+    it gives up; waiting on ``shown`` here instead means a loop that
+    never opened (backend failure, user closed it early) releases this
+    thread promptly, while a window that opens late still gets closed.
+    """
+    outcome.done.wait()
+    while not window.events.shown.is_set():
+        if loop_finished.wait(0.2):
+            return
+    try:
+        window.destroy()
+    except Exception as e:
+        get_logger().warning("splash: pywebview destroy failed: %s", e)
+
+
+def _run_pywebview(server: SplashServer, outcome: _Outcome) -> bool:
+    if not _is_main_thread():
+        return False
     try:
         import webview  # type: ignore
     except ImportError:
         return False
 
-    html = _render_html(server.endpoint)
-    # The window is created asynchronously, so the server's close callback
-    # needs this shared container to reach it.
-    window_box: list = []
-
-    def _run():
-        try:
-            window = webview.create_window(
-                "KohakuTerrarium",
-                html=html,
-                width=420,
-                height=260,
-                frameless=True,
-                easy_drag=True,
-                resizable=False,
-                on_top=True,
-            )
-            window_box.append(window)
-            webview.start()
-        except Exception as e:  # pragma: no cover - backend-specific
-            get_logger().warning("splash: pywebview backend failed: %s", e)
-
-    t = threading.Thread(target=_run, name="kt-splash-pywebview", daemon=True)
-    t.start()
-
-    def _close() -> None:
-        # Destroying the splash releases pywebview's global event loop before
-        # the main application creates another window.
-        if not window_box:
-            return
-        try:
-            window_box[0].destroy()
-        except Exception as e:  # pragma: no cover - backend-specific
-            get_logger().warning("splash: pywebview destroy failed: %s", e)
-
-    server.register_close_callback(_close)
+    log = get_logger()
+    try:
+        window = webview.create_window(
+            "KohakuTerrarium",
+            url=server.page_url,
+            width=420,
+            height=260,
+            frameless=True,
+            easy_drag=True,
+            resizable=False,
+            on_top=True,
+        )
+    except Exception as e:
+        log.warning("splash: pywebview backend failed: %s", e)
+        return False
+    loop_finished = threading.Event()
+    threading.Thread(
+        target=_destroy_when_done,
+        args=(window, outcome, loop_finished),
+        name="kt-splash-closer",
+        daemon=True,
+    ).start()
+    try:
+        webview.start()
+    except Exception as e:
+        log.warning("splash: pywebview backend failed: %s", e)
+        return False
+    finally:
+        loop_finished.set()
+        _unregister(webview, window)
+    log.info("splash: pywebview window closed")
     return True
 
 
-def _try_tk(server: SplashServer) -> bool:
-    """Start a Tk splash when the standard GUI backend is available."""
+# ── Tk backend ──────────────────────────────────────────────────────
+
+
+def _run_tk(server: SplashServer, outcome: _Outcome) -> bool:
+    if not _is_main_thread():
+        return False
     try:
         import tkinter as tk
         from tkinter import ttk
     except ImportError:
         return False
 
-    root_box: list = []
+    log = get_logger()
+    try:
+        root = tk.Tk()
+    except Exception as e:
+        log.warning("splash: tk backend failed: %s", e)
+        return False
+    try:
+        root.title("KohakuTerrarium")
+        root.geometry("420x180")
+        tk.Label(root, text="KohakuTerrarium — setting up", font=("", 12, "bold")).pack(
+            pady=(20, 8)
+        )
+        phase_var = tk.StringVar(value="Starting…")
+        tk.Label(root, textvariable=phase_var).pack(pady=(0, 8))
+        bar = ttk.Progressbar(root, length=320, mode="determinate", maximum=100)
+        bar.pack(pady=(0, 8))
+        msg_var = tk.StringVar(value="")
+        tk.Label(root, textvariable=msg_var, fg="#888", font=("Menlo", 9)).pack()
 
-    def _run():
+        def _poll() -> None:
+            frame = server.snapshot()
+            phase_var.set(frame.phase or "Starting…")
+            bar["value"] = max(0, min(100, frame.percent))
+            msg_var.set(frame.message or "")
+            if outcome.done.is_set():
+                root.destroy()
+                return
+            root.after(250, _poll)
+
+        root.after(50, _poll)
+        root.mainloop()
+    except Exception as e:
+        log.warning("splash: tk backend failed: %s", e)
         try:
-            root = tk.Tk()
-            root_box.append(root)
-            root.title("KohakuTerrarium")
-            root.geometry("420x180")
-            tk.Label(
-                root, text="KohakuTerrarium — setting up", font=("", 12, "bold")
-            ).pack(pady=(20, 8))
-            phase_var = tk.StringVar(value="Starting…")
-            tk.Label(root, textvariable=phase_var).pack(pady=(0, 8))
-            bar = ttk.Progressbar(root, length=320, mode="determinate", maximum=100)
-            bar.pack(pady=(0, 8))
-            msg_var = tk.StringVar(value="")
-            tk.Label(root, textvariable=msg_var, fg="#888", font=("Menlo", 9)).pack()
-
-            def _poll():
-                f = server.snapshot()
-                phase_var.set(f.phase or "Starting…")
-                bar["value"] = max(0, min(100, f.percent))
-                msg_var.set(f.message or "")
-                if f.status in ("ok", "failed"):
-                    root.after(800, root.destroy)
-                    return
-                root.after(250, _poll)
-
-            root.after(50, _poll)
-            root.mainloop()
-        except Exception as e:  # pragma: no cover - backend-specific
-            get_logger().warning("splash: tk backend failed: %s", e)
-
-    t = threading.Thread(target=_run, name="kt-splash-tk", daemon=True)
-    t.start()
-
-    def _close() -> None:
-        # Explicit teardown covers exits that occur before a terminal frame
-        # reaches Tk's polling loop.
-        if not root_box:
-            return
-        try:
-            root_box[0].after(0, root_box[0].destroy)
-        except Exception:  # pragma: no cover - root may already be gone
+            root.destroy()
+        except Exception:
             pass
-
-    server.register_close_callback(_close)
+        return False
+    log.info("splash: Tk window closed")
     return True
 
 
-def open_splash() -> SplashServer:
-    """Start progress serving, open the first available UI, and return it.
+# ── Public entry ────────────────────────────────────────────────────
 
-    The progress server is returned even without a graphical backend so
-    callers can publish through one consistent interface.
+
+def run_with_splash(work: Callable[[SplashServer], T]) -> T:
+    """Run ``work`` on a worker thread behind a splash window.
+
+    The main thread hosts the toolkit's event loop for the duration of
+    ``work``; the window closes when ``work`` returns or raises, and the
+    result (or exception) is handed back here. ``work`` publishes its
+    progress through the :class:`SplashServer` it receives.
     """
-    server = SplashServer().start()
-    if _try_pywebview(server):
-        get_logger().info("splash: opened pywebview window")
-        return server
-    if _try_tk(server):
-        get_logger().info("splash: opened Tk window (pywebview unavailable)")
-        return server
-    get_logger().info("splash: no UI backend available — progress will be logged only")
-    return server
+    server = SplashServer(page_html=_HTML_PATH.read_text(encoding="utf-8")).start()
+    outcome = _Outcome()
+    worker = threading.Thread(
+        target=_run_work,
+        args=(work, server, outcome),
+        name="kt-launcher-work",
+        daemon=True,
+    )
+    try:
+        worker.start()
+        shown = False
+        for backend in (_run_pywebview, _run_tk):
+            # Work that already finished gets no window flashed at it.
+            if shown or outcome.done.is_set():
+                break
+            shown = backend(server, outcome)
+        if not shown and not outcome.done.is_set():
+            get_logger().info(
+                "splash: no UI backend available — progress will be logged only"
+            )
+        outcome.done.wait()
+    finally:
+        server.stop()
+    return outcome.result()
 
 
-__all__ = ["open_splash"]
+__all__ = ["run_with_splash"]

--- a/tests/unit/launcher/test_bootloader.py
+++ b/tests/unit/launcher/test_bootloader.py
@@ -1,0 +1,101 @@
+"""Unit tests for the launcher bootloader's ``prepare`` orchestration.
+
+The GUI backends are blocked so the first-launch splash runs headless;
+everything else (settings, update lock, bundled-release extract, smoke,
+pointer swap) is the real launcher code against a temp config dir.
+"""
+
+import io
+import json
+import sys
+import tarfile
+import types
+
+import pytest
+
+from kohakuterrarium.launcher import bootloader
+from kohakuterrarium.launcher import paths as _paths
+from kohakuterrarium.launcher import settings as _settings
+from kohakuterrarium.launcher import tree_ops as _tree
+from kohakuterrarium.launcher import update_runner as _runner
+from kohakuterrarium.launcher.feeds import FeedError
+
+
+def _make_release_tarball(path, *, version: str) -> None:
+    members = {
+        "manifest.json": json.dumps({"version": version, "build_id": "tb"}).encode(),
+        "site-packages/kohakuterrarium/__init__.py": (
+            f'__version__ = "{version}"\n'.encode()
+        ),
+    }
+    with tarfile.open(str(path), mode="w:gz") as tar:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+
+@pytest.fixture
+def headless(monkeypatch, tmp_path):
+    monkeypatch.setenv("KT_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setitem(sys.modules, "webview", None)
+    monkeypatch.setitem(sys.modules, "tkinter", None)
+    # The terminal-frame linger is UX only; keep the suite fast.
+    monkeypatch.setattr(bootloader, "time", types.SimpleNamespace(sleep=lambda s: None))
+    return tmp_path
+
+
+class TestPrepare:
+    def test_first_launch_installs_bundled_release_then_reuses_it(
+        self, monkeypatch, headless
+    ):
+        bundled = headless / "bundled-release"
+        bundled.mkdir()
+        _make_release_tarball(
+            bundled / "kohakuterrarium-9.9.9-win-x64-py3.13.tar.gz", version="9.9.9"
+        )
+        monkeypatch.setattr(
+            _paths, "_candidate_bundled_release_dirs", lambda: [bundled]
+        )
+
+        result = bootloader.prepare([])
+
+        assert result.done is False
+        assert result.exit_code == 0
+        assert result.error is None
+        assert result.version == "9.9.9"
+        expected_site = _paths.site_packages_dir(_paths.version_dir("9.9.9"))
+        assert result.site_packages == expected_site
+        assert (expected_site / "kohakuterrarium" / "__init__.py").is_file()
+        assert _tree.read_active_pointer().version == "9.9.9"
+        assert _settings.load().runtime.active_version == "9.9.9"
+
+        # Second launch: pointer present, notify-on-launch default → no
+        # install work, same tree handed back.
+        again = bootloader.prepare([])
+        assert again.done is False
+        assert again.site_packages == expected_site
+        assert again.version == "9.9.9"
+
+    def test_first_launch_failure_surfaces_exit_code_5(self, monkeypatch, headless):
+        monkeypatch.setattr(_paths, "_candidate_bundled_release_dirs", lambda: [])
+
+        def offline(cfg, **_):
+            raise FeedError("manifest fetch network error: offline")
+
+        monkeypatch.setattr(_runner, "resolve_feed", offline)
+
+        result = bootloader.prepare([])
+
+        assert result.done is False
+        assert result.exit_code == 5
+        assert result.site_packages is None
+        assert "offline" in (result.error or "")
+        assert _tree.read_active_pointer() is None
+        assert "offline" in (_settings.load().runtime.last_check_error or "")
+
+    def test_splash_demo_is_a_one_shot_mode(self, headless):
+        result = bootloader.prepare(["--splash-demo"])
+        assert result.done is True
+        assert result.exit_code == 0
+        assert result.site_packages is None

--- a/tests/unit/launcher/test_splash_server.py
+++ b/tests/unit/launcher/test_splash_server.py
@@ -1,14 +1,13 @@
 """Unit tests for the launcher splash HTTP server.
 
-The splash page is loaded into pywebview via the ``html=`` argument
-(no http origin), so a same-origin policy treats the polling fetch as
-cross-origin.  Without CORS headers the browser drops the response and
-the splash sits forever on its hardcoded "Starting…" / 0% defaults.
+The server feeds the splash page its progress frames and, since the
+page is served from the same origin, the poll never crosses an origin
+boundary.  CORS headers stay on the feed so an embedder loading the
+page from elsewhere still gets frames instead of a silently dropped
+response and a splash stuck on its "Starting…" / 0% defaults.
 
-Window-close callbacks are the other side of that story: ``stop()``
-only killed the HTTP server, leaving the pywebview window on screen
-forever.  Registered callbacks now fire from ``stop()`` so the window
-is torn down with the server.
+Window-close callbacks registered on the server fire from ``stop()``
+so any UI bound to it is torn down together with the server.
 """
 
 import json
@@ -157,3 +156,35 @@ class TestProgressFrameDefaults:
         assert frame.percent == 0.0
         # ``None`` keeps the JS polling — only ok/failed terminate.
         assert frame.status is None
+
+
+class TestSplashServerPage:
+    """The splash page is served by the progress server itself.
+
+    Loading it from the same ``http://127.0.0.1:<port>`` origin as
+    ``/progress`` keeps the poll same-origin, so neither CORS nor the
+    browser's private-network gate can strand the page on its defaults.
+    """
+
+    def test_page_url_serves_html_and_progress_stays_json(self):
+        srv = SplashServer(page_html="<html><body>splash</body></html>").start()
+        try:
+            assert srv.page_url == srv.endpoint[: -len("progress")]
+            status, headers, body = _get(srv.endpoint, path="/")
+            assert status == 200
+            assert headers.get("Content-Type", "").startswith("text/html")
+            assert body == b"<html><body>splash</body></html>"
+            status, headers, body = _get(srv.endpoint)
+            assert status == 200
+            assert headers.get("Content-Type") == "application/json"
+            assert json.loads(body)["seq"] == 0
+        finally:
+            srv.stop()
+
+    def test_page_is_404_without_html(self, server):
+        status, _, _ = _get(server.endpoint, path="/")
+        assert status == 404
+
+    def test_page_url_requires_started_server(self):
+        with pytest.raises(RuntimeError):
+            SplashServer(page_html="x").page_url

--- a/tests/unit/launcher/test_splash_window.py
+++ b/tests/unit/launcher/test_splash_window.py
@@ -1,0 +1,233 @@
+"""Unit tests for the launcher splash window driver.
+
+Every GUI toolkit pywebview wraps insists on owning the process's main
+thread. The original splash ran ``webview.start()`` on a background
+thread, which raised immediately — but ``webview.create_window()`` had
+already appended the splash to pywebview's process-global window list.
+The framework's own ``webview.start()`` (same process, main thread,
+right after the launcher hands off) then materialised that stale entry
+as a frameless, always-on-top window polling a progress server that was
+long gone: "Starting…" with a 0% bar the user could not close.
+
+``run_with_splash`` inverts the threading: the toolkit loop owns the
+main thread, the install work runs on a worker, and the window is
+unregistered on every exit path. The fake ``webview`` module below
+mirrors exactly the surface the driver uses (``windows`` registry,
+``create_window``, ``start``, ``Window.destroy``, ``Window.events``).
+"""
+
+import http.client
+import json
+import sys
+import threading
+import types
+
+import pytest
+
+from kohakuterrarium.launcher import splash_window
+from kohakuterrarium.launcher.splash_server import SplashServer
+
+MAIN_THREAD_ERROR = "pywebview must be run on a main thread."
+
+
+class _FakeEvent:
+    def __init__(self) -> None:
+        self._event = threading.Event()
+
+    def set(self) -> None:
+        self._event.set()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._event.wait(timeout)
+
+
+class _FakeWindow:
+    def __init__(self, module, title: str, url: str | None, kwargs: dict) -> None:
+        self.module = module
+        self.title = title
+        self.url = url
+        self.kwargs = kwargs
+        self.events = types.SimpleNamespace(shown=_FakeEvent(), closed=_FakeEvent())
+        self.destroy_calls = 0
+        self.destroyed_after: list[str] = []
+
+    def destroy(self) -> None:
+        # pywebview blocks destroy() until the window has been shown and
+        # raises once it gives up waiting.
+        if not self.events.shown.wait(20):
+            raise RuntimeError("Main window failed to start")
+        self.destroy_calls += 1
+        self.destroyed_after = list(self.module.trace)
+        self.module.trace.append("destroy")
+        self.module.close(self)
+
+
+class _FakeWebview(types.ModuleType):
+    """Stand-in for the ``webview`` package with pywebview's threading rules."""
+
+    def __init__(self, *, fail_start: str | None = None) -> None:
+        super().__init__("webview")
+        self.windows: list[_FakeWindow] = []
+        self.created: list[_FakeWindow] = []
+        self.start_threads: list[str] = []
+        self.fail_start = fail_start
+        self.trace: list[str] = []
+        # Work functions block on this so the worker cannot outrun the
+        # main thread; work that finishes first legitimately gets no
+        # window at all.
+        self.started = threading.Event()
+        self._changed = threading.Event()
+
+    def create_window(self, title, url=None, html=None, **kwargs):
+        window = _FakeWindow(self, title, url, kwargs)
+        self.windows.append(window)
+        self.created.append(window)
+        return window
+
+    def start(self, func=None, args=None):
+        self.start_threads.append(threading.current_thread().name)
+        self.started.set()
+        if threading.current_thread() is not threading.main_thread():
+            raise RuntimeError(MAIN_THREAD_ERROR)
+        if not self.windows:
+            raise RuntimeError("You must create a window first")
+        if self.fail_start is not None:
+            raise RuntimeError(self.fail_start)
+        for window in list(self.windows):
+            window.events.shown.set()
+        while self.windows:
+            self._changed.wait(0.05)
+            self._changed.clear()
+
+    def close(self, window: _FakeWindow) -> None:
+        if window in self.windows:
+            self.windows.remove(window)
+        window.events.closed.set()
+        self._changed.set()
+
+
+def _get_progress(endpoint: str) -> dict:
+    host_port = endpoint.split("://", 1)[1].split("/", 1)[0]
+    host, port = host_port.split(":", 1)
+    conn = http.client.HTTPConnection(host, int(port), timeout=2.0)
+    try:
+        conn.request("GET", "/progress")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        return json.loads(resp.read())
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def no_tk(monkeypatch):
+    # Tk would open a real window on a desktop test box; the Tk backend
+    # is a visual fallback and stays out of the unit tier.
+    monkeypatch.setitem(sys.modules, "tkinter", None)
+
+
+@pytest.fixture
+def fake_webview(monkeypatch, no_tk):
+    fake = _FakeWebview()
+    monkeypatch.setitem(sys.modules, "webview", fake)
+    return fake
+
+
+class TestRunWithSplashPywebview:
+    def test_loop_owns_main_thread_and_window_is_torn_down_after_work(
+        self, fake_webview
+    ):
+        seen: dict[str, object] = {}
+
+        def work(server: SplashServer) -> str:
+            seen["thread"] = threading.current_thread().name
+            server.publish("Extracting", percent=42, message="tree")
+            seen["frame"] = _get_progress(server.endpoint)
+            seen["page_url"] = server.page_url
+            assert fake_webview.started.wait(5)
+            fake_webview.trace.append("work-done")
+            return "installed"
+
+        assert splash_window.run_with_splash(work) == "installed"
+
+        assert seen["thread"] != "MainThread"
+        assert seen["frame"]["phase"] == "Extracting"
+        assert seen["frame"]["percent"] == 42.0
+        assert fake_webview.start_threads == ["MainThread"]
+        window = fake_webview.created[0]
+        assert window.title == "KohakuTerrarium"
+        # Same-origin page: no CORS / private-network gate between the
+        # page and its progress feed.
+        assert window.url == seen["page_url"]
+        assert window.kwargs["frameless"] is True
+        assert window.destroy_calls == 1
+        assert window.destroyed_after == ["work-done"]
+        assert fake_webview.windows == []
+
+    def test_start_failure_unregisters_window_and_runs_work_once(
+        self, monkeypatch, no_tk
+    ):
+        fake = _FakeWebview(fail_start="You must have either QT or GTK")
+        monkeypatch.setitem(sys.modules, "webview", fake)
+        calls: list[int] = []
+
+        def work(server: SplashServer) -> int:
+            calls.append(1)
+            assert fake.started.wait(5)
+            return 7
+
+        assert splash_window.run_with_splash(work) == 7
+        assert calls == [1]
+        assert fake.start_threads == ["MainThread"]
+        # The stale entry is what the framework's later start() would
+        # resurrect as an unclosable zombie splash.
+        assert fake.windows == []
+
+    def test_off_main_thread_never_registers_a_window(self, fake_webview):
+        outcome: dict[str, object] = {}
+
+        def run() -> None:
+            outcome["value"] = splash_window.run_with_splash(lambda server: "ok")
+
+        thread = threading.Thread(target=run, name="not-main")
+        thread.start()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+        assert outcome["value"] == "ok"
+        assert fake_webview.created == []
+        assert fake_webview.start_threads == []
+        assert fake_webview.windows == []
+
+    def test_work_exception_propagates_and_stops_server(self, fake_webview):
+        captured: dict[str, str] = {}
+
+        def work(server: SplashServer) -> None:
+            captured["endpoint"] = server.endpoint
+            assert fake_webview.started.wait(5)
+            raise ValueError("extract failed")
+
+        with pytest.raises(ValueError, match="extract failed"):
+            splash_window.run_with_splash(work)
+
+        assert fake_webview.windows == []
+        assert fake_webview.created[0].destroy_calls == 1
+        with pytest.raises(OSError):
+            _get_progress(captured["endpoint"])
+
+
+class TestRunWithSplashHeadless:
+    def test_no_backend_still_runs_work_with_live_server(self, monkeypatch, no_tk):
+        monkeypatch.setitem(sys.modules, "webview", None)
+        seen: dict[str, object] = {}
+
+        def work(server: SplashServer) -> str:
+            server.publish("Ready", percent=100, status="ok")
+            seen["frame"] = _get_progress(server.endpoint)
+            return "done"
+
+        assert splash_window.run_with_splash(work) == "done"
+        assert seen["frame"]["status"] == "ok"
+        assert seen["frame"]["percent"] == 100.0


### PR DESCRIPTION
## Summary

On the Windows MSI, first launch showed an uncloseable frameless "Starting…" window with a frozen progress bar next to the real main window, and the process kept running after the main window was closed. The launcher's splash ran `webview.start()` on a background thread (which pywebview rejects), but the preceding `create_window()` had already registered the splash in pywebview's process-global window list, so the framework's own `webview.start()` later materialised the dead splash as its master window. This PR runs the splash loop on the main thread with the install on a worker thread and unregisters the window on every exit path.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Fixes #283. Full root-cause analysis, logs and a minimal in-process reproduction are in the issue. In short:

1. `webview.start()` off the main thread raises `pywebview must be run on a main thread.` on every first launch, so no splash was ever shown during the ~50 s extract.
2. The splash `Window` stayed in `webview.windows`; `stop()` then blocked 20 s in `destroy()` waiting for a window that was never shown.
3. `serving/web.py::_run_desktop_app_blocking` calls `webview.start()` on the same thread right after hand-off; pywebview materialises every registered window, so the stale splash came up as `windows[0]` (master): frameless, always-on-top, polling a `SplashServer` that had already been shut down. No close button, and closing the main (child) window does not end the loop.

## Changes

- `launcher/splash_window.py`: replace `open_splash()` with `run_with_splash(work)`. The main thread hosts the toolkit loop (pywebview → Tk → headless fallback), `work` runs exactly once on a worker thread, a closer thread destroys the window once the work is done (waiting on the `shown` event itself instead of pywebview's 20 s internal timeout), and the window is removed from `webview.windows` in a `finally` so no later `start()` can resurrect it. Off the main thread, pywebview is never touched.
- `launcher/splash_server.py` + `splash.html`: the server now serves the page itself at `/` (`page_url`), so the `/progress` poll is same-origin instead of an `about:blank` (`NavigateToString`) page fetching `127.0.0.1` cross-origin. CORS headers are kept.
- `launcher/bootloader.py`: first-install and `--splash-demo` go through `run_with_splash`; the progress mirroring and terminal "Ready"/"Failed" frames are unchanged.
- `scripts/dep_graph_allowlist.json`: re-key the tkinter in-function import entry to function+target (`_run_tk` / `tkinter`) so line moves do not re-break the gate.
- Tests: new `tests/unit/launcher/test_splash_window.py` (deterministic fake `webview` module mirroring the surface the driver uses: registry, `create_window`, `start`, `destroy`, `events.shown`), new `tests/unit/launcher/test_bootloader.py` (first launch installs the bundled release headless → second launch reuses it; feed failure surfaces exit code 5; `--splash-demo` is one-shot), and same-origin page cases in `test_splash_server.py`. The negative case that pins the bug: a failing `start()` must leave `webview.windows` empty and still run the work once.

## Validation

```bash
ruff check src/ tests/                      # All checks passed!
black --check src/ tests/                   # 1593 files would be left unchanged
pytest tests/unit/launcher tests/unit/test_dep_graph_lint.py tests/unit/test_file_sizes.py -q   # 1859 passed
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py --ignore=tests/unit/test_dep_graph_lint.py
                                            # 14194 passed, 10 skipped, 4 failed (2 mcp + 2 studio drive-settings, see Exceptions)
pytest tests/integration/ -q                # 170 passed, 3 failed (all tests/integration/test_mcp.py, see Exceptions)
```

Real-GUI validation on Windows 11 with pywebview 6.1 (WebView2), driving the actual `bootloader.prepare()` from a scratch venv:

- `prepare(["--splash-demo"])`: pywebview splash opens on the main thread, renders the scripted phases and closes itself (4.4 s); `webview.windows == []` afterwards.
- `prepare([])` with a scratch `bundled-release/` tarball: splash shown during extract, pointer written, `site_packages` returned, `webview.windows == []`.
- A framework-style `webview.create_window(...) + webview.start()` in the same process afterwards shows **only** the main window (`uid == "master"`), and `start()` returns when it is closed.
- Before the fix, the same script reproduces the report exactly: `stop()` blocks 20.3 s, the stale splash stays registered as `master`, and the framework `start()` opens both windows.

Not validated here: macOS (cocoa) and Linux (GTK/QT) second `webview.start()` in one process. pywebview's cocoa backend removes the window on close and only calls `app.run()` when `not app.isRunning()`, so the sequential loop should be fine there too, but I could only test Windows.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (no user-facing docs describe the splash; nothing to update)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/` (no frontend changes)
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #283 (opened 2026-09-03 with the full analysis; bug fix, so per `CONTRIBUTING.md` it goes straight to PR)

## Notes for Reviewers

- Rebased onto upstream `main` (7bfe2f48). The conflicts were with the launcher docstring cleanup (2d5fd64f) and the allowlist re-keying (e57829c4); the splash logic itself was unchanged upstream, so the fix applies as designed. Validation numbers above are from the rebased branch.

- `run_with_splash` starts the worker *before* the GUI loop so the install never depends on GUI health; the window is purely decorative. If the work finishes before a backend is entered, no window is flashed at all.
- The `open_splash()` API is gone; `bootloader.py` was its only caller (grep confirmed no other users in `src/`, `tests/`, `docs/`).
- `SplashServer.register_close_callback` / `stop()` semantics are unchanged (still pinned by tests) even though the new driver closes windows via the worker's completion event instead.
- The launcher ships inside the MSI shell and is not updated by self-update, so this needs a new desktop build to reach users; after their first successful launch the bug does not recur for an existing install because the splash is only created when no `active` pointer exists.

## Screenshots / Logs (if applicable)

`~/.kohakuterrarium/logs/launcher.log` from the affected install:

```
00:06:14,824 [WARNING] splash: pywebview backend failed: pywebview must be run on a main thread.
00:06:14,824 [INFO] splash: opened pywebview window
00:07:07,922 [INFO] launcher: first_install succeeded at 2.1.1
00:07:28,333 [WARNING] splash: pywebview destroy failed: Main window failed to start
```

## Exceptions / Not Run

- The 3 failing integration tests and 2 of the 4 failing unit tests are MCP tests that break with `mcp` 2.x in my venv (`No module named 'mcp.server.fastmcp' ... This is mcp 2.x, where FastMCP was renamed to MCPServer`). They fail identically on upstream `main` (7bfe2f48) and are unrelated to this change; `pyproject.toml` only pins `mcp>=1.0.0`, which probably deserves its own issue.
- The other 2 unit failures (`tests/unit/studio/test_drive_settings.py::TestSaveDurability::test_dir_barrier_einval_reports_file_only_and_warns`, `tests/unit/studio/test_drive_settings_io.py::TestAtomicWriteDirBarrier::test_dir_fsync_einval_is_tolerated_but_signalled`) also fail identically on upstream `main` on this Windows 11 box (the FILE_ONLY durability warning is not emitted); unrelated to the launcher.
- The e2e tier was not run (nothing here touches the multi-node / Studio / serving stack).
- CI on my fork was triggered by this push and had not finished when the PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvSH4LFNQZpyjAeeCzFRRM
