### PR TITLE
fix: preserve tool history across interrupt and edit reruns

### DIFF
--- a/src/kohakuterrarium-frontend/src/stores/chat.editRerunGuards.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.editRerunGuards.test.js
@@ -8,6 +8,33 @@ beforeEach(() => {
 })
 
 describe("chat store — edit/rerun semantic guards", () => {
+  it("keeps a newer running turn after an earlier interrupt response", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "graph_1"
+    chat._instanceGraphId = "graph_1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.processingByTab = { main: true }
+    const { terrariumAPI } = await import("@/utils/api")
+    let finishInterrupt
+    const interrupt = vi.spyOn(terrariumAPI, "interruptCreature").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishInterrupt = resolve
+        }),
+    )
+    const history = vi
+      .spyOn(terrariumAPI, "getHistory")
+      .mockResolvedValue({ events: [], messages: [], is_processing: true })
+    const pending = chat.interrupt("main")
+    finishInterrupt({ status: "interrupted" })
+    await pending
+    expect(history).toHaveBeenCalledWith("graph_1", "main")
+    expect(chat.processingByTab.main).toBe(true)
+    interrupt.mockRestore()
+    history.mockRestore()
+  })
+
   it("does not let injected mid-turn rows shift canonical user locators", () => {
     const events = [
       { type: "user_input", event_id: 1, content: "first", turn_index: 1, branch_id: 1 },

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -2295,6 +2295,7 @@ const _chatStoreOptions = {
       if (!this._instanceId) return
       const target = tab || this.activeTab
       if (!target || target.startsWith("ch:")) return
+      const generation = this._instanceGeneration
 
       try {
         // Interrupt the main agent processing only.
@@ -2306,7 +2307,9 @@ const _chatStoreOptions = {
           // and creatures keyed by name. ``interruptCreature`` works
           // for both solo (1-creature graph) and multi-creature.
           await terrariumAPI.interruptCreature(this._instanceGraphId, target)
-          this.processingByTab[target] = false
+          if (generation === this._instanceGeneration) {
+            await this._resyncHistory(target, { generation })
+          }
         }
         // Do NOT mark running parts as interrupted or remove running jobs.
         // The backend will send proper done/error events when jobs complete.

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -5379,6 +5379,13 @@ describe("chat store — interrupt targets the given tab", () => {
 
     const importActual = await vi.importActual("@/utils/api")
     const spy = vi.spyOn(importActual.terrariumAPI, "interruptCreature").mockResolvedValue({})
+    const history = vi
+      .spyOn(importActual.terrariumAPI, "getHistory")
+      .mockResolvedValue({ events: [], messages: [], is_processing: false })
+    spy.mockImplementation(async () => {
+      chat._onMessage({ type: "processing_end", source: "root_b" })
+      return { status: "interrupted" }
+    })
 
     await chat.interrupt("root_b")
 
@@ -5389,6 +5396,8 @@ describe("chat store — interrupt targets the given tab", () => {
     expect(chat.processingByTab.root_a).toBe(true)
 
     spy.mockRestore()
+    history.mockRestore()
+    chat._clearBranchResyncTimers()
   })
 })
 

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_ctl.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_ctl.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from kohakuterrarium.api.deps import get_service
 from kohakuterrarium.api.routes.sessions_v2._helpers import resolve_creature_id
+from kohakuterrarium.errors import ConflictError
 from kohakuterrarium.studio.sessions import creature_ctl
 from kohakuterrarium.terrarium.service import TerrariumService
 
@@ -24,6 +25,8 @@ async def interrupt_creature(
     try:
         await creature_ctl.interrupt(service, session_id, cid)
         return {"status": "interrupted"}
+    except ConflictError as exc:
+        raise HTTPException(409, str(exc)) from exc
     except KeyError:
         raise HTTPException(404, f"creature {creature_id!r} not found")
 

--- a/src/kohakuterrarium/core/agent.py
+++ b/src/kohakuterrarium/core/agent.py
@@ -181,6 +181,7 @@ class Agent(
         # Interrupt: flag + task reference for immediate cancellation
         self._interrupt_requested = False
         self._processing_task: asyncio.Task | None = None
+        self._turn_completion: asyncio.Future[None] | None = None
         self._branch_request_id: str | None = None
 
         self._active_handles: dict[str, Any] = {}
@@ -576,10 +577,11 @@ class Agent(
         are dropped WITHOUT running and their settlement resolved
         ``interrupted`` so the dispatcher redelivers, matching the prior
         drop-drive-on-interrupt behavior."""
+        already_requested = self._interrupt_requested
         self._interrupt_requested = True
         self.controller._interrupted = True
         processing = getattr(self, "_processing_task", None)
-        if processing and not processing.done():
+        if processing and not processing.done() and not already_requested:
             processing.cancel()
         for job_id in list(self._active_handles.keys()):
             self._interrupt_direct_job(job_id)

--- a/src/kohakuterrarium/core/agent_event_loop.py
+++ b/src/kohakuterrarium/core/agent_event_loop.py
@@ -137,6 +137,8 @@ class AgentEventLoopMixin:
         events = [env.event for env in run]
         primary = events[0]
         captures = [env.capture for env in run if env.capture is not None]
+        completion = asyncio.get_running_loop().create_future()
+        self._turn_completion = completion
         self._active_event_run = run
         self._active_event_captures = captures
         for cap in captures:
@@ -165,6 +167,10 @@ class AgentEventLoopMixin:
                 self.output_router.remove_secondary(cap)
             self._active_event_run = None
             self._active_event_captures = None
+            if self._turn_completion is completion:
+                self._turn_completion = None
+            if not completion.done():
+                completion.set_result(None)
         self._resolve_run(
             run,
             status="interrupted" if interrupted else "ok",

--- a/src/kohakuterrarium/core/agent_handlers.py
+++ b/src/kohakuterrarium/core/agent_handlers.py
@@ -225,8 +225,6 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
         """Inner loop: run LLM → dispatch tools → collect feedback → repeat."""
         while True:
             if self._interrupt_requested:
-                self._interrupt_requested = False
-                controller._interrupted = False
                 self.output_router.notify_activity(
                     "interrupt", "[system] Processing interrupted"
                 )
@@ -249,8 +247,6 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
             # Check interrupt after LLM turn (before waiting for tools)
             if self._interrupt_requested:
                 self._cancel_handles(round_result.handles)
-                self._interrupt_requested = False
-                controller._interrupted = False
                 self.output_router.notify_activity(
                     "interrupt", "[system] Processing interrupted"
                 )
@@ -434,7 +430,9 @@ class AgentHandlersMixin(AgentMidTurnMixin, AgentToolsMixin, AgentOutputWiringMi
         )
 
         await self._flush_output()
-        self._notify_tool_start(parse_event, job_id, is_direct)
+        self._notify_tool_start(
+            parse_event, job_id, is_direct, tool_call_id=tool_call_id
+        )
 
     async def _dispatch_subagent_event(
         self,

--- a/src/kohakuterrarium/core/agent_lifecycle.py
+++ b/src/kohakuterrarium/core/agent_lifecycle.py
@@ -7,9 +7,26 @@ import asyncio
 from typing import Any
 
 from kohakuterrarium.core.job import JobState, JobType
+from kohakuterrarium.errors import ConflictError
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+async def wait_for_turn_completion(
+    agent: Any, completion: asyncio.Future | None, *, timeout: float = 10.0
+) -> None:
+    """Join one captured turn without cancelling it when the waiter times out."""
+    if completion is None or completion.done():
+        return
+    if getattr(agent, "_turn_lock_holder", None) is asyncio.current_task():
+        raise ConflictError("Cannot wait for the current turn from its own callback")
+    try:
+        await asyncio.wait_for(asyncio.shield(completion), timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        raise ConflictError(
+            "The previous turn is still finishing; retry after it stops"
+        ) from exc
 
 
 class AgentLifecycleMixin:
@@ -26,6 +43,21 @@ class AgentLifecycleMixin:
     _running: bool
     _paused: bool
     _shutdown_event: Any
+
+    @property
+    def is_processing(self) -> bool:
+        """Whether a turn is active, finalizing, or waiting in the inbox."""
+        lock = getattr(self, "_processing_lock", None)
+        inbox = getattr(self, "_event_inbox", None)
+        return bool(
+            (lock is not None and lock.locked()) or (inbox is not None and len(inbox))
+        )
+
+    async def interrupt_and_wait(self, *, timeout: float = 10.0) -> None:
+        """Interrupt the captured turn and wait until its finalization releases it."""
+        completion = getattr(self, "_turn_completion", None)
+        self.interrupt()
+        await wait_for_turn_completion(self, completion, timeout=timeout)
 
     @property
     def paused(self) -> bool:

--- a/src/kohakuterrarium/core/agent_messages.py
+++ b/src/kohakuterrarium/core/agent_messages.py
@@ -5,6 +5,7 @@ Modify past messages, regenerate responses, and replay conversation branches.
 
 import asyncio
 
+from kohakuterrarium.core.agent_lifecycle import wait_for_turn_completion
 from kohakuterrarium.core.agent_message_history import (
     live_user_turns as _live_user_turns,
     max_branch_id_for_turn as _max_branch_id_for_turn,
@@ -106,6 +107,7 @@ class AgentMessagesMixin:
 
     async def _regenerate_tail_response(self, *, request_id: str | None) -> None:
         """Regenerate the current tail while holding the mutation lock."""
+        await self._wait_for_history_finalization()
         self._ensure_history_mutation_idle()
         self._ensure_rerun_available()
         conv = self.controller.conversation
@@ -203,6 +205,7 @@ class AgentMessagesMixin:
         truncation target resolves correctly even when the user has
         switched to an older subtree in the UI.
         """
+        await self._wait_for_history_finalization()
         self._ensure_history_mutation_idle()
         self._ensure_rerun_available()
         # Canonical persisted targets reconstruct original context before
@@ -315,6 +318,7 @@ class AgentMessagesMixin:
     async def rewind_to(self, message_idx: int) -> None:
         """Drop messages from ``message_idx`` onward without re-running."""
         async with self._get_message_mutation_lock():
+            await self._wait_for_history_finalization()
             self._ensure_history_mutation_idle()
             conv = self.controller.conversation
             removed = conv.truncate_from(message_idx)
@@ -338,6 +342,16 @@ class AgentMessagesMixin:
             lock = asyncio.Lock()
             self._message_mutation_lock = lock
         return lock
+
+    async def _wait_for_history_finalization(self) -> None:
+        """Wait for cancellation or finalization, never for an actively generating turn."""
+        if (
+            getattr(self, "_interrupt_requested", False)
+            or getattr(self, "_processing_task", None) is None
+        ):
+            await wait_for_turn_completion(
+                self, getattr(self, "_turn_completion", None)
+            )
 
     def _ensure_history_mutation_idle(self) -> None:
         """Reject destructive history changes while another turn can observe it."""

--- a/src/kohakuterrarium/core/agent_runtime_tools.py
+++ b/src/kohakuterrarium/core/agent_runtime_tools.py
@@ -33,7 +33,12 @@ class AgentRuntimeToolsMixin:
         self.output_router.notify_activity(activity, detail)
 
     def _notify_tool_start(
-        self, parse_event: ToolCallEvent, job_id: str, is_direct: bool
+        self,
+        parse_event: ToolCallEvent,
+        job_id: str,
+        is_direct: bool,
+        *,
+        tool_call_id: str | None = None,
     ) -> None:
         """Notify output of a tool start with a human-readable preview."""
         _, label = _make_job_label(job_id)
@@ -44,10 +49,20 @@ class AgentRuntimeToolsMixin:
             full_args[k] = v
             arg_parts.append(f"{k}={str(v)[:40]}")
         bg_tag = " (bg)" if not is_direct else ""
+        metadata = {
+            "job_id": job_id,
+            "tool_name": parse_event.name,
+            "args": full_args,
+            "background": not is_direct,
+        }
+        if tool_call_id:
+            metadata.update(
+                tool_call_id=tool_call_id, tool_call_arguments=parse_event.raw
+            )
         self.output_router.notify_activity(
             "tool_start",
             f"[{label}]{bg_tag} {' '.join(arg_parts)[:80]}",
-            metadata={"job_id": job_id, "args": full_args, "background": not is_direct},
+            metadata=metadata,
         )
 
     def _emit_token_usage(self, controller: Controller) -> None:

--- a/src/kohakuterrarium/core/agent_turn.py
+++ b/src/kohakuterrarium/core/agent_turn.py
@@ -232,9 +232,10 @@ class AgentTurnMixin:
             if capture.error is None:
                 capture.error = str(exc)
 
-        # A rejected outcome means the consumer never ran the event (agent
-        # stopped / warm-paused) — surface a rejection rather than a hollow
-        # ``ok`` with empty text.
-        if outcome is not None and outcome.status == "rejected" and status == "ok":
-            status = "rejected"
-        return capture.build_result(status, duration_s=time.monotonic() - t0)
+        # Preserve the consumer's terminal status unless this caller timed out
+        # or failed independently. Cancellation must not become an empty success.
+        if outcome is not None and status == "ok":
+            status = outcome.status
+        result = capture.build_result(status, duration_s=time.monotonic() - t0)
+        result.interrupted_by_user = bool(outcome and outcome.interrupted_by_user)
+        return result

--- a/src/kohakuterrarium/core/conversation.py
+++ b/src/kohakuterrarium/core/conversation.py
@@ -20,6 +20,7 @@ from kohakuterrarium.core.conversation_sanitize import (  # noqa: F401
     _is_empty_content,
 )
 from kohakuterrarium.core.conversation_sanitize import (
+    normalize_tool_names,
     prune_orphan_tool_pairs as _prune_orphan_tool_pairs,
 )
 from kohakuterrarium.core.conversation_sanitize import (
@@ -159,7 +160,7 @@ class Conversation:
         ``include_metadata`` is for session snapshots only; provider calls leave
         it disabled so internal message identity never reaches the wire.
         """
-        messages = messages_to_dicts(self._messages)
+        messages = normalize_tool_names(messages_to_dicts(self._messages))
         if include_metadata:
             for msg, serialized in zip(self._messages, messages):
                 if msg.metadata:

--- a/src/kohakuterrarium/core/conversation_sanitize.py
+++ b/src/kohakuterrarium/core/conversation_sanitize.py
@@ -3,10 +3,37 @@
 from datetime import datetime
 from typing import Any
 
+from kohakuterrarium.core.job_label import canonical_tool_name
 from kohakuterrarium.llm.message import TextPart, messages_to_dicts
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def normalize_tool_names(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Repair legacy tool labels without modifying the source or provider state."""
+    normalized = []
+    for message in messages:
+        result = message
+        if message.get("role") == "tool" and isinstance(message.get("name"), str):
+            name = canonical_tool_name(message["name"])
+            if name != message["name"]:
+                result = {**result, "name": name}
+        calls = message.get("tool_calls") or []
+        repaired = []
+        for call in calls:
+            function = call.get("function") or {}
+            name = function.get("name")
+            canonical = canonical_tool_name(name) if isinstance(name, str) else name
+            repaired.append(
+                {**call, "function": {**function, "name": canonical}}
+                if canonical != name
+                else call
+            )
+        if any(a is not b for a, b in zip(calls, repaired)):
+            result = {**result, "tool_calls": repaired}
+        normalized.append(result)
+    return normalized
 
 
 def _is_empty_content(content: Any) -> bool:

--- a/src/kohakuterrarium/core/job_label.py
+++ b/src/kohakuterrarium/core/job_label.py
@@ -8,6 +8,16 @@ truth. Kept free of any KohakuTerrarium imports so low-level modules
 (e.g. session.history) can use it without import cycles.
 """
 
+import re
+
+_JOB_LABEL = re.compile(r"([^\[\]\r\n]+)\[[0-9a-fA-F]{6}\]")
+
+
+def canonical_tool_name(name: str) -> str:
+    """Restore names from the hex-suffixed display labels emitted by KT."""
+    match = _JOB_LABEL.fullmatch(name)
+    return match[1] if match else name
+
 
 def make_job_label(job_id: str) -> tuple[str, str]:
     """Extract ``(tool_name, label)`` from a job id.

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
@@ -61,6 +61,7 @@ from kohakuterrarium.terrarium.wire import (
     unpack_creature_build_input,
 )
 from kohakuterrarium.utils.logging import get_logger
+from kohakuterrarium.errors import ConflictError
 
 logger = get_logger(__name__)
 
@@ -142,6 +143,8 @@ class TerrariumRuntimeAdapter:
             return {"error": {"kind": "creature_not_hosted", "message": str(e)}}
         except KeyError as e:
             return {"error": {"kind": "not_found", "message": str(e)}}
+        except ConflictError as e:
+            return {"error": {"kind": "conflict", "message": str(e)}}
         except ValueError as e:
             return {"error": {"kind": "invalid", "message": str(e)}}
         except Exception as e:  # pragma: no cover - defensive
@@ -489,7 +492,7 @@ class TerrariumRuntimeAdapter:
             case "interrupt":
                 cid = msg.body["creature_id"]
                 creature = self._require_hosted(cid)
-                creature.agent.interrupt()
+                await creature.agent.interrupt_and_wait()
                 return {}
 
             case "list_jobs":

--- a/src/kohakuterrarium/session/history.py
+++ b/src/kohakuterrarium/session/history.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import Hashable, Mapping
 from typing import Any, Iterable
 
-from kohakuterrarium.core.job_label import make_job_label
+from kohakuterrarium.core.job_label import canonical_tool_name, make_job_label
 
 # Parent paths identify the selected branches of earlier turns. Legacy events
 # derive this ancestry from event order when no explicit path was persisted.
@@ -457,24 +457,15 @@ def dedupe_adjacent_duplicate_events(
 
 
 def _clean_tool_name(evt: dict) -> str:
-    """Resolve the provider-safe tool name for a ``tool_result`` event.
-
-    The event's ``name`` may be a UI display label (``bash[ff6427]``) or
-    already clean (``bash``). A clean name is used as-is; a label or a
-    missing name is resolved from the job id through the shared job-label
-    helper (``bash_ff642767`` -> ``bash``), the same source the live
-    conversation path uses. Falls back to stripping the bracketed suffix.
-    """
-    name = evt.get("name", "")
-    if isinstance(name, str) and name and "[" not in name:
-        return name
+    """Prefer recorded identity, repairing legacy labels or missing names."""
+    name = evt.get("tool_name") or evt.get("name", "")
+    if isinstance(name, str) and name:
+        return canonical_tool_name(name)
     call_id = evt.get("call_id") or evt.get("job_id") or ""
     if call_id:
         tool_name, _ = make_job_label(str(call_id))
         if tool_name:
             return tool_name
-    if isinstance(name, str) and "[" in name:
-        return name.split("[", 1)[0]
     return name if isinstance(name, str) else ""
 
 
@@ -563,6 +554,13 @@ def replay_conversation(
     # Nested branch ancestry determines the live event set and the selected
     # branch projection compaction rules are validated against.
     live_ids = select_live_event_ids(events_list, branch_view=branch_view)
+    provider_ids = {
+        evt.get("call_id") or evt.get("job_id"): evt["tool_call_id"]
+        for evt in events_list
+        if evt.get("type") == "tool_call"
+        and evt.get("tool_call_id")
+        and (not isinstance(evt.get("event_id"), int) or evt["event_id"] in live_ids)
+    }
     selected = resolve_selected_branches(
         events_list, index_parent_paths(events_list), branch_view
     )
@@ -750,11 +748,13 @@ def replay_conversation(
                     }
                 )
         elif etype == "tool_result":
+            job_id = evt.get("call_id", "") or evt.get("job_id", "")
             messages.append(
                 {
                     "role": "tool",
                     "content": evt.get("output", "") or "",
-                    "tool_call_id": evt.get("call_id", "") or evt.get("job_id", ""),
+                    "tool_call_id": evt.get("tool_call_id")
+                    or provider_ids.get(job_id, job_id),
                     "name": _clean_tool_name(evt),
                 }
             )
@@ -819,11 +819,13 @@ def _inject_synthetic_announcements(
         for tc in items:
             tool_calls.append(
                 {
-                    "id": str(tc.get("call_id") or tc.get("job_id") or ""),
+                    "id": _provider_call_id(tc),
                     "type": "function",
                     "function": {
-                        "name": tc.get("name", "") or "",
-                        "arguments": _coerce_tool_args_to_json(tc.get("args")),
+                        "name": _clean_tool_name(tc),
+                        "arguments": _coerce_tool_args_to_json(
+                            tc.get("tool_call_arguments") or tc.get("args")
+                        ),
                     },
                 }
             )
@@ -840,7 +842,7 @@ def _inject_synthetic_announcements(
             return
         result.append(_build_announce(pending))
         for tc in pending:
-            cid = str(tc.get("call_id") or tc.get("job_id") or "")
+            cid = _provider_call_id(tc)
             if cid:
                 announced_ids.add(cid)
         pending.clear()
@@ -849,7 +851,7 @@ def _inject_synthetic_announcements(
         etype = evt.get("type", "")
 
         if etype == "tool_call":
-            cid = str(evt.get("call_id") or evt.get("job_id") or "")
+            cid = _provider_call_id(evt)
             # Calls already announced must not be synthesized again.
             if cid and cid in announced_ids:
                 result.append(evt)
@@ -871,9 +873,7 @@ def _inject_synthetic_announcements(
                 if tid:
                     announced_ids.add(tid)
             pending = [
-                tc
-                for tc in pending
-                if str(tc.get("call_id") or tc.get("job_id") or "") not in announced_ids
+                tc for tc in pending if _provider_call_id(tc) not in announced_ids
             ]
             result.append(evt)
             continue
@@ -885,6 +885,12 @@ def _inject_synthetic_announcements(
     # An unfinished stream still needs a valid trailing assistant announcement.
     _flush_pending()
     return result
+
+
+def _provider_call_id(event: dict[str, Any]) -> str:
+    return str(
+        event.get("tool_call_id") or event.get("call_id") or event.get("job_id") or ""
+    )
 
 
 def normalize_tool_call_events(

--- a/src/kohakuterrarium/session/output.py
+++ b/src/kohakuterrarium/session/output.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any
 
+from kohakuterrarium.core.job_label import canonical_tool_name, make_job_label
 from kohakuterrarium.modules.output.base import OutputModule
 from kohakuterrarium.modules.output.event import OutputEvent
 from kohakuterrarium.session.history import replay_conversation
@@ -471,18 +472,22 @@ class SessionOutput(OutputModule):
         )
 
     def _handle_tool_start(self, name: str, detail: str, metadata: dict) -> None:
+        data = {
+            "name": metadata.get("tool_name") or canonical_tool_name(name),
+            "call_id": metadata.get("job_id", ""),
+            "args": metadata.get("args", {}),
+        }
+        if metadata.get("tool_call_id"):
+            data["tool_call_id"] = metadata["tool_call_id"]
+            data["tool_call_arguments"] = metadata.get("tool_call_arguments")
         self._record(
             "tool_call",
-            {
-                "name": name,
-                "call_id": metadata.get("job_id", ""),
-                "args": metadata.get("args", {}),
-            },
+            data,
         )
 
     def _handle_tool_done(self, name: str, detail: str, metadata: dict) -> None:
         event_data: dict[str, Any] = {
-            "name": name,
+            "name": _tool_name(name, metadata),
             "call_id": metadata.get("job_id", ""),
             "output": metadata.get("result", metadata.get("output", detail)),
             "exit_code": metadata.get("exit_code", 0),
@@ -500,7 +505,7 @@ class SessionOutput(OutputModule):
         self._record(
             "tool_result",
             {
-                "name": name,
+                "name": _tool_name(name, metadata),
                 "call_id": metadata.get("job_id", ""),
                 "output": metadata.get("result", metadata.get("output", detail)),
                 "exit_code": metadata.get("exit_code", 1),
@@ -906,6 +911,15 @@ def _token_metadata(metadata: dict) -> dict[str, Any]:
     if "cost_usd" in metadata:
         data["cost_usd"] = metadata.get("cost_usd")
     return data
+
+
+def _tool_name(label: str, metadata: dict) -> str:
+    """Resolve canonical identity from structured activity or legacy labels."""
+    return metadata.get("tool_name") or (
+        make_job_label(metadata["job_id"])[0]
+        if "_" in metadata.get("job_id", "")
+        else canonical_tool_name(label)
+    )
 
 
 def _parse_detail(detail: str) -> tuple[str, str]:

--- a/src/kohakuterrarium/session/resume_build.py
+++ b/src/kohakuterrarium/session/resume_build.py
@@ -5,6 +5,7 @@ facade stays under the source-file size guard.
 """
 
 from kohakuterrarium.core.conversation import Conversation
+from kohakuterrarium.core.conversation_sanitize import normalize_tool_names
 
 
 def build_conversation(messages: list[dict]) -> Conversation:
@@ -15,11 +16,8 @@ def build_conversation(messages: list[dict]) -> Conversation:
     retained when present.
     """
     conv = Conversation()
-    for msg in messages:
-        if not isinstance(msg, dict):
-            # Malformed persisted entry (corrupt snapshot): skip it rather
-            # than crashing on msg.get(...).
-            continue
+    # Skip malformed persisted entries before repairing legacy tool labels.
+    for msg in normalize_tool_names([m for m in messages if isinstance(m, dict)]):
         role = msg.get("role", "user")
         content = msg.get("content", "")
         kwargs = {}

--- a/src/kohakuterrarium/studio/attach/input_ops.py
+++ b/src/kohakuterrarium/studio/attach/input_ops.py
@@ -140,6 +140,9 @@ async def _process_input(
         except asyncio.QueueFull:
             logger.debug("input_queued frame dropped — queue full")
         return
+    # A queued turn can start before this older input coroutine resumes.
+    if agent.is_processing:
+        return
     try:
         queue.put_nowait({"type": "idle", "source": source_name, "ts": time.time()})
     except asyncio.QueueFull:

--- a/src/kohakuterrarium/terrarium/creature_ops.py
+++ b/src/kohakuterrarium/terrarium/creature_ops.py
@@ -670,7 +670,7 @@ def chat_history_for(engine: Terrarium, creature_id: str) -> dict[str, Any]:
         "session_id": creature.graph_id,
         "messages": list(getattr(agent, "conversation_history", []) or []),
         "events": events,
-        "is_processing": bool(getattr(agent, "_processing_task", None)),
+        "is_processing": bool(agent.is_processing),
     }
 
 

--- a/src/kohakuterrarium/terrarium/service.py
+++ b/src/kohakuterrarium/terrarium/service.py
@@ -686,7 +686,7 @@ class LocalTerrariumService(LocalCommandServiceMixin, DriveServiceMixin):
 
     async def interrupt(self, creature_id: str) -> None:
         agent = self._engine.get_creature(creature_id).agent
-        agent.interrupt()
+        await agent.interrupt_and_wait()
 
     async def list_jobs(self, creature_id: str) -> list[dict[str, Any]]:
         agent = self._engine.get_creature(creature_id).agent

--- a/src/kohakuterrarium/testing/terrarium.py
+++ b/src/kohakuterrarium/testing/terrarium.py
@@ -56,6 +56,7 @@ class _FakeAgent:
         self.tools: list[Any] = []
         self.subagents: list[Any] = []
         self._processing_task = None
+        self.is_processing = False
         self.trigger_manager = _FakeTriggerManager()
         self.output_router = _FakeOutputRouter()
         self.output_handlers: list[Any] = []
@@ -84,6 +85,12 @@ class _FakeAgent:
     async def stop(self) -> None:
         self._running = False
         self.stop_calls += 1
+
+    def interrupt(self) -> None:
+        self.is_processing = False
+
+    async def interrupt_and_wait(self, *, timeout: float = 10.0) -> None:
+        self.interrupt()
 
     def attach_session_store(
         self, store: Any, *, capture_activity: bool = True

--- a/tests/e2e/test_api_creature.py
+++ b/tests/e2e/test_api_creature.py
@@ -68,6 +68,7 @@ _REPLY_SECOND_APP = "Second app instance reply."
 _CREATURE_CONFIG = """\
 name: alice
 system_prompt: "You are a deterministic e2e-test creature."
+tool_format: bracket
 input:
   type: none
 output:
@@ -98,6 +99,7 @@ def scripted_llm(monkeypatch: pytest.MonkeyPatch) -> ScriptedLLM:
             ScriptEntry(
                 _REPLY_SLOW, match="long turn", chunk_size=1, delay_per_chunk=0.05
             ),
+            ScriptEntry("Edited turn completed.", match="replacement after interrupt"),
             ScriptEntry(_REPLY_TRACE, match="trace turn"),
             ScriptEntry(_REPLY_RENAMED, match="after rename"),
             ScriptEntry(_REPLY_SECOND_APP, match="second app turn"),
@@ -429,6 +431,36 @@ class TestApiCreatureJourney:
             assert resp.status_code == 200
             assert resp.json() == {"status": "interrupted"}
 
+            # The stop acknowledgement is the edit boundary; no polling or sleep.
+            stopped = client.get(
+                f"/api/sessions/{session_id}/creatures/{creature_id}/history"
+            ).json()
+            assert stopped["is_processing"] is False
+            target = next(
+                e
+                for e in stopped["events"]
+                if e.get("type") == "user_message"
+                and e.get("content") == "long turn now"
+            )
+            edited = client.post(
+                f"/api/sessions/{session_id}/creatures/{creature_id}/messages/0/edit",
+                json={
+                    "content": "replacement after interrupt",
+                    "target": {
+                        key: target[key]
+                        for key in ("event_id", "turn_index", "branch_id")
+                    },
+                },
+            )
+            assert edited.status_code == 200, edited.text
+            replayed = client.get(
+                f"/api/sessions/{session_id}/creatures/{creature_id}/history"
+            ).json()
+            assert replayed["messages"][-1]["content"] == "Edited turn completed."
+            for message in replayed["messages"]:
+                for call in message.get("tool_calls") or []:
+                    assert call["function"]["name"] == "scratchpad"
+
             saw_interrupt = False
             collected = ""
             while True:
@@ -533,7 +565,7 @@ class TestApiCreatureJourney:
             json={"turn_index": 1},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "regenerating"
+        assert resp.json()["status"] == "completed"
 
         resp = client.get(f"/api/sessions/{session_id}/creatures/{creature_id}/history")
         assert resp.status_code == 200
@@ -554,7 +586,7 @@ class TestApiCreatureJourney:
             json={"content": "edited hello creature", "turn_index": 1},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "edited"
+        assert resp.json()["status"] == "completed"
 
         resp = client.get(f"/api/sessions/{session_id}/creatures/{creature_id}/history")
         assert resp.status_code == 200
@@ -789,7 +821,7 @@ class TestApiCreatureJourney:
             json={"turn_index": 1},
         )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "regenerating"
+        assert resp.json()["status"] == "completed"
         resp = client.get(f"/api/sessions/{resumed_id}/creatures/alice/history")
         assert resp.status_code == 200
         turn1_branches_after = {

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -24,6 +24,7 @@ side effect (conversation contents, tool output text, engine state).
 """
 
 import asyncio
+import re
 from pathlib import Path
 
 import pytest
@@ -45,6 +46,10 @@ from kohakuterrarium.core.events import (
     create_user_input_event,
 )
 from kohakuterrarium.llm.message import FilePart, ImagePart, TextPart
+from kohakuterrarium.llm.base import NativeToolCall
+from kohakuterrarium.llm.codex_format import to_responses_input
+from kohakuterrarium.session.raw_history import UserMessageSelector
+from kohakuterrarium.terrarium.service import LocalTerrariumService
 from kohakuterrarium.modules.plugin.base import BasePlugin, PluginBlockError
 from kohakuterrarium.modules.subagent.config import SubAgentConfig
 from kohakuterrarium.modules.tool.base import (
@@ -63,6 +68,42 @@ from kohakuterrarium.testing.output import OutputRecorder
 # ---------------------------------------------------------------------------
 # Deterministic tool stubs — real BaseTool subclasses, no faked methods.
 # ---------------------------------------------------------------------------
+
+
+class _HistoryReplayLLM(ScriptedLLM):
+    """Supply native/text tool calls and a cancellable response for history workflows."""
+
+    def __init__(self, native):
+        super().__init__(["OK"])
+        self.native = native
+        self.started = asyncio.Event()
+        self.last_tool_calls = []
+
+    async def chat(self, messages, **kwargs):
+        normalized = self._normalize_messages(messages)
+        self.call_log.append(normalized)
+        self.call_count += 1
+        for item in to_responses_input(normalized):
+            if item.get("type") == "function_call":
+                assert re.fullmatch(r"[a-zA-Z0-9_-]+", item["name"])
+        self.last_tool_calls = []
+        if self.call_count == 1:
+            if self.native:
+                self.last_tool_calls = [
+                    NativeToolCall(
+                        "call_history_1",
+                        "scratchpad",
+                        '{"action":"set","key":"history","value":"preserved"}',
+                    )
+                ]
+                yield ""
+            else:
+                yield "[/scratchpad]@@action=set\n@@key=history\n@@value=preserved\n[scratchpad/]"
+        elif self.call_count == 3:
+            self.started.set()
+            await asyncio.Event().wait()
+        else:
+            yield "OK"
 
 
 class _EchoTool(BaseTool):
@@ -1281,7 +1322,7 @@ class TestCoreIntegration:
             )
             assert "background-kaboom" in (bgboom_result.error or "")
 
-    async def test_history_ops(self, make_creature):
+    async def test_history_ops(self, make_creature, tmp_path):
         """One workflow over the three history operations: run a turn,
         ``regenerate_last_response`` opens a new branch, ``edit_and_rerun``
         replaces the user message and re-runs, ``rewind_to`` drops the
@@ -1530,6 +1571,79 @@ class TestCoreIntegration:
             assert replay_call_id in {
                 call["id"] for call in replay_announcement.tool_calls
             }
+
+        for mode in ("native", "bracket"):
+            folder = tmp_path / mode
+            folder.mkdir()
+            config = folder / "config.yaml"
+            config.write_text(
+                f"name: history_probe\nsystem_prompt: offline\ntool_format: {mode}\n"
+                "input: {type: none}\noutput: {type: stdout}\n"
+                "tools:\n  - {name: scratchpad, type: builtin}\n"
+            )
+            llm = _HistoryReplayLLM(mode == "native")
+            async with Terrarium(session_dir=folder / "sessions") as engine:
+                creature = await engine.add_creature(
+                    str(config), llm=llm, io="headless", pwd=folder, start=True
+                )
+                service = LocalTerrariumService(engine)
+                agent = creature.agent
+                assert (await creature.run("seed", timeout=5)).ok
+                assert agent.scratchpad.get("history") == "preserved"
+                pending = asyncio.create_task(
+                    creature.run("original", timeout=5, raise_on_error=False)
+                )
+                await asyncio.wait_for(llm.started.wait(), 2)
+                await service.interrupt(creature.creature_id)
+                await pending
+                assert not agent.is_processing
+                assert not (await service.chat_history(creature.creature_id))[
+                    "is_processing"
+                ]
+                events = agent.session_store.get_events(agent.config.name)
+                target = [e for e in events if e["type"] == "user_message"][-1]
+                recorded_call = next(e for e in events if e["type"] == "tool_call")
+                assert recorded_call["name"] == "scratchpad"
+                expected_id = (
+                    "call_history_1" if llm.native else recorded_call["call_id"]
+                )
+                selector = UserMessageSelector(
+                    target["event_id"], target["turn_index"], target["branch_id"]
+                )
+                result = await service.edit_message(
+                    creature.creature_id, 0, "edited", target=selector
+                )
+                assert result["branch_id"] == 2
+                calls = [
+                    call
+                    for message in llm.last_messages
+                    for call in message.get("tool_calls") or []
+                ]
+                assert [(call["id"], call["function"]["name"]) for call in calls] == [
+                    (expected_id, "scratchpad")
+                ]
+                assert any(
+                    m.get("tool_call_id") == expected_id for m in llm.last_messages
+                )
+                assert (await creature.run("followup", timeout=5)).text == "OK"
+                session_path = agent.session_store.path
+            resumed = await Terrarium.resume(
+                str(session_path), llm=ScriptedLLM(["resumed OK"])
+            )
+            async with resumed:
+                restored = resumed.list_creatures()[0]
+                assert (
+                    await restored.run("after resume", timeout=5)
+                ).text == "resumed OK"
+                messages = restored.agent.controller.conversation.to_messages()
+                calls = [
+                    call
+                    for message in messages
+                    for call in message.get("tool_calls") or []
+                ]
+                assert [(call["id"], call["function"]["name"]) for call in calls] == [
+                    (expected_id, "scratchpad")
+                ]
 
     async def test_inject_event_and_unified_trigger_model(self, make_creature):
         """The unified ``TriggerEvent`` model: a non-user-input event

--- a/tests/unit/core/test_agent_lifecycle.py
+++ b/tests/unit/core/test_agent_lifecycle.py
@@ -1,0 +1,100 @@
+"""Turn completion and cancellation boundaries with a real running agent."""
+
+import asyncio
+
+import pytest
+
+from kohakuterrarium import Agent
+from kohakuterrarium.errors import ConflictError
+from kohakuterrarium.testing.llm import ScriptedLLM
+
+
+class CleanupLLM(ScriptedLLM):
+    def __init__(self):
+        super().__init__(["OK"])
+        self.started = asyncio.Event()
+        self.cancelling = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def chat(self, messages, **kwargs):
+        if not self.started.is_set():
+            self.started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelling.set()
+                await self.release.wait()
+                raise
+        async for chunk in super().chat(messages, **kwargs):
+            yield chunk
+
+
+@pytest.fixture
+async def running_agent(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "name: cleanup\nsystem_prompt: offline\ninput: {type: none}\noutput: {type: stdout}\n"
+    )
+    llm = CleanupLLM()
+    agent = await Agent.build(str(config), llm=llm, io="headless", pwd=tmp_path)
+    await agent.start()
+    try:
+        yield agent, llm
+    finally:
+        llm.release.set()
+        await agent.stop()
+
+
+async def test_interrupt_waits_for_cleanup_and_concurrent_edit(running_agent):
+    agent, llm = running_agent
+    turn = asyncio.create_task(agent.run("original", timeout=5, raise_on_error=False))
+    await asyncio.wait_for(llm.started.wait(), 2)
+    agent.interrupt()
+    await asyncio.wait_for(llm.cancelling.wait(), 2)
+    stop = asyncio.create_task(agent.interrupt_and_wait())
+    edit = asyncio.create_task(agent.edit_and_rerun(1, "edited"))
+    await asyncio.sleep(0)
+    assert not stop.done()
+    assert not edit.done()
+    assert agent.is_processing
+    llm.release.set()
+    await asyncio.wait_for(stop, 2)
+    await asyncio.wait_for(turn, 2)
+    assert await asyncio.wait_for(edit, 2) is True
+    assert not agent.is_processing
+    assert llm.last_user_message == "edited"
+    assert agent.controller.conversation.get_messages()[-1].content == "OK"
+
+
+async def test_interrupt_timeout_preserves_cleanup_and_accepts_retry(running_agent):
+    agent, llm = running_agent
+    turn = asyncio.create_task(agent.run("original", timeout=5, raise_on_error=False))
+    await asyncio.wait_for(llm.started.wait(), 2)
+    with pytest.raises(ConflictError, match="still finishing"):
+        await agent.interrupt_and_wait(timeout=0.01)
+    assert llm.cancelling.is_set()
+    completion = agent._turn_completion
+    assert completion is not None and not completion.done()
+    assert agent.is_processing
+    retry = asyncio.create_task(agent.interrupt_and_wait())
+    await asyncio.sleep(0)
+    assert not retry.done()
+    assert not completion.cancelled()
+    llm.release.set()
+    await asyncio.wait_for(retry, 2)
+    assert (await asyncio.wait_for(turn, 2)).status == "interrupted"
+    assert not agent.is_processing
+    assert (await agent.run("follow up", timeout=2)).text == "OK"
+    assert not agent._interrupt_requested
+
+
+async def test_active_generation_still_rejects_history_edits(running_agent):
+    agent, llm = running_agent
+    turn = asyncio.create_task(agent.run("original", timeout=5, raise_on_error=False))
+    await asyncio.wait_for(llm.started.wait(), 2)
+    with pytest.raises(ConflictError):
+        await agent.edit_and_rerun(1, "edited")
+    assert llm.last_user_message != "edited"
+    llm.release.set()
+    await agent.interrupt_and_wait()
+    await turn

--- a/tests/unit/core/test_agent_real.py
+++ b/tests/unit/core/test_agent_real.py
@@ -4054,8 +4054,10 @@ class TestInterruptMidStream:
                 )
 
             agent._run_single_turn = fake_run_single_turn
-            await agent._process_event(create_user_input_event("hi"))
-            assert agent._interrupt_requested is False
+            event = create_user_input_event("hi")
+            await agent._process_event(event)
+            assert event.context["interrupted_by_user"] is True
+            assert agent._interrupt_requested is True  # reset by the next turn
         finally:
             await agent.stop()
 

--- a/tests/unit/core/test_conversation.py
+++ b/tests/unit/core/test_conversation.py
@@ -19,6 +19,34 @@ from kohakuterrarium.llm.message import (
 # ── private helpers ──────────────────────────────────────────────
 
 
+def test_legacy_tool_labels_are_repaired_without_changing_snapshot_context():
+    conv = Conversation()
+    original_call = {
+        "id": "call_original",
+        "type": "function",
+        "function": {"name": "web_search[abc123]", "arguments": '{"q":"exact"}'},
+    }
+    conv.append("system", "compressed summary")
+    conv.append(
+        "assistant",
+        "before",
+        tool_calls=[original_call],
+        extra_fields={"reasoning_content": "preserved"},
+    )
+    conv.append(
+        "tool", "result", tool_call_id="call_original", name="web_search[abc123]"
+    )
+    wire = conv.to_messages()
+    assert wire[0]["content"] == "compressed summary"
+    assert wire[1]["tool_calls"][0]["function"]["name"] == "web_search"
+    assert wire[1]["tool_calls"][0]["id"] == "call_original"
+    assert wire[1]["reasoning_content"] == "preserved"
+    assert wire[2]["name"] == "web_search"
+    assert wire[2]["tool_call_id"] == "call_original"
+    assert original_call["function"]["name"] == "web_search[abc123]"
+    assert conv.snapshot_messages() == wire
+
+
 class TestGetContentTextLength:
     def test_none(self):
         assert _get_content_text_length(None) == 0

--- a/tests/unit/core/test_job_label.py
+++ b/tests/unit/core/test_job_label.py
@@ -1,0 +1,18 @@
+"""Canonical tool identities and their legacy UI labels."""
+
+import pytest
+
+from kohakuterrarium.core.job_label import canonical_tool_name, make_job_label
+
+
+@pytest.mark.parametrize("name", ["web_search", "mcp__server_tool", "read-file"])
+def test_canonical_name_round_trips_display_label(name):
+    canonical, label = make_job_label(f"{name}_abc123ff")
+    assert canonical == name
+    assert canonical_tool_name(label) == name
+    assert canonical_tool_name(name) == name
+
+
+@pytest.mark.parametrize("name", ["tool[custom]", "tool[abc12]", "tool_suffix", ""])
+def test_unrecognized_names_remain_unchanged(name):
+    assert canonical_tool_name(name) == name

--- a/tests/unit/laboratory/test_terrarium_runtime_adapter_ops.py
+++ b/tests/unit/laboratory/test_terrarium_runtime_adapter_ops.py
@@ -10,6 +10,7 @@ test-builder's `_FakeAgent` lacks the production agent surface.
 
 from types import SimpleNamespace
 
+from kohakuterrarium.errors import ConflictError
 
 from kohakuterrarium.laboratory._internal.app import AppMessage
 from kohakuterrarium.laboratory.adapters.terrarium_runtime import (
@@ -111,8 +112,12 @@ def _stub_agent_control(creature):
     async def _sa_cancel(jid):
         return jid == "sa-job"
 
+    async def _interrupt_and_wait():
+        state["interrupted"] = True
+
     creature.agent = SimpleNamespace(
         is_running=False,
+        interrupt_and_wait=_interrupt_and_wait,
         interrupt=lambda: state.__setitem__("interrupted", True),
         executor=SimpleNamespace(get_running_jobs=lambda: running, cancel=_ex_cancel),
         subagent_manager=SimpleNamespace(
@@ -125,6 +130,20 @@ def _stub_agent_control(creature):
 
 
 class TestControlOps:
+    async def test_interrupt_conflict_retains_retryable_error_kind(self):
+        adapter = await _make_adapter()
+        try:
+
+            async def finishing():
+                raise ConflictError("The previous turn is still finishing")
+
+            adapter._engine.get_creature("alice").agent.interrupt_and_wait = finishing
+            out = await adapter._dispatch(_msg("interrupt", {"creature_id": "alice"}))
+            assert out["error"]["kind"] == "conflict"
+            assert "still finishing" in out["error"]["message"]
+        finally:
+            await adapter._engine.shutdown()
+
     async def test_interrupt_calls_agent_interrupt(self):
         adapter = await _make_adapter()
         try:
@@ -223,6 +242,7 @@ class TestChatOps:
     async def test_chat_history_returns_history_payload(self):
         adapter = await _make_adapter()
         try:
+            adapter._engine.get_creature("alice").agent.is_processing = False
             out = await adapter._dispatch(
                 _msg("chat_history", {"creature_id": "alice"})
             )

--- a/tests/unit/session/test_history.py
+++ b/tests/unit/session/test_history.py
@@ -1108,6 +1108,44 @@ class TestDedupe:
 
 
 class TestNormalizeToolCallEvents:
+    @pytest.mark.parametrize(
+        "normalize", [normalize_tool_call_events, normalize_resumable_events]
+    )
+    def test_display_labels_and_native_identity_survive_replay(self, normalize):
+        events = [
+            {"type": "user_message", "content": "go"},
+            {
+                "type": "tool_call",
+                "name": "web_search[abc123]",
+                "call_id": "web_search_abc123ff",
+                "tool_call_id": "call_provider_1",
+                "tool_call_arguments": '{"query": "exact", "_option": true}',
+                "args": {"query": "exact"},
+            },
+            {
+                "type": "tool_result",
+                "name": "web_search[abc123]",
+                "call_id": "web_search_abc123ff",
+                "output": "found",
+            },
+        ]
+        normalized = normalize(events)
+        replayed = replay_conversation(normalized)
+        call = next(m for m in replayed if m.get("tool_calls"))["tool_calls"][0]
+        result = next(m for m in replayed if m["role"] == "tool")
+        assert call == {
+            "id": "call_provider_1",
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "arguments": '{"query": "exact", "_option": true}',
+            },
+        }
+        assert result["tool_call_id"] == call["id"]
+        assert result["name"] == "web_search"
+        assert events[1]["name"] == "web_search[abc123]"
+        assert normalized[1]["call_id"] == "web_search_abc123ff"
+
     def test_restores_announcement_without_finalizing_unfinished_call(self):
         events = [{"type": "tool_call", "call_id": "c1", "name": "bash", "ts": 1.0}]
 

--- a/tests/unit/session/test_output.py
+++ b/tests/unit/session/test_output.py
@@ -577,6 +577,30 @@ class TestActivityHandlers:
         finally:
             store.close()
 
+    def test_tool_start_persists_identity_independently_of_display(self, tmp_path):
+        store, out = _make(tmp_path)
+        try:
+            out.on_activity_with_metadata(
+                "tool_start",
+                "[unrelated[abc123]] running",
+                {
+                    "job_id": "web_search_abc123ff",
+                    "tool_name": "web_search",
+                    "tool_call_id": "call_provider",
+                    "tool_call_arguments": '{"_option":true}',
+                    "args": {},
+                },
+            )
+            event = next(
+                e for e in store.get_events("alice") if e["type"] == "tool_call"
+            )
+            assert event["name"] == "web_search"
+            assert event["call_id"] == "web_search_abc123ff"
+            assert event["tool_call_id"] == "call_provider"
+            assert event["tool_call_arguments"] == '{"_option":true}'
+        finally:
+            store.close()
+
     def test_tool_done(self, tmp_path):
         store, out = _make(tmp_path)
         try:

--- a/tests/unit/session/test_resume_build.py
+++ b/tests/unit/session/test_resume_build.py
@@ -1,0 +1,40 @@
+"""Legacy snapshot repair preserves context and provider identity."""
+
+from kohakuterrarium.session.resume_build import build_conversation
+
+
+def test_snapshot_repairs_labels_without_replaying_away_summary():
+    messages = [
+        {"role": "system", "content": "compacted summary"},
+        None,
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "keep reasoning",
+            "tool_calls": [
+                {
+                    "id": "call_provider",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search[abc123]",
+                        "arguments": '{"q":"x"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "result",
+            "tool_call_id": "call_provider",
+            "name": "web_search[abc123]",
+        },
+    ]
+    restored = build_conversation(messages).to_messages()
+    assert restored[0]["content"] == "compacted summary"
+    assert restored[2]["reasoning_content"] == "keep reasoning"
+    call = restored[2]["tool_calls"][0]
+    assert call["id"] == restored[3]["tool_call_id"] == "call_provider"
+    assert call["function"]["name"] == restored[3]["name"] == "web_search"
+    assert call["function"]["arguments"] == '{"q":"x"}'
+    assert messages[3]["tool_calls"][0]["function"]["name"] == "web_search[abc123]"

--- a/tests/unit/studio/test_attach_input_ops.py
+++ b/tests/unit/studio/test_attach_input_ops.py
@@ -1,0 +1,55 @@
+"""Attach terminal notices during a real turn handoff."""
+
+import asyncio
+
+from kohakuterrarium import Agent
+from kohakuterrarium.studio.attach.input_ops import _process_input
+from kohakuterrarium.testing.llm import ScriptedLLM
+
+
+class HandoffLLM(ScriptedLLM):
+    def __init__(self):
+        super().__init__(["OK"])
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.followup_started = asyncio.Event()
+        self.followup_release = asyncio.Event()
+
+    async def chat(self, messages, **kwargs):
+        if not self.started.is_set():
+            self.started.set()
+            await self.release.wait()
+        else:
+            self.followup_started.set()
+            await self.followup_release.wait()
+        async for chunk in super().chat(messages, **kwargs):
+            yield chunk
+
+
+async def test_previous_input_cannot_mark_a_new_turn_idle(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("name: handoff\nsystem_prompt: offline\ninput: {type: none}\n")
+    llm = HandoffLLM()
+    agent = await Agent.build(str(config), llm=llm, io="headless", pwd=tmp_path)
+    await agent.start()
+    queue = asyncio.Queue()
+    first = asyncio.create_task(_process_input(agent, "first", queue, "handoff", "p1"))
+    try:
+        await asyncio.wait_for(llm.started.wait(), 2)
+        second = asyncio.create_task(agent.run("second", timeout=5))
+        # Let the awaiting input reach the inbox while the first turn is gated.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert len(agent._event_inbox) == 1
+        agent.interrupt()
+        llm.release.set()
+        await asyncio.wait_for(llm.followup_started.wait(), 2)
+        await asyncio.wait_for(first, 2)
+        assert agent.is_processing
+        assert queue.empty(), "An old input emitted idle during the next turn"
+        llm.followup_release.set()
+        assert (await second).text == "OK"
+    finally:
+        llm.release.set()
+        llm.followup_release.set()
+        await agent.stop()

--- a/tests/unit/studio/test_attach_io.py
+++ b/tests/unit/studio/test_attach_io.py
@@ -161,6 +161,7 @@ class TestHandleUiReply:
 class TestProcessInput:
     async def test_success_emits_idle(self):
         agent = MagicMock()
+        agent.is_processing = False
         agent.inject_input = AsyncMock(return_value=True)
         q = asyncio.Queue()
         await io_mod._process_input(agent, "hi", q, "src", "pending_1")
@@ -198,6 +199,7 @@ class TestProcessInput:
 
     async def test_queue_full_dropped_on_idle(self):
         agent = MagicMock()
+        agent.is_processing = False
         agent.inject_input = AsyncMock(return_value=True)
         q = asyncio.Queue(maxsize=1)
         q.put_nowait({"x": 1})

--- a/tests/unit/terrarium/test_creature_ops.py
+++ b/tests/unit/terrarium/test_creature_ops.py
@@ -550,6 +550,7 @@ class TestChatHistoryFor:
             conversation_history=[],
             session_store=None,
             _processing_task=None,
+            is_processing=False,
             _direct_job_meta={},
         )
         eng = _Engine(creatures={"c1": _Creature(agent)})

--- a/tests/unit/terrarium/test_creature_ops_branches.py
+++ b/tests/unit/terrarium/test_creature_ops_branches.py
@@ -259,6 +259,7 @@ class TestChatHistoryForBranches:
         agent = SimpleNamespace(
             conversation_history=["msg"],
             session_store=_Store(),
+            is_processing=False,
             _processing_task=None,
             _direct_job_meta={},
         )
@@ -278,6 +279,7 @@ class TestChatHistoryForBranches:
         agent = SimpleNamespace(
             conversation_history=[],
             session_store=None,
+            is_processing=False,
             _processing_task=None,
             _direct_job_meta={},
         )

--- a/tests/unit/terrarium/test_service_delegates.py
+++ b/tests/unit/terrarium/test_service_delegates.py
@@ -60,6 +60,8 @@ class _MockAgent:
         self.edit_and_rerun = AsyncMock(return_value=True)
         self.rewind_to = AsyncMock()
         self.interrupt = MagicMock()
+        self.interrupt_and_wait = AsyncMock(side_effect=self.interrupt)
+        self.is_processing = False
         self._interrupt_direct_job = MagicMock(return_value=False)
         self._promote_handle = MagicMock(return_value=True)
         self.session = None


### PR DESCRIPTION
## Summary

Fix stop → edit/rerun failures when persisted tool history contains UI labels or loses provider-native call identity. Wait for interrupted-turn finalization before acknowledging stop, and keep stale stop/idle responses from clearing a newer turn's processing state.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Fixes #286.

A desktop session that switched from Grok to Codex Spark failed after stop/edit/rerun with `Invalid 'input[4].name'`: replay submitted a label such as `web_search[791e0f]` as a function name. A separate deterministic workflow exposed lost native call IDs and the gap between requesting cancellation and releasing the old turn's history lock.

This restores existing stop/edit, tool-history and interrupted-status contracts. It does not redesign scheduling or branch/compaction semantics.

## Changes

- Persist canonical tool names, provider call IDs and raw arguments separately from display labels/internal job IDs. Use the provider identity consistently for synthetic announcements and matching results.
- Repair the known six-hex-digit KT display suffix in legacy events, snapshots and outgoing messages, preserving valid names and other message fields.
- Capture one turn's completion future and resolve it after cleanup and lock release. Await it with a shielded, bounded wait; keep edits rejected during active generation and prevent repeated interrupts from cancelling cleanup again.
- Return a retryable conflict if finalization exceeds the wait limit, propagate the real interrupted outcome, and prevent stale frontend/attach completions from clearing a subsequent turn.
- Add negative-case unit tests and extend the existing core integration and real HTTP/WebSocket creature journeys.

## Validation

Actual upstream PR [CI run #756](https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/33946192667) passed all **13 jobs** for head `1953edeb`, including the OS/Python unit and integration matrix, lint, frontend, file-size/dependency guards, and package checks.

Rebased onto upstream `main` at `8139b048`. `git range-diff` confirms that the repair patch is identical to the reviewed patch before rebase.

Post-rebase regression: **677 passed** (Windows 11, Python 3.12.10):

```powershell
$ktTestTemp = Join-Path $env:TEMP ('kt-interrupt-publish-' + [guid]::NewGuid().ToString('N'))
.venv/Scripts/python.exe -m pytest tests/unit/core/test_agent_lifecycle.py tests/unit/core/test_job_label.py tests/unit/core/test_agent_real.py tests/unit/core/test_conversation.py tests/unit/session/test_history.py tests/unit/session/test_output.py tests/unit/session/test_resume_build.py tests/unit/studio/test_attach_input_ops.py tests/unit/studio/test_attach_io.py tests/unit/laboratory/test_terrarium_runtime_adapter_ops.py tests/unit/terrarium/test_creature_ops.py tests/unit/terrarium/test_creature_ops_branches.py tests/unit/terrarium/test_service_delegates.py tests/integration/test_core.py tests/e2e/test_api_creature.py -q -p no:cacheprovider --basetemp $ktTestTemp
.venv/Scripts/python.exe -m ruff check src/ tests/
git diff --check origin/main...HEAD
```

All passed. The fresh temporary path avoids an existing Windows permission failure in the default pytest temporary directory.

Black's `format_file_contents(..., fast=False, mode=black.Mode())` API checked all **1,597 tracked Python files** under `src/` and `tests/`: **0 formatting failures**, including AST-equivalence validation. The equivalent CLI worker process had previously hung during shutdown on this Windows setup; the serial API check completed successfully.

Frontend validation on the same repair patch:

```bash
# In src/kohakuterrarium-frontend/
npm run test -- --maxWorkers=4 --testTimeout=15000
npm run format:check
npm run build
```

- **133 files / 1,264 tests passed**.
- Formatting and production build passed; formatting was rechecked after rebase.
- Negative regressions were reproduced before their fixes, including delayed cancellation plus concurrent edit, repeated-stop/timeout behavior, native identity replay, and old-turn idle during a new turn.

Manual desktop validation with existing tool history:

- Grok: stop while thinking → edit/rerun → normal completion.
- Switch to `codex/gpt-5.3-codex-spark`: stop during a tool → edit/rerun → stop again → ordinary follow-up completed.
- Final saved/rebuilt conversation contained **40 calls and 40 matching results**, valid function names and preserved call IDs; the original provider 400 did not recur.

Broader local validation before rebase found **7 e2e failures** and **2 Studio settings warning-capture failures**. Every one reproduced in an isolated, unchanged `6cd6801f` baseline (tree-identical to rewritten upstream `1229aa72`); these are recorded below rather than presented as a green full suite.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [ ] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #286.
- Related prior replay-normalization work: #256.

## Notes for Reviewers

Please focus on native call/result identity across replay and on the completion boundary after cancellation. Stop requests are still issued immediately; their acknowledgment now waits only for the captured turn's cleanup. The default 10-second limit returns a conflict without cancelling that cleanup. Normal active generation continues to reject history edits.

The actual upstream PR CI is the authoritative gate and has passed. This PR is ready for review following local review, regression tests, manual desktop verification and the upstream CI run linked above.

## Screenshots / Logs (if applicable)

The original failure was:

```text
Invalid 'input[4].name' ... ^[a-zA-Z0-9_-]+$
```

Private sessions, prompts, credentials and local diagnostic logs are not included in the patch.

## Breaking Changes (if applicable)

No migration or configuration change is required. Cancelled turns now correctly return `interrupted` instead of an empty `ok`; stop acknowledgment can wait for cleanup, or return a retryable conflict if cleanup is still pending.

## Exceptions / Not Run

- Prior feature approval and documentation checklist items are not applicable to restoring these existing bugged contracts. No new config or end-user workflow is introduced.
- Black CLI completion is not claimed locally; the serial Black API check described above completed across every tracked Python source/test file. The upstream CI lint job also passed `black --check src/ tests/`.
- Full local unit/integration/e2e validation is not claimed green. The following failures reproduced unchanged on the baseline:
  - `test_cross_node_forwarding_audit.py`: broadcast delivery, burst ordering and injection forwarding (3 tests).
  - `test_multinode_deep_probes.py::TestMultinodeDeepProbes::test_channel_trigger_drives_receiver_turn`.
  - `test_multinode_journey.py::TestMultinodeJourney::test_full_creature_session_on_subprocess_worker`.
  - `test_multinode_real.py::test_subagent_dispatch_on_worker`.
  - `test_prog_terrarium.py::TestProgTerrariumJourney::test_recipe_to_broadcast_to_privileged_mutation_journey`.
  - `test_drive_settings.py::TestSaveDurability::test_dir_barrier_einval_reports_file_only_and_warns`.
  - `test_drive_settings_io.py::TestAtomicWriteDirBarrier::test_dir_fsync_einval_is_tolerated_but_signalled`.
- Linux/macOS and the full Python matrix are delegated to actual upstream PR CI.
- Fork CI is not a prerequisite for this Draft submission, as explicitly requested by the contributor. The current CI workflow triggers on pushes to `main` or pull requests targeting `main`, not on pushes to this feature branch.
- The existing frontend dependency installation had an `nopt` package-metadata problem; validation used the working local dependencies after restoring the already-declared TanStack packages. Package manifests and lockfiles are unchanged; clean dependency installation is left to PR CI.
