### PR TITLE
fix(tui): replay multimodal session history and make resume race-safe

### DIFF
--- a/src/kohakuterrarium/builtins/cli_rich/commit.py
+++ b/src/kohakuterrarium/builtins/cli_rich/commit.py
@@ -20,6 +20,7 @@ from kohakuterrarium.builtins.cli_rich.live_region import render_to_ansi
 from kohakuterrarium.builtins.cli_rich.runtime import spawn
 from kohakuterrarium.builtins.cli_rich.theme import COLOR_USER, ICON_USER
 from kohakuterrarium.builtins.outputs.stdout import _write_safe
+from kohakuterrarium.llm.message import content_display_text
 from kohakuterrarium.session.history import (
     dedupe_adjacent_duplicate_events,
     select_live_event_ids,
@@ -250,7 +251,9 @@ class SessionReplay:
         data = event.get("data", event)
 
         if etype == "user_input":
-            content = data.get("content", "")
+            # Web sessions persist multimodal content-part lists; Rich Text
+            # only accepts str, so render display text first.
+            content = content_display_text(data.get("content", ""))
             if content:
                 self._committer.user_message(content)
                 self._committer.blank_line()

--- a/src/kohakuterrarium/builtins/outputs/stdout.py
+++ b/src/kohakuterrarium/builtins/outputs/stdout.py
@@ -3,6 +3,7 @@
 import sys
 from typing import TextIO
 
+from kohakuterrarium.llm.message import content_display_text
 from kohakuterrarium.modules.output.base import BaseOutputModule
 from kohakuterrarium.session.history import (
     dedupe_adjacent_duplicate_events,
@@ -42,8 +43,9 @@ def _group_resume_events(events: list[dict]) -> list[dict]:
         if etype == "user_input":
             if current["user"] or current["text"]:
                 turns.append(current)
+            # Multimodal content lists render as display text, not Python repr.
             current = {
-                "user": evt.get("content", ""),
+                "user": content_display_text(evt.get("content", "")),
                 "text": "",
                 "tools": [],
             }

--- a/src/kohakuterrarium/builtins/tui/output.py
+++ b/src/kohakuterrarium/builtins/tui/output.py
@@ -48,6 +48,9 @@ class TUIOutput(BaseOutputModule):
         # agent clears its pending copy right after emitting, so losing this
         # buffer loses the history permanently.
         self._buffered_resume_events: list[dict] = []
+        # In-flight replay of the buffer, scheduled by the wiring flush;
+        # live rendering awaits it so history mounts before newer output.
+        self._pending_resume_task: asyncio.Task | None = None
         self._turn_started = False
         self._default_target: str = ""
         self._interactive_screens: dict[str, Any] = {}
@@ -94,7 +97,29 @@ class TUIOutput(BaseOutputModule):
             # later bind or module start replays the history.
             self._buffered_resume_events = buffered
             return
-        asyncio.ensure_future(self.on_resume(buffered))
+        self._pending_resume_task = asyncio.ensure_future(self.on_resume(buffered))
+
+    async def _await_resume_replay(self) -> None:
+        """Serialize rendering behind an in-flight buffered resume replay.
+
+        The wiring flush cannot await (a property setter is sync), so the
+        replay runs as a task. Live events must not interleave with it —
+        widgets mounted after newer output would render the transcript out
+        of order — so every rendering entry point except ``resume_batch``
+        itself drains the pending task first.
+        """
+        task = self._pending_resume_task
+        if task is None:
+            return
+        try:
+            await task
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Buffered resume replay failed", exc_info=True)
+        finally:
+            if self._pending_resume_task is task:
+                self._pending_resume_task = None
 
     @property
     def _target(self) -> str:
@@ -165,6 +190,10 @@ class TUIOutput(BaseOutputModule):
 
     async def emit(self, event: OutputEvent) -> None:
         """Render an output event or collect its interactive reply."""
+        # ``resume_batch`` IS the replay path; everything else must wait for
+        # an in-flight buffered replay so history mounts before newer output.
+        if event.type != "resume_batch":
+            await self._await_resume_replay()
         match event.type:
             case "text":
                 content = event.content

--- a/src/kohakuterrarium/builtins/tui/output.py
+++ b/src/kohakuterrarium/builtins/tui/output.py
@@ -4,25 +4,22 @@ import asyncio
 from typing import Any
 
 from textual.containers import VerticalScroll
-from textual.widgets import Markdown
 
 from kohakuterrarium.builtins.tui import attention
 from kohakuterrarium.builtins.tui._injection import handle_user_input_injected
 from kohakuterrarium.builtins.tui.model_info import handle_session_info
 from kohakuterrarium.builtins.tui.reply_submit import submit_reply
+from kohakuterrarium.builtins.tui.resume import (
+    _build_resume_widgets,
+    _group_into_turns,
+    _iter_all_steps,
+)
 from kohakuterrarium.builtins.tui.session import CULL_KEEP, TUISession
 from kohakuterrarium.builtins.tui.tool_args import (
     format_args_detail,
     format_args_preview,
 )
-from kohakuterrarium.builtins.tui.widgets import (
-    CompactSummaryBlock,
-    LoadOlderButton,
-    SubAgentBlock,
-    ToolBlock,
-    TriggerMessage,
-    UserMessage,
-)
+from kohakuterrarium.builtins.tui.widgets import LoadOlderButton
 from kohakuterrarium.builtins.tui.widgets.ui_event_modals import (
     BusAskTextModal,
     BusConfirmModal,
@@ -31,13 +28,13 @@ from kohakuterrarium.builtins.tui.widgets.ui_event_modals import (
 from kohakuterrarium.core.session import get_session
 from kohakuterrarium.modules.output.base import BaseOutputModule
 from kohakuterrarium.modules.output.event import OutputEvent, UIReply
-from kohakuterrarium.session.history import (
-    dedupe_adjacent_duplicate_events,
-    select_live_event_ids,
-)
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# Bounded wait for the resume widget mount; the mount itself finishes in the
+# background when this fires so a slow mount cannot kill the input loop.
+RESUME_MOUNT_TIMEOUT = 10.0
 
 
 class TUIOutput(BaseOutputModule):
@@ -46,14 +43,26 @@ class TUIOutput(BaseOutputModule):
     def __init__(self, session_key: str | None = None, **options: Any):
         super().__init__()
         self._session_key = session_key
-        self._tui = None
+        self._tui_session: TUISession | None = None
+        # Resume events that arrived before the TUI session was wired; the
+        # agent clears its pending copy right after emitting, so losing this
+        # buffer loses the history permanently.
+        self._buffered_resume_events: list[dict] = []
         self._turn_started = False
         self._default_target: str = ""
         self._interactive_screens: dict[str, Any] = {}
 
     @property
-    def _target(self) -> str:
-        return self._default_target
+    def _tui(self) -> TUISession | None:
+        return self._tui_session
+
+    @_tui.setter
+    def _tui(self, session: TUISession | None) -> None:
+        # Engine surfaces (terrarium.engine_cli*) bind the session directly
+        # onto started outputs; replay any resume batch buffered until now.
+        self._tui_session = session
+        if session is not None:
+            self._flush_buffered_resume()
 
     async def _on_start(self) -> None:
         # Engine-managed sessions are wired before startup and must remain the
@@ -63,6 +72,7 @@ class TUIOutput(BaseOutputModule):
                 "TUI output reusing externally-wired session",
                 session_key=self._session_key,
             )
+            self._flush_buffered_resume()
             return
         session = get_session(self._session_key)
         if session.tui is None:
@@ -71,6 +81,24 @@ class TUIOutput(BaseOutputModule):
             )
         self._tui = session.tui
         logger.debug("TUI output started", session_key=self._session_key)
+
+    def _flush_buffered_resume(self) -> None:
+        """Replay resume events buffered before the TUI session was wired."""
+        buffered, self._buffered_resume_events = self._buffered_resume_events, []
+        if not buffered or self._tui_session is None:
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # Binding outside a running loop cannot render yet; restore so a
+            # later bind or module start replays the history.
+            self._buffered_resume_events = buffered
+            return
+        asyncio.ensure_future(self.on_resume(buffered))
+
+    @property
+    def _target(self) -> str:
+        return self._default_target
 
     async def _on_stop(self) -> None:
         if self._tui:
@@ -604,7 +632,15 @@ class TUIOutput(BaseOutputModule):
 
     async def on_resume(self, events: list[dict]) -> None:
         """Render session history in one race-free widget batch."""
-        if not self._tui or not events:
+        if not events:
+            return
+        if self._tui is None:
+            # The resume_batch can race creature startup before the engine
+            # wires this output; the agent clears its pending copy right
+            # after emitting, so buffer for replay on bind instead of
+            # silently dropping the history.
+            logger.debug("TUI not wired; buffering resume events", count=len(events))
+            self._buffered_resume_events.extend(events)
             return
 
         await self._tui.wait_ready()
@@ -660,8 +696,17 @@ class TUIOutput(BaseOutputModule):
                 asyncio.ensure_future(_inner())
 
             app.call_later(_do_build_and_mount)
-            # Resume must not race subsequent output against an incomplete mount.
-            await asyncio.wait_for(done_event.wait(), timeout=10.0)
+            try:
+                # Resume must not race subsequent output against an incomplete
+                # mount, but a slow mount must not kill the input loop either.
+                await asyncio.wait_for(done_event.wait(), timeout=RESUME_MOUNT_TIMEOUT)
+            except asyncio.TimeoutError:
+                # The mount task finishes in the background regardless.
+                logger.debug(
+                    "Resume mount wait timed out",
+                    session_key=self._session_key,
+                    scroll_id=scroll_id,
+                )
 
 
 # -- Helpers ---------------------------------------------------------------
@@ -689,310 +734,3 @@ def _command_name(metadata: dict) -> str:
         return "command"
     name = raw.lstrip("/").split(None, 1)[0]
     return name or "command"
-
-
-# -- Resume rendering ------------------------------------------------------
-
-
-def _group_into_turns(events: list[dict]) -> list[dict]:
-    """Group events into turns while preserving step order."""
-    events = dedupe_adjacent_duplicate_events(events)
-    live_ids = select_live_event_ids(events)
-    turns: list[dict] = []
-    current: dict | None = None
-
-    for evt in events:
-        etype = evt.get("type", "")
-        eid = evt.get("event_id")
-        if isinstance(eid, int) and eid not in live_ids:
-            continue
-        if etype == "user_input":
-            if current:
-                turns.append(current)
-            current = {
-                "input_type": "user_input",
-                "input": evt.get("content", ""),
-                "steps": [],
-            }
-        elif etype == "trigger_fired":
-            if current:
-                turns.append(current)
-            ch = evt.get("channel", "")
-            sender = evt.get("sender", "")
-            content = evt.get("content", "")
-            current = {
-                "input_type": "trigger",
-                "input": f"[{ch}] {sender}",
-                "trigger_content": content,
-                "steps": [],
-            }
-        elif etype in ("compact_start", "compact_complete", "compact_skipped"):
-            # Background compaction belongs to the nearest active or prior turn.
-            target = current if current else (turns[-1] if turns else None)
-            if target:
-                target["steps"].append((etype, evt))
-        elif current is not None:
-            if etype in ("text", "text_chunk"):
-                # Replay treats streamed chunks and complete text identically.
-                if current["steps"] and current["steps"][-1][0] == "text":
-                    current["steps"][-1] = (
-                        "text",
-                        current["steps"][-1][1] + evt.get("content", ""),
-                    )
-                else:
-                    current["steps"].append(("text", evt.get("content", "")))
-            elif etype in (
-                "tool_call",
-                "tool_result",
-                "subagent_call",
-                "subagent_result",
-                "subagent_tool",
-                "processing_start",
-                "processing_end",
-                "token_usage",
-            ):
-                current["steps"].append((etype, evt))
-
-    if current:
-        turns.append(current)
-    return turns
-
-
-def _iter_all_steps(turns: list[dict]):
-    """Yield each step across all turns."""
-    for turn in turns:
-        for step in turn.get("steps", []):
-            yield step
-
-
-def _build_resume_widgets(turns: list[dict]) -> list:
-    """Build resume widgets synchronously without mounting them."""
-    widgets: list = []
-    current_subagent: SubAgentBlock | None = None
-    pending_tools: dict[str, str] = {}
-    sa_pending_tools: dict[str, str] = {}
-
-    for turn in turns:
-        turn_ws, current_subagent, sa_pending_tools = _build_turn_widgets(
-            turn, current_subagent, pending_tools, sa_pending_tools
-        )
-        widgets.extend(turn_ws)
-
-    if current_subagent:
-        current_subagent.mark_interrupted()
-
-    # A restored session cannot retain live tool executions.
-    for w in widgets:
-        if isinstance(w, ToolBlock) and w.state == "running":
-            w.mark_done("")
-
-    return widgets
-
-
-def _find_matching_block(
-    widgets: list, tool_name: str, call_id: str
-) -> "ToolBlock | None":
-    """Find the newest matching tool block, preferring its call ID."""
-    if call_id:
-        for w in reversed(widgets):
-            if isinstance(w, ToolBlock) and w.tool_id == call_id:
-                return w
-    # Older histories may lack call IDs, so fall back to the newest running name.
-    for w in reversed(widgets):
-        if (
-            isinstance(w, ToolBlock)
-            and w.tool_name == tool_name
-            and w.state == "running"
-        ):
-            return w
-    return None
-
-
-def _build_turn_widgets(
-    turn: dict,
-    current_subagent: SubAgentBlock | None,
-    pending_tools: dict[str, str],
-    sa_pending_tools: dict[str, str],
-) -> tuple[list, SubAgentBlock | None, dict[str, str]]:
-    """Build one turn's widgets and return its carried sub-agent state."""
-    widgets: list = []
-
-    # User/trigger message
-    if turn["input_type"] == "user_input":
-        widgets.append(UserMessage(turn["input"]))
-    else:
-        widgets.append(TriggerMessage(turn["input"], turn.get("trigger_content", "")))
-
-    for step_type, data in turn.get("steps", []):
-        if step_type == "text":
-            text = data if isinstance(data, str) else str(data)
-            if text.strip():
-                # Markdown preserves selectable rendered history instead of a stream widget.
-                widgets.append(Markdown(text))
-
-        elif step_type == "tool_call":
-            raw_name = data.get("name", "tool")
-            name = _clean_name(raw_name)
-            call_id = data.get("call_id", "")
-            args = data.get("args", {})
-            preview = format_args_preview(name, args)
-            detail = format_args_detail(name, args)
-
-            if current_subagent:
-                current_subagent.add_tool_line(name, preview)
-            else:
-                block = ToolBlock(name, preview, call_id, args_detail=detail)
-                widgets.append(block)
-            if call_id:
-                pending_tools[call_id] = name
-
-        elif step_type == "tool_result":
-            call_id = data.get("call_id", "")
-            name = pending_tools.pop(call_id, _clean_name(data.get("name", "tool")))
-            error = data.get("error")
-            output = data.get("output", "")
-            if output.strip() in ("OK", ""):
-                output = ""
-
-            if current_subagent:
-                current_subagent.update_tool_line(
-                    name, done=not error, error=bool(error)
-                )
-            else:
-                matched = _find_matching_block(widgets, name, call_id)
-                if matched is not None:
-                    if error:
-                        matched.mark_error(str(error))
-                    else:
-                        matched.mark_done(output)
-
-        elif step_type == "subagent_call":
-            # Finalize any leftover sub-agent tools from previous sub-agent
-            if current_subagent:
-                for tn in list(sa_pending_tools):
-                    current_subagent.update_tool_line(tn, done=True)
-                sa_pending_tools.clear()
-            raw_name = data.get("name", "subagent")
-            name = _clean_name(raw_name)
-            task = data.get("task", "")
-            block = SubAgentBlock(name, sa_task=task)
-            current_subagent = block
-            widgets.append(block)
-
-        elif step_type == "subagent_result":
-            # Mark any remaining sub-agent tools as done
-            if current_subagent:
-                for tn in list(sa_pending_tools):
-                    current_subagent.update_tool_line(tn, done=True)
-                sa_pending_tools.clear()
-            if current_subagent:
-                current_subagent.mark_done(
-                    output=data.get("output", ""),
-                    tools_used=data.get("tools_used"),
-                    turns=data.get("turns", 0),
-                    duration=data.get("duration", 0),
-                )
-                current_subagent = None
-
-        elif step_type == "subagent_tool":
-            tool_name = data.get("tool_name", "")
-            activity = data.get("activity", "")
-            detail = data.get("detail", "")
-            if current_subagent:
-                if activity == "tool_start":
-                    # Pre-mount widgets receive their current state directly.
-                    sa_pending_tools[tool_name] = detail[:50]
-                    current_subagent.add_tool_line(tool_name, detail[:50])
-                elif activity == "tool_done":
-                    sa_pending_tools.pop(tool_name, None)
-                    current_subagent.update_tool_line(tool_name, done=True)
-                elif activity == "tool_error":
-                    sa_pending_tools.pop(tool_name, None)
-                    current_subagent.update_tool_line(tool_name, done=False, error=True)
-
-        elif step_type == "compact_complete":
-            summary = data.get("summary", "") if isinstance(data, dict) else ""
-            widgets.append(CompactSummaryBlock(summary, done=True))
-
-        elif step_type == "compact_skipped":
-            reason = data.get("reason", "skipped") if isinstance(data, dict) else ""
-            widgets.append(
-                CompactSummaryBlock(f"(skipped: {reason or 'skipped'})", done=True)
-            )
-
-    return widgets, current_subagent, sa_pending_tools
-
-
-def _clean_name(raw: str) -> str:
-    """Remove stored job ID and sub-agent prefixes from a name."""
-    if "[" in raw:
-        return raw[: raw.index("[")]
-    if raw.startswith("agent_"):
-        return raw[6:]
-    return raw
-
-
-def _render_turn_to_tui(tui, turn: dict) -> None:
-    """Render one historical turn as TUI widgets, preserving interleaving."""
-    if turn["input_type"] == "user_input":
-        tui.add_user_message(turn["input"])
-    else:
-        tui.add_trigger_message(turn["input"], turn.get("trigger_content", ""))
-
-    pending_tools: dict[str, str] = {}
-
-    for step_type, data in turn["steps"]:
-        if step_type == "text":
-            tui.begin_streaming()
-            tui.append_stream(data)
-            tui.end_streaming()
-
-        elif step_type == "tool_call":
-            raw_name = data.get("name", "tool")
-            name = _clean_name(raw_name)
-            call_id = data.get("call_id", "")
-            args = data.get("args", {})
-            preview = format_args_preview(name, args)
-            tui.add_tool_block(
-                name,
-                preview,
-                call_id,
-                args_detail=format_args_detail(name, args),
-            )
-            if call_id:
-                pending_tools[call_id] = name
-
-        elif step_type == "tool_result":
-            call_id = data.get("call_id", "")
-            name = pending_tools.pop(call_id, _clean_name(data.get("name", "tool")))
-            error = data.get("error")
-            output = data.get("output", "")
-            if output.strip() in ("OK", ""):
-                output = ""
-            tui.update_tool_block(name, output=output, error=error, tool_id=call_id)
-
-        elif step_type == "subagent_call":
-            raw_name = data.get("name", "subagent")
-            name = _clean_name(raw_name)
-            task = data.get("task", "")
-            tui.add_subagent_block(name, task)
-
-        elif step_type == "subagent_result":
-            tui.end_subagent_block(
-                output=data.get("output", ""),
-                tools_used=data.get("tools_used"),
-                turns=data.get("turns", 0),
-                duration=data.get("duration", 0),
-            )
-
-        elif step_type == "subagent_tool":
-            tool_name = data.get("tool_name", "")
-            activity = data.get("activity", "")
-            detail = data.get("detail", "")
-            if activity == "tool_start":
-                tui.add_tool_block(tool_name, detail[:50])
-            elif activity == "tool_done":
-                tui.update_tool_block(tool_name)
-            elif activity == "tool_error":
-                tui.update_tool_block(tool_name, error="error")
-        tui.end_streaming()

--- a/src/kohakuterrarium/builtins/tui/resume.py
+++ b/src/kohakuterrarium/builtins/tui/resume.py
@@ -1,0 +1,330 @@
+"""Resume-history replay helpers: turn grouping and widget construction.
+
+Extracted from ``output.py`` so the TUI output module stays focused on
+event routing; these functions are pure building blocks over session
+events and Textual widgets.
+"""
+
+from textual.widgets import Markdown
+
+from kohakuterrarium.builtins.tui.tool_args import (
+    format_args_detail,
+    format_args_preview,
+)
+from kohakuterrarium.builtins.tui.widgets import (
+    CompactSummaryBlock,
+    SubAgentBlock,
+    ToolBlock,
+    TriggerMessage,
+    UserMessage,
+)
+from kohakuterrarium.llm.message import content_display_text
+from kohakuterrarium.session.history import (
+    dedupe_adjacent_duplicate_events,
+    select_live_event_ids,
+)
+
+
+def _group_into_turns(events: list[dict]) -> list[dict]:
+    """Group events into turns while preserving step order."""
+    events = dedupe_adjacent_duplicate_events(events)
+    live_ids = select_live_event_ids(events)
+    turns: list[dict] = []
+    current: dict | None = None
+
+    for evt in events:
+        etype = evt.get("type", "")
+        eid = evt.get("event_id")
+        if isinstance(eid, int) and eid not in live_ids:
+            continue
+        if etype == "user_input":
+            if current:
+                turns.append(current)
+            current = {
+                "input_type": "user_input",
+                # Web sessions persist multimodal content-part lists; widgets
+                # require display text.
+                "input": content_display_text(evt.get("content", "")),
+                "steps": [],
+            }
+        elif etype == "trigger_fired":
+            if current:
+                turns.append(current)
+            ch = evt.get("channel", "")
+            sender = evt.get("sender", "")
+            current = {
+                "input_type": "trigger",
+                "input": f"[{ch}] {sender}",
+                "trigger_content": content_display_text(evt.get("content", "")),
+                "steps": [],
+            }
+        elif etype in ("compact_start", "compact_complete", "compact_skipped"):
+            # Background compaction belongs to the nearest active or prior turn.
+            target = current if current else (turns[-1] if turns else None)
+            if target:
+                target["steps"].append((etype, evt))
+        elif current is not None:
+            if etype in ("text", "text_chunk"):
+                # Replay treats streamed chunks and complete text identically.
+                if current["steps"] and current["steps"][-1][0] == "text":
+                    current["steps"][-1] = (
+                        "text",
+                        current["steps"][-1][1] + evt.get("content", ""),
+                    )
+                else:
+                    current["steps"].append(("text", evt.get("content", "")))
+            elif etype in (
+                "tool_call",
+                "tool_result",
+                "subagent_call",
+                "subagent_result",
+                "subagent_tool",
+                "processing_start",
+                "processing_end",
+                "token_usage",
+            ):
+                current["steps"].append((etype, evt))
+
+    if current:
+        turns.append(current)
+    return turns
+
+
+def _iter_all_steps(turns: list[dict]):
+    """Yield each step across all turns."""
+    for turn in turns:
+        for step in turn.get("steps", []):
+            yield step
+
+
+def _build_resume_widgets(turns: list[dict]) -> list:
+    """Build resume widgets synchronously without mounting them."""
+    widgets: list = []
+    current_subagent: SubAgentBlock | None = None
+    pending_tools: dict[str, str] = {}
+    sa_pending_tools: dict[str, str] = {}
+
+    for turn in turns:
+        turn_ws, current_subagent, sa_pending_tools = _build_turn_widgets(
+            turn, current_subagent, pending_tools, sa_pending_tools
+        )
+        widgets.extend(turn_ws)
+
+    if current_subagent:
+        current_subagent.mark_interrupted()
+
+    # A restored session cannot retain live tool executions.
+    for w in widgets:
+        if isinstance(w, ToolBlock) and w.state == "running":
+            w.mark_done("")
+
+    return widgets
+
+
+def _find_matching_block(
+    widgets: list, tool_name: str, call_id: str
+) -> "ToolBlock | None":
+    """Find the newest matching tool block, preferring its call ID."""
+    if call_id:
+        for w in reversed(widgets):
+            if isinstance(w, ToolBlock) and w.tool_id == call_id:
+                return w
+    # Older histories may lack call IDs, so fall back to the newest running name.
+    for w in reversed(widgets):
+        if (
+            isinstance(w, ToolBlock)
+            and w.tool_name == tool_name
+            and w.state == "running"
+        ):
+            return w
+    return None
+
+
+def _build_turn_widgets(
+    turn: dict,
+    current_subagent: SubAgentBlock | None,
+    pending_tools: dict[str, str],
+    sa_pending_tools: dict[str, str],
+) -> tuple[list, SubAgentBlock | None, dict[str, str]]:
+    """Build one turn's widgets and return its carried sub-agent state."""
+    widgets: list = []
+
+    # User/trigger message
+    if turn["input_type"] == "user_input":
+        widgets.append(UserMessage(turn["input"]))
+    else:
+        widgets.append(TriggerMessage(turn["input"], turn.get("trigger_content", "")))
+
+    for step_type, data in turn.get("steps", []):
+        if step_type == "text":
+            text = data if isinstance(data, str) else str(data)
+            if text.strip():
+                # Markdown preserves selectable rendered history instead of a stream widget.
+                widgets.append(Markdown(text))
+
+        elif step_type == "tool_call":
+            raw_name = data.get("name", "tool")
+            name = _clean_name(raw_name)
+            call_id = data.get("call_id", "")
+            args = data.get("args", {})
+            preview = format_args_preview(name, args)
+            detail = format_args_detail(name, args)
+
+            if current_subagent:
+                current_subagent.add_tool_line(name, preview)
+            else:
+                block = ToolBlock(name, preview, call_id, args_detail=detail)
+                widgets.append(block)
+            if call_id:
+                pending_tools[call_id] = name
+
+        elif step_type == "tool_result":
+            call_id = data.get("call_id", "")
+            name = pending_tools.pop(call_id, _clean_name(data.get("name", "tool")))
+            error = data.get("error")
+            output = data.get("output", "")
+            if output.strip() in ("OK", ""):
+                output = ""
+
+            if current_subagent:
+                current_subagent.update_tool_line(
+                    name, done=not error, error=bool(error)
+                )
+            else:
+                matched = _find_matching_block(widgets, name, call_id)
+                if matched is not None:
+                    if error:
+                        matched.mark_error(str(error))
+                    else:
+                        matched.mark_done(output)
+
+        elif step_type == "subagent_call":
+            # Finalize any leftover sub-agent tools from previous sub-agent
+            if current_subagent:
+                for tn in list(sa_pending_tools):
+                    current_subagent.update_tool_line(tn, done=True)
+                sa_pending_tools.clear()
+            raw_name = data.get("name", "subagent")
+            name = _clean_name(raw_name)
+            task = data.get("task", "")
+            block = SubAgentBlock(name, sa_task=task)
+            current_subagent = block
+            widgets.append(block)
+
+        elif step_type == "subagent_result":
+            # Mark any remaining sub-agent tools as done
+            if current_subagent:
+                for tn in list(sa_pending_tools):
+                    current_subagent.update_tool_line(tn, done=True)
+                sa_pending_tools.clear()
+            if current_subagent:
+                current_subagent.mark_done(
+                    output=data.get("output", ""),
+                    tools_used=data.get("tools_used"),
+                    turns=data.get("turns", 0),
+                    duration=data.get("duration", 0),
+                )
+                current_subagent = None
+
+        elif step_type == "subagent_tool":
+            tool_name = data.get("tool_name", "")
+            activity = data.get("activity", "")
+            detail = data.get("detail", "")
+            if current_subagent:
+                if activity == "tool_start":
+                    # Pre-mount widgets receive their current state directly.
+                    sa_pending_tools[tool_name] = detail[:50]
+                    current_subagent.add_tool_line(tool_name, detail[:50])
+                elif activity == "tool_done":
+                    sa_pending_tools.pop(tool_name, None)
+                    current_subagent.update_tool_line(tool_name, done=True)
+                elif activity == "tool_error":
+                    sa_pending_tools.pop(tool_name, None)
+                    current_subagent.update_tool_line(tool_name, done=False, error=True)
+
+        elif step_type == "compact_complete":
+            summary = data.get("summary", "") if isinstance(data, dict) else ""
+            widgets.append(CompactSummaryBlock(summary, done=True))
+
+        elif step_type == "compact_skipped":
+            reason = data.get("reason", "skipped") if isinstance(data, dict) else ""
+            widgets.append(
+                CompactSummaryBlock(f"(skipped: {reason or 'skipped'})", done=True)
+            )
+
+    return widgets, current_subagent, sa_pending_tools
+
+
+def _clean_name(raw: str) -> str:
+    """Remove stored job ID and sub-agent prefixes from a name."""
+    if "[" in raw:
+        return raw[: raw.index("[")]
+    if raw.startswith("agent_"):
+        return raw[6:]
+    return raw
+
+
+def _render_turn_to_tui(tui, turn: dict) -> None:
+    """Render one historical turn as TUI widgets, preserving interleaving."""
+    if turn["input_type"] == "user_input":
+        tui.add_user_message(turn["input"])
+    else:
+        tui.add_trigger_message(turn["input"], turn.get("trigger_content", ""))
+
+    pending_tools: dict[str, str] = {}
+
+    for step_type, data in turn["steps"]:
+        if step_type == "text":
+            tui.begin_streaming()
+            tui.append_stream(data)
+            tui.end_streaming()
+
+        elif step_type == "tool_call":
+            raw_name = data.get("name", "tool")
+            name = _clean_name(raw_name)
+            call_id = data.get("call_id", "")
+            args = data.get("args", {})
+            preview = format_args_preview(name, args)
+            tui.add_tool_block(
+                name,
+                preview,
+                call_id,
+                args_detail=format_args_detail(name, args),
+            )
+            if call_id:
+                pending_tools[call_id] = name
+
+        elif step_type == "tool_result":
+            call_id = data.get("call_id", "")
+            name = pending_tools.pop(call_id, _clean_name(data.get("name", "tool")))
+            error = data.get("error")
+            output = data.get("output", "")
+            if output.strip() in ("OK", ""):
+                output = ""
+            tui.update_tool_block(name, output=output, error=error, tool_id=call_id)
+
+        elif step_type == "subagent_call":
+            raw_name = data.get("name", "subagent")
+            name = _clean_name(raw_name)
+            task = data.get("task", "")
+            tui.add_subagent_block(name, task)
+
+        elif step_type == "subagent_result":
+            tui.end_subagent_block(
+                output=data.get("output", ""),
+                tools_used=data.get("tools_used"),
+                turns=data.get("turns", 0),
+                duration=data.get("duration", 0),
+            )
+
+        elif step_type == "subagent_tool":
+            tool_name = data.get("tool_name", "")
+            activity = data.get("activity", "")
+            detail = data.get("detail", "")
+            if activity == "tool_start":
+                tui.add_tool_block(tool_name, detail[:50])
+            elif activity == "tool_done":
+                tui.update_tool_block(tool_name)
+            elif activity == "tool_error":
+                tui.update_tool_block(tool_name, error="error")
+        tui.end_streaming()

--- a/src/kohakuterrarium/llm/message.py
+++ b/src/kohakuterrarium/llm/message.py
@@ -140,6 +140,38 @@ def content_parts_to_dicts(parts: list[ContentPart]) -> list[dict[str, Any]]:
     return [part if isinstance(part, dict) else part.to_dict() for part in parts]
 
 
+def content_display_text(
+    content: str | list[ContentPart | RawContentPart] | None,
+) -> str:
+    """Render content as display text, replacing non-text parts with short labels.
+
+    String content passes through untouched. Multimodal content-part lists
+    (e.g. web submissions persisted by ``create_user_input_event``) become
+    plain text: text parts are joined with newlines, images render as
+    ``[image]``-style descriptions, and files as ``[file: <name>]``.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+
+    parts = normalize_content_parts(content)
+    if not isinstance(parts, list):
+        return ""
+
+    lines: list[str] = []
+    for part in parts:
+        if isinstance(part, TextPart):
+            if part.text:
+                lines.append(part.text)
+        elif isinstance(part, ImagePart):
+            lines.append(part.get_description())
+        elif isinstance(part, FilePart):
+            label = part.name or part.path or "file"
+            lines.append(f"[file: {label}]")
+    return "\n".join(lines)
+
+
 # Non-standard fields are preserved separately so provider state survives round-trips.
 _STANDARD_MESSAGE_KEYS = frozenset(
     {"role", "content", "name", "tool_call_id", "tool_calls"}

--- a/tests/unit/builtins/cli_rich/test_commit.py
+++ b/tests/unit/builtins/cli_rich/test_commit.py
@@ -1,0 +1,41 @@
+"""Unit tests for ``builtins/cli_rich/commit.py`` — SessionReplay rendering."""
+
+from kohakuterrarium.builtins.cli_rich.commit import (
+    ScrollbackCommitter,
+    SessionReplay,
+)
+
+
+class StubApp:
+    """Duck-typed RichCLIApp: committer writes straight to stdout."""
+
+    def __init__(self):
+        self.app = None
+        self.committer = ScrollbackCommitter(self)
+
+    def _terminal_width(self) -> int:
+        return 80
+
+
+def test_replay_renders_multimodal_user_input_as_text(capsys):
+    replay = SessionReplay(StubApp())
+    events = [
+        {
+            "type": "user_input",
+            "content": [{"text": "hello from web", "type": "text"}],
+        },
+        {"type": "text", "content": "answer"},
+        {"type": "processing_end", "content": ""},
+    ]
+
+    replay.replay(events)
+
+    assert "hello from web" in capsys.readouterr().out
+
+
+def test_replay_keeps_plain_string_user_input(capsys):
+    replay = SessionReplay(StubApp())
+
+    replay.replay([{"type": "user_input", "content": "plain text"}])
+
+    assert "plain text" in capsys.readouterr().out

--- a/tests/unit/builtins/outputs/test_stdout.py
+++ b/tests/unit/builtins/outputs/test_stdout.py
@@ -1,0 +1,46 @@
+"""Unit tests for ``builtins/outputs/stdout.py`` — resume history summary."""
+
+from kohakuterrarium.builtins.outputs.stdout import StdoutOutput, _group_resume_events
+
+
+def test_group_resume_events_renders_multimodal_user_input_as_text():
+    events = [
+        {
+            "type": "user_input",
+            "content": [{"text": "hello from web", "type": "text"}],
+        },
+        {"type": "text", "content": "answer"},
+    ]
+
+    turns = _group_resume_events(events)
+
+    assert turns[0]["user"] == "hello from web"
+    assert turns[0]["text"] == "answer"
+
+
+def test_group_resume_events_keeps_plain_string_content():
+    events = [
+        {"type": "user_input", "content": "plain"},
+        {"type": "text", "content": "reply"},
+    ]
+
+    turns = _group_resume_events(events)
+
+    assert turns[0]["user"] == "plain"
+    assert turns[0]["text"] == "reply"
+
+
+async def test_on_resume_prints_text_not_repr(capsys):
+    output = StdoutOutput()
+    events = [
+        {
+            "type": "user_input",
+            "content": [{"text": "hello from web", "type": "text"}],
+        },
+    ]
+
+    await output.on_resume(events)
+
+    out = capsys.readouterr().out
+    assert "You: hello from web" in out
+    assert "'type': 'text'" not in out

--- a/tests/unit/builtins/tui/test_output.py
+++ b/tests/unit/builtins/tui/test_output.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from textual.widgets import Label
 from textual.widgets._markdown import MarkdownFence
@@ -6,6 +8,7 @@ from kohakuterrarium.builtins.tui.output import TUIOutput
 from kohakuterrarium.builtins.tui.session import TUISession
 from kohakuterrarium.builtins.tui.widgets import UserMessage
 from kohakuterrarium.builtins.tui.widgets.blocks import ToolBlock
+from kohakuterrarium.modules.output.event import OutputEvent
 
 
 class FakeTUI:
@@ -191,6 +194,41 @@ async def test_resume_buffers_events_until_tui_session_wired():
 
         user = session._app.query_one(UserMessage)
         assert "early history" in user.render().plain
+
+
+async def test_emit_serializes_live_output_behind_a_buffered_resume_replay():
+    session = TUISession()
+    await session.start()
+    assert session._app is not None
+    output = TUIOutput()
+    order: list[str] = []
+
+    async with session._app.run_test(size=(60, 20)):
+
+        async def slow_replay(events):
+            order.append("resume-start")
+            await asyncio.sleep(0.05)
+            order.append("resume-end")
+
+        output.on_resume = slow_replay  # type: ignore[method-assign]
+        original_write_stream = output.write_stream
+
+        async def recording_write_stream(chunk: str) -> None:
+            order.append("text")
+            await original_write_stream(chunk)
+
+        output.write_stream = recording_write_stream  # type: ignore[method-assign]
+        output._buffered_resume_events = [
+            {"type": "user_input", "content": "early history"}
+        ]
+        output._tui = session  # wiring flush schedules the replay as a task
+
+        await output.emit(OutputEvent(type="text", content="live"))
+        await asyncio.sleep(0.1)
+
+        # Live output must wait for the in-flight replay; rendering it while
+        # the history is still mounting would order the transcript wrong.
+        assert order == ["resume-start", "resume-end", "text"]
 
 
 async def test_resume_survives_slow_mount_without_raising(

--- a/tests/unit/builtins/tui/test_output.py
+++ b/tests/unit/builtins/tui/test_output.py
@@ -1,8 +1,10 @@
+import pytest
 from textual.widgets import Label
 from textual.widgets._markdown import MarkdownFence
 
 from kohakuterrarium.builtins.tui.output import TUIOutput
 from kohakuterrarium.builtins.tui.session import TUISession
+from kohakuterrarium.builtins.tui.widgets import UserMessage
 from kohakuterrarium.builtins.tui.widgets.blocks import ToolBlock
 
 
@@ -143,3 +145,72 @@ async def test_live_tool_start_mounts_complete_safe_arguments():
         )
         assert "hidden content" not in tool._args_widget.render().plain
         assert "hidden internal" not in tool._args_widget.render().plain
+
+
+async def test_resume_renders_multimodal_user_input_as_text():
+    session = TUISession()
+    await session.start()
+    assert session._app is not None
+    output = TUIOutput()
+    output._tui = session
+
+    events = [
+        {
+            "type": "user_input",
+            "content": [{"text": "hello from web", "type": "text"}],
+        },
+        {"type": "text", "content": "hi there"},
+    ]
+
+    async with session._app.run_test(size=(60, 20)) as pilot:
+        await output.on_resume(events)
+        await pilot.pause()
+
+        user = session._app.query_one(UserMessage)
+        assert "hello from web" in user.render().plain
+
+
+async def test_resume_buffers_events_until_tui_session_wired():
+    session = TUISession()
+    await session.start()
+    assert session._app is not None
+    output = TUIOutput()
+    events = [{"type": "user_input", "content": "early history"}]
+
+    async with session._app.run_test(size=(60, 20)) as pilot:
+        # The resume_batch arrives before the TUI session is wired; the
+        # agent clears its pending copy right after emitting, so losing
+        # the buffer here loses the history permanently.
+        await output.on_resume(events)
+        await pilot.pause()
+        assert not list(session._app.query(UserMessage))
+
+        output._tui = session
+        for _ in range(3):
+            await pilot.pause()
+
+        user = session._app.query_one(UserMessage)
+        assert "early history" in user.render().plain
+
+
+async def test_resume_survives_slow_mount_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = TUISession()
+    await session.start()
+    assert session._app is not None
+    output = TUIOutput()
+    output._tui = session
+
+    monkeypatch.setattr(
+        "kohakuterrarium.builtins.tui.output.RESUME_MOUNT_TIMEOUT", 0.05
+    )
+
+    async with session._app.run_test(size=(60, 20)) as pilot:
+        original_call_later = session._app.call_later
+        # A mount task that never signals completion must not propagate a
+        # timeout into the agent's input loop.
+        monkeypatch.setattr(session._app, "call_later", lambda *a, **k: None)
+        await output.on_resume([{"type": "user_input", "content": "turn"}])
+        monkeypatch.setattr(session._app, "call_later", original_call_later)
+        await pilot.pause()

--- a/tests/unit/builtins/tui/test_resume.py
+++ b/tests/unit/builtins/tui/test_resume.py
@@ -1,0 +1,44 @@
+"""Unit tests for ``builtins/tui/resume.py`` — replay turn grouping."""
+
+from kohakuterrarium.builtins.tui.resume import _group_into_turns
+
+
+def test_user_input_list_content_becomes_display_text():
+    events = [
+        {
+            "type": "user_input",
+            "content": [{"text": "hello from web", "type": "text"}],
+        },
+    ]
+
+    turns = _group_into_turns(events)
+
+    assert len(turns) == 1
+    assert turns[0]["input"] == "hello from web"
+
+
+def test_trigger_list_content_becomes_display_text():
+    events = [
+        {
+            "type": "trigger_fired",
+            "channel": "tasks",
+            "sender": "bot",
+            "content": [{"text": "channel work", "type": "text"}],
+        },
+    ]
+
+    turns = _group_into_turns(events)
+
+    assert turns[0]["trigger_content"] == "channel work"
+
+
+def test_string_content_unchanged():
+    events = [
+        {"type": "user_input", "content": "plain"},
+        {"type": "text", "content": "reply"},
+    ]
+
+    turns = _group_into_turns(events)
+
+    assert turns[0]["input"] == "plain"
+    assert turns[0]["steps"] == [("text", "reply")]

--- a/tests/unit/llm/test_message.py
+++ b/tests/unit/llm/test_message.py
@@ -17,6 +17,7 @@ from kohakuterrarium.llm.message import (
     TextPart,
     ToolMessage,
     UserMessage,
+    content_display_text,
     content_part_from_dict,
     content_parts_to_dicts,
     create_message,
@@ -461,3 +462,65 @@ class TestConversionHelpers:
 
     def test_make_multimodal_content_empty_image_list_returns_string(self):
         assert make_multimodal_content("text", []) == "text"
+
+
+# ---------------------------------------------------------------------------
+# content_display_text — replay-facing display normalization
+# ---------------------------------------------------------------------------
+
+
+class TestContentDisplayText:
+    def test_string_passthrough(self):
+        assert content_display_text("hello") == "hello"
+
+    def test_none_is_empty(self):
+        assert content_display_text(None) == ""
+
+    def test_empty_part_list_is_empty_string(self):
+        assert content_display_text([]) == ""
+
+    def test_web_submission_text_part_dict(self):
+        content = [{"text": "hello from web", "type": "text"}]
+        assert content_display_text(content) == "hello from web"
+
+    def test_multiple_text_parts_join_with_newline(self):
+        content = [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+        assert content_display_text(content) == "a\nb"
+
+    def test_empty_text_parts_are_dropped(self):
+        content = [{"type": "text", "text": ""}, {"type": "text", "text": "kept"}]
+        assert content_display_text(content) == "kept"
+
+    def test_image_part_without_source_shows_placeholder(self):
+        content = [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
+        assert content_display_text(content) == "[image]"
+
+    def test_image_part_with_source_names_it(self):
+        content = [
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://x/y.png"},
+                "meta": {"source_type": "attachment", "source_name": "cat.png"},
+            }
+        ]
+        assert content_display_text(content) == "[attachment: cat.png]"
+
+    def test_file_part_shows_name_placeholder(self):
+        content = [{"type": "file", "file": {"name": "notes.txt", "content": "body"}}]
+        assert content_display_text(content) == "[file: notes.txt]"
+
+    def test_mixed_parts_render_text_and_placeholder(self):
+        content = [
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": "u"}},
+            {"type": "text", "text": "nice"},
+        ]
+        assert content_display_text(content) == "look\n[image]\nnice"
+
+    def test_typed_parts_accepted(self):
+        content = [TextPart(text="t"), ImagePart(url="u")]
+        assert content_display_text(content) == "t\n[image]"
+
+    def test_unknown_part_dicts_are_ignored(self):
+        content = [{"type": "mystery", "payload": "x"}]
+        assert content_display_text(content) == ""


### PR DESCRIPTION
## Summary

Resume-history replay now normalizes multimodal (content-part list) `user_input` content before rendering, the TUI no longer silently drops resume history when the output module is wired after the resume batch arrives, and a slow history mount can no longer kill the agent input loop.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Sessions created through the web dashboard persist every `user_input` event's `content` as a multimodal content-part list (`normalize_content_parts`), not a plain string. Every replay consumer assumed `str`, so resuming any dashboard-originated session rendered **no history at all**: the TUI crashed inside Textual `Content` (`'list' object has no attribute 'translate'`, swallowed as a `Resume mount failed` warning), and the rich CLI aborted on the first turn with Rich's `TypeError: Only str or Text can be appended to Text`. Full analysis, logs, and repro in #293.

While validating the fix, two adjacent resume-replay reliability bugs surfaced and are included (same code path, same user symptom):

1. The resume batch is emitted when the creature starts, which can precede TUI wiring; `TUIOutput.on_resume` early-returned, the events were dropped, and `_pending_resume_events` had already been cleared — history permanently lost with no warning at all.
2. `on_resume` awaited the widget mount with a 10 s timeout but did not catch `asyncio.TimeoutError`; on large sessions the exception propagates through the output router into `_drive_input` and kills the agent's input loop.

## Changes

- `llm/message.py`: add `content_display_text()` — `str` passes through; content-part lists flatten to text (text parts joined; image/file parts rendered as short placeholders like `[image]` / `[file: name]`).
- `builtins/tui/output.py` + new `builtins/tui/resume.py`: resume-replay grouping/widget-building moved verbatim out of `output.py` (which sat at the 1000-line hard cap; now 736) with normalization applied where turns are built; `on_resume` buffers events until the TUI session is wired, then flushes; mount wait catches `asyncio.TimeoutError` (constant `RESUME_MOUNT_TIMEOUT`).
- `builtins/cli_rich/commit.py`: `SessionReplay` normalizes `user_input` content before rendering.
- `builtins/outputs/stdout.py`: the bounded resume summary shows flattened text instead of a Python list repr.
- Widgets keep their strict `str` contract; normalization happens only at the replay layer.
- Tests: new unit tests for the normalizer, all three replay surfaces, the TUI buffering race, and the timeout guard (written red-first; the TUI/CLI tests initially reproduced the exact errors from #293).

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
pytest tests/unit/test_file_sizes.py -q
pytest tests/integration/ -q
```

Behavioral check on a real 331 MB / 75,474-event dashboard-created session (137/137 user turns stored as content parts): `_build_resume_widgets` previously raised on the first turn; it now builds 137 `UserMessage` widgets (3,569 widgets total) with the original text; `SessionReplay` renders the full 7.7 MB replay without errors. Store opened read-only.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (no doc contract changed: this restores replay behavior on surfaces that never documented dropping it)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/` (no frontend files changed)
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #293

## Notes for Reviewers

- The move of `_group_into_turns` / `_build_resume_widgets` / helpers into `builtins/tui/resume.py` is verbatim apart from the two normalization call sites; `output.py` was pinned at the file-size hard cap and could not take the additions.
- Buffering race: `TUIOutput._tui` became a property over `_tui_session` with a flush-on-bind setter so the existing direct assignments (engine TUI host, tests) keep working.

## Exceptions / Not Run

- Local `pytest tests/unit/` shows 6 failures, all in `tests/unit/packages/test_git_backend_dulwich_integration.py`; they reproduce on a clean checkout of this machine without the patch (dulwich/Windows refs environment issue, `KeyError: b'refs/heads/master'`). The remaining 12,909 unit tests and all 175 integration tests pass.
- `pytest tests/e2e/` was not run for this change (TUI/CLI output rendering only; no multi-node / Studio / serving surface touched).
