### PR TITLE
perf(resume): cut resume event-table scans from 3-4 to 1

### DIFF
--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -91,11 +91,9 @@ def _load_conversation_with_replay_fallback(
     counter is NOT an upper bound of the event table. ``append_event``
     flushes the events cache BEFORE ``persist_event_counter`` runs, and
     that persist swallows failures (session/store.py), so the stored
-    counter can lag the table by any amount (measured on a production
-    331MB session copy: counter=75699 vs true max=75700). A snapshot
-    watermarked at the lagging counter would then pass a
-    ``cached_up_to >= counter`` check while newer events exist, silently
-    dropping the tail replay.
+    counter can lag the table by any amount. A snapshot watermarked at a
+    lagging counter would then pass a ``cached_up_to >= counter`` check
+    while newer events exist, silently dropping the tail replay.
     """
     snapshot = store.load_conversation(agent_name)
     if events is None:

--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -18,6 +18,7 @@ from kohakuterrarium.modules.input.base import InputModule
 from kohakuterrarium.modules.output.base import OutputModule
 from kohakuterrarium.packages.resolve import resolve_any_path
 from kohakuterrarium.session.history import (
+    dedupe_adjacent_duplicate_events,
     index_parent_paths,
     normalize_resumable_events,
     replay_conversation,
@@ -30,6 +31,7 @@ from kohakuterrarium.session.migrations import (
 from kohakuterrarium.session.readonly import read_session_meta
 from kohakuterrarium.session.resume_branch import (
     backfill_turn_metadata,
+    fresh_snapshot_watermark,
     replayed_messages_for,
     snapshot_has_turn_metadata,
     snapshot_mismatches_branch,
@@ -74,15 +76,26 @@ def _create_io_modules(
 
 
 def _load_conversation_with_replay_fallback(
-    store: SessionStore, agent_name: str
+    store: SessionStore,
+    agent_name: str,
+    events: list[dict] | None = None,
 ) -> list[dict] | None:
     """Load the conversation snapshot and replay events when it is stale.
 
     Post-snapshot events are appended when branch ancestry is unchanged; new
     branch forks require a full replay to preserve coherent selection.
+    ``events`` (when given) is the caller's single raw read of the event
+    log, shared across the resume helpers so one scan serves them all.
     """
     snapshot = store.load_conversation(agent_name)
-    events = store.get_events(agent_name)
+    if (
+        events is None
+        and fresh_snapshot_watermark(store, agent_name, snapshot) is not None
+    ):
+        # O(1) counter check: the event log holds nothing past the snapshot.
+        return snapshot
+    if events is None:
+        events = store.get_events(agent_name)
     if not events:
         return snapshot
     last_event_id = 0
@@ -176,23 +189,30 @@ def _load_conversation_with_replay_fallback(
     return snapshot
 
 
-def _restore_turn_branch_state(agent, store: SessionStore, agent_name: str) -> None:
+def _restore_turn_branch_state(
+    agent,
+    store: SessionStore,
+    agent_name: str,
+    events: list[dict] | None = None,
+) -> None:
     """Set turn / branch / parent-path state on the agent from saved events.
 
     Picks the latest live subtree on resume (parent path = the latest
     branch of every prior turn). This matches ``replay_conversation``
     default selection so the in-memory conversation, the saved
-    snapshot, and the agent's branch counters all agree.
+    snapshot, and the agent's branch counters all agree. ``events`` is
+    the caller's shared raw read; omit it to read the store here.
     """
-    try:
-        events = store.get_events(agent_name)
-    except Exception as e:
-        logger.warning(
-            "Failed to read events for turn/branch restore",
-            error=str(e),
-            exc_info=True,
-        )
-        return
+    if events is None:
+        try:
+            events = store.get_events(agent_name)
+        except Exception as e:
+            logger.warning(
+                "Failed to read events for turn/branch restore",
+                error=str(e),
+                exc_info=True,
+            )
+            return
     # Use replay's path-aware selector so restored branch ancestry actually existed.
     events_list = list(events)
     parent_paths = index_parent_paths(events_list)
@@ -280,7 +300,10 @@ def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
     queued for the rebuilt agent's resume flow.
     """
     align_agent_name(agent, agent_name)
-    saved_messages = _load_conversation_with_replay_fallback(store, agent_name)
+    # ONE raw read of the event log feeds every consumer below (conversation
+    # replay, branch restore, mismatch replay) — not the old 3-4 scans.
+    events = store.get_events(agent_name)
+    saved_messages = _load_conversation_with_replay_fallback(store, agent_name, events)
     if saved_messages:
         agent.controller.conversation = _build_conversation(saved_messages)
         _apply_restore_elision(agent)
@@ -288,7 +311,7 @@ def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
             "Conversation restored", agent=agent_name, messages=len(saved_messages)
         )
 
-    _restore_turn_branch_state(agent, store, agent_name)
+    _restore_turn_branch_state(agent, store, agent_name, events)
 
     # A snapshot saved on a DIFFERENT branch (a sibling path) is stale for
     # the restored target branch: discard it and rebuild via the branch-aware
@@ -298,7 +321,7 @@ def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
             "Snapshot belongs to another branch — replaying target branch",
             agent=agent_name,
         )
-        replayed = replayed_messages_for(store, agent_name)
+        replayed = replayed_messages_for(store, agent_name, events)
         if replayed:
             agent.controller.conversation = _build_conversation(replayed)
             _apply_restore_elision(agent)
@@ -321,7 +344,9 @@ def inject_saved_state(agent, store: SessionStore, agent_name: str) -> None:
     _reapply_options(agent, agent_name, "native_tool_options")
     _reapply_options(agent, agent_name, "tool_options")
 
-    resume_events = store.get_resumable_events(agent_name)
+    # Same dedupe→normalize pipeline as SessionStore.get_resumable_events,
+    # computed from the shared read instead of a second full table scan.
+    resume_events = normalize_resumable_events(dedupe_adjacent_duplicate_events(events))
     if resume_events:
         agent._pending_resume_events = resume_events
         logger.info("Resume events loaded", agent=agent_name, count=len(resume_events))

--- a/src/kohakuterrarium/session/resume.py
+++ b/src/kohakuterrarium/session/resume.py
@@ -31,7 +31,6 @@ from kohakuterrarium.session.migrations import (
 from kohakuterrarium.session.readonly import read_session_meta
 from kohakuterrarium.session.resume_branch import (
     backfill_turn_metadata,
-    fresh_snapshot_watermark,
     replayed_messages_for,
     snapshot_has_turn_metadata,
     snapshot_mismatches_branch,
@@ -85,15 +84,20 @@ def _load_conversation_with_replay_fallback(
     Post-snapshot events are appended when branch ancestry is unchanged; new
     branch forks require a full replay to preserve coherent selection.
     ``events`` (when given) is the caller's single raw read of the event
-    log, shared across the resume helpers so one scan serves them all.
+    log, shared across the resume helpers so one scan serves them all;
+    without it the store is read here.
+
+    Deliberately NO counter-based freshness shortcut: the persisted event
+    counter is NOT an upper bound of the event table. ``append_event``
+    flushes the events cache BEFORE ``persist_event_counter`` runs, and
+    that persist swallows failures (session/store.py), so the stored
+    counter can lag the table by any amount (measured on a production
+    331MB session copy: counter=75699 vs true max=75700). A snapshot
+    watermarked at the lagging counter would then pass a
+    ``cached_up_to >= counter`` check while newer events exist, silently
+    dropping the tail replay.
     """
     snapshot = store.load_conversation(agent_name)
-    if (
-        events is None
-        and fresh_snapshot_watermark(store, agent_name, snapshot) is not None
-    ):
-        # O(1) counter check: the event log holds nothing past the snapshot.
-        return snapshot
     if events is None:
         events = store.get_events(agent_name)
     if not events:

--- a/src/kohakuterrarium/session/resume_branch.py
+++ b/src/kohakuterrarium/session/resume_branch.py
@@ -51,6 +51,37 @@ def snapshot_has_turn_metadata(snapshot: list[dict]) -> bool:
     )
 
 
+def fresh_snapshot_watermark(store: Any, agent_name: str, snapshot: Any) -> int | None:
+    """Return the snapshot watermark when it provably covers every event.
+
+    Uses the O(1) persisted event counter (append-time monotonic; missing
+    slots fall back to a full value scan in ``store_counters``, so it never
+    under-reports the table). "Fresh" means: the snapshot exists, its
+    watermark is an int ``>= max_event_id``, and it carries valid turn
+    metadata — the exact condition under which the conversation loader may
+    return the snapshot verbatim without replaying anything. Duck-typed
+    stores without the counter return ``None`` so callers degrade to the
+    ordinary event-table scan.
+    """
+    try:
+        cached_up_to = store.state.get(f"{agent_name}:snapshot_event_id")
+    except (KeyError, TypeError):
+        return None
+    try:
+        max_seen = store.max_event_id(agent_name)
+    except AttributeError:
+        return None
+    if (
+        snapshot is not None
+        and isinstance(cached_up_to, int)
+        and isinstance(max_seen, int)
+        and snapshot_has_turn_metadata(snapshot)
+        and cached_up_to >= max_seen
+    ):
+        return cached_up_to
+    return None
+
+
 def backfill_turn_metadata(snapshot: list[dict], events: list[dict]) -> list[dict]:
     """Backfill user-turn metadata onto a legacy metadata-less snapshot.
 
@@ -205,15 +236,22 @@ def snapshot_mismatches_branch(store: Any, agent: Any, agent_name: str) -> bool:
     return not is_path_prefix(snapshot_path, agent_path)
 
 
-def replayed_messages_for(store: Any, agent_name: str) -> list[dict]:
+def replayed_messages_for(
+    store: Any,
+    agent_name: str,
+    events: list[dict] | None = None,
+) -> list[dict]:
     """Replay the latest live subtree from the event log (branch-aware).
 
     Used by resume when the saved snapshot belongs to a different branch.
+    ``events`` is the caller's shared raw read; without it the store is
+    read here.
     """
-    try:
-        events = list(store.get_events(agent_name))
-    except Exception:  # pragma: no cover - defensive
-        return []
+    if events is None:
+        try:
+            events = list(store.get_events(agent_name))
+        except Exception:  # pragma: no cover - defensive
+            return []
     if not events:
         return []
     return replay_conversation(

--- a/src/kohakuterrarium/session/resume_branch.py
+++ b/src/kohakuterrarium/session/resume_branch.py
@@ -51,37 +51,6 @@ def snapshot_has_turn_metadata(snapshot: list[dict]) -> bool:
     )
 
 
-def fresh_snapshot_watermark(store: Any, agent_name: str, snapshot: Any) -> int | None:
-    """Return the snapshot watermark when it provably covers every event.
-
-    Uses the O(1) persisted event counter (append-time monotonic; missing
-    slots fall back to a full value scan in ``store_counters``, so it never
-    under-reports the table). "Fresh" means: the snapshot exists, its
-    watermark is an int ``>= max_event_id``, and it carries valid turn
-    metadata — the exact condition under which the conversation loader may
-    return the snapshot verbatim without replaying anything. Duck-typed
-    stores without the counter return ``None`` so callers degrade to the
-    ordinary event-table scan.
-    """
-    try:
-        cached_up_to = store.state.get(f"{agent_name}:snapshot_event_id")
-    except (KeyError, TypeError):
-        return None
-    try:
-        max_seen = store.max_event_id(agent_name)
-    except AttributeError:
-        return None
-    if (
-        snapshot is not None
-        and isinstance(cached_up_to, int)
-        and isinstance(max_seen, int)
-        and snapshot_has_turn_metadata(snapshot)
-        and cached_up_to >= max_seen
-    ):
-        return cached_up_to
-    return None
-
-
 def backfill_turn_metadata(snapshot: list[dict], events: list[dict]) -> list[dict]:
     """Backfill user-turn metadata onto a legacy metadata-less snapshot.
 

--- a/tests/unit/session/test_resume.py
+++ b/tests/unit/session/test_resume.py
@@ -63,20 +63,27 @@ def _write_agent_config(config_dir) -> None:
 
 
 class _CountingStore:
-    """Delegate-everything proxy that counts ``get_events`` calls.
+    """Proxy that counts EVERY ``get_events`` call on the wrapped store.
 
-    The resume scan budget metric: conversation replay, branch restore,
+    The resume scan-budget metric: conversation replay, branch restore,
     and pending resume events must share a single full read of the event
-    table, and the fresh-snapshot fast path must need none.
+    table. The count is installed on the INNER store's ``get_events`` so
+    reads hidden behind ``__getattr__`` delegation (e.g. a
+    ``get_resumable_events`` re-read reaching the real store) are counted
+    too — a regression back to a second full scan turns the budget
+    assertions red instead of silently passing.
     """
 
     def __init__(self, store):
         self._store = store
         self.get_events_calls = 0
+        inner = store.get_events
 
-    def get_events(self, agent, since_event_id=None):
-        self.get_events_calls += 1
-        return self._store.get_events(agent, since_event_id=since_event_id)
+        def _counted_get_events(agent, since_event_id=None):
+            self.get_events_calls += 1
+            return inner(agent, since_event_id=since_event_id)
+
+        store.get_events = _counted_get_events
 
     def __getattr__(self, name):
         return getattr(self._store, name)
@@ -765,43 +772,67 @@ class TestLoadConversationFallback:
         finally:
             store.close()
 
-    def test_fresh_snapshot_fast_path_skips_event_scan(self, tmp_path):
-        # A snapshot covering every persisted event (verified through the
-        # O(1) persisted counter, never under-reporting the table) must be
-        # returned WITHOUT scanning the event table — the scan just to
-        # compute last_event_id is what made large-session resume crawl.
-        store = SessionStore(str(tmp_path / "x.kohakutr"))
-        try:
-            _, eid = store.append_event(
-                "alice",
-                "user_message",
-                {"content": "x"},
-                turn_index=1,
-                branch_id=1,
-            )
-            store.save_conversation(
-                "alice",
-                [
-                    {
-                        "role": "user",
-                        "content": "snap",
-                        "metadata": {"turn_index": 1, "branch_id": 1},
-                    }
-                ],
-            )
-            store.state["alice:snapshot_event_id"] = eid
-            store.flush()
-            counting = _CountingStore(store)
-            out = _load_conversation_with_replay_fallback(counting, "alice")
-            assert out[0]["content"] == "snap"
-            assert out[0]["metadata"]["turn_index"] == 1
-            assert counting.get_events_calls == 0
-        finally:
-            store.close()
+    def test_lagging_persisted_counter_cannot_skip_tail(self, tmp_path):
+        # P1 regression (reviewer-confirmed on production data): the
+        # persisted counter can LAG the event table — append_event flushes
+        # the events cache BEFORE persist_event_counter runs, and that
+        # persist swallows failures (session/store.py). A production file
+        # measured counter=75699 vs true max=75700. When the snapshot
+        # watermark sits at the lagging counter, a counter-based
+        # freshness check would return the snapshot and silently drop the
+        # tail; the helper must ignore the counter and scan.
+        from kohakuvault import KVault
 
-    def test_fast_path_still_replays_when_watermark_stale(self, tmp_path):
-        # Guard against the fast path over-triggering: when the watermark
-        # is behind the persisted counter, the tail MUST still be appended.
+        path = tmp_path / "lag.kohakutr"
+        store = SessionStore(str(path))
+        _, eid = store.append_event(
+            "alice",
+            "user_message",
+            {"content": "kept"},
+            turn_index=1,
+            branch_id=1,
+        )
+        store.save_conversation(
+            "alice",
+            [
+                {
+                    "role": "user",
+                    "content": "snap",
+                    "metadata": {"turn_index": 1, "branch_id": 1},
+                }
+            ],
+        )
+        store.state["alice:snapshot_event_id"] = eid
+        store.append_event("alice", "user_message", {"content": "dropped"})
+        store.close()
+
+        # Simulate the crash window: the counter persisted BEHIND the
+        # table's true max.
+        state = KVault(str(path), table="state")
+        try:
+            state["counters:max_event_id"] = eid
+        finally:
+            state.close()
+
+        reopened = SessionStore(str(path))
+        try:
+            assert reopened.max_event_id("alice") == eid  # lagging counter
+            true_max = max(evt["event_id"] for evt in reopened.get_events("alice"))
+            assert true_max == eid + 1  # table holds a newer event
+            counting = _CountingStore(reopened)
+            out = _load_conversation_with_replay_fallback(counting, "alice")
+            contents = [m["content"] for m in out if m["role"] == "user"]
+            assert contents == [
+                "snap",
+                "dropped",
+            ], "a tail past the LAGGING counter watermark must still replay"
+            assert counting.get_events_calls == 1
+        finally:
+            reopened.close(update_status=False)
+
+    def test_stale_watermark_scans_and_replays_tail(self, tmp_path):
+        # When the watermark is behind the event table, the tail MUST be
+        # appended (the snapshot alone would lose post-snapshot turns).
         store = SessionStore(str(tmp_path / "x.kohakutr"))
         try:
             store.append_event("alice", "user_message", {"content": "fresh"})
@@ -873,8 +904,9 @@ class TestLoadConversationFallback:
     def test_legacy_store_without_counter_slot_keeps_tail(self, tmp_path):
         # Old session files carry no counters:max_event_id slot. The reopen
         # fallback must full-scan the values (returning the true max, never
-        # a silent 0), so the fast path cannot misfire on legacy files: the
-        # stale watermark still triggers the tail replay.
+        # a silent 0) — max_event_id stamps snapshot watermarks
+        # (session/output.py), and this file shape must keep replaying the
+        # stale-watermark tail regardless.
         from kohakuvault import KVault
 
         path = tmp_path / "legacy.kohakutr"
@@ -904,7 +936,6 @@ class TestLoadConversationFallback:
             out = _load_conversation_with_replay_fallback(counting, "alice")
             contents = [m["content"] for m in out if m["role"] == "user"]
             assert contents == ["snap", "old"]
-            # Legacy file: counter absent → no fast path → exactly one read.
             assert counting.get_events_calls == 1
         finally:
             reopened.close(update_status=False)
@@ -1931,6 +1962,27 @@ class TestInjectSavedState:
             assert "b1" in contents
             assert "a2" not in contents
             assert counting.get_events_calls == 1
+        finally:
+            store.close()
+
+    def test_counting_proxy_sees_reads_hidden_behind_public_api(self, tmp_path):
+        # Negative case guarding the scan-budget metric itself: a read
+        # made behind __getattr__ delegation (get_resumable_events reaching
+        # the inner store's get_events) must be counted. If it were not,
+        # reverting inject_saved_state to a second full scan via the store
+        # API would pass the ==1 assertions while doing 2 scans.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event("alice", "user_message", {"content": "q"})
+            store.flush()
+            counting = _CountingStore(store)
+            assert counting.get_events_calls == 0
+            counting.get_events("alice")
+            assert counting.get_events_calls == 1
+            counting.get_resumable_events("alice")
+            assert (
+                counting.get_events_calls == 2
+            ), "a get_resumable_events re-read must be visible to the count"
         finally:
             store.close()
 

--- a/tests/unit/session/test_resume.py
+++ b/tests/unit/session/test_resume.py
@@ -62,6 +62,26 @@ def _write_agent_config(config_dir) -> None:
     )
 
 
+class _CountingStore:
+    """Delegate-everything proxy that counts ``get_events`` calls.
+
+    The resume scan budget metric: conversation replay, branch restore,
+    and pending resume events must share a single full read of the event
+    table, and the fresh-snapshot fast path must need none.
+    """
+
+    def __init__(self, store):
+        self._store = store
+        self.get_events_calls = 0
+
+    def get_events(self, agent, since_event_id=None):
+        self.get_events_calls += 1
+        return self._store.get_events(agent, since_event_id=since_event_id)
+
+    def __getattr__(self, name):
+        return getattr(self._store, name)
+
+
 # ── _create_io_modules ────────────────────────────────────────────
 
 
@@ -359,6 +379,52 @@ class TestRestoreTurnBranchState:
             assert agent._turn_index == 0
             assert agent._branch_id == 0
             assert agent._parent_branch_path == []
+        finally:
+            store.close()
+
+    def test_accepts_preloaded_events_without_reread(self, tmp_path):
+        # The caller's single raw read must serve the restore entirely:
+        # branch state comes from the passed list with zero store reads.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            for ti in (1, 2, 3):
+                store.append_event(
+                    "alice", "user_message", {}, turn_index=ti, branch_id=1
+                )
+            store.flush()
+            events = store.get_events("alice")
+            counting = _CountingStore(store)
+            agent = _FakeAgent()
+            _restore_turn_branch_state(agent, counting, "alice", events=events)
+            assert agent._turn_index == 3
+            assert agent._parent_branch_path == [(1, 1), (2, 1)]
+            assert counting.get_events_calls == 0
+        finally:
+            store.close()
+
+    def test_preloaded_truncated_events_select_truncated_tail(self, tmp_path):
+        # Negative case proving the helper consumes the caller's list: a
+        # list missing the later turns must restore THAT state (turn 1),
+        # not the store's real latest turn (3). A hidden re-read would
+        # restore turn 3 and fail here.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            for ti in (1, 2, 3):
+                store.append_event(
+                    "alice",
+                    "user_message",
+                    {"content": f"t{ti}"},
+                    turn_index=ti,
+                    branch_id=1,
+                )
+            store.flush()
+            truncated = store.get_events("alice")[:1]
+            counting = _CountingStore(store)
+            agent = _FakeAgent()
+            _restore_turn_branch_state(agent, counting, "alice", events=truncated)
+            assert agent._turn_index == 1
+            assert agent._branch_id == 1
+            assert counting.get_events_calls == 0
         finally:
             store.close()
 
@@ -698,6 +764,150 @@ class TestLoadConversationFallback:
             assert out[0]["metadata"]["turn_index"] == 1
         finally:
             store.close()
+
+    def test_fresh_snapshot_fast_path_skips_event_scan(self, tmp_path):
+        # A snapshot covering every persisted event (verified through the
+        # O(1) persisted counter, never under-reporting the table) must be
+        # returned WITHOUT scanning the event table — the scan just to
+        # compute last_event_id is what made large-session resume crawl.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            _, eid = store.append_event(
+                "alice",
+                "user_message",
+                {"content": "x"},
+                turn_index=1,
+                branch_id=1,
+            )
+            store.save_conversation(
+                "alice",
+                [
+                    {
+                        "role": "user",
+                        "content": "snap",
+                        "metadata": {"turn_index": 1, "branch_id": 1},
+                    }
+                ],
+            )
+            store.state["alice:snapshot_event_id"] = eid
+            store.flush()
+            counting = _CountingStore(store)
+            out = _load_conversation_with_replay_fallback(counting, "alice")
+            assert out[0]["content"] == "snap"
+            assert out[0]["metadata"]["turn_index"] == 1
+            assert counting.get_events_calls == 0
+        finally:
+            store.close()
+
+    def test_fast_path_still_replays_when_watermark_stale(self, tmp_path):
+        # Guard against the fast path over-triggering: when the watermark
+        # is behind the persisted counter, the tail MUST still be appended.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event("alice", "user_message", {"content": "fresh"})
+            store.save_conversation(
+                "alice",
+                [
+                    {
+                        "role": "user",
+                        "content": "snap",
+                        "metadata": {"turn_index": 1, "branch_id": 1},
+                    }
+                ],
+            )
+            store.state["alice:snapshot_event_id"] = 0
+            store.flush()
+            counting = _CountingStore(store)
+            out = _load_conversation_with_replay_fallback(counting, "alice")
+            contents = [m["content"] for m in out if m["role"] == "user"]
+            assert contents == ["snap", "fresh"]
+            assert counting.get_events_calls == 1
+        finally:
+            store.close()
+
+    def test_preloaded_events_drive_replay_without_reread(self, tmp_path):
+        # Passing the caller's single raw read must serve the tail replay
+        # AND skip the helper's own store read entirely.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event("alice", "user_message", {"content": "fresh"})
+            store.append_event("alice", "user_message", {"content": "newer"})
+            store.save_conversation("alice", [{"role": "user", "content": "stale"}])
+            store.state["alice:snapshot_event_id"] = 1
+            store.flush()
+            events = store.get_events("alice")
+            counting = _CountingStore(store)
+            out = _load_conversation_with_replay_fallback(
+                counting, "alice", events=events
+            )
+            contents = [m["content"] for m in out if m["role"] == "user"]
+            assert contents == ["stale", "newer"]
+            assert counting.get_events_calls == 0
+        finally:
+            store.close()
+
+    def test_preloaded_truncated_events_prove_data_source(self, tmp_path):
+        # Negative case: a truncated caller list must produce the truncated
+        # result ("newer" dropped with the cut). An implementation that
+        # ignores the passed list and quietly re-reads the store would
+        # resurrect the tail and fail here.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event("alice", "user_message", {"content": "fresh"})
+            store.append_event("alice", "user_message", {"content": "newer"})
+            store.save_conversation("alice", [{"role": "user", "content": "stale"}])
+            store.state["alice:snapshot_event_id"] = 0
+            store.flush()
+            truncated = store.get_events("alice")[:1]
+            counting = _CountingStore(store)
+            out = _load_conversation_with_replay_fallback(
+                counting, "alice", events=truncated
+            )
+            contents = [m["content"] for m in out if m["role"] == "user"]
+            assert contents == ["stale", "fresh"]
+            assert "newer" not in contents
+            assert counting.get_events_calls == 0
+        finally:
+            store.close()
+
+    def test_legacy_store_without_counter_slot_keeps_tail(self, tmp_path):
+        # Old session files carry no counters:max_event_id slot. The reopen
+        # fallback must full-scan the values (returning the true max, never
+        # a silent 0), so the fast path cannot misfire on legacy files: the
+        # stale watermark still triggers the tail replay.
+        from kohakuvault import KVault
+
+        path = tmp_path / "legacy.kohakutr"
+        store = SessionStore(str(path))
+        store.append_event(
+            "alice",
+            "user_message",
+            {"content": "old"},
+            turn_index=1,
+            branch_id=1,
+        )
+        store.close()
+        state = KVault(str(path), table="state")
+        try:
+            state.delete("counters:max_event_id")
+        finally:
+            state.close()
+
+        reopened = SessionStore(str(path))
+        try:
+            # Scanned fallback reports the true max, not 0.
+            assert reopened.max_event_id("alice") == 1
+            reopened.save_conversation("alice", [{"role": "user", "content": "snap"}])
+            reopened.state["alice:snapshot_event_id"] = 0
+            reopened.flush()
+            counting = _CountingStore(reopened)
+            out = _load_conversation_with_replay_fallback(counting, "alice")
+            contents = [m["content"] for m in out if m["role"] == "user"]
+            assert contents == ["snap", "old"]
+            # Legacy file: counter absent → no fast path → exactly one read.
+            assert counting.get_events_calls == 1
+        finally:
+            reopened.close(update_status=False)
 
 
 # ── detect_session_type ──────────────────────────────────────────
@@ -1575,6 +1785,205 @@ class TestInjectSavedState:
                 if m.role == "user"
             ]
             assert contents == ["U1", "U2a"]
+        finally:
+            store.close()
+
+    def test_event_table_scanned_once_tail_path(self, tmp_path):
+        # Scan-budget regression guard: conversation replay, branch
+        # restore, and pending resume events must share ONE raw read of
+        # the event table (previously three full scans on resume).
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event("alice", "user_message", {"content": "q"})
+            store.save_conversation("alice", [{"role": "user", "content": "q"}])
+            store.state["alice:snapshot_event_id"] = 1
+            store.append_event("alice", "user_message", {"content": "newer"})
+            store.flush()
+            counting = _CountingStore(store)
+            agent = _FakeAgentForInject()
+            inject_saved_state(agent, counting, "alice")
+            contents = [
+                m.get("content")
+                for m in agent.controller.conversation.to_messages()
+                if m.get("role") == "user"
+            ]
+            assert contents == ["q", "newer"]
+            assert counting.get_events_calls == 1
+        finally:
+            store.close()
+
+    def test_event_table_scanned_once_fresh_snapshot(self, tmp_path):
+        # The fresh-snapshot conversation path needs no event read of its
+        # own; the single remaining read feeds branch restore + pending
+        # resume events (which cannot be derived without the log).
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            _, eid = store.append_event(
+                "alice",
+                "user_message",
+                {"content": "q"},
+                turn_index=1,
+                branch_id=1,
+            )
+            store.save_conversation(
+                "alice",
+                [
+                    {
+                        "role": "user",
+                        "content": "snap",
+                        "metadata": {"turn_index": 1, "branch_id": 1},
+                    }
+                ],
+            )
+            store.state["alice:snapshot_event_id"] = eid
+            store.flush()
+            counting = _CountingStore(store)
+            agent = _FakeAgentForInject()
+            inject_saved_state(agent, counting, "alice")
+            contents = [
+                m.get("content")
+                for m in agent.controller.conversation.to_messages()
+                if m.get("role") == "user"
+            ]
+            assert contents == ["snap"]
+            assert counting.get_events_calls == 1
+        finally:
+            store.close()
+
+    def test_event_table_scanned_once_fork_tail(self, tmp_path):
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event(
+                "alice",
+                "user_message",
+                {"content": "original"},
+                turn_index=1,
+                branch_id=1,
+            )
+            store.save_conversation("alice", [{"role": "user", "content": "original"}])
+            store.state["alice:snapshot_event_id"] = 1
+            store.append_event(
+                "alice",
+                "user_message",
+                {"content": "edited"},
+                turn_index=1,
+                branch_id=2,
+            )
+            store.flush()
+            counting = _CountingStore(store)
+            agent = _FakeAgentForInject()
+            inject_saved_state(agent, counting, "alice")
+            contents = [
+                m.get("content")
+                for m in agent.controller.conversation.to_messages()
+                if m.get("role") == "user"
+            ]
+            assert contents == ["edited"]
+            assert counting.get_events_calls == 1
+        finally:
+            store.close()
+
+    def test_event_table_scanned_once_branch_mismatch_replay(self, tmp_path):
+        # Snapshot tagged on a sibling branch: the mismatch rebuild must
+        # reuse the same single raw read (the mismatch replay used to be
+        # an additional full scan).
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event(
+                "alice",
+                "user_message",
+                {"content": "a1"},
+                turn_index=1,
+                branch_id=1,
+            )
+            store.append_event(
+                "alice",
+                "user_message",
+                {"content": "a2"},
+                turn_index=2,
+                branch_id=1,
+                parent_branch_path=[(1, 1)],
+            )
+            store.save_conversation("alice", [{"role": "user", "content": "stale"}])
+            store.state["alice:snapshot_event_id"] = 2
+            store.state["alice:snapshot_branch"] = {
+                "turn_index": 2,
+                "branch_id": 1,
+                "parent_branch_path": [(1, 1)],
+            }
+            # The agent lands on a SIBLING of the snapshot branch.
+            store.append_event(
+                "alice",
+                "user_message",
+                {"content": "b1"},
+                turn_index=1,
+                branch_id=2,
+            )
+            store.flush()
+            counting = _CountingStore(store)
+            agent = _FakeAgentForInject()
+            inject_saved_state(agent, counting, "alice")
+            contents = [
+                m.get("content")
+                for m in agent.controller.conversation.to_messages()
+                if m.get("role") == "user"
+            ]
+            assert "b1" in contents
+            assert "a2" not in contents
+            assert counting.get_events_calls == 1
+        finally:
+            store.close()
+
+    def test_pending_resume_events_match_store_public_api(self, tmp_path):
+        # The inlined dedupe+normalize must stay byte-identical to the
+        # untouched public SessionStore.get_resumable_events — an
+        # independent oracle computed straight from the store.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event("alice", "user_message", {"content": "q"})
+            store.append_event("alice", "tool_call", {"call_id": "c9", "name": "bash"})
+            store.flush()
+            agent = _FakeAgentForInject()
+            inject_saved_state(agent, store, "alice")
+            assert agent._pending_resume_events == store.get_resumable_events("alice")
+        finally:
+            store.close()
+
+    def test_inject_matches_self_reading_helpers(self, tmp_path):
+        # The single-read path (inject passing one shared list) and the
+        # backward-compatible self-reading helpers must produce identical
+        # conversation and branch state for the same store.
+        store = SessionStore(str(tmp_path / "x.kohakutr"))
+        try:
+            store.append_event(
+                "alice",
+                "user_message",
+                {"content": "U1"},
+                turn_index=1,
+                branch_id=1,
+            )
+            store.save_conversation("alice", [{"role": "user", "content": "U1"}])
+            store.state["alice:snapshot_event_id"] = 1
+            store.append_event(
+                "alice",
+                "user_message",
+                {"content": "U2"},
+                turn_index=2,
+                branch_id=1,
+                parent_branch_path=[(1, 1)],
+            )
+            store.append_event("alice", "tool_call", {"call_id": "cx", "name": "bash"})
+            store.flush()
+            agent = _FakeAgentForInject()
+            inject_saved_state(agent, store, "alice")
+            rebuilt = agent.controller.conversation.to_messages()
+            via_helper = _load_conversation_with_replay_fallback(store, "alice")
+            assert rebuilt == _build_conversation(via_helper).to_messages()
+            branch_agent = _FakeAgent()
+            _restore_turn_branch_state(branch_agent, store, "alice")
+            assert agent._turn_index == branch_agent._turn_index
+            assert agent._branch_id == branch_agent._branch_id
+            assert agent._parent_branch_path == branch_agent._parent_branch_path
         finally:
             store.close()
 

--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -70,6 +70,32 @@ def test_max_event_id_matches_full_scan(tmp_path):
         store.close()
 
 
+def test_max_event_id_survives_legacy_missing_counter_slot(tmp_path):
+    # Old session files carry no counters:max_event_id. The reopen
+    # fallback must full-scan event VALUES and report the true max — a
+    # silent 0 would let the resume fast path skip a stale tail.
+    from kohakuvault import KVault
+
+    path = tmp_path / "legacy.kohakutr"
+    store = SessionStore(str(path))
+    store.append_event("a", "text", {"content": "one"})
+    store.append_event("a", "text", {"content": "two"})
+    store.close()
+    state = KVault(str(path), table="state")
+    try:
+        state.delete("counters:max_event_id")
+    finally:
+        state.close()
+
+    reopened = SessionStore(str(path))
+    try:
+        expected = max(e["event_id"] for e in reopened.get_events("a"))
+        assert expected == 2
+        assert reopened.max_event_id("a") == 2
+    finally:
+        reopened.close()
+
+
 def test_append_persists_event_counter_for_reopen(tmp_path):
     path = tmp_path / "sess.kohakutr"
     store = SessionStore(str(path))


### PR DESCRIPTION
## Summary

Resume no longer re-reads the full session event table 3-4 times: `inject_saved_state` reads raw events once and shares them across every consumer. Behavior is byte-for-byte equivalent; for a 75k-event session this removes roughly two thirds of the resume read cost and brings dashboard resumes back under the 30 s client timeout.

A follow-up commit also **removes** an earlier draft's counter-based "fresh-snapshot, zero-scan" shortcut: review found the persisted event counter is not an upper bound of the event table (`append_event` flushes the cache before `persist_event_counter`, which swallows failures), so relying on it could silently skip tail replay after a crash. The main resume flow never used that shortcut, so removing it costs nothing in production.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [x] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Web-dashboard resume of a large (331 MB, 75,474-event) session consistently takes 34-37 s server-side while the dashboard client aborts at 30 s (`timeout: 30000`), so every resume surfaces as a timeout error even though it completes moments later (#294). The dominant cost is `inject_saved_state` (`session/resume.py`), which performs 3-4 full `get_events` scans: one inside `_load_conversation_with_replay_fallback` even on the fresh-snapshot fast path (only to compute `last_event_id`), one in `_restore_turn_branch_state`, and one through `get_resumable_events`. Scan cost scales linearly with event count (warm-cache full scan: 4.4-8.4 s on this session).

## Changes

- `session/resume.py`: `inject_saved_state` reads raw events once and passes them via optional parameters to `_load_conversation_with_replay_fallback` / `_restore_turn_branch_state` (signatures backward compatible); pending resume events are computed from the same list via the same `dedupe_adjacent_duplicate_events` + `normalize_resumable_events` pipeline instead of a second store read. `SessionStore.get_resumable_events` public behavior is unchanged.
- `session/resume_branch.py`: `replayed_messages_for` accepts pre-read events; no counter-based freshness shortcut exists — `_load_conversation_with_replay_fallback` deliberately reads the event table (or takes the caller's shared read) because the persisted counter can lag the event table by any amount and must not be trusted as an upper bound. The full rationale (append_event flush/persist ordering) is documented in the function docstring.
- All snapshot / tail-replay / branch-fork / backfill decisions are untouched; only the data source is shared.
- Tests: read-count assertions (counting proxy on the inner store's `get_events`, including reads hidden behind `get_resumable_events`) prove exactly 1 scan on tail/fresh/fork/mismatch paths (previously 3-4); a lagging-counter negative test proves a tail is replayed even when the persisted counter is stale; equivalence oracles assert identical conversation, branch state, and pending resume events before/after on synthetic stores and on the real 75,474-event session.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
pytest tests/unit/test_file_sizes.py -q
pytest tests/integration/ -q
```

Read-only timing on the real 331 MB / 75,474-event session (warm cache): the three full `get_events` passes cost 4.50 + 5.06 + 4.58 ≈ 14.1 s; the new single-scan path costs 4.49 s scan + 2.09 s in-memory dedupe + 0.16 s normalize ≈ 6.7 s (~2.1x on the scan segment, which dominates the 34-37 s dashboard resume).

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow (internal read-pattern change only; no API or doc contract touched)
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/` (no frontend files changed)
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #294

## Notes for Reviewers

- Equivalence was pinned by two oracles: (1) pending events after inject == untouched `store.get_resumable_events()`; (2) restored conversation/branch state == self-read helpers, compared byte-for-byte via `to_messages()`.
- The only observable difference found during diff audit is events-table cache flush ordering (the single read happens earlier); the conversation table has no cache, so nothing else observes it.
- The zero-scan shortcut was dropped after review (see Summary); the commit that removed it carries the full evidence chain.

## Exceptions / Not Run

- Local `pytest tests/unit/` shows 6 failures, all in `tests/unit/packages/test_git_backend_dulwich_integration.py`; they reproduce on a clean checkout of this machine without the patch (dulwich/Windows refs environment issue). The remaining 12,900 unit tests and all 175 integration tests pass.
- `pytest tests/e2e/` was not run (session-layer read pattern only; no multi-node / Studio / serving surface touched).
