### PR TITLE
fix(settings): make the default model changeable from the web/desktop Models page

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/settings/PresetEditor.test.js
+++ b/src/kohakuterrarium-frontend/src/components/settings/PresetEditor.test.js
@@ -1,0 +1,98 @@
+import { mount } from "@vue/test-utils"
+import { describe, expect, it, vi } from "vitest"
+import ElementPlus from "element-plus"
+
+vi.mock("@/utils/i18n", () => ({
+  useI18n: () => ({
+    t: (key, params) => (params?.name ? `${key}:${params.name}` : key),
+  }),
+}))
+
+import PresetEditor from "./PresetEditor.vue"
+
+const BUILTIN_PRESET = {
+  name: "claude-opus-4.8",
+  model: "claude-opus-4-8",
+  provider: "anthropic",
+  source: "preset",
+  is_default: false,
+}
+
+function mountEditor(props) {
+  return mount(PresetEditor, {
+    props: { backends: [{ name: "anthropic", backend_type: "anthropic" }], ...props },
+    global: { plugins: [ElementPlus] },
+  })
+}
+
+const setDefaultButton = (wrapper) =>
+  wrapper.findAll("button").find((b) => b.text().includes("settings.models.setAsDefault"))
+
+const defaultTag = (wrapper) =>
+  wrapper.findAll(".el-tag").find((tag) => tag.text() === "settings.models.isDefault")
+
+describe("PresetEditor default-model controls", () => {
+  it("offers a read-only built-in preset as a default candidate", async () => {
+    // Built-in presets render in "view" mode; hiding the button there is
+    // what made the default unchangeable from the web dashboard.
+    const wrapper = mountEditor({ preset: BUILTIN_PRESET, mode: "view" })
+
+    const button = setDefaultButton(wrapper)
+    expect(button).toBeDefined()
+    expect(defaultTag(wrapper)).toBeUndefined()
+
+    await button.trigger("click")
+
+    expect(wrapper.emitted("set-default")).toEqual([[BUILTIN_PRESET]])
+  })
+
+  it("shows the default tag instead of the button for the current default", () => {
+    const wrapper = mountEditor({
+      preset: { ...BUILTIN_PRESET, is_default: true },
+      mode: "view",
+    })
+
+    expect(defaultTag(wrapper)).toBeDefined()
+    expect(setDefaultButton(wrapper)).toBeUndefined()
+  })
+
+  it("keeps offering the button for an editable user preset", () => {
+    const wrapper = mountEditor({
+      preset: {
+        name: "fast",
+        model: "m",
+        provider: "anthropic",
+        source: "user",
+        is_default: false,
+      },
+      mode: "edit",
+    })
+
+    expect(setDefaultButton(wrapper)).toBeDefined()
+  })
+
+  it("offers neither control for an unsaved preset", () => {
+    const wrapper = mountEditor({ preset: null, mode: "new" })
+
+    expect(setDefaultButton(wrapper)).toBeUndefined()
+    expect(defaultTag(wrapper)).toBeUndefined()
+  })
+
+  it("offers neither control while cloning the current default", () => {
+    // Clone spreads the source preset — including is_default — into a
+    // "new" editor; the copy does not exist server-side yet, so it can
+    // neither claim the default tag nor be made the default.
+    const wrapper = mountEditor({
+      preset: {
+        ...BUILTIN_PRESET,
+        name: "claude-opus-4.8-custom",
+        source: "user",
+        is_default: true,
+      },
+      mode: "new",
+    })
+
+    expect(setDefaultButton(wrapper)).toBeUndefined()
+    expect(defaultTag(wrapper)).toBeUndefined()
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/settings/PresetEditor.vue
+++ b/src/kohakuterrarium-frontend/src/components/settings/PresetEditor.vue
@@ -15,11 +15,11 @@
       </div>
       <el-button v-if="isBuiltin" size="small" type="primary" @click="$emit('clone')">Clone</el-button>
       <el-button v-if="isEditing && !isBuiltin" size="small" @click="$emit('cancel')">Close</el-button>
-      <el-button v-if="isEditing && !preset?.is_default" size="small" type="success" plain :title="t('settings.models.setDefaultHint')" @click="$emit('set-default', preset)">
+      <el-button v-if="isSavedPreset && !preset?.is_default" size="small" type="success" plain :title="t('settings.models.setDefaultHint')" @click="$emit('set-default', preset)">
         <span class="i-carbon-checkmark-filled mr-1" />
         {{ t("settings.models.setAsDefault") }}
       </el-button>
-      <el-tag v-if="isEditing && preset?.is_default" type="success" size="small">{{ t("settings.models.isDefault") }}</el-tag>
+      <el-tag v-if="isSavedPreset && preset?.is_default" type="success" size="small">{{ t("settings.models.isDefault") }}</el-tag>
     </div>
 
     <!-- Core section -->
@@ -193,6 +193,8 @@ const form = reactive({
 
 const isBuiltin = computed(() => props.mode === "view")
 const isEditing = computed(() => props.mode === "edit")
+// Built-in presets ("view") are read-only but can still become the default.
+const isSavedPreset = computed(() => props.mode !== "new")
 
 const headerTitle = computed(() => {
   if (!props.preset) return "New preset"

--- a/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.test.js
+++ b/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.test.js
@@ -161,6 +161,7 @@ describe("SettingsPage model presets", () => {
     const preset = { name: "fast", provider: "openai", source: "user", is_default: false }
     const refreshed = { ...preset, is_default: true }
     configAPI.getModels.mockResolvedValueOnce([preset]).mockResolvedValueOnce([refreshed])
+    settingsAPI.setDefaultModel.mockResolvedValue({ status: "set", default_model: "openai/fast" })
     const success = vi.spyOn(ElMessage, "success").mockImplementation(() => {})
     const error = vi.spyOn(ElMessage, "error").mockImplementation(() => {})
 
@@ -170,8 +171,39 @@ describe("SettingsPage model presets", () => {
 
     await wrapper.vm.handleSetDefault(preset)
 
-    expect(settingsAPI.setDefaultModel).toHaveBeenCalledWith("fast")
-    expect(success).toHaveBeenCalledOnce()
+    // A bare name would resolve to whichever provider ships it first.
+    expect(settingsAPI.setDefaultModel).toHaveBeenCalledWith("openai/fast")
+    expect(success).toHaveBeenCalledWith("settings.models.defaultSet:openai/fast")
+    expect(error).not.toHaveBeenCalled()
+    expect(wrapper.vm.editorPreset).toEqual(refreshed)
+  })
+
+  it("sets a built-in preset as default with its provider-qualified identifier", async () => {
+    const preset = {
+      name: "claude-opus-4.8",
+      provider: "anthropic",
+      source: "preset",
+      is_default: false,
+    }
+    const refreshed = { ...preset, is_default: true }
+    configAPI.getModels.mockResolvedValueOnce([preset]).mockResolvedValueOnce([refreshed])
+    settingsAPI.setDefaultModel.mockResolvedValue({
+      status: "set",
+      default_model: "anthropic/claude-opus-4.8",
+    })
+    const success = vi.spyOn(ElMessage, "success").mockImplementation(() => {})
+    const error = vi.spyOn(ElMessage, "error").mockImplementation(() => {})
+
+    const wrapper = mountSettingsPage()
+    await flushPromises()
+    wrapper.vm.selectPreset(preset)
+    // Built-in presets open read-only, which used to hide the button.
+    expect(wrapper.vm.editorMode).toBe("view")
+
+    await wrapper.vm.handleSetDefault(preset)
+
+    expect(settingsAPI.setDefaultModel).toHaveBeenCalledWith("anthropic/claude-opus-4.8")
+    expect(success).toHaveBeenCalledWith("settings.models.defaultSet:anthropic/claude-opus-4.8")
     expect(error).not.toHaveBeenCalled()
     expect(wrapper.vm.editorPreset).toEqual(refreshed)
   })

--- a/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.vue
+++ b/src/kohakuterrarium-frontend/src/components/settings/SettingsPage.vue
@@ -1052,9 +1052,11 @@ async function handleSavePreset(payload) {
 
 async function handleSetDefault(preset) {
   if (!preset || !preset.name) return
+  // Send "provider/name": a bare name can exist under several providers.
+  const identifier = preset.provider ? presetKey(preset) : preset.name
   try {
-    await settingsAPI.setDefaultModel(preset.name)
-    ElMessage.success(t("settings.models.defaultSet", { name: preset.name }))
+    const result = await settingsAPI.setDefaultModel(identifier)
+    ElMessage.success(t("settings.models.defaultSet", { name: result?.default_model || identifier }))
     await loadPresets()
   } catch (err) {
     ElMessage.error(err.response?.data?.detail || t("settings.models.defaultSetFailed"))

--- a/src/kohakuterrarium/api/routes/identity/llm.py
+++ b/src/kohakuterrarium/api/routes/identity/llm.py
@@ -14,6 +14,7 @@ from kohakuterrarium.studio.identity.llm_backends import (
 from kohakuterrarium.studio.identity.llm_default import (
     get_default,
     list_all_models_combined,
+    resolve_and_set_default,
     set_default,
 )
 from kohakuterrarium.studio.identity.llm_native_tools import list_native_tools
@@ -53,7 +54,11 @@ class ProfileRequest(BaseModel):
 
 
 class DefaultModelRequest(BaseModel):
-    """Select the profile used as the default model."""
+    """Select the profile used as the default model.
+
+    ``name`` accepts ``provider/name`` or a bare preset name that resolves
+    to exactly one preset; an empty string clears the default.
+    """
 
     name: str
 
@@ -147,9 +152,21 @@ async def get_default_model_route():
 
 @router.post("/default-model", dependencies=[Depends(verify_admin_token)])
 async def set_default_model_route(req: DefaultModelRequest):
-    """Persist the model profile used as the default."""
-    set_default(req.name)
-    return {"status": "set", "default_model": req.name}
+    """Persist the default model, resolving the request to ``provider/name``.
+
+    An empty name clears the default; anything else must resolve to exactly
+    one preset, so a bare name shared by several providers is rejected
+    instead of silently binding to the wrong one.
+    """
+    if not req.name:
+        set_default("")
+        return {"status": "set", "default_model": ""}
+    identifier, error = resolve_and_set_default(req.name)
+    if error:
+        if error.startswith("Preset not found"):
+            raise HTTPException(404, error)
+        raise HTTPException(400, error)
+    return {"status": "set", "default_model": identifier}
 
 
 @router.get("/models")

--- a/src/kohakuterrarium/builtins/cli_rich/dialogs/settings.py
+++ b/src/kohakuterrarium/builtins/cli_rich/dialogs/settings.py
@@ -405,9 +405,12 @@ class SettingsOverlay:
             if not row.get("available"):
                 self._flash = f"{row['name']}: provider has no key configured"
                 return
+            # Bare names are ambiguous across providers — persist the row's own.
+            provider = row.get("provider") or ""
+            identifier = f"{provider}/{row['name']}" if provider else row["name"]
             try:
-                set_default_model(row["name"])
-                self._flash = f"Default model set: {row['name']}"
+                set_default_model(identifier)
+                self._flash = f"Default model set: {identifier}"
                 self._refresh_tab("Models")
             except Exception as e:
                 self._flash = f"Error: {e}"

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -153,13 +153,12 @@ def client(
     (saved-session list / resume / on-disk history) reads and writes
     the same isolated directory the engine saves into.
 
-    NOTE: the identity LLM stores (``llm/api_keys.py``,
-    ``llm/backends.py``, ``studio/identity/mcp_servers.py``,
-    ``ui_prefs.py``, ``editors/skills_state.py``) bind
-    ``Path.home() / ".kohakuterrarium"`` as an import-time constant
-    and honour no env override — so this tier exercises only the
-    *read* side of those routes plus error paths that 4xx before any
-    write.  See the report's ``B-fat2-api`` notes.
+    The identity LLM stores resolve their path fresh through
+    ``utils/config_dir.py::config_dir()`` on every read and write, and
+    ``tests/conftest.py::_default_isolated_config_dir`` pins
+    ``KT_CONFIG_DIR`` at a per-test tmp dir — so identity *writes*
+    (backends / profiles / default-model) are exercised for real here
+    without touching the operator's ``~/.kohakuterrarium``.
     """
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
@@ -618,8 +617,7 @@ class TestApiIntegration:
         resp = client.delete("/api/settings/backends/does-not-exist")
         assert resp.status_code == 404
         # Deleting a profile / api-key / MCP server that does not exist
-        # likewise 404s — these error branches resolve before any
-        # write touches the (unrelocatable) real config tree.
+        # likewise 404s.
         resp = client.delete("/api/settings/profiles/ghost-provider/ghost-name")
         assert resp.status_code == 404
         resp = client.delete("/api/settings/keys/definitely-not-a-provider")
@@ -633,6 +631,52 @@ class TestApiIntegration:
             json={"name": "x", "model": "m", "provider": "no-such-provider-xyz"},
         )
         assert resp.status_code == 404
+
+        # Identity write round-trip the Settings → Models pane commits:
+        # register a backend, add a profile under it, then click a row to
+        # make it the default.
+        resp = client.post(
+            "/api/settings/backends",
+            json={
+                "name": "acme",
+                "backend_type": "openai",
+                "base_url": "https://acme.example/v1",
+            },
+        )
+        assert resp.status_code == 200
+        resp = client.post(
+            "/api/settings/profiles",
+            json={"name": "acme-fast", "model": "acme-model-1", "provider": "acme"},
+        )
+        assert resp.status_code == 200
+        # The pane sends the row it clicked; a bare name is upgraded to the
+        # canonical provider-qualified identifier before it is persisted.
+        resp = client.post("/api/settings/default-model", json={"name": "acme-fast"})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "set", "default_model": "acme/acme-fast"}
+        resp = client.get("/api/settings/default-model")
+        assert resp.json()["default_model"] == "acme/acme-fast"
+        # The catalog the Models pane renders marks exactly that row.
+        resp = client.get("/api/settings/models")
+        assert resp.status_code == 200
+        assert [(m["provider"], m["name"]) for m in resp.json() if m["is_default"]] == [
+            ("acme", "acme-fast")
+        ]
+        # A bare name carried by several built-in providers is rejected
+        # rather than silently bound to whichever provider sorts first.
+        resp = client.post(
+            "/api/settings/default-model", json={"name": "claude-opus-4.8"}
+        )
+        assert resp.status_code == 400
+        assert "exists under multiple providers" in resp.json()["detail"]
+        resp = client.post(
+            "/api/settings/default-model", json={"name": "no-such-preset"}
+        )
+        assert resp.status_code == 404
+        # Neither rejection disturbed the stored default.
+        resp = client.get("/api/settings/default-model")
+        assert resp.json()["default_model"] == "acme/acme-fast"
+
         # MCP registry read round-trips.
         resp = client.get("/api/settings/mcp")
         assert resp.status_code == 200

--- a/tests/unit/api/test_identity_llm_mcp_routes.py
+++ b/tests/unit/api/test_identity_llm_mcp_routes.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from kohakuterrarium.api.routes.identity import llm as llm_mod
 from kohakuterrarium.api.routes.identity import mcp as mcp_mod
+from kohakuterrarium.llm import profiles
 
 
 def _app(*routers) -> FastAPI:
@@ -194,22 +195,109 @@ class TestLlmProfilesRoutes:
 
 
 class TestLlmDefaultModelRoutes:
+    """The default-model routes against the real profile store.
+
+    ``KT_CONFIG_DIR`` is a per-test tmp dir (``tests/conftest.py``
+    ``_default_isolated_config_dir``) and every profile read/write
+    resolves it fresh, so these drive the real resolver instead of a
+    stub — the resolution is the behaviour under test.
+    """
+
+    def _client(self) -> TestClient:
+        return TestClient(_app(llm_mod.router))
+
+    def _register_acme(self, client: TestClient) -> None:
+        """Create the ``acme`` backend plus its ``acme-fast`` profile."""
+        resp = client.post("/backends", json={"name": "acme", "backend_type": "openai"})
+        assert resp.status_code == 200
+        resp = client.post(
+            "/profiles",
+            json={"name": "acme-fast", "model": "acme-model-1", "provider": "acme"},
+        )
+        assert resp.status_code == 200
+
     def test_get_default_model(self, monkeypatch):
         monkeypatch.setattr(llm_mod, "get_default", lambda: "openai/gpt-4")
-        client = TestClient(_app(llm_mod.router))
+        client = self._client()
         resp = client.get("/default-model")
         assert resp.status_code == 200
         assert resp.json() == {"default_model": "openai/gpt-4"}
 
-    def test_set_default_model(self, monkeypatch):
-        captured = []
-        monkeypatch.setattr(llm_mod, "set_default", lambda n: captured.append(n))
-        client = TestClient(_app(llm_mod.router))
-        resp = client.post("/default-model", json={"name": "openai/gpt-5"})
+    def test_set_default_model_upgrades_bare_user_profile(self):
+        client = self._client()
+        self._register_acme(client)
+        resp = client.post("/default-model", json={"name": "acme-fast"})
         assert resp.status_code == 200
-        assert resp.json() == {"status": "set", "default_model": "openai/gpt-5"}
-        # The route actually persisted the new default.
-        assert captured == ["openai/gpt-5"]
+        assert resp.json() == {"status": "set", "default_model": "acme/acme-fast"}
+        assert client.get("/default-model").json() == {
+            "default_model": "acme/acme-fast"
+        }
+
+    def test_set_default_model_accepts_qualified_user_profile(self):
+        client = self._client()
+        self._register_acme(client)
+        resp = client.post("/default-model", json={"name": "acme/acme-fast"})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "set", "default_model": "acme/acme-fast"}
+        assert client.get("/default-model").json() == {
+            "default_model": "acme/acme-fast"
+        }
+
+    def test_set_default_model_qualified_builtin(self):
+        client = self._client()
+        resp = client.post("/default-model", json={"name": "anthropic/claude-opus-4.8"})
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "set",
+            "default_model": "anthropic/claude-opus-4.8",
+        }
+        assert client.get("/default-model").json() == {
+            "default_model": "anthropic/claude-opus-4.8"
+        }
+
+    def test_set_default_model_ambiguous_bare_name_rejected(self):
+        # ``claude-opus-4.8`` ships under both anthropic and openrouter.
+        # The bare name used to persist verbatim and read back as the
+        # openrouter row no matter which provider the user clicked.
+        client = self._client()
+        self._register_acme(client)
+        assert (
+            client.post("/default-model", json={"name": "acme-fast"}).status_code == 200
+        )
+        resp = client.post("/default-model", json={"name": "claude-opus-4.8"})
+        assert resp.status_code == 400
+        assert "exists under multiple providers" in resp.json()["detail"]
+        # The rejected write left the previous default untouched.
+        assert client.get("/default-model").json() == {
+            "default_model": "acme/acme-fast"
+        }
+        assert profiles._load_yaml().get("default_model", "") == "acme/acme-fast"
+
+    def test_set_default_model_unknown_name_404(self):
+        client = self._client()
+        self._register_acme(client)
+        assert (
+            client.post("/default-model", json={"name": "acme-fast"}).status_code == 200
+        )
+        resp = client.post("/default-model", json={"name": "no-such-preset"})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Preset not found: no-such-preset"
+        assert client.get("/default-model").json() == {
+            "default_model": "acme/acme-fast"
+        }
+
+    def test_set_default_model_empty_name_clears(self):
+        client = self._client()
+        self._register_acme(client)
+        assert (
+            client.post("/default-model", json={"name": "acme-fast"}).status_code == 200
+        )
+        resp = client.post("/default-model", json={"name": ""})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "set", "default_model": ""}
+        # The explicit default is gone from the store; what ``GET`` now
+        # reports is the built-in fallback, not a persisted choice.
+        assert profiles._load_yaml().get("default_model", "") == ""
 
     def test_get_all_models(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/unit/builtins/cli_rich/dialogs/test_settings_models.py
+++ b/tests/unit/builtins/cli_rich/dialogs/test_settings_models.py
@@ -1,0 +1,92 @@
+"""Unit tests for the Models tab in the Rich settings overlay."""
+
+from kohakuterrarium.builtins.cli_rich.dialogs import settings
+from kohakuterrarium.builtins.cli_rich.dialogs.settings import SettingsOverlay
+
+
+class TestSettingsModelsTab:
+    def _overlay(self, row: dict) -> SettingsOverlay:
+        overlay = SettingsOverlay()
+        overlay.tab = "Models"
+        overlay._entries["Models"] = [row]
+        overlay._cursor["Models"] = 0
+        return overlay
+
+    def test_activation_persists_the_provider_qualified_identifier(self, monkeypatch):
+        # A bare name shared by several providers would read back as the
+        # wrong provider's preset; the row carries the one the user picked.
+        captured: list[str] = []
+        monkeypatch.setattr(settings, "set_default_model", captured.append)
+        overlay = self._overlay(
+            {
+                "name": "gpt-5.5",
+                "provider": "openai",
+                "available": True,
+                "is_default": False,
+                "source": "preset",
+            }
+        )
+
+        overlay._list_activate()
+
+        assert captured == ["openai/gpt-5.5"]
+        assert overlay._flash == "Default model set: openai/gpt-5.5"
+
+    def test_activation_of_a_provider_less_row_keeps_the_bare_name(self, monkeypatch):
+        captured: list[str] = []
+        monkeypatch.setattr(settings, "set_default_model", captured.append)
+        overlay = self._overlay(
+            {
+                "name": "orphan",
+                "provider": "",
+                "available": True,
+                "is_default": False,
+                "source": "user",
+            }
+        )
+
+        overlay._list_activate()
+
+        assert captured == ["orphan"]
+        assert overlay._flash == "Default model set: orphan"
+
+    def test_activation_marks_only_the_clicked_provider_row(self):
+        # Real write + reload against the per-test tmp ``KT_CONFIG_DIR``.
+        # A bare default is read back through the fixed provider
+        # preference, so activating the anthropic row used to leave the
+        # openrouter row of the same preset flagged as the default.
+        overlay = self._overlay(
+            {
+                "name": "claude-opus-4.8",
+                "provider": "anthropic",
+                "available": True,
+                "is_default": False,
+                "source": "preset",
+            }
+        )
+
+        overlay._list_activate()
+
+        assert [
+            (row["provider"], row["name"])
+            for row in overlay._entries["Models"]
+            if row["is_default"]
+        ] == [("anthropic", "claude-opus-4.8")]
+
+    def test_activation_without_a_key_does_not_write(self, monkeypatch):
+        captured: list[str] = []
+        monkeypatch.setattr(settings, "set_default_model", captured.append)
+        overlay = self._overlay(
+            {
+                "name": "gpt-5.5",
+                "provider": "openai",
+                "available": False,
+                "is_default": False,
+                "source": "preset",
+            }
+        )
+
+        overlay._list_activate()
+
+        assert captured == []
+        assert overlay._flash == "gpt-5.5: provider has no key configured"


### PR DESCRIPTION
## Summary

Settings → Models in the web dashboard / desktop app could not change the default model: built-in presets never showed the "Set as default" button, and when a user preset was set as default the backend stored the bare name, which later resolved to a different provider (`claude-opus-4.8` → `openrouter/…`, `gpt-5.5` → `codex/…`). This PR shows the button for every existing preset, sends the `provider/name` identifier, and makes `POST /api/settings/default-model` resolve names the same way `kt config llm default` does.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Fixes #282. Most users run built-in presets, and for those the editor opened read-only with only a "Clone" button, so the default could not be changed from the UI at all. For user presets the bare-name write silently moved the default to whichever provider `get_default_model()`'s upgrade preference picked first, and the models list then flagged the wrong row. 20 of the 78 built-in preset names exist under more than one provider, so this was easy to hit.

## Changes

- `api/routes/identity/llm.py`: `POST /default-model` now goes through `resolve_and_set_default`; returns the canonical `provider/name`, 404 for an unknown preset, 400 for an ambiguous bare name; an empty name still clears the default.
- `PresetEditor.vue`: "Set as default" button and "default" tag render for any existing preset (user or built-in), never for a new unsaved one.
- `SettingsPage.vue`: `handleSetDefault` sends `provider/name` and reports the identifier the API persisted.
- `builtins/cli_rich/dialogs/settings.py`: the Rich CLI Models tab had the same bare-name write; it now passes `provider/name` too (one-line change, same defect).
- Tests: route unit tests use the real resolver against a tmp config dir (bare → canonical, ambiguous → 400, unknown → 404, clear); the API integration workflow gains the default-model round-trip including the `is_default` flag in `/api/settings/models`; new `PresetEditor.test.js` pins button/tag visibility per mode; `SettingsPage.test.js` pins the qualified identifier; a Rich CLI overlay test pins the qualified write.

## Validation

```bash
black --check src/ tests/          # 1592 files would be left unchanged
ruff check src/ tests/             # All checks passed!
pytest tests/unit -q               # 14202 passed, 1 skipped
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
pytest tests/integration/test_api.py -q          # 11 passed
pytest tests/e2e/test_api_settings.py tests/e2e/test_prog_studio.py -q   # 4 passed
cd src/kohakuterrarium-frontend
npm run test           # 1238 passed; MacroShell.test.js fails to collect on main too (missing monaco-editor import), unrelated
npm run format:check   # All matched files use Prettier code style!
npm run build          # built
```

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #282
- Relates to #240 (spurious failure toast after a successful save; the selection defects here are separate)

## Notes for Reviewers

- `POST /api/settings/default-model` previously accepted any string. It now validates: unknown → 404, ambiguous bare name → 400. Qualified identifiers (what the frontend and `kt config llm default` send) and unique bare names keep working; `""` still clears the explicit default. `docs/en/guides/cli-and-ui-equivalents.md` already documents the button, so no doc change.
- The Rich CLI overlay fix is included because it is the identical bare-name write; happy to split it out if you prefer.
- Because the route now resolves through `resolve_and_set_default`, a variation selector in the request (`openai/gpt-5.5@reasoning=high`) is normalised to `openai/gpt-5.5`, the same as `kt config llm default`. The response echoes what was stored. No client sends selectors to this endpoint today.

## Screenshots / Logs (if applicable)

Before, from a fresh config dir:

```text
set_default("gpt-5.5")          -> get_default() == "codex/gpt-5.5"
set_default("claude-opus-4.8")  -> get_default() == "openrouter/claude-opus-4.8"
```

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

Fork CI: https://github.com/treeleaves30760/KohakuTerrarium/actions/runs/33664527074 is green after re-running one job.

Upstream CI on this PR fails only in `test (windows-latest, 3.12)`, each time on a single pre-existing timing test that this PR does not touch:

- run 33668844407: `tests/unit/builtins/tui/test_session.py::test_long_markdown_fence_keeps_content_and_has_visible_scrollbar` (`assert 0 > 0`)
- run 33671867782 (reopened to retrigger): `tests/unit/studio/persistence/session_index/test_hooks.py::TestSessionIndexHook::test_event_flush_debounced_by_time` (`assert '' == 'after gate'`)
- run 33673862755 (reopened again): both of the above, with the job taking 18 minutes against about 8 on Linux

Both are flaky on upstream `main` independent of this change: of the last 28 completed CI runs, the Windows 3.12 job failed in 15, including 4 pushes to `main` (33667618409, 33644916225, 33464440307, 33323021218) and PRs from six unrelated branches; the TUI scrollbar test accounts for 14 of those and the debounce test for 2 (33624922265, 33537842912). The same commit passed the Windows 3.12 job on the fork on re-run. The TUI test reads `max_scroll_x` / `show_horizontal_scrollbar` right after one `pilot.pause()`, before the layout pass that sizes the asynchronously mounted fence; the debounce test relies on real `time.sleep(0.01)` crossing a `flush_every_seconds=0.001` gate. Happy to send a separate PR hardening both if wanted.

The e2e tier is not run in CI; `tests/e2e/test_api_settings.py` and `tests/e2e/test_prog_studio.py` were run locally.
