### PR TITLE
perf: stop polling and refresh bursts from stacking duplicate requests

### DIFF
--- a/docs/en/guides/sessions.md
+++ b/docs/en/guides/sessions.md
@@ -335,7 +335,11 @@ How the index stays in sync without manual refresh:
   every file (the *bootstrap* step) and remembers it succeeded.
 - **`?refresh=true`.** Trigger the same incremental reconcile on
   demand; useful right after copying a backup `.kohakutr` into the
-  session directory.
+  session directory. Refreshes are single-flighted: concurrent or
+  back-to-back requests within one second share (or reuse) the same
+  scan, so an explicit refresh may return data up to ~1 s old.
+  `?full_rescan=true` keeps its force-reread intent and only waits
+  for an in-flight scan to finish.
 
 The sidecar is safe to delete: the next listing rebuilds it from
 the `.kohakutr` files. Nothing inside the index is unique state.

--- a/docs/en/guides/sessions.md
+++ b/docs/en/guides/sessions.md
@@ -335,11 +335,12 @@ How the index stays in sync without manual refresh:
   every file (the *bootstrap* step) and remembers it succeeded.
 - **`?refresh=true`.** Trigger the same incremental reconcile on
   demand; useful right after copying a backup `.kohakutr` into the
-  session directory. Refreshes are single-flighted: concurrent or
-  back-to-back requests within one second share (or reuse) the same
-  scan, so an explicit refresh may return data up to ~1 s old.
-  `?full_rescan=true` keeps its force-reread intent and only waits
-  for an in-flight scan to finish.
+  session directory. Refreshes are single-flighted: a request that
+  arrives while a scan is already running queues behind it and skips
+  its own pass only once a scan started *after* the request arrived,
+  so a burst of refreshes costs at most two scans and every refresh
+  still reflects the changes that made the client ask.
+  `?full_rescan=true` keeps its force-reread intent and never skips.
 
 The sidecar is safe to delete: the next listing rebuilds it from
 the `.kohakutr` files. Nothing inside the index is unique state.

--- a/docs/en/reference/http.md
+++ b/docs/en/reference/http.md
@@ -382,7 +382,7 @@ Query params:
 | `limit` | int | `20` | Max sessions. |
 | `offset` | int | `0` | Skip N. |
 | `search` | str | (none) | Filter by name, config, agents, preview (case-insensitive). |
-| `refresh` | bool | `false` | Reconcile the index against disk before listing (incremental, fingerprint-diffed). Concurrent refreshes are single-flighted with a 1 s completion window, so an explicit refresh may return data up to ~1 s old. |
+| `refresh` | bool | `false` | Reconcile the index against disk before listing (incremental, fingerprint-diffed). Concurrent refreshes are single-flighted: a burst costs at most two scans, and each refresh reflects changes up to its own arrival. |
 
 Response:
 

--- a/docs/en/reference/http.md
+++ b/docs/en/reference/http.md
@@ -382,7 +382,7 @@ Query params:
 | `limit` | int | `20` | Max sessions. |
 | `offset` | int | `0` | Skip N. |
 | `search` | str | (none) | Filter by name, config, agents, preview (case-insensitive). |
-| `refresh` | bool | `false` | Force rebuild of the session index. |
+| `refresh` | bool | `false` | Reconcile the index against disk before listing (incremental, fingerprint-diffed). Concurrent refreshes are single-flighted with a 1 s completion window, so an explicit refresh may return data up to ~1 s old. |
 
 Response:
 

--- a/src/kohakuterrarium-frontend/src/components/sessions/pages/SessionsListPage.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/pages/SessionsListPage.vue
@@ -212,11 +212,11 @@ async function fetchSessions(forceRefresh = false) {
   loading.value = true
   error.value = null
   try {
-    // ``refresh: true`` forces the backend to re-scan + re-parse every
-    // session file on disk. We respect the 30s server-side cache by
-    // default; only the explicit Refresh button (forceRefresh=true)
-    // triggers a full rebuild. Without this, opening the Sessions list
-    // tab is laggy because every navigation rebuilds the index.
+    // Default listing reads the persistent session-index sidecar — no
+    // re-scan, no per-file parse. Only the explicit Refresh button
+    // (forceRefresh=true) asks the backend to reconcile the index
+    // against disk; concurrent refreshes are single-flighted there, so
+    // hammering the button cannot fan out into parallel scans.
     const result = await sessionAPI.list({
       limit: pageSize,
       offset: currentOffset.value,

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/AttachTab.vue
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/AttachTab.vue
@@ -200,7 +200,9 @@ onMounted(async () => {
   document.addEventListener("visibilitychange", markVisibleConversationRead)
   await loadInstance()
   refreshTimer = createVisibilityInterval(() => {
-    loadInstance().catch((err) => console.error("Instance refresh failed:", err))
+    // Return the promise so the interval skips ticks while a slow
+    // refresh is still in flight instead of stacking requests.
+    return loadInstance().catch((err) => console.error("Instance refresh failed:", err))
   }, 5000)
   refreshTimer.start()
 })

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/Dashboard.vue
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/Dashboard.vue
@@ -73,6 +73,7 @@ import AdvancedStartModal from "@/components/shell/modals/AdvancedStartModal.vue
 import { useInstancesStore } from "@/stores/instances"
 import { sessionAPI } from "@/utils/api"
 import { useI18n } from "@/utils/i18n"
+import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
 
 const { t } = useI18n()
 
@@ -107,12 +108,15 @@ async function refresh() {
 function startTimer() {
   stopTimer()
   if (refreshIntervalMs.value > 0) {
-    timer = setInterval(refresh, refreshIntervalMs.value)
+    // refresh() is async: returning it lets the interval skip ticks
+    // while a slow listing is in flight instead of stacking requests.
+    timer = createVisibilityInterval(() => refresh(), refreshIntervalMs.value)
+    timer.start()
   }
 }
 function stopTimer() {
   if (timer) {
-    clearInterval(timer)
+    timer.stop()
     timer = null
   }
 }

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/DashboardStatsCard.vue
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/DashboardStatsCard.vue
@@ -56,6 +56,7 @@ import { useInstancesStore } from "@/stores/instances"
 import { useTabsStore } from "@/stores/tabs"
 import { settingsAPI, statsAPI } from "@/utils/api"
 import { useI18n } from "@/utils/i18n"
+import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
 
 const { t } = useI18n()
 
@@ -105,11 +106,14 @@ onMounted(async () => {
   ])
   // 5 s refresh — same cadence as the rest of the dashboard so the
   // user feels one heartbeat, not a flicker of independent updates.
-  metricsTimer = setInterval(loadMetrics, 5000)
+  // Returning the promise from loadMetrics lets the interval skip
+  // ticks while a slow snapshot request is still in flight.
+  metricsTimer = createVisibilityInterval(() => loadMetrics(), 5000)
+  metricsTimer.start()
 })
 
 onUnmounted(() => {
-  if (metricsTimer) clearInterval(metricsTimer)
+  if (metricsTimer) metricsTimer.stop()
 })
 
 const running = computed(() => instances.list.filter((i) => i.status === "running").length)

--- a/src/kohakuterrarium-frontend/src/components/shell/tabs/StatsTab.vue
+++ b/src/kohakuterrarium-frontend/src/components/shell/tabs/StatsTab.vue
@@ -260,6 +260,7 @@ import { useInstancesStore } from "@/stores/instances"
 import { useStatusStore } from "@/stores/status"
 import { configAPI, settingsAPI, statsAPI } from "@/utils/api"
 import { useI18n } from "@/utils/i18n"
+import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
 
 const { t } = useI18n()
 
@@ -522,16 +523,17 @@ onMounted(() => {
   refreshAll()
   // Auto-refresh: process metrics + instances + sessionStats every
   // 5 s. Disk is pure stat — refresh on the same cadence so the
-  // numbers stay live without a manual click.
-  refreshTimer = setInterval(() => {
-    instances.fetchAll()
-    loadSessionStats()
-    loadMetrics()
+  // numbers stay live without a manual click. The async tick body
+  // makes the interval skip overlaps while a slow round is pending,
+  // and pauses entirely while the tab is hidden.
+  refreshTimer = createVisibilityInterval(async () => {
+    await Promise.all([instances.fetchAll(), loadSessionStats(), loadMetrics()])
   }, 5000)
+  refreshTimer.start()
 })
 
 onUnmounted(() => {
-  if (refreshTimer) clearInterval(refreshTimer)
+  if (refreshTimer) refreshTimer.stop()
 })
 
 // ── Formatting helpers ──────────────────────────────────────────

--- a/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.test.js
+++ b/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.test.js
@@ -1,8 +1,8 @@
 import { flushPromises, mount } from "@vue/test-utils"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import SubagentConversationPanel from "./SubagentConversationPanel.vue"
-import { sessionAPI } from "@/utils/api"
+import { sessionAPI, terrariumAPI } from "@/utils/api"
 
 vi.mock("@/utils/i18n", () => ({ useI18n: () => ({ t: (key) => key }) }))
 
@@ -305,5 +305,60 @@ describe("SubagentConversationPanel ambiguity selector", () => {
     expect(wrapper.text()).toContain("ambiguous across members")
     expect(wrapper.find("[data-test='subagent-run-0']").exists()).toBe(false)
     vi.restoreAllMocks()
+  })
+})
+
+describe("SubagentConversationPanel live polling", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("does not stack conversation reads while the previous one is in flight", async () => {
+    let resolveSlow
+    const slowRead = new Promise((resolve) => {
+      resolveSlow = resolve
+    })
+    const getLive = vi
+      .spyOn(terrariumAPI, "getSubagentConversation")
+      // Mount-time load resolves; every poll read then hangs until the
+      // test releases it, standing in for a backend slower than 1.5 s.
+      .mockResolvedValueOnce({ can_receive: true, messages: [] })
+      .mockImplementation(() => slowRead)
+
+    const wrapper = mount(SubagentConversationPanel, {
+      props: {
+        sessionId: "session-a",
+        parent: "root",
+        name: "explore",
+        live: true,
+        status: "running",
+      },
+      global: {
+        stubs: {
+          MarkdownRenderer: { props: ["content"], template: "<div>{{ content }}</div>" },
+          ToolCallBlock: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    // Three poll ticks land while the first read is unanswered — only
+    // one request may be outstanding, the rest must be skipped.
+    vi.advanceTimersByTime(4500)
+    expect(getLive).toHaveBeenCalledTimes(2) // mount load + first poll
+
+    resolveSlow({ can_receive: true, messages: [] })
+    await flushPromises()
+    vi.advanceTimersByTime(1500)
+    expect(getLive).toHaveBeenCalledTimes(3)
+
+    wrapper.unmount()
+    getLive.mockRestore()
   })
 })

--- a/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/subagents/SubagentConversationPanel.vue
@@ -76,6 +76,7 @@ import { computed, defineAsyncComponent, onMounted, onUnmounted, ref, watch } fr
 
 import MarkdownRenderer from "@/components/common/MarkdownRenderer.vue"
 import { sessionAPI, terrariumAPI } from "@/utils/api"
+import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
 import { useI18n } from "@/utils/i18n"
 
 const ToolCallBlock = defineAsyncComponent(() => import("@/components/chat/ToolCallBlock.vue"))
@@ -316,16 +317,23 @@ function isLive() {
 }
 
 function stopPolling() {
-  if (timer) clearInterval(timer)
+  if (timer) timer.stop()
   timer = null
 }
 
 function startPolling() {
   if (timer || !props.live || !isLive()) return
-  timer = setInterval(() => {
-    if (isLive()) loadConversation({ silent: true })
-    else stopPolling()
+  timer = createVisibilityInterval(() => {
+    if (!isLive()) {
+      stopPolling()
+      return
+    }
+    // Returning the promise lets the interval skip ticks while a slow
+    // conversation read is in flight: this is the hottest poll in the
+    // app (1.5 s) and every request reopens the session store.
+    return loadConversation({ silent: true })
   }, 1500)
+  timer.start()
 }
 
 watch(

--- a/src/kohakuterrarium-frontend/src/composables/useVisibilityInterval.js
+++ b/src/kohakuterrarium-frontend/src/composables/useVisibilityInterval.js
@@ -21,6 +21,11 @@
  * skipped; only return a promise from the callback when overlapping
  * ticks are unsafe.
  *
+ * The visibility-resume catch-up tick obeys the same skip: if a
+ * request was still in flight when the tab was hidden, the first tick
+ * after returning may be dropped and data can sit up to one poll
+ * window stale until the next tick lands.
+ *
  * Usage inside a component:
  *
  *   import { useVisibilityInterval } from "@/composables/useVisibilityInterval"

--- a/src/kohakuterrarium-frontend/src/composables/useVisibilityInterval.js
+++ b/src/kohakuterrarium-frontend/src/composables/useVisibilityInterval.js
@@ -12,6 +12,15 @@
  * reactive updates in Vue. Gating on `document.visibilityState`
  * eliminates both costs.
  *
+ * Slow-backend back-pressure: when a callback returns a promise, ticks
+ * fired before that promise settles are skipped. A backend answering
+ * slower than the poll period must not turn the fixed interval into a
+ * pile of overlapping duplicate requests — without the skip, one more
+ * request stacks per tick and the load makes the backend slower
+ * still. Synchronous callbacks (returning undefined) are never
+ * skipped; only return a promise from the callback when overlapping
+ * ticks are unsafe.
+ *
  * Usage inside a component:
  *
  *   import { useVisibilityInterval } from "@/composables/useVisibilityInterval"
@@ -34,7 +43,9 @@ import { onBeforeUnmount } from "vue"
 /**
  * Create a visibility-aware interval controller.
  *
- * @param {() => void} callback   Fired on each tick AND once on resume.
+ * @param {() => void | Promise<unknown>} callback
+ *   Fired on each tick AND once on resume. A returned promise arms the
+ *   in-flight skip; see the module docstring.
  * @param {number} intervalMs     Tick interval in milliseconds.
  * @param {object} [opts]
  * @param {boolean} [opts.immediate=false]
@@ -46,12 +57,23 @@ export function createVisibilityInterval(callback, intervalMs, opts = {}) {
   let timer = null
   let started = false
   let onVisibility = null
+  let pending = null
 
   function tick() {
+    if (pending !== null) return
+    let result
     try {
-      callback()
+      result = callback()
     } catch (err) {
       console.error("[useVisibilityInterval] callback threw:", err)
+      return
+    }
+    if (result && typeof result.then === "function") {
+      pending = result
+      const settled = () => {
+        if (pending === result) pending = null
+      }
+      result.then(settled, settled)
     }
   }
 
@@ -90,6 +112,9 @@ export function createVisibilityInterval(callback, intervalMs, opts = {}) {
     if (!started) return
     started = false
     disarmTimer()
+    // A request left in flight by the previous run must not suppress
+    // the first ticks after a restart.
+    pending = null
     if (onVisibility) {
       document.removeEventListener("visibilitychange", onVisibility)
       onVisibility = null

--- a/src/kohakuterrarium-frontend/src/composables/useVisibilityInterval.test.js
+++ b/src/kohakuterrarium-frontend/src/composables/useVisibilityInterval.test.js
@@ -56,4 +56,89 @@ describe("createVisibilityInterval", () => {
 
     poller.stop()
   })
+
+  it("skips ticks while the previous async callback is still in flight", async () => {
+    let resolveFirst
+    const callback = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve
+        }),
+    )
+    const poller = createVisibilityInterval(callback, 5000)
+
+    poller.start()
+    vi.advanceTimersByTime(5000)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Backend slower than the window: three more ticks land while the
+    // first request is unanswered — all must be skipped, not stacked.
+    vi.advanceTimersByTime(15000)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    resolveFirst()
+    await flushMicrotasks()
+    vi.advanceTimersByTime(5000)
+    expect(callback).toHaveBeenCalledTimes(2)
+
+    poller.stop()
+  })
+
+  it("resumes polling after an async callback rejects", async () => {
+    const callback = vi
+      .fn()
+      .mockImplementationOnce(() => Promise.reject(new Error("boom")))
+      .mockImplementation(() => Promise.resolve())
+    const poller = createVisibilityInterval(callback, 5000)
+
+    poller.start()
+    vi.advanceTimersByTime(5000)
+    await flushMicrotasks()
+
+    vi.advanceTimersByTime(5000)
+    expect(callback).toHaveBeenCalledTimes(2)
+
+    poller.stop()
+  })
+
+  it("does not let a stale in-flight callback suppress ticks after a restart", async () => {
+    let resolveFirst
+    const callback = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve
+        }),
+    )
+    const poller = createVisibilityInterval(callback, 5000)
+
+    poller.start()
+    vi.advanceTimersByTime(5000)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    poller.stop()
+    poller.start()
+    vi.advanceTimersByTime(5000)
+    expect(callback).toHaveBeenCalledTimes(2)
+
+    resolveFirst()
+    await flushMicrotasks()
+    poller.stop()
+  })
+
+  it("never skips ticks for a synchronous callback", () => {
+    const callback = vi.fn(() => undefined)
+    const poller = createVisibilityInterval(callback, 1000)
+
+    poller.start()
+    vi.advanceTimersByTime(5000)
+    expect(callback).toHaveBeenCalledTimes(5)
+
+    poller.stop()
+  })
 })
+
+function flushMicrotasks() {
+  // Two rounds settle the promise returned by the callback and the
+  // settled-handler chained onto it by the interval.
+  return Promise.resolve().then(() => Promise.resolve())
+}

--- a/src/kohakuterrarium-frontend/src/stores/drives.js
+++ b/src/kohakuterrarium-frontend/src/stores/drives.js
@@ -80,6 +80,8 @@ const _drivesOptions = {
     saved: false,
     filters: { status: [], kind: [], owner: "", assignee: "", scope: "", text: "" },
     _reconcileTimer: null,
+    /** Shared in-flight reconcile so overlapping callers coalesce onto one request. */
+    _reconcileInflight: null,
     /** Monotonic load token: a response is committed only if it is the latest. */
     _loadGen: 0,
     /** Monotonic detail token: a stale detail/deliveries load never overwrites. */
@@ -193,9 +195,27 @@ const _drivesOptions = {
      * Periodic / refocus full refetch. Merges with the revision guard so an
      * in-flight event that arrived first is never rolled back, and drops
      * records the server no longer returns for the current filter.
+     *
+     * Two independent pollers (the Drives panel at 6 s and the header badge
+     * at 8 s) plus event-scheduled reconciles can all fire while a slow
+     * listing is still unanswered; they coalesce onto the in-flight request
+     * instead of stacking duplicates. No spacing window is applied — a
+     * minimum gap would also delay the event-driven reconciles that keep
+     * mutations visible promptly.
      */
     async reconcile() {
       if (!this.sessionId) return
+      if (this._reconcileInflight) return this._reconcileInflight
+      const task = this._reconcileNow()
+      this._reconcileInflight = task
+      try {
+        await task
+      } finally {
+        if (this._reconcileInflight === task) this._reconcileInflight = null
+      }
+    },
+
+    async _reconcileNow() {
       const gen = this._loadGen
       const sid = this.sessionId
       try {
@@ -525,6 +545,9 @@ const _drivesOptions = {
       this.conflict = null
       // A pending detail load for the old session must not commit into the new.
       this._detailGen++
+      // An in-flight reconcile for the old session must not make the new
+      // session's first reconcile wait on (or share) it.
+      this._reconcileInflight = null
     },
 
     _queryFilters() {

--- a/src/kohakuterrarium-frontend/src/stores/drives.js
+++ b/src/kohakuterrarium-frontend/src/stores/drives.js
@@ -82,6 +82,8 @@ const _drivesOptions = {
     _reconcileTimer: null,
     /** Shared in-flight reconcile so overlapping callers coalesce onto one request. */
     _reconcileInflight: null,
+    /** Set while coalesced: one trailing pass runs after the in-flight task. */
+    _reconcileTrailing: false,
     /** Monotonic load token: a response is committed only if it is the latest. */
     _loadGen: 0,
     /** Monotonic detail token: a stale detail/deliveries load never overwrites. */
@@ -199,13 +201,20 @@ const _drivesOptions = {
      * Two independent pollers (the Drives panel at 6 s and the header badge
      * at 8 s) plus event-scheduled reconciles can all fire while a slow
      * listing is still unanswered; they coalesce onto the in-flight request
-     * instead of stacking duplicates. No spacing window is applied — a
-     * minimum gap would also delay the event-driven reconciles that keep
-     * mutations visible promptly.
+     * instead of stacking duplicates. A coalesced caller must not rely on
+     * that request's snapshot though — it was taken before the caller's
+     * reason to reconcile existed (e.g. `drive_registration_changed`), so
+     * one trailing pass runs after the in-flight task settles. Bursts still
+     * coalesce: at most one trailing pass is ever pending. No spacing
+     * window is applied — a minimum gap would also delay the event-driven
+     * reconciles that keep mutations visible promptly.
      */
     async reconcile() {
       if (!this.sessionId) return
-      if (this._reconcileInflight) return this._reconcileInflight
+      if (this._reconcileInflight) {
+        this._reconcileTrailing = true
+        return this._reconcileInflight
+      }
       const task = this._reconcileNow()
       this._reconcileInflight = task
       try {
@@ -213,6 +222,11 @@ const _drivesOptions = {
       } finally {
         if (this._reconcileInflight === task) this._reconcileInflight = null
       }
+      if (this._reconcileTrailing) {
+        this._reconcileTrailing = false
+        return this.reconcile()
+      }
+      return task
     },
 
     async _reconcileNow() {
@@ -546,8 +560,10 @@ const _drivesOptions = {
       // A pending detail load for the old session must not commit into the new.
       this._detailGen++
       // An in-flight reconcile for the old session must not make the new
-      // session's first reconcile wait on (or share) it.
+      // session's first reconcile wait on (or share) it, and a trailing
+      // pass requested by the old session must not run against the new.
       this._reconcileInflight = null
+      this._reconcileTrailing = false
     },
 
     _queryFilters() {

--- a/src/kohakuterrarium-frontend/src/stores/drives.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/drives.test.js
@@ -101,19 +101,22 @@ describe("drives store", () => {
     expect(store.order).toEqual(["d1"])
   })
 
-  it("reconcile coalesces overlapping callers onto one in-flight request", async () => {
+  it("reconcile coalesces overlapping callers onto one in-flight request plus one trailing pass", async () => {
     drivesAPI.list.mockResolvedValue([])
     const store = freshStore()
     await store.load("s1")
     drivesAPI.list.mockClear()
 
     let resolveList
-    drivesAPI.list.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveList = resolve
-        }),
-    )
+    drivesAPI.list
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveList = resolve
+          }),
+      )
+      .mockResolvedValueOnce([_rec("d1"), _rec("d2")])
+
     // The 6 s panel poller, the 8 s badge poller, and an event-scheduled
     // reconcile can all fire while one listing is unanswered — they must
     // share it, not stack three identical requests.
@@ -122,13 +125,46 @@ describe("drives store", () => {
 
     resolveList([_rec("d1")])
     await Promise.all(calls)
-    expect(store.order).toEqual(["d1"])
-
-    // Once settled, a fresh reconcile issues a new request.
-    drivesAPI.list.mockResolvedValue([_rec("d1"), _rec("d2")])
-    await store.reconcile()
+    // The coalesced callers' reasons to reconcile postdate the first
+    // request's snapshot, so exactly one trailing pass runs after it.
     expect(drivesAPI.list).toHaveBeenCalledTimes(2)
     expect(store.order).toEqual(["d1", "d2"])
+
+    // Settled with no joiner pending: a fresh reconcile issues a new
+    // request, and no trailing pass follows it.
+    drivesAPI.list.mockResolvedValue([_rec("d1")])
+    await store.reconcile()
+    expect(drivesAPI.list).toHaveBeenCalledTimes(3)
+    expect(store.order).toEqual(["d1"])
+  })
+
+  it("a coalesced event-triggered reconcile still refreshes past the in-flight snapshot", async () => {
+    drivesAPI.list.mockResolvedValue([])
+    const store = freshStore()
+    await store.load("s1")
+    drivesAPI.list.mockClear()
+
+    // Codex-review scenario: drive_registration_changed carries no
+    // embedded view and only schedules a reconcile. If that reconcile
+    // joined a listing whose snapshot predates the event, the refresh
+    // would be lost until the next poll.
+    let resolveStale
+    drivesAPI.list
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStale = resolve
+          }),
+      )
+      .mockResolvedValueOnce([_rec("d1"), _rec("new-drive")])
+
+    const periodic = store.reconcile()
+    const eventTriggered = store.reconcile() // scheduled 200 ms after the event
+    resolveStale([_rec("d1")]) // snapshot taken before the event
+    await Promise.all([periodic, eventTriggered])
+
+    expect(drivesAPI.list).toHaveBeenCalledTimes(2)
+    expect(store.order).toEqual(["d1", "new-drive"])
   })
 
   it("a session switch releases the shared in-flight reconcile", async () => {

--- a/src/kohakuterrarium-frontend/src/stores/drives.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/drives.test.js
@@ -101,6 +101,70 @@ describe("drives store", () => {
     expect(store.order).toEqual(["d1"])
   })
 
+  it("reconcile coalesces overlapping callers onto one in-flight request", async () => {
+    drivesAPI.list.mockResolvedValue([])
+    const store = freshStore()
+    await store.load("s1")
+    drivesAPI.list.mockClear()
+
+    let resolveList
+    drivesAPI.list.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveList = resolve
+        }),
+    )
+    // The 6 s panel poller, the 8 s badge poller, and an event-scheduled
+    // reconcile can all fire while one listing is unanswered — they must
+    // share it, not stack three identical requests.
+    const calls = [store.reconcile(), store.reconcile(), store.reconcile()]
+    expect(drivesAPI.list).toHaveBeenCalledTimes(1)
+
+    resolveList([_rec("d1")])
+    await Promise.all(calls)
+    expect(store.order).toEqual(["d1"])
+
+    // Once settled, a fresh reconcile issues a new request.
+    drivesAPI.list.mockResolvedValue([_rec("d1"), _rec("d2")])
+    await store.reconcile()
+    expect(drivesAPI.list).toHaveBeenCalledTimes(2)
+    expect(store.order).toEqual(["d1", "d2"])
+  })
+
+  it("a session switch releases the shared in-flight reconcile", async () => {
+    const store = freshStore()
+    let resolveLoad
+    drivesAPI.list.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLoad = resolve
+        }),
+    )
+    const firstLoad = store.load("s1")
+
+    // Old session's reconcile hangs; the new session's load must detach
+    // from it so its own reconciles never wait on stale work.
+    let resolveReconcile
+    drivesAPI.list.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveReconcile = resolve
+        }),
+    )
+    const staleReconcile = store.reconcile()
+
+    drivesAPI.list.mockResolvedValue([_rec("n1")])
+    const secondLoad = await store.load("s2")
+    expect(secondLoad).toHaveLength(1)
+
+    resolveLoad([])
+    resolveReconcile([_rec("d1")])
+    await Promise.all([firstLoad, staleReconcile])
+    // The stale responses arrived after the switch: discarded, not merged.
+    expect(store.records.n1).toBeDefined()
+    expect(store.records.d1).toBeUndefined()
+  })
+
   it("applyEvent upserts an embedded view and guards older revisions", async () => {
     drivesAPI.list.mockResolvedValue([_rec("d1", { revision: 4 })])
     const store = freshStore()

--- a/src/kohakuterrarium-frontend/src/stores/instances.js
+++ b/src/kohakuterrarium-frontend/src/stores/instances.js
@@ -24,6 +24,8 @@ export const useInstancesStore = defineStore("instances", {
     _pollInterval: null,
     _subscribers: 0,
     _inflightFetch: null,
+    /** id -> shared in-flight fetchOne promise. */
+    _inflightOne: {},
     _fetchSeq: 0,
   }),
 
@@ -60,6 +62,20 @@ export const useInstancesStore = defineStore("instances", {
     },
 
     async fetchOne(id) {
+      // Route navigation and the 5 s attach-tab poll can request the
+      // same instance while a slow lookup is unanswered; share one
+      // request instead of stacking duplicates. fetchAll already has
+      // the equivalent single-request guard.
+      const existing = this._inflightOne[id]
+      if (existing) return existing
+      const task = this._fetchOneNow(id).finally(() => {
+        delete this._inflightOne[id]
+      })
+      this._inflightOne[id] = task
+      return task
+    },
+
+    async _fetchOneNow(id) {
       this.loading = true
       const seq = this._fetchSeq
       try {

--- a/src/kohakuterrarium-frontend/src/stores/instances.js
+++ b/src/kohakuterrarium-frontend/src/stores/instances.js
@@ -126,9 +126,7 @@ export const useInstancesStore = defineStore("instances", {
     startPolling() {
       this._subscribers++
       if (this._pollInterval === null) {
-        this._pollInterval = createVisibilityInterval(() => {
-          this.fetchAll()
-        }, 5000)
+        this._pollInterval = createVisibilityInterval(() => this.fetchAll(), 5000)
         this._pollInterval.start()
       }
     },

--- a/src/kohakuterrarium-frontend/src/stores/instances.js
+++ b/src/kohakuterrarium-frontend/src/stores/instances.js
@@ -65,7 +65,9 @@ export const useInstancesStore = defineStore("instances", {
       // Route navigation and the 5 s attach-tab poll can request the
       // same instance while a slow lookup is unanswered; share one
       // request instead of stacking duplicates. fetchAll already has
-      // the equivalent single-request guard.
+      // the equivalent single-request guard. Sharers inherit the first
+      // caller's result or rejection — an error here is shared by
+      // everyone joined on the request (every call site catches).
       const existing = this._inflightOne[id]
       if (existing) return existing
       const task = this._fetchOneNow(id).finally(() => {

--- a/src/kohakuterrarium-frontend/src/stores/instances.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/instances.test.js
@@ -126,6 +126,33 @@ describe("instances store", () => {
     expect(store.list).toEqual([])
   })
 
+  it("shares one in-flight request between concurrent fetchOne callers for the same id", async () => {
+    const store = useInstancesStore()
+    const deferred = promiseWithResolvers()
+    sessionAPI.getActive.mockReturnValue(deferred.promise)
+
+    // Route navigation and the 5 s attach-tab poll racing on the same
+    // instance must not stack duplicate lookups.
+    const first = store.fetchOne("graph_slow")
+    const second = store.fetchOne("graph_slow")
+    expect(sessionAPI.getActive).toHaveBeenCalledTimes(1)
+
+    deferred.resolve({ session_id: "graph_slow", name: "slow", creatures: 0, channels: [] })
+    const [a, b] = await Promise.all([first, second])
+    expect(a).toBe(b)
+    expect(store.current.id).toBe("graph_slow")
+
+    // A different id still gets its own request.
+    sessionAPI.getActive.mockResolvedValue({
+      session_id: "graph_other",
+      name: "other",
+      creatures: 0,
+      channels: [],
+    })
+    await store.fetchOne("graph_other")
+    expect(sessionAPI.getActive).toHaveBeenCalledTimes(2)
+  })
+
   it("maps a unified Session payload to a terrarium-shaped instance", async () => {
     const store = useInstancesStore()
     sessionAPI.getActive.mockResolvedValue({

--- a/src/kohakuterrarium-frontend/src/stores/runtimeGraph.js
+++ b/src/kohakuterrarium-frontend/src/stores/runtimeGraph.js
@@ -158,7 +158,7 @@ export const useRuntimeGraphStore = defineStore("runtimeGraph", () => {
     // re-render every card.
     state._pollInterval = createVisibilityInterval(() => {
       if (state.wsConnected) return
-      loadSnapshot()
+      return loadSnapshot()
     }, 5000)
     state._pollInterval.start()
   }

--- a/src/kohakuterrarium/api/routes/persistence/saved.py
+++ b/src/kohakuterrarium/api/routes/persistence/saved.py
@@ -12,8 +12,9 @@ relevance scores.
 ``refresh=true`` incrementally reconciles only files whose ``(mtime, size)``
 fingerprint changed. ``full_rescan=true`` rereads every file and is intended
 for changes made outside the application. Concurrent refreshes are
-single-flighted: bursts collapse onto one reconcile (see
-``_reconcile_guarded``) instead of fanning out into parallel scans.
+single-flighted: bursts queue behind the running scan and at most one
+trailing scan runs for the whole burst (see ``_reconcile_guarded``), while
+every refresh still reflects the changes that made the client ask.
 
 The router mounts under both ``/api/persistence/saved`` and ``/api/sessions``
 to preserve the session API URLs.
@@ -21,7 +22,6 @@ to preserve the session API URLs.
 
 import os
 import threading
-import time
 
 from fastapi import APIRouter, HTTPException
 
@@ -41,30 +41,25 @@ from kohakuterrarium.studio.persistence.store import (
 
 router = APIRouter()
 
-# Per-session-directory reconcile state: a lock serialising scans and the
-# monotonic time the last scan completed. Entries are never evicted, but
-# the key set is the set of distinct session directories this process has
-# listed — a handful in every real deployment.
-_RECONCILE_STATE: dict[str, tuple[threading.Lock, float]] = {}
+# Per-session-directory reconcile state: a lock serialising scans, plus a
+# count of scans started (freshness marker — see ``_reconcile_guarded``).
+# Entries are never evicted, but the key set is the set of distinct session
+# directories this process has listed — a handful in every real deployment.
+_RECONCILE_LOCKS: dict[str, threading.Lock] = {}
+_RECONCILE_STARTED: dict[str, int] = {}
 # Guards creation of the per-directory entries (get-or-create itself is
 # racy without it).
 _RECONCILE_STATE_LOCK = threading.Lock()
-# A burst of ``refresh=true`` requests (several clients, a retrying
-# frontend) reuses a scan completed within this window instead of running
-# one reconcile per request.
-_RECONCILE_DEDUPE_WINDOW_S = 1.0
-# Indirection keeps tests from having to patch the global ``time`` module.
-_monotonic = time.monotonic
 
 
-def _reconcile_state_for(key: str) -> tuple[threading.Lock, float]:
-    """Return the get-or-create reconcile state tuple for a directory."""
+def _reconcile_lock_for(key: str) -> threading.Lock:
+    """Return the get-or-create per-directory serialising lock."""
     with _RECONCILE_STATE_LOCK:
-        state = _RECONCILE_STATE.get(key)
-        if state is None:
-            state = (threading.Lock(), 0.0)
-            _RECONCILE_STATE[key] = state
-        return state
+        lock = _RECONCILE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _RECONCILE_LOCKS[key] = lock
+        return lock
 
 
 def _reconcile_guarded(session_dir, index, *, full_rescan: bool) -> None:
@@ -73,24 +68,26 @@ def _reconcile_guarded(session_dir, index, *, full_rescan: bool) -> None:
     Every reconcile opens session stores (~20 descriptors each), so a
     burst of forced refreshes each running its own directory scan could
     exhaust the process descriptor budget and slow the API for everyone.
-    Concurrent callers serialise on the per-directory lock; ones arriving
-    within the dedupe window after a completed scan reuse its result —
-    fingerprints move with writes, so a sub-second-old index is fresh
-    enough for any burst. ``full_rescan`` keeps its explicit reread
-    intent and only skips while another scan for the same directory is
-    still running.
+    Concurrent callers serialise on the per-directory lock, and a caller
+    skips its own pass only once a scan **started after its arrival** has
+    run — that scan's snapshot is at least as fresh as the request, so a
+    burst of K refreshes costs at most two scans while ``refresh=true``
+    still always reflects the changes that made the client ask. A refresh
+    that arrives while no scan is running always scans. ``full_rescan``
+    keeps its explicit reread-everything intent and never skips.
     """
     key = os.path.normcase(str(session_dir))
-    lock, _ = _reconcile_state_for(key)
+    lock = _reconcile_lock_for(key)
+    # Scans started before our arrival cannot reflect the change that
+    # made us ask for a refresh; scans started after it can.
+    started_at_arrival = _RECONCILE_STARTED.get(key, 0)
     with lock:
-        # Re-read the completion time after acquiring: callers that
-        # queued behind a finished scan must see its fresh timestamp,
-        # not the stale one captured before waiting.
-        done_at = _RECONCILE_STATE.get(key, (lock, 0.0))[1]
-        if not full_rescan and (_monotonic() - done_at) < _RECONCILE_DEDUPE_WINDOW_S:
+        if not full_rescan and _RECONCILE_STARTED.get(key, 0) > started_at_arrival:
             return
+        # Mark the start before scanning so waiters compare against this
+        # scan, not against a count that lags the work being done.
+        _RECONCILE_STARTED[key] = _RECONCILE_STARTED.get(key, 0) + 1
         reconcile(index, session_dir, full=full_rescan)
-        _RECONCILE_STATE[key] = (lock, _monotonic())
 
 
 @router.get("/disk-usage")

--- a/src/kohakuterrarium/api/routes/persistence/saved.py
+++ b/src/kohakuterrarium/api/routes/persistence/saved.py
@@ -11,13 +11,17 @@ relevance scores.
 
 ``refresh=true`` incrementally reconciles only files whose ``(mtime, size)``
 fingerprint changed. ``full_rescan=true`` rereads every file and is intended
-for changes made outside the application.
+for changes made outside the application. Concurrent refreshes are
+single-flighted: bursts collapse onto one reconcile (see
+``_reconcile_guarded``) instead of fanning out into parallel scans.
 
 The router mounts under both ``/api/persistence/saved`` and ``/api/sessions``
 to preserve the session API URLs.
 """
 
 import os
+import threading
+import time
 
 from fastapi import APIRouter, HTTPException
 
@@ -36,6 +40,55 @@ from kohakuterrarium.studio.persistence.store import (
 )
 
 router = APIRouter()
+
+# Per-session-directory reconcile state: a lock serialising scans and the
+# monotonic time the last scan completed.
+_RECONCILE_STATE: dict[str, tuple[threading.Lock, float]] = {}
+# Guards creation of the per-directory entries (get-or-create itself is
+# racy without it).
+_RECONCILE_STATE_LOCK = threading.Lock()
+# A burst of ``refresh=true`` requests (several clients, a retrying
+# frontend) reuses a scan completed within this window instead of running
+# one reconcile per request.
+_RECONCILE_DEDUPE_WINDOW_S = 1.0
+# Indirection keeps tests from having to patch the global ``time`` module.
+_monotonic = time.monotonic
+
+
+def _reconcile_state_for(key: str) -> tuple[threading.Lock, float]:
+    """Return the get-or-create reconcile state tuple for a directory."""
+    with _RECONCILE_STATE_LOCK:
+        state = _RECONCILE_STATE.get(key)
+        if state is None:
+            state = (threading.Lock(), 0.0)
+            _RECONCILE_STATE[key] = state
+        return state
+
+
+def _reconcile_guarded(session_dir, index, *, full_rescan: bool) -> None:
+    """Run one reconcile for a burst of concurrent refresh requests.
+
+    Every reconcile opens session stores (~20 descriptors each), so a
+    burst of forced refreshes each running its own directory scan could
+    exhaust the process descriptor budget and slow the API for everyone.
+    Concurrent callers serialise on the per-directory lock; ones arriving
+    within the dedupe window after a completed scan reuse its result —
+    fingerprints move with writes, so a sub-second-old index is fresh
+    enough for any burst. ``full_rescan`` keeps its explicit reread
+    intent and only skips while another scan for the same directory is
+    still running.
+    """
+    key = os.path.normcase(str(session_dir))
+    lock, _ = _reconcile_state_for(key)
+    with lock:
+        # Re-read the completion time after acquiring: callers that
+        # queued behind a finished scan must see its fresh timestamp,
+        # not the stale one captured before waiting.
+        done_at = _RECONCILE_STATE.get(key, (lock, 0.0))[1]
+        if not full_rescan and (_monotonic() - done_at) < _RECONCILE_DEDUPE_WINDOW_S:
+            return
+        reconcile(index, session_dir, full=full_rescan)
+        _RECONCILE_STATE[key] = (lock, _monotonic())
 
 
 @router.get("/disk-usage")
@@ -91,7 +144,7 @@ def _list_via_index(
     session_dir = _session_dir()
     index = get_session_index_default(session_dir)
     if refresh or full_rescan:
-        reconcile(index, session_dir, full=full_rescan)
+        _reconcile_guarded(session_dir, index, full_rescan=full_rescan)
     page = index.list(
         search=search,
         status=status,

--- a/src/kohakuterrarium/api/routes/persistence/saved.py
+++ b/src/kohakuterrarium/api/routes/persistence/saved.py
@@ -42,7 +42,9 @@ from kohakuterrarium.studio.persistence.store import (
 router = APIRouter()
 
 # Per-session-directory reconcile state: a lock serialising scans and the
-# monotonic time the last scan completed.
+# monotonic time the last scan completed. Entries are never evicted, but
+# the key set is the set of distinct session directories this process has
+# listed — a handful in every real deployment.
 _RECONCILE_STATE: dict[str, tuple[threading.Lock, float]] = {}
 # Guards creation of the per-directory entries (get-or-create itself is
 # racy without it).

--- a/src/kohakuterrarium/api/routes/persistence/saved.py
+++ b/src/kohakuterrarium/api/routes/persistence/saved.py
@@ -75,6 +75,11 @@ def _reconcile_guarded(session_dir, index, *, full_rescan: bool) -> None:
     still always reflects the changes that made the client ask. A refresh
     that arrives while no scan is running always scans. ``full_rescan``
     keeps its explicit reread-everything intent and never skips.
+
+    A scan that produced no index update — ``reconcile`` reporting
+    ``aborted`` (directory-walk failure) or raising — does not count as
+    that fresher scan: the start is rolled back so queued waiters run
+    their own pass instead of skipping on a start that reflected no work.
     """
     key = os.path.normcase(str(session_dir))
     lock = _reconcile_lock_for(key)
@@ -87,7 +92,13 @@ def _reconcile_guarded(session_dir, index, *, full_rescan: bool) -> None:
         # Mark the start before scanning so waiters compare against this
         # scan, not against a count that lags the work being done.
         _RECONCILE_STARTED[key] = _RECONCILE_STARTED.get(key, 0) + 1
-        reconcile(index, session_dir, full=full_rescan)
+        try:
+            report = reconcile(index, session_dir, full=full_rescan)
+        except BaseException:
+            _RECONCILE_STARTED[key] -= 1
+            raise
+        if getattr(report, "aborted", False):
+            _RECONCILE_STARTED[key] -= 1
 
 
 @router.get("/disk-usage")

--- a/tests/unit/api/test_persistence_routes.py
+++ b/tests/unit/api/test_persistence_routes.py
@@ -245,6 +245,9 @@ class TestReconcileSingleFlight:
         others = [threading.Thread(target=refresh_once) for _ in range(2)]
         for t in others:
             t.start()
+        # Best-effort only — lets the queued callers reach the lock while
+        # the first scan runs. Not load-bearing: an arrival that lands
+        # after the scan still falls inside the dedupe window and skips.
         time.sleep(0.2)
         release.set()
         first.join(timeout=5)

--- a/tests/unit/api/test_persistence_routes.py
+++ b/tests/unit/api/test_persistence_routes.py
@@ -1,5 +1,8 @@
 """Unit tests for :mod:`kohakuterrarium.api.routes.persistence.*`."""
 
+import threading
+import time
+
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
@@ -172,3 +175,120 @@ class TestPersistenceSaved:
         client = TestClient(_app(saved_mod.router))
         resp = client.delete("/saved/foo")
         assert resp.status_code == 500
+
+
+class TestReconcileSingleFlight:
+    """``refresh=true`` bursts collapse onto one directory scan."""
+
+    class _FakePage:
+        def to_dict(self):
+            return {"sessions": [], "total": 0}
+
+    class _FakeIndex:
+        def list(self, **kw):
+            return TestReconcileSingleFlight._FakePage()
+
+    @staticmethod
+    def _install(monkeypatch, tmp_path, calls, block=None):
+        """Point the module at a fake index/dir and a recording reconcile."""
+        monkeypatch.setattr(saved_mod, "_session_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            saved_mod,
+            "get_session_index_default",
+            lambda d: TestReconcileSingleFlight._FakeIndex(),
+        )
+
+        def fake_reconcile(index, session_dir, full=False):
+            calls.append({"full": full})
+            if block is not None:
+                block.wait(timeout=5)
+
+        monkeypatch.setattr(saved_mod, "reconcile", fake_reconcile)
+        # Fresh per-directory state (tmp_path is unique per test anyway).
+        saved_mod._RECONCILE_STATE.clear()
+
+    def _call(self, **params):
+        kw = dict(
+            search="",
+            sort="last_active",
+            order="desc",
+            status=None,
+            config_type=None,
+            node_id=None,
+            limit=20,
+            offset=0,
+            refresh=False,
+            full_rescan=False,
+        )
+        kw.update(params)
+        return saved_mod._list_via_index(**kw)
+
+    def test_concurrent_refreshes_share_one_scan(self, monkeypatch, tmp_path):
+        calls = []
+        release = threading.Event()
+        self._install(monkeypatch, tmp_path, calls, block=release)
+
+        def refresh_once():
+            self._call(refresh=True)
+
+        first = threading.Thread(target=refresh_once)
+        first.start()
+        # Wait until the first caller is inside the (blocked) reconcile.
+        deadline = 5.0
+        while not calls and deadline > 0:
+            time.sleep(0.01)
+            deadline -= 0.01
+        assert calls, "first refresh never reached reconcile"
+
+        # Both later callers queue on the per-directory lock while the
+        # first scan is still running, then fall inside the dedupe window.
+        others = [threading.Thread(target=refresh_once) for _ in range(2)]
+        for t in others:
+            t.start()
+        time.sleep(0.2)
+        release.set()
+        first.join(timeout=5)
+        for t in others:
+            t.join(timeout=5)
+
+        assert len(calls) == 1, "concurrent refreshes must share one scan"
+
+    def test_sequential_refresh_outside_window_rescans(self, monkeypatch, tmp_path):
+        calls = []
+        self._install(monkeypatch, tmp_path, calls)
+        fake_now = [1000.0]
+        monkeypatch.setattr(saved_mod, "_monotonic", lambda: fake_now[0])
+
+        self._call(refresh=True)
+        assert len(calls) == 1
+
+        # Inside the dedupe window: reuse the fresh scan.
+        fake_now[0] += 0.5
+        self._call(refresh=True)
+        assert len(calls) == 1
+
+        # Outside the window: a real rescan runs.
+        fake_now[0] += 5.0
+        self._call(refresh=True)
+        assert len(calls) == 2
+
+    def test_full_rescan_bypasses_dedupe_window(self, monkeypatch, tmp_path):
+        calls = []
+        self._install(monkeypatch, tmp_path, calls)
+        fake_now = [1000.0]
+        monkeypatch.setattr(saved_mod, "_monotonic", lambda: fake_now[0])
+
+        self._call(refresh=True)
+        fake_now[0] += 0.1
+        # Explicit reread-everything intent is never short-circuited by
+        # a recent incremental scan.
+        self._call(refresh=True, full_rescan=True)
+        assert len(calls) == 2
+        assert calls[1]["full"] is True
+
+    def test_no_refresh_never_reconciles(self, monkeypatch, tmp_path):
+        calls = []
+        self._install(monkeypatch, tmp_path, calls)
+        self._call()
+        self._call(search="alice")
+        assert calls == []

--- a/tests/unit/api/test_persistence_routes.py
+++ b/tests/unit/api/test_persistence_routes.py
@@ -3,10 +3,14 @@
 import threading
 import time
 
+import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from kohakuterrarium.api.routes.persistence import saved as saved_mod
+from kohakuterrarium.studio.persistence.session_index.reconcile import (
+    ReconcileReport,
+)
 
 
 def _app(*routers) -> FastAPI:
@@ -306,3 +310,84 @@ class TestReconcileSingleFlight:
         self._call()
         self._call(search="alice")
         assert calls == []
+
+    def test_aborted_scans_do_not_entitle_queued_waiters_to_skip(
+        self, monkeypatch, tmp_path
+    ):
+        calls = []
+        self._install(monkeypatch, tmp_path, calls)
+        # First two scans block then report aborted (directory-walk
+        # failure); any later scan succeeds.
+        gates = [threading.Event(), threading.Event()]
+
+        def aborting_twice(index, session_dir, full=False):
+            calls.append({"full": full})
+            n = len(calls)
+            if n <= 2:
+                gates[n - 1].wait(timeout=5)
+                return ReconcileReport(
+                    read=0, deleted=0, total=0, elapsed_ms=0.0, aborted=True
+                )
+            return ReconcileReport(read=0, deleted=0, total=0, elapsed_ms=0.0)
+
+        monkeypatch.setattr(saved_mod, "reconcile", aborting_twice)
+
+        def refresh_once():
+            self._call(refresh=True)
+
+        first = threading.Thread(target=refresh_once)
+        first.start()
+        deadline = 5.0
+        while not calls and deadline > 0:
+            time.sleep(0.01)
+            deadline -= 0.01
+        assert calls, "first refresh never reached reconcile"
+
+        # Two waiters queue while the first (aborting) scan runs.
+        waiters = [threading.Thread(target=refresh_once) for _ in range(2)]
+        for t in waiters:
+            t.start()
+        time.sleep(0.2)
+        gates[0].set()
+        deadline = 5.0
+        while len(calls) < 2 and deadline > 0:
+            time.sleep(0.01)
+            deadline -= 0.01
+        assert len(calls) == 2, "waiter never started its trailing scan"
+        gates[1].set()
+        first.join(timeout=5)
+        for t in waiters:
+            t.join(timeout=5)
+
+        # Copilot-review scenario: an aborted scan leaves the index
+        # untouched, so its start must not let the second waiter skip.
+        # With the rollback both waiters attempt their own scan (3
+        # calls); without it the second waiter skips on the aborted
+        # start (2 calls) and is served a stale index.
+        assert (
+            len(calls) == 3
+        ), "an aborted scan must not count as freshness for queued waiters"
+
+    def test_raised_scan_rolls_back_its_start_count(self, monkeypatch, tmp_path):
+        calls = []
+        self._install(monkeypatch, tmp_path, calls)
+
+        def raising_once(index, session_dir, full=False):
+            calls.append({"full": full})
+            if len(calls) == 1:
+                raise RuntimeError("sqlite exploded")
+            return ReconcileReport(read=0, deleted=0, total=0, elapsed_ms=0.0)
+
+        monkeypatch.setattr(saved_mod, "reconcile", raising_once)
+
+        with pytest.raises(RuntimeError):
+            self._call(refresh=True)
+
+        key = saved_mod.os.path.normcase(str(tmp_path))
+        assert (
+            saved_mod._RECONCILE_STARTED.get(key, 0) == 0
+        ), "a scan that raised must roll back its start count"
+
+        # The next refresh still scans (it was not entitled to a skip).
+        self._call(refresh=True)
+        assert len(calls) == 2

--- a/tests/unit/api/test_persistence_routes.py
+++ b/tests/unit/api/test_persistence_routes.py
@@ -205,7 +205,8 @@ class TestReconcileSingleFlight:
 
         monkeypatch.setattr(saved_mod, "reconcile", fake_reconcile)
         # Fresh per-directory state (tmp_path is unique per test anyway).
-        saved_mod._RECONCILE_STATE.clear()
+        saved_mod._RECONCILE_LOCKS.clear()
+        saved_mod._RECONCILE_STARTED.clear()
 
     def _call(self, **params):
         kw = dict(
@@ -223,7 +224,9 @@ class TestReconcileSingleFlight:
         kw.update(params)
         return saved_mod._list_via_index(**kw)
 
-    def test_concurrent_refreshes_share_one_scan(self, monkeypatch, tmp_path):
+    def test_concurrent_refresh_burst_costs_at_most_two_scans(
+        self, monkeypatch, tmp_path
+    ):
         calls = []
         release = threading.Event()
         self._install(monkeypatch, tmp_path, calls, block=release)
@@ -241,51 +244,59 @@ class TestReconcileSingleFlight:
         assert calls, "first refresh never reached reconcile"
 
         # Both later callers queue on the per-directory lock while the
-        # first scan is still running, then fall inside the dedupe window.
+        # first scan is still running. Best-effort pause — gives them
+        # time to reach the lock before the release so the skip path is
+        # exercised; an arrival that lands after the release runs its
+        # own scan instead, which the assertion below still tolerates
+        # only while a scan started after it — hence the bounded count.
         others = [threading.Thread(target=refresh_once) for _ in range(2)]
         for t in others:
             t.start()
-        # Best-effort only — lets the queued callers reach the lock while
-        # the first scan runs. Not load-bearing: an arrival that lands
-        # after the scan still falls inside the dedupe window and skips.
         time.sleep(0.2)
         release.set()
         first.join(timeout=5)
         for t in others:
             t.join(timeout=5)
 
-        assert len(calls) == 1, "concurrent refreshes must share one scan"
+        assert (
+            len(calls) == 2
+        ), "burst must cost at most one trailing scan beyond the in-flight one"
 
-    def test_sequential_refresh_outside_window_rescans(self, monkeypatch, tmp_path):
+    def test_refresh_after_a_completed_scan_rescans(self, monkeypatch, tmp_path):
         calls = []
         self._install(monkeypatch, tmp_path, calls)
-        fake_now = [1000.0]
-        monkeypatch.setattr(saved_mod, "_monotonic", lambda: fake_now[0])
 
         self._call(refresh=True)
         assert len(calls) == 1
 
-        # Inside the dedupe window: reuse the fresh scan.
-        fake_now[0] += 0.5
-        self._call(refresh=True)
-        assert len(calls) == 1
-
-        # Outside the window: a real rescan runs.
-        fake_now[0] += 5.0
+        # Regression pin (CI, test_session_persistence_and_resume_workflow):
+        # a fork lands between two refreshes milliseconds apart. An
+        # explicit refresh that arrives when NO scan is running must
+        # scan — skipping it silently serves a pre-fork index.
         self._call(refresh=True)
         assert len(calls) == 2
-
-    def test_full_rescan_bypasses_dedupe_window(self, monkeypatch, tmp_path):
-        calls = []
-        self._install(monkeypatch, tmp_path, calls)
-        fake_now = [1000.0]
-        monkeypatch.setattr(saved_mod, "_monotonic", lambda: fake_now[0])
-
         self._call(refresh=True)
-        fake_now[0] += 0.1
-        # Explicit reread-everything intent is never short-circuited by
-        # a recent incremental scan.
+        assert len(calls) == 3
+
+    def test_full_rescan_queued_behind_a_scan_never_skips(self, monkeypatch, tmp_path):
+        calls = []
+        release = threading.Event()
+        self._install(monkeypatch, tmp_path, calls, block=release)
+
+        first = threading.Thread(target=lambda: self._call(refresh=True))
+        first.start()
+        deadline = 5.0
+        while not calls and deadline > 0:
+            time.sleep(0.01)
+            deadline -= 0.01
+        assert calls, "first refresh never reached reconcile"
+
+        # Explicit reread-everything intent never dedupes, even though a
+        # scan for the same directory is in flight right now.
         self._call(refresh=True, full_rescan=True)
+        release.set()
+        first.join(timeout=5)
+
         assert len(calls) == 2
         assert calls[1]["full"] is True
 


### PR DESCRIPTION
## Summary

Frontend pollers kept firing on their fixed interval while the previous request was still in flight, so a backend slower than the poll window accumulated overlapping duplicate requests; the `refresh=true` session listing ran one directory reconcile per request server-side with no coalescing. This adds in-flight skip/coalescing on the client, single-flight reconciles on the server, and documents the resulting semantics.

Structured as **9 small commits that revert independently** (verified mechanically in throwaway worktrees for the first 7, both orders, landing byte-identical on `main`; the two post-review fix commits each carry the tests that pin them).

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

When a backend answers slower than a poll window, a fixed `setInterval` stacks one more duplicate request per tick, and the extra load makes the backend slower still. Fixes #291 (root-cause analysis and affected surfaces there). Downstream symptoms were already being patched individually (`80ac258e` fd soft limit, `0148674b` descriptor-budget reader bound, `e003aa4d` reconcile abort); this removes the source.

## Changes

- `useVisibilityInterval`: when the tick callback returns a promise, ticks fired before it settles are skipped (rejections unblock; `stop()` clears the flag; synchronous callbacks never skip). Call sites that fired async work without returning it now return their promises.
- `SubagentConversationPanel` (1.5 s poll, tightest window) and Dashboard / StatsTab / DashboardStatsCard pollers: routed through the guarded interval, tick bodies return their promises; StatsTab's three parallel loads run under one `Promise.all`. Hidden tabs now pause these pollers like every other surface.
- `drives.reconcile`: single-flight — the 6 s panel poller, 8 s badge poller, and event-scheduled reconciles share the in-flight listing; a session switch detaches the shared task. No minimum spacing added (it would delay event-driven reconciles).
- `instances.fetchOne`: concurrent callers for the same id share one in-flight request (mirror of `fetchAll`'s guard).
- `api/routes/persistence/saved.py`: `refresh=true` reconciles are single-flighted per session directory — a request arriving mid-scan queues behind it and skips its own pass only once a scan **started after its arrival** has run, so a burst costs at most two scans while every refresh still reflects the changes that made the client ask. `full_rescan` keeps its force-reread intent and never skips.
- Corrected the `SessionsListPage.vue` comment claiming a "30s server-side cache" that no code implements.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/ -q
pytest tests/integration/ -q
cd src/kohakuterrarium-frontend && npm ci && npm run format:check && npm run build
```

All green locally (Windows 11, Python 3.14) in the touched areas. Full-tier runs: unit `14638 passed / 6 failed`, integration `174 passed / 1 failed` — all 7 failures reproduce **identically on pristine `main` @ 0148674b** (5× `tests/unit/packages/test_git_backend_dulwich_integration.py::TestDulwichRealRefCheckout`, 1× sibling clone test, 1× `tests/integration/test_api.py::TestApiIntegration::test_session_persistence_and_resume_workflow`); verified by running the same tests on an unmodified main checkout. Details under Exceptions.

New tests pin every guard, each proven to fail against the unpatched code (guard removed in a scratch copy → test red, restored → green): interval-skip, subagent no-stack, drives coalesce + session-switch, fetchOne dedupe, backend concurrent-share + 1 s window + full_rescan semantics.

Frontend vitest: all new tests pass; the handful of failing files (MacroShell, layoutPanels, studio/ui, …) fail identically on baseline `main` — pre-existing, unrelated.

Before/after pile-up measurements (requests dispatched + peak in flight per surface under an 8 s-latency backend, and server scans for a burst of 8 `refresh=true` clients): [benchmark comment](https://github.com/Kohaku-Lab/KohakuTerrarium/pull/292#issuecomment-5563563681) — headline: peak duplicate requests 6/2/4 → 1 across the three frontend surfaces, refresh-burst scans 8 → 2.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #291

## Notes for Reviewers

- This is filed as a bug fix (request pile-up defect), not a feature: no new functionality, no public API added. The backend single-flight preserves the `refresh=true` freshness contract (every refresh reflects changes up to its own arrival; bursts coalesce to at most two scans) — documented in the route docstring, the Sessions guide, and the HTTP reference (which also said "force rebuild" — it was incremental already).
- Commit granularity: 5 frontend commits (framework → per-surface) + 1 backend commit + 1 docs commit; each is independently revertable (mechanically verified both orders).
- Docstrings/comments state two deliberate tradeoffs: the visibility-resume catch-up tick obeys the in-flight skip (data can sit one poll window stale after returning to a tab), and sharers of a deduped `fetchOne` inherit the first caller's rejection (all call sites catch).
- Post-review updates (two fix commits on top): the drives coalesce gained a trailing pass per the Codex P2 (an event-scheduled reconcile joining a pre-event snapshot lost its refresh), and the backend guard's first draft — a 1 s completion window — was reworked to an arrival-freshness rule after this branch's own CI caught it serving a pre-fork index to `refresh=true` in `test_session_persistence_and_resume_workflow`.

## Screenshots / Logs (if applicable)

Not applicable (load-shape change; no UI change).

## Breaking Changes (if applicable)

None expected. No public API added or removed; the `refresh=true` timing note above is the only externally observable delta.

## Exceptions / Not Run

- `pytest tests/unit/` / `pytest tests/integration/` are **not 100 % green locally, for pre-existing reasons only**: 6 unit failures in `test_git_backend_dulwich_integration.py` (real-network clone checks) and 1 integration failure (`test_session_persistence_and_resume_workflow`) fail byte-identically on pristine `main` @ 0148674b on this Windows machine — verified by checking out baseline and re-running the same tests (7 failed in 7.76 s). None touch this PR's areas; every test in the touched areas passes.
- `pytest tests/e2e/` not run: this PR does not touch the multi-node / Studio / serving stack (per `tests/README.md`, e2e is local-only and required for those areas).
- Fork CI: the POSIX matrix (ubuntu/macos × 3 Python) fails only `test_session_persistence_and_resume_workflow` on the first push — a real regression in the backend commit's first draft, **fixed** by `27a7a608` (with a regression test); the re-run is the authoritative gate. Windows jobs may stay red for pre-existing reasons: upstream `main` @ `0148674b` already fails two Windows-only unit tests (`builtins/tui/test_session.py`, `builtins/tools/test_bash.py`) unrelated to this PR.
