### PR TITLE
perf(api): page session history responses (limit/before cursors) for saved and live surfaces

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.pagedScroll.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.pagedScroll.test.js
@@ -1,0 +1,213 @@
+import { flushPromises, mount } from "@vue/test-utils"
+import { createPinia, setActivePinia } from "pinia"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import ChatPanel from "./ChatPanel.vue"
+import { useChatStore } from "@/stores/chat"
+
+const mountedWrappers = new Set()
+
+function mountChatPanel(options) {
+  const wrapper = mount(ChatPanel, options)
+  mountedWrappers.add(wrapper)
+  return wrapper
+}
+
+let frames = new Map()
+let nextFrameId = 1
+
+beforeEach(() => {
+  const values = new Map()
+  vi.stubGlobal("localStorage", {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+  })
+  nextFrameId = 1
+  frames = new Map()
+  vi.stubGlobal("requestAnimationFrame", (callback) => {
+    const id = nextFrameId++
+    frames.set(id, callback)
+    return id
+  })
+  vi.stubGlobal("cancelAnimationFrame", (id) => frames.delete(id))
+  setActivePinia(createPinia())
+})
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers) {
+    if (wrapper.exists()) wrapper.unmount()
+  }
+  mountedWrappers.clear()
+  vi.unstubAllGlobals()
+})
+
+function runScrollFrames() {
+  const pending = [...frames.values()]
+  frames.clear()
+  for (const frame of pending) frame()
+}
+
+// Live tab driven by server-side history paging: the store holds one
+// bounded page (historyPagingByTab.hasMore) and older pages arrive via
+// ``loadOlderLiveHistory``. The pre-paging scroll contract must survive:
+// scrolling up auto-loads the next page, scrolling back to the bottom
+// narrows the render window back to the live tail.
+describe("ChatPanel paged live history scrolling", () => {
+  const PAGE = 120
+
+  function seedFirstPage(chat) {
+    chat._instanceId = "graph_1"
+    chat._instanceGraphId = "graph_1"
+    if (!chat.activeTab) chat.activeTab = "kohaku"
+    if (!chat.tabs.length) chat.tabs = ["kohaku"]
+    chat.commandInventoryByTab = { kohaku: { commands: [], skills: [] } }
+    chat._commandInventoryFetchedAtByTab = { kohaku: Date.now() }
+    chat.messagesByTab = {
+      kohaku: Array.from({ length: PAGE }, (_, i) => ({
+        id: `m_${i}`,
+        role: i % 2 ? "assistant" : "user",
+        content: `message ${i}`,
+      })),
+    }
+    chat.historyPagingByTab = {
+      kohaku: { hasMore: true, oldestEventId: PAGE, total: 1000 },
+    }
+  }
+
+  function mountPanel(chat) {
+    return mountChatPanel({
+      props: {
+        instance: {
+          id: "graph_1",
+          graph_id: "graph_1",
+          creatures: [{ name: "kohaku", status: "idle" }],
+        },
+      },
+      global: {
+        provide: { chatStore: chat },
+        stubs: {
+          ChatMessage: {
+            props: ["message"],
+            template: '<div class="chat-message-stub">{{ message?.id }}</div>',
+          },
+          ModelSwitcher: true,
+          SiteChip: true,
+          StatusDot: true,
+        },
+      },
+    })
+  }
+
+  function spyLoadOlder(chat, { pages = Infinity } = {}) {
+    const calls = []
+    chat.loadOlderLiveHistory = async (tab) => {
+      calls.push(tab)
+      const current = chat.messagesByTab[tab]
+      const firstSeq = Number(current[0].id.replace("m_", "")) || 0
+      const prepended = Array.from({ length: PAGE }, (_, i) => ({
+        id: `m_${firstSeq - PAGE + i}`,
+        role: "user",
+        content: `message ${firstSeq - PAGE + i}`,
+      }))
+      chat.messagesByTab[tab] = [...prepended, ...current]
+      chat.historyPagingByTab[tab] = {
+        ...chat.historyPagingByTab[tab],
+        hasMore: calls.length < pages,
+        oldestEventId: (chat.historyPagingByTab[tab].oldestEventId ?? 0) - PAGE,
+      }
+      return calls.length < pages
+    }
+    return calls
+  }
+
+  function renderedIds(wrapper) {
+    return wrapper.findAll(".chat-message-stub").map((el) => el.text())
+  }
+
+  function stubGeometry(wrapper, { scrollHeight = 10000, clientHeight = 200 } = {}) {
+    const viewport = wrapper.find(".chat-messages-viewport").element
+    Object.defineProperty(viewport, "scrollHeight", {
+      configurable: true,
+      value: scrollHeight,
+    })
+    Object.defineProperty(viewport, "clientHeight", {
+      configurable: true,
+      value: clientHeight,
+    })
+    return viewport
+  }
+
+  function scrollViewport(viewport, scrollTop) {
+    viewport.scrollTop = scrollTop
+    viewport.dispatchEvent(new Event("scroll"))
+    runScrollFrames()
+  }
+
+  it("auto-fetches the next page when scrolled to the top of the loaded log", async () => {
+    const chat = useChatStore("graph_1")
+    seedFirstPage(chat)
+    const calls = spyLoadOlder(chat)
+    const wrapper = mountPanel(chat)
+    await flushPromises()
+    const viewport = stubGeometry(wrapper)
+
+    scrollViewport(viewport, 9800)
+    scrollViewport(viewport, 0)
+    await flushPromises()
+
+    expect(calls.length).toBe(1)
+    // The freshly prepended page must be RENDERED, not just in the store.
+    expect(renderedIds(wrapper)[0]).toBe("m_-120")
+    expect(renderedIds(wrapper).length).toBe(2 * PAGE)
+    wrapper.unmount()
+  })
+
+  it("keeps auto-fetching while the reader keeps scrolling up", async () => {
+    const chat = useChatStore("graph_1")
+    seedFirstPage(chat)
+    const calls = spyLoadOlder(chat)
+    const wrapper = mountPanel(chat)
+    await flushPromises()
+    const viewport = stubGeometry(wrapper)
+
+    scrollViewport(viewport, 9800)
+    scrollViewport(viewport, 0)
+    await flushPromises()
+    scrollViewport(viewport, 0)
+    await flushPromises()
+
+    // The reader is still pinned at the top of the log; the next older
+    // page must load automatically instead of requiring the button.
+    expect(calls.length).toBe(2)
+    expect(renderedIds(wrapper).length).toBe(3 * PAGE)
+    wrapper.unmount()
+  })
+
+  it("narrows the render window back to the tail when scrolling to the bottom", async () => {
+    const chat = useChatStore("graph_1")
+    seedFirstPage(chat)
+    const calls = spyLoadOlder(chat, { pages: 2 })
+    const wrapper = mountPanel(chat)
+    await flushPromises()
+    const viewport = stubGeometry(wrapper, { scrollHeight: 40000 })
+
+    scrollViewport(viewport, 39800)
+    scrollViewport(viewport, 0)
+    await flushPromises()
+    scrollViewport(viewport, 0)
+    await flushPromises()
+    const expandedCount = renderedIds(wrapper).length
+    expect(expandedCount).toBe(3 * PAGE)
+
+    // Scroll back to the bottom: history mode must close and the render
+    // window must narrow back to the live tail.
+    scrollViewport(viewport, 40000)
+    await flushPromises()
+
+    const narrowedCount = renderedIds(wrapper).length
+    expect(narrowedCount).toBeLessThan(expandedCount)
+    expect(narrowedCount).toBeLessThanOrEqual(200)
+    wrapper.unmount()
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.pagedScroll.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.pagedScroll.test.js
@@ -125,11 +125,15 @@ describe("ChatPanel paged live history scrolling", () => {
     return wrapper.findAll(".chat-message-stub").map((el) => el.text())
   }
 
-  function stubGeometry(wrapper, { scrollHeight = 10000, clientHeight = 200 } = {}) {
+  function stubGeometry(wrapper, { clientHeight = 200 } = {}) {
     const viewport = wrapper.find(".chat-messages-viewport").element
+    // Track the rendered row count so scrollHeight moves like a real
+    // scrollbar would: narrowing the window must visibly shrink it.
     Object.defineProperty(viewport, "scrollHeight", {
       configurable: true,
-      value: scrollHeight,
+      get() {
+        return wrapper.findAll(".chat-message-stub").length * 30
+      },
     })
     Object.defineProperty(viewport, "clientHeight", {
       configurable: true,
@@ -190,24 +194,27 @@ describe("ChatPanel paged live history scrolling", () => {
     const calls = spyLoadOlder(chat, { pages: 2 })
     const wrapper = mountPanel(chat)
     await flushPromises()
-    const viewport = stubGeometry(wrapper, { scrollHeight: 40000 })
+    const viewport = stubGeometry(wrapper)
 
-    scrollViewport(viewport, 39800)
+    scrollViewport(viewport, 9800)
     scrollViewport(viewport, 0)
     await flushPromises()
     scrollViewport(viewport, 0)
     await flushPromises()
     const expandedCount = renderedIds(wrapper).length
+    const expandedHeight = viewport.scrollHeight
     expect(expandedCount).toBe(3 * PAGE)
 
     // Scroll back to the bottom: history mode must close and the render
-    // window must narrow back to the live tail.
+    // window must narrow back to the live tail. The scrollbar-visible
+    // signal is the scrollHeight drop.
     scrollViewport(viewport, 40000)
     await flushPromises()
 
     const narrowedCount = renderedIds(wrapper).length
     expect(narrowedCount).toBeLessThan(expandedCount)
     expect(narrowedCount).toBeLessThanOrEqual(200)
+    expect(viewport.scrollHeight).toBeLessThan(expandedHeight * 0.75)
     wrapper.unmount()
   })
 })

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -206,7 +206,7 @@ import { inject } from "vue"
 import StatusDot from "@/components/common/StatusDot.vue"
 import ChatMessage from "@/components/chat/ChatMessage.vue"
 import { useChatRenderWindow, CHAT_RENDER_EXPAND_MESSAGE_LIMIT, CHAT_RENDER_EXPAND_UNIT_BUDGET } from "@/components/chat/chatRenderWindow"
-import { createChatHistoryExpander, captureViewportAnchor, restoreViewportAnchor } from "@/components/chat/chatHistoryExpand"
+import { CHAT_AUTO_EXPAND_TOP_PX, createChatHistoryExpander, captureViewportAnchor, restoreViewportAnchor } from "@/components/chat/chatHistoryExpand"
 import { createChatScrollScheduler } from "@/components/chat/chatScrollScheduler"
 import SlashCommandMenu from "@/components/chat/SlashCommandMenu.vue"
 import ModelSwitcher from "@/components/chrome/ModelSwitcher.vue"
@@ -279,10 +279,13 @@ async function loadOlderLive() {
   if (!tab || loadingOlder.value) return
   loadingOlder.value = true
   // A prepended page rebuilds the transcript; keep the viewport anchored on
-  // the rows the reader was looking at (same contract as expandHistory).
+  // the rows the reader was looking at (same contract as expandHistory), and
+  // re-anchor the render window at the oldest loaded row so the freshly
+  // fetched page is actually inside the rendered range.
   const anchor = captureViewportAnchor(() => messagesEl.value)
   try {
     await chat.loadOlderLiveHistory(tab)
+    if (viewMessages.value.length) enterHistoryAt(0)
     await nextTick()
     restoreViewportAnchor(() => messagesEl.value, anchor)
   } catch (err) {
@@ -644,11 +647,11 @@ function onMessagesScroll() {
     } else if (el) {
       historyExpander.maybeExpandAtTop(el.scrollTop)
     }
-    // The render window expands over already-loaded messages only. Once it
-    // reaches the first loaded row, further up-scroll must come from the
-    // server — mirror the window auto-expansion with a persisted-page fetch
-    // so scrolling up keeps loading (the button remains as a manual entry).
-    if (el && !isNearBottom.value && windowStart.value === 0 && canLoadOlderLive.value) {
+    // The render window expands over already-loaded messages only; once
+    // the reader is near the very top of the loaded log, further up-scroll
+    // must come from the server — mirror the window auto-expansion with a
+    // persisted-page fetch (the button remains as a manual entry).
+    if (el && !isNearBottom.value && el.scrollTop <= CHAT_AUTO_EXPAND_TOP_PX && canLoadOlderLive.value) {
       loadOlderLive()
     }
     saveScrollPosition()

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -278,8 +278,13 @@ async function loadOlderLive() {
   const tab = viewActiveTab.value
   if (!tab || loadingOlder.value) return
   loadingOlder.value = true
+  // A prepended page rebuilds the transcript; keep the viewport anchored on
+  // the rows the reader was looking at (same contract as expandHistory).
+  const anchor = captureViewportAnchor(() => messagesEl.value)
   try {
     await chat.loadOlderLiveHistory(tab)
+    await nextTick()
+    restoreViewportAnchor(() => messagesEl.value, anchor)
   } catch (err) {
     console.warn("Failed to load older history:", err)
   } finally {
@@ -638,6 +643,13 @@ function onMessagesScroll() {
       scrollScheduler.resume()
     } else if (el) {
       historyExpander.maybeExpandAtTop(el.scrollTop)
+    }
+    // The render window expands over already-loaded messages only. Once it
+    // reaches the first loaded row, further up-scroll must come from the
+    // server — mirror the window auto-expansion with a persisted-page fetch
+    // so scrolling up keeps loading (the button remains as a manual entry).
+    if (el && !isNearBottom.value && windowStart.value === 0 && canLoadOlderLive.value) {
+      loadOlderLive()
     }
     saveScrollPosition()
   })

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -78,6 +78,17 @@
               <p class="text-warm-300 dark:text-warm-600 text-xs mt-1">{{ resolvedEmptySubtitle }}</p>
             </div>
           </template>
+          <!-- Server-side paging entry (live tabs): the store records
+               ``historyPagingByTab`` when the attach/tab-switch resync
+               fetched the bounded newest page. Mirrors the saved
+               viewer's "Load earlier messages" affordance. The button
+               below it only expands the CLIENT render window over
+               already-loaded messages; this one fetches the next-older
+               persisted page. -->
+          <button v-if="canLoadOlderLive" class="self-center text-xs flex items-center gap-1 text-iolite dark:text-iolite-light hover:underline disabled:opacity-50" :disabled="loadingOlder" @click="loadOlderLive">
+            <span class="i-carbon-chevron-up" />
+            {{ loadingOlder ? t("chat.loadEarlierLoading") : t("chat.loadEarlier") }}
+          </button>
           <button v-if="windowStart > 0" class="self-center text-xs text-iolite dark:text-iolite-light hover:underline" @click="loadEarlierMessages">
             {{ t("chat.showEarlier", { count: windowStart }) }}
           </button>
@@ -253,6 +264,28 @@ const viewProcessing = computed(() => {
   const t = viewActiveTab.value
   return t ? !!chat.processingByTab[t] : false
 })
+// Server-side history paging ("load earlier") for LIVE tabs. The store's
+// ``historyPagingByTab`` records the bounded newest page fetched by the
+// attach/tab-switch resync; saved-session tabs already have their own
+// entry in SessionHistoryViewer, so this button is live-mode only.
+const loadingOlder = ref(false)
+const activePaging = computed(() => {
+  const t = viewActiveTab.value
+  return t ? chat.historyPagingByTab[t] : null
+})
+const canLoadOlderLive = computed(() => !props.readOnly && !!activePaging.value?.hasMore && !viewProcessing.value)
+async function loadOlderLive() {
+  const tab = viewActiveTab.value
+  if (!tab || loadingOlder.value) return
+  loadingOlder.value = true
+  try {
+    await chat.loadOlderLiveHistory(tab)
+  } catch (err) {
+    console.warn("Failed to load older history:", err)
+  } finally {
+    loadingOlder.value = false
+  }
+}
 const viewModelInfo = computed(() => {
   const t = viewActiveTab.value
   const info = (t && chat.modelByTab[t]) || {}

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -274,6 +274,24 @@ const activePaging = computed(() => {
   return t ? chat.historyPagingByTab[t] : null
 })
 const canLoadOlderLive = computed(() => !props.readOnly && !!activePaging.value?.hasMore && !viewProcessing.value)
+// Mirrors the render window's idle lookahead for persisted pages: after a
+// fetch, keep at most one page ahead of the reader while they stay within
+// roughly a viewport of the top of the loaded log, so upward scrolling
+// never hits an unloaded wall. The condition drops out once a prepend has
+// pushed the reading position away from the top, so this never chains
+// through the whole history on its own.
+let pagedPrefetchTimer = null
+function schedulePagedPrefetch() {
+  if (!canLoadOlderLive.value || pagedPrefetchTimer !== null) return
+  pagedPrefetchTimer = setTimeout(() => {
+    pagedPrefetchTimer = null
+    const el = messagesEl.value
+    if (!el || loadingOlder.value || !canLoadOlderLive.value) return
+    if (el.scrollTop > el.clientHeight) return
+    loadOlderLive()
+  }, 250)
+}
+
 async function loadOlderLive() {
   const tab = viewActiveTab.value
   if (!tab || loadingOlder.value) return
@@ -288,6 +306,7 @@ async function loadOlderLive() {
     if (viewMessages.value.length) enterHistoryAt(0)
     await nextTick()
     restoreViewportAnchor(() => messagesEl.value, anchor)
+    schedulePagedPrefetch()
   } catch (err) {
     console.warn("Failed to load older history:", err)
   } finally {
@@ -653,6 +672,11 @@ function onMessagesScroll() {
     // persisted-page fetch (the button remains as a manual entry).
     if (el && !isNearBottom.value && el.scrollTop <= CHAT_AUTO_EXPAND_TOP_PX && canLoadOlderLive.value) {
       loadOlderLive()
+    } else if (el && !isNearBottom.value && el.scrollTop <= el.clientHeight) {
+      // Idle lookahead: arm a persisted-page prefetch one viewport before
+      // the wall so upward scrolling stays seamless (mirrors the render
+      // window's scheduleIdleExpand).
+      schedulePagedPrefetch()
     }
     saveScrollPosition()
   })

--- a/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
@@ -48,8 +48,14 @@
             <div class="text-secondary text-xs mb-4">{{ error }}</div>
             <button class="btn-secondary" @click="loadSession">Retry</button>
           </div>
-          <div v-else class="h-full min-h-0 overflow-hidden">
-            <ChatPanel :instance="viewerInstance" :read-only="true" empty-title="No saved messages" empty-subtitle="This target has no persisted history yet" />
+          <div v-else class="h-full min-h-0 flex flex-col gap-2 overflow-hidden">
+            <div v-if="canLoadOlder" class="shrink-0 flex justify-center">
+              <button class="btn-secondary text-xs" :disabled="loadingOlder" @click="loadOlder">
+                <span class="i-carbon-chevron-up mr-1" />
+                {{ loadingOlder ? "Loading..." : "Load earlier messages" }}
+              </button>
+            </div>
+            <ChatPanel class="flex-1 min-h-0" :instance="viewerInstance" :read-only="true" empty-title="No saved messages" empty-subtitle="This target has no persisted history yet" />
           </div>
         </div>
       </div>
@@ -60,7 +66,7 @@
 <script setup>
 import ChatPanel from "@/components/chat/ChatPanel.vue"
 import { useDensity } from "@/composables/useDensity"
-import { useChatStore, _convertHistory, _replayEvents } from "@/stores/chat"
+import { useChatStore } from "@/stores/chat"
 import { useSessionDetailStore } from "@/stores/sessionDetail"
 import { sessionAPI } from "@/utils/api"
 import { extractReasoning } from "@/utils/chatReasoning"
@@ -131,6 +137,11 @@ const historyTargets = ref([])
 const reasoningEntriesByTab = reactive({})
 const showReasoning = ref(false)
 const activeReasoningEntries = computed(() => reasoningEntriesByTab[chat.activeTab] || [])
+const loadingOlder = ref(false)
+// Pagination state lives on the chat store (``historyPagingByTab``) and
+// is maintained by ``loadHistoryPage`` / ``loadOlderHistory``.
+const activePaging = computed(() => (chat.activeTab ? chat.historyPagingByTab[chat.activeTab] : null))
+const canLoadOlder = computed(() => !!activePaging.value?.hasMore)
 
 const viewerInstance = computed(() => {
   const meta = viewerMeta.value || {}
@@ -180,8 +191,14 @@ function ensureTabs(tabs) {
 
 async function loadTarget(tab) {
   if (!tab) return
+  // Newest page through the chat store's paged loader: it applies the
+  // event replay into ``messagesByTab`` and records pagination state
+  // for the "Load earlier messages" entry. The raw payload still drives
+  // the reasoning pane (older pages omit the snapshot server-side, and
+  // the snapshot covers the whole conversation, so once is enough).
+  const data = await chat.loadHistoryPage(sessionName.value, tab)
+  if (!data) return
   const entries = []
-  const data = await sessionAPI.getHistory(sessionName.value, tab)
   for (const [messageIndex, message] of (data.messages || []).entries()) {
     // New sessions render segments inline through ChatMessage; the
     // fallback panel only serves old snapshots without ordered segments.
@@ -191,14 +208,18 @@ async function loadTarget(tab) {
     }
   }
   reasoningEntriesByTab[tab] = entries
-  if (data.events?.length) {
-    // Read-only saved history: never populate ``runningJobs`` — a frozen
-    // session has no live work, and its unfinished jobs already replay as
-    // ``interrupted`` via the backend's synthetic terminals (UXI-04).
-    const { messages } = _replayEvents(data.messages || [], data.events)
-    chat.messagesByTab[tab] = messages
-  } else {
-    chat.messagesByTab[tab] = _convertHistory(data.messages || [])
+}
+
+async function loadOlder() {
+  const tab = chat.activeTab
+  if (!tab || loadingOlder.value) return
+  loadingOlder.value = true
+  try {
+    await chat.loadOlderHistory(sessionName.value, tab)
+  } catch (err) {
+    error.value = err?.response?.data?.detail || err?.message || String(err)
+  } finally {
+    loadingOlder.value = false
   }
 }
 

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -37,6 +37,11 @@ const COMMAND_INVENTORY_TTL_MS = 30_000
 // Matches the server's default bounded page for
 // ``GET /sessions/{name}/history/{target}`` (400 events or ~4MB).
 const HISTORY_PAGE_SIZE = 400
+// Ceiling on ``before``-walk iterations during one incremental resync.
+// Beyond it the escalation to a single full fetch is cheaper than more
+// round-trips (and correctness is identical — the full log covers the
+// cursor by construction).
+const MAX_INCREMENTAL_PAGES = 50
 // A pending branch op whose expected branch never lands (e.g. the edit
 // request was lost before dispatch) must not keep the stale-history
 // guard alive forever — after this many incomplete retries the guard is
@@ -4455,15 +4460,41 @@ const _chatStoreOptions = {
         const { agentAPI } = await import("@/utils/api")
         const [sid, cid] = [this._instanceGraphId, tab]
         await agentAPI.rewindTo(sid, cid, messageIdx)
-        await this._resyncHistory(tab)
+        // Rewind TRUNCATES the log — the new max can fall below the
+        // applied watermark, which an incremental ``since_event_id``
+        // cursor cannot express (the out-of-order guard would reject
+        // the truncated snapshot as stale). Full fetch is mandatory.
+        await this._resyncHistory(tab, { full: true })
       } catch (e) {
         console.warn("Failed to rewind:", e)
       }
     },
 
-    /** Re-fetch conversation history from the backend and rebuild the
-     *  local message list. Called after edit/regenerate/rewind so the
-     *  frontend matches the backend's truncated conversation.
+    /** Re-fetch conversation history and rebuild the tab's message list.
+     *
+     *  Fetch modes (one shared apply pipeline):
+     *  - FULL (``options.full`` or a pending branch op): ``limit=0``,
+     *    the whole log. Branch completeness needs the full parent
+     *    chain; rewind truncation lowers the log max, which an
+     *    incremental cursor cannot express.
+     *    PAGE TRADEOFF: on huge sessions (75k+ events) this is again
+     *    the multi-second full build — kept deliberately, correctness
+     *    over latency. Related known cost: ``<k/N>`` branch metadata
+     *    for turns older than a bounded page only reappears after such
+     *    a full resync or enough load-older pages walked back to them.
+     *  - INITIAL (``options.initialLoad``): the server-bounded newest
+     *    page (400 events / ~4MB, server-side default). Records
+     *    ``historyPagingByTab`` so the transcript can offer "load
+     *    earlier".
+     *  - INCREMENTAL (default with a warm cache and no branch op):
+     *    ``since_event_id`` = the applied watermark, bounded page,
+     *    APPENDED to the cached log — cheaper than the old full
+     *    refetch after every turn. When more than a page landed since
+     *    the cursor the remainder is walked with ``before`` pages
+     *    (still bounded); a capped walk escalates to one FULL fetch.
+     *    Responses carrying rows at/below the cursor (older servers,
+     *    or transports that ignore the cursor) degrade to the full
+     *    snapshot REPLACE below.
      *
      *  Robustness: ALWAYS rebuild messages from whatever events the
      *  backend has at the moment of the call, even when the expected
@@ -4495,21 +4526,37 @@ const _chatStoreOptions = {
       const mutationGeneration = this._historyMutationSeqByTab[tab] || 0
       const requestedInstanceId = this._instanceId
       const preFetchMessages = options.initialLoad ? this.messagesByTab[tab] || [] : null
+      const isStale = () =>
+        requestId !== this._historyRequestSeqByTab[tab] ||
+        this._instanceId !== requestedInstanceId ||
+        this._instanceGeneration !== instanceGeneration ||
+        (this._historyMutationSeqByTab[tab] || 0) !== mutationGeneration
+      // Mode dispatch happens NOW (a branch op started mid-flight is
+      // re-read after the await below, like the original guard did).
+      const watermarkAtStart = this._appliedMaxEventIdByTab[tab]
+      const incrementalMode =
+        !options.initialLoad &&
+        !options.full &&
+        watermarkAtStart != null &&
+        Array.isArray(this.eventsByTab[tab]) &&
+        this.eventsByTab[tab].length > 0 &&
+        !this._branchResyncPendingByTab[tab]?.active
       try {
         const { terrariumAPI } = await import("@/utils/api")
         // Capture BEFORE the fetch: a tab-owned job that starts while
         // this request is in flight is newer than the history it
         // returns, so job-reconciliation must not prune it.
         const fetchedAt = Date.now()
-        const data = await terrariumAPI.getHistory(this._instanceGraphId, tab)
-        if (
-          requestId !== this._historyRequestSeqByTab[tab] ||
-          this._instanceId !== requestedInstanceId ||
-          this._instanceGeneration !== instanceGeneration ||
-          (this._historyMutationSeqByTab[tab] || 0) !== mutationGeneration
-        ) {
-          return false
-        }
+        let fetchOpts = null
+        if (options.full) fetchOpts = { limit: 0 }
+        else if (incrementalMode) fetchOpts = { sinceEventId: watermarkAtStart }
+        // Omit the options arg entirely for the unbounded default call —
+        // the server's bounded page applies either way, and the 2-arg
+        // shape is what the pre-paging callers/tests observed.
+        let data = fetchOpts
+          ? await terrariumAPI.getHistory(this._instanceGraphId, tab, fetchOpts)
+          : await terrariumAPI.getHistory(this._instanceGraphId, tab)
+        if (isStale()) return false
         if (!data?.events) {
           if (this._branchResyncPendingByTab[tab]?.active) return false
           if (Array.isArray(data?.messages)) {
@@ -4553,18 +4600,110 @@ const _chatStoreOptions = {
           return true
         }
 
+        if (incrementalMode) {
+          const watermark = watermarkAtStart
+          // Full-log truth preferred over a page maximum: advancing the
+          // since-cursor from a page-bounded value would re-fetch or
+          // skip events. The live route guarantees the FULL log's max.
+          const incomingMax =
+            typeof data?.max_event_id === "number"
+              ? data.max_event_id
+              : this._maxEventId(data?.events)
+          if (incomingMax != null && incomingMax < watermark) {
+            // Out-of-order guard: an older snapshot must not clobber.
+            return true
+          }
+          const rows = Array.isArray(data?.events) ? data.events : []
+          // A response holding rows at/below the cursor is a FULL
+          // snapshot (server ignored the cursor) — REPLACE below.
+          const isSnapshot = rows.some(
+            (evt) => typeof evt?.event_id === "number" && evt.event_id <= watermark,
+          )
+          if (!isSnapshot) {
+            let delta = rows
+            let page = data
+            let pages = 1
+            // The trim lost its head when the page lies entirely past
+            // the cursor: walk older pages (still bounded) until the
+            // cursor is covered.
+            while (
+              page?.has_more &&
+              page?.oldest_event_id != null &&
+              page.oldest_event_id > watermark &&
+              pages < MAX_INCREMENTAL_PAGES
+            ) {
+              pages += 1
+              page = await terrariumAPI.getHistory(this._instanceGraphId, tab, {
+                limit: HISTORY_PAGE_SIZE,
+                before: page.oldest_event_id,
+              })
+              if (isStale()) return false
+              delta = [...(Array.isArray(page?.events) ? page.events : []), ...delta]
+            }
+            const covered = !(
+              page?.has_more &&
+              page?.oldest_event_id != null &&
+              page.oldest_event_id > watermark
+            )
+            if (covered && !this._branchResyncPendingByTab[tab]?.active) {
+              const cached = (this.eventsByTab[tab] || []).filter((evt) => !evt?._optimistic)
+              const known = new Set(
+                cached.map((evt) => evt?.event_id).filter((id) => typeof id === "number"),
+              )
+              // ``before`` pages can straddle the cursor; rows the
+              // cache already holds (or predate the cursor) are dropped.
+              const fresh = delta.filter((evt) => {
+                if (!evt || evt._optimistic) return false
+                if (typeof evt.event_id !== "number") return true
+                return evt.event_id > watermark && !known.has(evt.event_id)
+              })
+              if (isStale()) return false
+              if (!this.branchViewByTab[tab]) this.branchViewByTab[tab] = {}
+              const prepared = _prepareReplayEvents(
+                [...cached, ...fresh],
+                this.branchViewByTab[tab],
+              )
+              this._setEvents(tab, prepared.events)
+              this._restoreTokenUsage(tab, prepared.events, true)
+              this._rebuildMessages(tab, fetchedAt, prepared)
+              const scope = scopeOfStoreId(this.$id) || "default"
+              this.attentionByTab[tab] = restoreAttentionFromHistory(
+                this.eventsByTab[tab],
+                this.attentionByTab[tab] || createAttentionState(),
+              )
+              publishAttention(scope, tab, this.attentionByTab[tab])
+              this._appliedMaxEventIdByTab[tab] = incomingMax ?? watermark
+              if (data.is_processing === true) this.processingByTab[tab] = true
+              return true
+            }
+            // Walk capped, or a branch op started mid-flight: fall back
+            // to the FULL log so the completeness machinery below sees
+            // the whole parent chain.
+            data = await terrariumAPI.getHistory(this._instanceGraphId, tab, { limit: 0 })
+            if (isStale()) return false
+          }
+        }
+
+        // ---- snapshot pipeline (full / initial page / legacy replace) ----
+
         // Out-of-order guard by content: a response whose newest
         // persisted event predates what we already applied for this tab
         // is stale and must not clobber it. event_id is monotonic and
         // append-only, so a lower max means an earlier backend snapshot.
         // Branch ops are exempt — a pending regen/edit legitimately
         // presents a smaller live view until the new branch lands, and
-        // the completeness logic below governs that case.
+        // the completeness logic below governs that case. FULL fetches
+        // are exempt too: an explicit full pull is authoritative by
+        // definition (rewind TRUNCATES the log, so its max legitimately
+        // lands below the watermark); request-order is already governed
+        // by the per-tab request sequence above.
         const branchOpActive = !!this._branchResyncPendingByTab[tab]?.active
-        const incomingMax = this._maxEventId(data.events)
+        const incomingMax =
+          typeof data?.max_event_id === "number" ? data.max_event_id : this._maxEventId(data.events)
         const watermark = this._appliedMaxEventIdByTab[tab]
         if (
           !branchOpActive &&
+          !options.full &&
           incomingMax != null &&
           watermark != null &&
           incomingMax < watermark
@@ -4653,6 +4792,15 @@ const _chatStoreOptions = {
         // Advance the applied-history watermark so a later out-of-order
         // response carrying an older snapshot is rejected above.
         if (incomingMax != null) this._appliedMaxEventIdByTab[tab] = incomingMax
+        // Record the cursor window this snapshot covers. A FULL (or
+        // escalated) fetch legitimately ends paging (the whole log is
+        // local); a bounded page keeps ``has_more`` for the transcript's
+        // "load earlier" entry.
+        this.historyPagingByTab[tab] = {
+          hasMore: !!data.has_more,
+          oldestEventId: data.oldest_event_id ?? null,
+          total: data.total ?? null,
+        }
         // Restore a running turn's flag (e.g. after a cap-drop forced
         // it off); the false edge stays WS-owned (idle frame).
         if (data.is_processing === true) this.processingByTab[tab] = true
@@ -4663,6 +4811,60 @@ const _chatStoreOptions = {
         if (options.suppressErrors) return false
         throw e
       }
+    },
+
+    /**
+     * "Load earlier" for a LIVE tab: fetch the next-older bounded page
+     * from the live history endpoint (``before`` = exclusive event_id
+     * cursor; per-channel sequence on ``ch:`` tabs) and PREPEND it to
+     * the cached event log, re-replaying ``messagesByTab``.
+     *
+     * Shares the per-tab request sequence with ``_resyncHistory`` so of
+     * any two overlapping history requests for the tab, the one that
+     * STARTED LATER wins. ``event_id`` overlap is dropped on merge, and
+     * adjacent duplicate pairs split by the page boundary fold during
+     * replay (``_prepareReplayEvents`` dedupes the whole merged array,
+     * mirroring the server's page-level collapse).
+     */
+    async loadOlderLiveHistory(tab = this.activeTab) {
+      const paging = tab ? this.historyPagingByTab[tab] : null
+      if (!tab || !this._instanceId || !paging?.hasMore || paging.oldestEventId == null) {
+        return false
+      }
+      const requestId = (this._historyRequestSeqByTab[tab] =
+        (this._historyRequestSeqByTab[tab] || 0) + 1)
+      const mutationGeneration = this._historyMutationSeqByTab[tab] || 0
+      const requestedInstanceId = this._instanceId
+      const { terrariumAPI } = await import("@/utils/api")
+      const data = await terrariumAPI.getHistory(this._instanceGraphId, tab, {
+        limit: HISTORY_PAGE_SIZE,
+        before: paging.oldestEventId,
+      })
+      if (
+        requestId !== this._historyRequestSeqByTab[tab] ||
+        this._instanceId !== requestedInstanceId ||
+        (this._historyMutationSeqByTab[tab] || 0) !== mutationGeneration
+      ) {
+        return false
+      }
+      const cached = this.eventsByTab[tab] || []
+      const known = new Set(
+        cached.map((evt) => evt?.event_id).filter((id) => typeof id === "number"),
+      )
+      const events = Array.isArray(data?.events) ? data.events : []
+      const fresh = events.filter(
+        (evt) => typeof evt?.event_id !== "number" || !known.has(evt.event_id),
+      )
+      this._setEvents(tab, [...fresh, ...cached])
+      this.historyPagingByTab[tab] = {
+        hasMore: !!data?.has_more,
+        oldestEventId: data?.oldest_event_id ?? null,
+        total: data?.total ?? null,
+      }
+      // Add-only job reconciliation (fetchedAt null): prepending older
+      // events must never prune currently running work.
+      this._rebuildMessages(tab)
+      return true
     },
 
     /**

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -34,6 +34,9 @@ import { wsUrl } from "@/utils/wsUrl"
 
 const BRANCH_RESYNC_DELAY_MS = 350
 const COMMAND_INVENTORY_TTL_MS = 30_000
+// Matches the server's default bounded page for
+// ``GET /sessions/{name}/history/{target}`` (400 events or ~4MB).
+const HISTORY_PAGE_SIZE = 400
 // A pending branch op whose expected branch never lands (e.g. the edit
 // request was lost before dispatch) must not keep the stale-history
 // guard alive forever — after this many incomplete retries the guard is
@@ -1780,6 +1783,29 @@ const _chatStoreOptions = {
      * @type {Object<string, any[]>}
      */
     eventsByTab: {},
+    /**
+     * Per-tab pagination state for the read-only session-history
+     * surface (``GET /sessions/{name}/history/{target}``):
+     * ``{hasMore, oldestEventId, total}``. ``oldestEventId`` is the
+     * exclusive cursor for the previous page (the per-channel message
+     * sequence for ``ch:`` targets, which carry no event ids).
+     * @type {Object<string, {hasMore: boolean, oldestEventId: number|null, total: number|null}>}
+     */
+    historyPagingByTab: {},
+    /**
+     * Accumulated raw paged events per tab — newest page first, older
+     * pages prepended by "load earlier". Powers the re-replay after each
+     * append without refetching pages.
+     * @type {Object<string, any[]>}
+     */
+    _historyPagedEventsByTab: {},
+    /**
+     * Conversation snapshot from the newest page per tab. Older pages
+     * omit the snapshot server-side; the newest one stays the replay
+     * fallback source for every prepend.
+     * @type {Object<string, any[]>}
+     */
+    _historyPagedSnapshotByTab: {},
     /**
      * Per-tab branch selection: ``{turnIndex: branchId}``. Empty
      * means "use latest branch for every turn" (the default).
@@ -4640,6 +4666,90 @@ const _chatStoreOptions = {
     },
 
     /**
+     * Load one page of persisted history for a tab through the read-only
+     * session-history endpoint (``sessionAPI.getHistory``). Without
+     * ``before`` this fetches the most recent page (the server's bounded
+     * default) and REPLACES the tab's messages; with
+     * ``before = oldestEventId`` it fetches the next-older page and
+     * PREPENDS it — the dashboard mirror of the TUI's LoadOlderButton.
+     *
+     * Stale-guard: shares ``_historyRequestSeqByTab`` with
+     * ``_resyncHistory`` so of any two overlapping history requests for
+     * the same tab (paged load vs. resync), the one that STARTED LATER
+     * is authoritative — the older one returns ``null`` instead of
+     * clobbering the newer view.
+     *
+     * @param {string} sessionName saved-session name the page belongs to
+     * @param {string} tab history target (agent or ``ch:`` channel)
+     * @param {{before?: number|null}} [options]
+     * @returns {Promise<object|null>} the raw history payload, or null
+     *   when the load was superseded by a newer history request.
+     */
+    async loadHistoryPage(sessionName, tab, options = {}) {
+      const before = options.before ?? null
+      if (!sessionName || !tab) return null
+      const requestId = (this._historyRequestSeqByTab[tab] =
+        (this._historyRequestSeqByTab[tab] || 0) + 1)
+      const mutationGeneration = this._historyMutationSeqByTab[tab] || 0
+      const { sessionAPI } = await import("@/utils/api")
+      const params = { limit: HISTORY_PAGE_SIZE }
+      if (before != null) params.before = before
+      const data = await sessionAPI.getHistory(sessionName, tab, params)
+      if (
+        requestId !== this._historyRequestSeqByTab[tab] ||
+        (this._historyMutationSeqByTab[tab] || 0) !== mutationGeneration
+      ) {
+        return null
+      }
+      this._applyHistoryPage(tab, data, before)
+      return data
+    },
+
+    /**
+     * Fetch the next-older page for a tab using its recorded
+     * ``oldest_event_id`` cursor. Returns true when an older page was
+     * fetched and applied.
+     */
+    async loadOlderHistory(sessionName, tab = this.activeTab) {
+      const paging = tab ? this.historyPagingByTab[tab] : null
+      if (!paging?.hasMore || paging.oldestEventId == null) return false
+      const data = await this.loadHistoryPage(sessionName, tab, {
+        before: paging.oldestEventId,
+      })
+      return data != null
+    },
+
+    /** Apply a fetched history page: replace (newest) or prepend (older). */
+    _applyHistoryPage(tab, data, before) {
+      const events = Array.isArray(data?.events) ? data.events : []
+      this.historyPagingByTab[tab] = {
+        hasMore: !!data?.has_more,
+        oldestEventId: data?.oldest_event_id ?? null,
+        total: data?.total ?? null,
+      }
+      if (before == null) {
+        this._historyPagedEventsByTab[tab] = events
+        this._historyPagedSnapshotByTab[tab] = Array.isArray(data?.messages) ? data.messages : []
+      } else {
+        // Older page: prepend, skipping rows the accumulated log already
+        // holds (a raced double-append must not duplicate history).
+        const accumulated = this._historyPagedEventsByTab[tab] || []
+        const known = new Set(accumulated.map((evt) => evt?.event_id).filter((id) => id != null))
+        const fresh = events.filter((evt) => evt?.event_id == null || !known.has(evt.event_id))
+        this._historyPagedEventsByTab[tab] = [...fresh, ...accumulated]
+      }
+      // Read-only saved history: never populate ``runningJobs`` — a
+      // frozen session has no live work, and its unfinished jobs already
+      // replay as ``interrupted`` via the backend's synthetic terminals
+      // (UXI-04).
+      const { messages } = _replayEvents(
+        this._historyPagedSnapshotByTab[tab] || [],
+        this._historyPagedEventsByTab[tab] || [],
+      )
+      this._setMessages(tab, messages)
+    },
+
+    /**
      * Rebuild ``messagesByTab[tab]`` from the cached event log,
      * applying the current ``branchViewByTab[tab]`` override.
      */
@@ -5344,6 +5454,9 @@ const _chatStoreOptions = {
       this._historyRequestSeqByTab = {}
       this._pendingCommandResultContextsByTab = {}
       this._appliedMaxEventIdByTab = {}
+      this.historyPagingByTab = {}
+      this._historyPagedEventsByTab = {}
+      this._historyPagedSnapshotByTab = {}
       this._clearBranchResyncTimers()
       if (this._reconnectTimer) {
         clearTimeout(this._reconnectTimer)

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -615,6 +615,19 @@ function _dedupeAdjacentDuplicateEvents(events) {
   return out
 }
 
+/**
+ * Signature mirroring the backend's adjacent-duplicate identity (every
+ * field except ``event_id`` / ``ts``). A duplicate-sink pair persisted
+ * with distinct ids can straddle a page boundary; the full-log dedupe
+ * keeps the first (oldest) row, so a prepend folds the newer copy out.
+ */
+function _pageBoundarySignature(evt) {
+  const clone = { ...(evt || {}) }
+  delete clone.event_id
+  delete clone.ts
+  return _stableStringify(clone)
+}
+
 export function _prepareReplayEvents(events, branchView = null) {
   const dedupedEvents = _dedupeAdjacentDuplicateEvents(events)
   return {
@@ -4935,9 +4948,20 @@ const _chatStoreOptions = {
       } else {
         // Older page: prepend, skipping rows the accumulated log already
         // holds (a raced double-append must not duplicate history).
-        const accumulated = this._historyPagedEventsByTab[tab] || []
+        let accumulated = this._historyPagedEventsByTab[tab] || []
         const known = new Set(accumulated.map((evt) => evt?.event_id).filter((id) => id != null))
         const fresh = events.filter((evt) => evt?.event_id == null || !known.has(evt.event_id))
+        // A duplicate-sink pair split across the page boundary renders
+        // twice: the newer sibling ends the accumulated log while the
+        // older one starts the fresh page. The full-log dedupe keeps the
+        // first (oldest) occurrence, so fold the newer copy out.
+        if (
+          fresh.length &&
+          accumulated.length &&
+          _pageBoundarySignature(fresh[fresh.length - 1]) === _pageBoundarySignature(accumulated[0])
+        ) {
+          accumulated = accumulated.slice(1)
+        }
         this._historyPagedEventsByTab[tab] = [...fresh, ...accumulated]
       }
       // Read-only saved history: never populate ``runningJobs`` — a

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -5717,151 +5717,6 @@ describe("chat store — drive-turn transcript marker", () => {
   })
 })
 
-describe("chat store — attention edge summaries", () => {
-  it("summarizes a completed live response from the streamed text parts", () => {
-    const chat = useChatStore()
-    chat._instanceId = "agent_1"
-    chat._instanceGraphId = "agent_1"
-    chat.activeTab = "main"
-    chat.tabs = ["main"]
-    chat.messagesByTab = { main: [] }
-
-    const edges = []
-    const unsubscribe = subscribeAttentionEdges((edge) => edges.push(edge))
-    chat._onMessage({ type: "processing_start", source: "main" })
-    chat._onMessage({ type: "text", source: "main", content: "Deploy finished. " })
-    chat._onMessage({ type: "text", source: "main", content: "All checks passed." })
-    chat._onMessage({ type: "processing_end", source: "main" })
-    unsubscribe()
-
-    expect(edges).toHaveLength(1)
-    expect(edges[0]).toMatchObject({
-      kind: "completed",
-      summary: "Deploy finished. All checks passed.",
-    })
-  })
-
-  it("summarizes the completed turn even when its chunks stream on a non-viewed branch", () => {
-    const chat = useChatStore()
-    chat._instanceId = "agent_1"
-    chat._instanceGraphId = "agent_1"
-    chat.activeTab = "main"
-    chat.tabs = ["main"]
-    chat.messagesByTab = { main: [] }
-    // The user is viewing branch 1 while the regen streams on branch 2:
-    // the branch-isolation gate drops the chunks from the displayed list.
-    chat.branchViewByTab = { main: { 1: 1 } }
-
-    const edges = []
-    const unsubscribe = subscribeAttentionEdges((edge) => edges.push(edge))
-    chat._onMessage({
-      type: "processing_start",
-      source: "main",
-      turn_index: 1,
-      branch_id: 2,
-    })
-    chat._onMessage({
-      type: "text",
-      source: "main",
-      content: "Regenerated answer.",
-      turn_index: 1,
-      branch_id: 2,
-    })
-    chat._onMessage({
-      type: "processing_end",
-      source: "main",
-      turn_index: 1,
-      branch_id: 2,
-    })
-    unsubscribe()
-
-    // Display isolation is intact…
-    expect(chat.messagesByTab.main.some((m) => m.role === "assistant")).toBe(false)
-    // …but the notification still previews the response that just completed.
-    expect(edges).toHaveLength(1)
-    expect(edges[0]).toMatchObject({ kind: "completed", summary: "Regenerated answer." })
-  })
-
-  it("does not surface a stale preview when a later turn completes without text", () => {
-    const chat = useChatStore()
-    chat._instanceId = "agent_1"
-    chat._instanceGraphId = "agent_1"
-    chat.activeTab = "main"
-    chat.tabs = ["main"]
-    chat.messagesByTab = { main: [] }
-
-    const edges = []
-    const unsubscribe = subscribeAttentionEdges((edge) => edges.push(edge))
-    chat._onMessage({ type: "processing_start", source: "main" })
-    chat._onMessage({ type: "text", source: "main", content: "First turn answer." })
-    chat._onMessage({ type: "processing_end", source: "main" })
-    chat._onMessage({ type: "processing_start", source: "main" })
-    chat._onMessage({ type: "processing_end", source: "main" })
-    unsubscribe()
-
-    expect(edges).toHaveLength(2)
-    expect(edges[0]).toMatchObject({ kind: "completed", summary: "First turn answer." })
-    expect(edges[1]).toMatchObject({ kind: "completed" })
-    expect(edges[1].summary).toBeUndefined()
-  })
-
-  it("summarizes an interactive prompt from its frame payload", () => {
-    const chat = useChatStore()
-    chat._instanceId = "agent_1"
-    chat._instanceGraphId = "agent_1"
-    chat.activeTab = "main"
-    chat.tabs = ["main"]
-    chat.messagesByTab = { main: [] }
-
-    const edges = []
-    const unsubscribe = subscribeAttentionEdges((edge) => edges.push(edge))
-    chat._onMessage({
-      type: "ask_text",
-      source: "main",
-      event_id: "prompt-1",
-      interactive: true,
-      surface: "chat",
-      payload: { prompt: "Deploy the staging build?" },
-    })
-    unsubscribe()
-
-    expect(edges).toHaveLength(1)
-    expect(edges[0]).toMatchObject({
-      kind: "waiting-input",
-      eventId: "prompt-1",
-      summary: "Deploy the staging build?",
-    })
-  })
-})
-
-describe("chat store — attention accumulator bounds", () => {
-  it("bounds the retained stream copy while preserving the summary", () => {
-    const chat = useChatStore()
-    chat._instanceId = "agent_1"
-    chat._instanceGraphId = "agent_1"
-    chat.activeTab = "main"
-    chat.tabs = ["main"]
-    chat.messagesByTab = { main: [] }
-
-    const edges = []
-    const unsubscribe = subscribeAttentionEdges((edge) => edges.push(edge))
-    chat._onMessage({ type: "processing_start", source: "main" })
-    const bigWord = "x".repeat(50)
-    for (let i = 0; i < 100; i++) {
-      chat._onMessage({ type: "text", source: "main", content: `${bigWord} ` })
-    }
-    // The retained accumulator never grows past the ceiling despite ~5000
-    // streamed characters.
-    expect(chat._attentionStreamTextByTab.main.length).toBeLessThanOrEqual(400)
-    chat._onMessage({ type: "processing_end", source: "main" })
-    unsubscribe()
-
-    expect(edges).toHaveLength(1)
-    expect(edges[0].summary).toHaveLength(200)
-    expect(edges[0].summary.endsWith("…")).toBe(true)
-  })
-})
-
 describe("chat store — paged history (load earlier)", () => {
   const PAGE_EVENTS = (ids) =>
     ids.map((id) => ({ type: "user_input", event_id: id, content: `m${id}` }))
@@ -6019,5 +5874,415 @@ describe("chat store — paged history (load earlier)", () => {
     await expect(chat.loadOlderHistory("s1", "alice")).resolves.toBe(false)
     expect(getHistory).not.toHaveBeenCalled()
     getHistory.mockRestore()
+  })
+})
+
+describe("chat store — live history paging modes", () => {
+  async function spyLiveHistory(impl) {
+    const importActual = await vi.importActual("@/utils/api")
+    return vi.spyOn(importActual.terrariumAPI, "getHistory").mockImplementation(impl)
+  }
+
+  function seedWarm(
+    chat,
+    cacheEvents,
+    watermark,
+    paging = { hasMore: false, oldestEventId: null, total: null },
+  ) {
+    chat._setEvents("main", cacheEvents)
+    chat._appliedMaxEventIdByTab.main = watermark
+    chat.historyPagingByTab.main = paging
+  }
+
+  it("initialLoad fetches the server-bounded page and records paging state", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    const spy = await spyLiveHistory(async (id, tab, opts) => {
+      // No cursor options: the server's bounded newest page applies.
+      expect(opts ?? null).toBeNull()
+      return {
+        events: [
+          { type: "user_input", event_id: 3, content: "m3" },
+          { type: "user_input", event_id: 4, content: "m4" },
+          { type: "user_input", event_id: 5, content: "m5" },
+        ],
+        messages: [],
+        has_more: true,
+        oldest_event_id: 3,
+        total: 5,
+        max_event_id: 5,
+        is_processing: false,
+      }
+    })
+    await expect(chat._loadHistory("main")).resolves.toBe(true)
+    expect(chat.historyPagingByTab.main).toEqual({ hasMore: true, oldestEventId: 3, total: 5 })
+    // The FULL-log max (not the page max) seeds the incremental cursor.
+    expect(chat._appliedMaxEventIdByTab.main).toBe(5)
+    expect(chat.messagesByTab.main.map((m) => m.content)).toEqual(["m3", "m4", "m5"])
+    spy.mockRestore()
+  })
+
+  it("a warm-cache resync fetches since the cursor and appends", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    seedWarm(
+      chat,
+      [
+        { type: "user_input", event_id: 4, content: "m4" },
+        { type: "user_input", event_id: 5, content: "m5" },
+      ],
+      5,
+      { hasMore: true, oldestEventId: 4, total: 5 },
+    )
+    const spy = await spyLiveHistory(async (id, tab, opts) => {
+      expect(opts).toEqual({ sinceEventId: 5 })
+      return {
+        // Server-side trimmed page: only events after the cursor.
+        events: [{ type: "user_input", event_id: 6, content: "m6" }],
+        has_more: true,
+        oldest_event_id: 4,
+        total: 6,
+        max_event_id: 6,
+        is_processing: false,
+      }
+    })
+    await expect(chat._resyncHistory("main")).resolves.toBe(true)
+    expect(chat.eventsByTab.main.map((e) => e.event_id)).toEqual([4, 5, 6])
+    expect(chat.messagesByTab.main.map((m) => m.content)).toEqual(["m4", "m5", "m6"])
+    expect(chat._appliedMaxEventIdByTab.main).toBe(6)
+    // The older boundary is unchanged — an incremental page must not
+    // clobber the load-older cursor.
+    expect(chat.historyPagingByTab.main).toEqual({ hasMore: true, oldestEventId: 4, total: 5 })
+    spy.mockRestore()
+  })
+
+  it("walks before-pages when more than one page landed since the cursor", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    seedWarm(chat, [{ type: "user_input", event_id: 10, content: "m10" }], 10)
+    const calls = []
+    const spy = await spyLiveHistory(async (id, tab, opts) => {
+      calls.push(opts)
+      if (opts?.sinceEventId != null) {
+        // The trimmed head was lost: page lies entirely past the cursor.
+        return {
+          events: [{ type: "user_input", event_id: 12, content: "m12" }],
+          has_more: true,
+          oldest_event_id: 12,
+          max_event_id: 12,
+        }
+      }
+      // Older page straddles the cursor; its ≤10 rows must be dropped.
+      return {
+        events: [
+          { type: "user_input", event_id: 11, content: "m11" },
+          { type: "user_input", event_id: 10, content: "m10" },
+        ],
+        has_more: true,
+        oldest_event_id: 10,
+      }
+    })
+    await expect(chat._resyncHistory("main")).resolves.toBe(true)
+    expect(calls).toEqual([{ sinceEventId: 10 }, { limit: 400, before: 12 }])
+    expect(chat.eventsByTab.main.map((e) => e.event_id)).toEqual([10, 11, 12])
+    spy.mockRestore()
+  })
+
+  it("escalates to one full fetch when the before-walk cannot cover the cursor", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    seedWarm(chat, [{ type: "user_input", event_id: 10, content: "m10" }], 10)
+    let beforeCalls = 0
+    let escalated = false
+    const spy = await spyLiveHistory(async (id, tab, opts) => {
+      if (opts?.sinceEventId != null) {
+        return {
+          events: [{ type: "user_input", event_id: 500, content: "far" }],
+          has_more: true,
+          oldest_event_id: 500,
+          max_event_id: 500,
+        }
+      }
+      if (opts?.limit === 0) {
+        escalated = true
+        return {
+          events: [
+            { type: "user_input", event_id: 10, content: "m10" },
+            { type: "user_input", event_id: 500, content: "far" },
+          ],
+          messages: [],
+          has_more: false,
+          oldest_event_id: 10,
+          total: 2,
+          max_event_id: 500,
+        }
+      }
+      beforeCalls += 1
+      // Every page stays entirely past the cursor → walk never covers.
+      return {
+        events: [{ type: "user_input", event_id: 500, content: "far" }],
+        has_more: true,
+        oldest_event_id: 400,
+      }
+    })
+    await expect(chat._resyncHistory("main")).resolves.toBe(true)
+    expect(beforeCalls).toBe(49) // MAX_INCREMENTAL_PAGES - 1 walk pages
+    expect(escalated).toBe(true)
+    expect(chat.eventsByTab.main.map((e) => e.event_id)).toEqual([10, 500])
+    expect(chat.historyPagingByTab.main).toEqual({ hasMore: false, oldestEventId: 10, total: 2 })
+    spy.mockRestore()
+  })
+
+  it("a response ignoring the cursor degrades to snapshot replace", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    seedWarm(
+      chat,
+      [
+        { type: "user_input", event_id: 4, content: "m4" },
+        { type: "user_input", event_id: 5, content: "m5" },
+      ],
+      5,
+    )
+    const spy = await spyLiveHistory(async (id, tab, opts) => {
+      expect(opts).toEqual({ sinceEventId: 5 })
+      // A transport that ignored since_event_id: full log back.
+      return {
+        events: [
+          { type: "user_input", event_id: 4, content: "m4" },
+          { type: "user_input", event_id: 5, content: "m5" },
+          { type: "user_input", event_id: 6, content: "m6" },
+        ],
+        messages: [],
+        is_processing: false,
+      }
+    })
+    await expect(chat._resyncHistory("main")).resolves.toBe(true)
+    // Replace (not append): still three distinct turns, no duplicates.
+    expect(chat.eventsByTab.main.map((e) => e.event_id)).toEqual([4, 5, 6])
+    expect(chat.messagesByTab.main.map((m) => m.content)).toEqual(["m4", "m5", "m6"])
+    spy.mockRestore()
+  })
+
+  it("rewind resyncs the full log so the truncated snapshot applies", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    seedWarm(
+      chat,
+      [
+        { type: "user_input", event_id: 9, content: "m9" },
+        { type: "user_input", event_id: 10, content: "m10" },
+      ],
+      10,
+    )
+    const importActual = await vi.importActual("@/utils/api")
+    const rewindSpy = vi.spyOn(importActual.agentAPI, "rewindTo").mockResolvedValue({})
+    const spy = await spyLiveHistory(async (id, tab, opts) => {
+      expect(opts).toEqual({ limit: 0 })
+      // Truncation: the full log's max now sits BELOW the old watermark.
+      return {
+        events: [
+          { type: "user_input", event_id: 1, content: "m1" },
+          { type: "user_input", event_id: 2, content: "m2" },
+        ],
+        messages: [],
+        has_more: false,
+        oldest_event_id: 1,
+        total: 2,
+        max_event_id: 2,
+        is_processing: false,
+      }
+    })
+    await chat.rewindTo(1)
+    expect(rewindSpy).toHaveBeenCalledWith("g1", "main", 1)
+    expect(chat.eventsByTab.main.map((e) => e.event_id)).toEqual([1, 2])
+    expect(chat._appliedMaxEventIdByTab.main).toBe(2)
+    rewindSpy.mockRestore()
+    spy.mockRestore()
+  })
+
+  it("load-older prepends the before-page, deduping the overlap", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    seedWarm(
+      chat,
+      [
+        { type: "user_input", event_id: 6, content: "m6" },
+        { type: "user_input", event_id: 7, content: "m7" },
+      ],
+      7,
+      { hasMore: true, oldestEventId: 6, total: 20 },
+    )
+    const spy = await spyLiveHistory(async (id, tab, opts) => {
+      expect(opts).toEqual({ limit: 400, before: 6 })
+      return {
+        events: [
+          { type: "user_input", event_id: 4, content: "m4" },
+          { type: "user_input", event_id: 5, content: "m5" },
+          // Overlapping row the client already has — must not duplicate.
+          { type: "user_input", event_id: 6, content: "m6" },
+        ],
+        has_more: true,
+        oldest_event_id: 4,
+        total: 20,
+      }
+    })
+    await expect(chat.loadOlderLiveHistory("main")).resolves.toBe(true)
+    expect(chat.eventsByTab.main.map((e) => e.event_id)).toEqual([4, 5, 6, 7])
+    expect(chat.messagesByTab.main.map((m) => m.content)).toEqual(["m4", "m5", "m6", "m7"])
+    expect(chat.historyPagingByTab.main).toEqual({ hasMore: true, oldestEventId: 4, total: 20 })
+    spy.mockRestore()
+  })
+
+  it("load-older refuses to apply when superseded by a newer request", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    seedWarm(chat, [{ type: "user_input", event_id: 10, content: "m10" }], 10, {
+      hasMore: true,
+      oldestEventId: 10,
+      total: 20,
+    })
+    let resolveOlder
+    const spy = await spyLiveHistory((id, tab, opts) => {
+      if (opts?.before != null) {
+        return new Promise((resolve) => (resolveOlder = resolve))
+      }
+      return Promise.resolve({
+        events: [{ type: "user_input", event_id: 11, content: "m11" }],
+        max_event_id: 11,
+        has_more: true,
+        oldest_event_id: 10,
+      })
+    })
+
+    const older = chat.loadOlderLiveHistory("main")
+    // Let the deferred dynamic import settle so the walk starts first.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await expect(chat._resyncHistory("main")).resolves.toBe(true)
+    resolveOlder({
+      events: [{ type: "user_input", event_id: 9, content: "m9-stale" }],
+      has_more: true,
+      oldest_event_id: 9,
+    })
+    await expect(older).resolves.toBe(false)
+    const ids = chat.eventsByTab.main.map((e) => e.event_id)
+    expect(ids).toEqual([10, 11])
+    spy.mockRestore()
+  })
+
+  it("folds an adjacent duplicate pair split by the live page boundary", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "agent_1"
+    chat._instanceGraphId = "g1"
+    chat.activeTab = "main"
+    chat.tabs = ["main"]
+    chat.messagesByTab = { main: [] }
+    chat.branchViewByTab = {}
+    // Newest page begins with the duplicate twin (event_id 10).
+    seedWarm(
+      chat,
+      [
+        { type: "text", event_id: 10, content: "DUP" },
+        { type: "processing_end", event_id: 11 },
+      ],
+      11,
+      { hasMore: true, oldestEventId: 10, total: 11 },
+    )
+    const spy = await spyLiveHistory(async () => ({
+      // Older page ENDS with the same twin (distinct event_id).
+      events: [
+        { type: "processing_start", event_id: 7 },
+        { type: "text", event_id: 8, content: "A" },
+        { type: "text", event_id: 9, content: "DUP" },
+      ],
+      has_more: false,
+      oldest_event_id: 7,
+      total: 11,
+    }))
+    await expect(chat.loadOlderLiveHistory("main")).resolves.toBe(true)
+    const assistant = chat.messagesByTab.main.find((m) => m.role === "assistant")
+    // The page-level dedupe collapsed each page internally; the merged
+    // replay must render the boundary twin exactly once. A/DUP stream
+    // into one text part, so an unfolded twin would read "ADUPDUP".
+    expect(assistant.parts[0].content).toBe("ADUP")
+    spy.mockRestore()
+  })
+
+  it("saved-page prepend folds the boundary twin through the same replay", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session:s1"
+    const importActual = await vi.importActual("@/utils/api")
+    const spy = vi
+      .spyOn(importActual.sessionAPI, "getHistory")
+      .mockImplementation(async (sessionName, tab, params) => {
+        if (params?.before == null) {
+          return {
+            events: [
+              { type: "text", event_id: 10, content: "DUP" },
+              { type: "processing_end", event_id: 11 },
+            ],
+            messages: [],
+            has_more: true,
+            oldest_event_id: 10,
+            total: 11,
+          }
+        }
+        return {
+          events: [
+            { type: "processing_start", event_id: 7 },
+            { type: "text", event_id: 8, content: "A" },
+            { type: "text", event_id: 9, content: "DUP" },
+          ],
+          messages: [],
+          has_more: false,
+          oldest_event_id: 7,
+          total: 11,
+        }
+      })
+    await chat.loadHistoryPage("s1", "alice")
+    await expect(chat.loadOlderHistory("s1", "alice")).resolves.toBe(true)
+    const assistant = chat.messagesByTab.alice.find((m) => m.role === "assistant")
+    // Same contract as the live path above: one text part, twin folded.
+    expect(assistant.parts[0].content).toBe("ADUP")
+    spy.mockRestore()
   })
 })

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -5861,3 +5861,163 @@ describe("chat store — attention accumulator bounds", () => {
     expect(edges[0].summary.endsWith("…")).toBe(true)
   })
 })
+
+describe("chat store — paged history (load earlier)", () => {
+  const PAGE_EVENTS = (ids) =>
+    ids.map((id) => ({ type: "user_input", event_id: id, content: `m${id}` }))
+
+  async function spySessionHistory(mock) {
+    const importActual = await vi.importActual("@/utils/api")
+    return vi.spyOn(importActual.sessionAPI, "getHistory").mockImplementation(mock)
+  }
+
+  it("loads the most recent page and records pagination state", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session:s1"
+    chat.messagesByTab = { alice: [] }
+    const getHistory = await spySessionHistory(async () => ({
+      target: "alice",
+      messages: [],
+      events: PAGE_EVENTS([389, 390, 450]),
+      has_more: true,
+      oldest_event_id: 389,
+      total: 450,
+    }))
+
+    const data = await chat.loadHistoryPage("s1", "alice")
+
+    expect(getHistory).toHaveBeenCalledWith("s1", "alice", { limit: 400 })
+    expect(data).not.toBeNull()
+    expect(chat.historyPagingByTab.alice).toEqual({
+      hasMore: true,
+      oldestEventId: 389,
+      total: 450,
+    })
+    expect(chat.messagesByTab.alice.map((m) => m.content)).toEqual(["m389", "m390", "m450"])
+    getHistory.mockRestore()
+  })
+
+  it("prepends an older page without clobbering or duplicating rows", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session:s1"
+    chat.messagesByTab = { alice: [] }
+    let latest = true
+    const getHistory = await spySessionHistory(async (_s, _t, params) => {
+      if (latest) {
+        latest = false
+        return {
+          target: "alice",
+          messages: [],
+          events: PAGE_EVENTS([3, 4]),
+          has_more: true,
+          oldest_event_id: 3,
+          total: 4,
+        }
+      }
+      expect(params).toEqual({ limit: 400, before: 3 })
+      return {
+        target: "alice",
+        messages: [],
+        events: PAGE_EVENTS([1, 2, 3]),
+        has_more: false,
+        oldest_event_id: 1,
+        total: 4,
+      }
+    })
+
+    await chat.loadHistoryPage("s1", "alice")
+    const applied = await chat.loadOlderHistory("s1", "alice")
+
+    expect(applied).toBe(true)
+    // Event 3 was already on the newest page — the prepend must skip it.
+    expect(chat.messagesByTab.alice.map((m) => m.content)).toEqual(["m1", "m2", "m3", "m4"])
+    expect(chat.historyPagingByTab.alice).toEqual({
+      hasMore: false,
+      oldestEventId: 1,
+      total: 4,
+    })
+    getHistory.mockRestore()
+  })
+
+  it("renders the conversation snapshot for a target with no events", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session:s1"
+    chat.messagesByTab = { alice: [] }
+    const getHistory = await spySessionHistory(async () => ({
+      target: "alice",
+      // Legacy empty-history shape: no events, snapshot only.
+      messages: [{ role: "user", content: "snapshot text" }],
+      events: [],
+      has_more: false,
+      oldest_event_id: null,
+      total: 0,
+    }))
+
+    const data = await chat.loadHistoryPage("s1", "alice")
+
+    // Events win when present (replay semantic); without any, the
+    // conversation snapshot is the fallback render — same as the
+    // previous non-paged viewer path.
+    expect(data).not.toBeNull()
+    expect(chat.messagesByTab.alice.map((m) => m.content)).toEqual(["snapshot text"])
+    await expect(chat.loadOlderHistory("s1", "alice")).resolves.toBe(false)
+    getHistory.mockRestore()
+  })
+
+  it("drops a page load superseded by a newer history request", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session:s1"
+    chat.messagesByTab = { alice: [] }
+    let resolveFirst
+    const first = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+    let call = 0
+    const getHistory = await spySessionHistory(() => {
+      call += 1
+      return call === 1
+        ? first
+        : Promise.resolve({
+            target: "alice",
+            messages: [],
+            events: PAGE_EVENTS([9]),
+            has_more: false,
+            oldest_event_id: 9,
+            total: 1,
+          })
+    })
+
+    const stale = chat.loadHistoryPage("s1", "alice")
+    const fresh = chat.loadHistoryPage("s1", "alice")
+    resolveFirst({
+      target: "alice",
+      messages: [],
+      events: PAGE_EVENTS([1]),
+      has_more: true,
+      oldest_event_id: 1,
+      total: 9,
+    })
+
+    // The request that STARTED LATER is authoritative; the stale one is
+    // discarded without touching messages or pagination state.
+    await expect(stale).resolves.toBeNull()
+    await expect(fresh).resolves.not.toBeNull()
+    expect(chat.messagesByTab.alice.map((m) => m.content)).toEqual(["m9"])
+    expect(chat.historyPagingByTab.alice.hasMore).toBe(false)
+    getHistory.mockRestore()
+  })
+
+  it("does not page past the oldest recorded cursor", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session:s1"
+    const getHistory = await spySessionHistory(async () => {
+      throw new Error("must not fetch")
+    })
+
+    await expect(chat.loadOlderHistory("s1", "alice")).resolves.toBe(false)
+    chat.historyPagingByTab.alice = { hasMore: true, oldestEventId: null, total: 0 }
+    await expect(chat.loadOlderHistory("s1", "alice")).resolves.toBe(false)
+    expect(getHistory).not.toHaveBeenCalled()
+    getHistory.mockRestore()
+  })
+})

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -5794,6 +5794,57 @@ describe("chat store — paged history (load earlier)", () => {
     getHistory.mockRestore()
   })
 
+  it("folds a duplicate-sink pair split across a page boundary", async () => {
+    const chat = useChatStore()
+    chat._instanceId = "session:s1"
+    chat.messagesByTab = { alice: [] }
+    // Duplicate-sink attachment persists equivalent neighbors with distinct
+    // ids. Here the pair straddles the boundary: id 4 ends the newest page,
+    // id 3 (identical except id/ts) starts the older page's newest rows.
+    const dup = (id) => ({ type: "user_input", event_id: id, ts: id, content: "dup" })
+    let latest = true
+    const getHistory = await spySessionHistory(async (_s, _t, params) => {
+      if (latest) {
+        latest = false
+        return {
+          target: "alice",
+          messages: [],
+          events: [dup(4)],
+          has_more: true,
+          oldest_event_id: 4,
+          total: 4,
+        }
+      }
+      expect(params).toEqual({ limit: 400, before: 4 })
+      return {
+        target: "alice",
+        messages: [],
+        events: [
+          { type: "user_input", event_id: 1, content: "m1" },
+          { type: "user_input", event_id: 2, content: "m2" },
+          dup(3),
+        ],
+        has_more: false,
+        oldest_event_id: 1,
+        total: 4,
+      }
+    })
+
+    await chat.loadHistoryPage("s1", "alice")
+    await chat.loadOlderHistory("s1", "alice")
+
+    // The full-log dedupe keeps the first (oldest) sibling, so the newer
+    // copy from the accumulated page must be folded out of the prepend.
+    expect(chat._historyPagedEventsByTab.alice.map((e) => e.event_id)).toEqual([1, 2, 3])
+    expect(chat.messagesByTab.alice.map((m) => m.content)).toEqual(["m1", "m2", "dup"])
+    expect(chat.historyPagingByTab.alice).toEqual({
+      hasMore: false,
+      oldestEventId: 1,
+      total: 4,
+    })
+    getHistory.mockRestore()
+  })
+
   it("renders the conversation snapshot for a target with no events", async () => {
     const chat = useChatStore()
     chat._instanceId = "session:s1"

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -337,14 +337,27 @@ export const terrariumAPI = {
   },
 
   /**
-   * Get full history for a creature/root in a terrarium.
-   * Returns { messages: [...], events: [...] }
+   * Get a paged history payload for a creature/root in a terrarium.
+   * Returns { messages, events, has_more, oldest_event_id, total,
+   * max_event_id, is_processing }.
+   *
+   * The server bounds the newest page by default (400 events / ~4MB);
+   * ``options`` may carry ``{limit, before, sinceEventId}``:
+   * ``limit=0`` requests the FULL log (branch/rewind resyncs),
+   * ``before`` is the exclusive event_id cursor for the next-older
+   * page (per-channel sequence for ``ch:`` tabs), and ``sinceEventId``
+   * trims the page to an incremental append. A bare number is accepted
+   * as the legacy ``sinceEventId`` positional form.
    */
-  async getHistory(id, target, sinceEventId = null) {
-    const params = sinceEventId != null ? { params: { since_event_id: sinceEventId } } : {}
+  async getHistory(id, target, options = null) {
+    const opts = typeof options === "number" ? { sinceEventId: options } : options || {}
+    const params = {}
+    if (opts.sinceEventId != null) params.since_event_id = opts.sinceEventId
+    if (opts.limit != null) params.limit = opts.limit
+    if (opts.before != null) params.before = opts.before
     const { data } = await api.get(
       `/sessions/${id}/creatures/${encodeTarget(target)}/history`,
-      params,
+      Object.keys(params).length ? { params } : {},
     )
     return data
   },

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -896,8 +896,20 @@ export const sessionAPI = {
     return data
   },
 
-  async getHistory(sessionName, target) {
-    const { data } = await api.get(`/sessions/${sessionName}/history/${encodeTarget(target)}`)
+  /**
+   * Get history for one target. By default the server returns a bounded
+   * most-recent page (400 events / ~4MB) plus ``has_more`` /
+   * ``oldest_event_id`` / ``total``. Pass ``{ before: oldest_event_id }``
+   * for the next-older page, or ``{ limit: 0 }`` for the full payload.
+   * @param {string} sessionName
+   * @param {string} target
+   * @param {{limit?: number, before?: number}} [params]
+   */
+  async getHistory(sessionName, target, params = null) {
+    const { data } = await api.get(
+      `/sessions/${sessionName}/history/${encodeTarget(target)}`,
+      params ? { params } : {},
+    )
     return data
   },
 

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -516,6 +516,8 @@ export default {
   "chat.dropToAttach": "Drop files to attach",
   "chat.queueShowMore": ({ count }) => `+${count} more queued`,
   "chat.showEarlier": ({ count }) => `Show ${count} earlier messages`,
+  "chat.loadEarlier": "Load earlier messages",
+  "chat.loadEarlierLoading": "Loading older messages…",
   "chat.queueCollapse": "Show fewer",
   "chat.queueEdit": "Edit queued message",
   "chat.queueCancel": "Cancel queued message",

--- a/src/kohakuterrarium/api/routes/persistence/history.py
+++ b/src/kohakuterrarium/api/routes/persistence/history.py
@@ -6,7 +6,9 @@ Paths use ``/{session_name}/history[/{target}]`` so mounting under
 Saved-session SQLite reads run in a worker thread. Live sessions reuse the
 engine-owned store on the event loop because a second connection to an actively
 written store can raise ``SQLITE_IOERR`` on POSIX; loop affinity also
-serializes reads with the writer.
+serializes reads with the writer. Target payloads are bounded by default (see
+``GET /{session_name}/history/{target}``), so the on-loop live work is a key
+enumeration plus one page of value reads instead of the whole log.
 """
 
 import asyncio
@@ -14,7 +16,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from kohakuterrarium.api.deps import get_service
 from kohakuterrarium.api.routes.persistence.live_paths import live_store_entry
@@ -26,7 +28,10 @@ from kohakuterrarium.studio.persistence.history import (
     history_index_payload,
     history_payload,
 )
-from kohakuterrarium.studio.persistence.store import resolve_session_path_default
+from kohakuterrarium.studio.persistence.store import (
+    DEFAULT_HISTORY_PAGE_LIMIT,
+    resolve_session_path_default,
+)
 from kohakuterrarium.terrarium.creature_ops import agent_live_job_ids
 from kohakuterrarium.terrarium.service import TerrariumService
 
@@ -92,13 +97,34 @@ async def get_session_history_index(
 async def get_session_history(
     session_name: str,
     target: str,
+    limit: int = Query(DEFAULT_HISTORY_PAGE_LIMIT, ge=0),
+    before: int | None = Query(None, ge=0),
     service: TerrariumService = Depends(get_service),
 ) -> dict[str, Any]:
-    """Return history for an agent, root, or channel target.
+    """Return a bounded page of history for an agent, root, or channel target.
+
+    The response carries the most recent ``limit`` events (400 by default) or
+    about 4MB of event JSON, whichever fills first, plus pagination fields:
+    ``has_more``, ``oldest_event_id`` (exclusive cursor for the previous
+    page), and ``total``. Pass ``oldest_event_id`` back as ``before`` to
+    fetch the next-older page. ``limit=0`` returns the FULL unbounded
+    payload for callers that need everything. Pages after the newest omit
+    the conversation snapshot (``messages``) — it describes the whole
+    conversation and belongs to the newest window. For ``ch:`` targets the
+    cursor is the per-channel message sequence because channel messages
+    carry no ``event_id``.
 
     Live job IDs prevent active background work from appearing interrupted.
-    Saved sessions have no live-job set, so persisted unfinished work receives
-    the normal terminal representation.
+    Saved sessions have no live-job set, so persisted unfinished work
+    receives the normal terminal representation.
+
+    LIVE PATH LOOP-AFFINITY TRADEOFF: a live session's history is built
+    synchronously on the event loop, reusing the engine-owned store — a
+    second connection to an actively written SQLite file raises
+    ``SQLITE_IOERR`` on POSIX, and loop affinity serializes reads with the
+    writer. Pagination keeps that on-loop work bounded (a key enumeration
+    plus one page of value reads) where the full payload once blocked the
+    loop for the whole log.
     """
     target = unquote(target)
     entry = live_store_entry(service, session_name)
@@ -106,7 +132,14 @@ async def get_session_history(
         graph_id, store = entry
         live_job_ids = _live_job_ids_for_graph(service, graph_id)
         return history_from_store(
-            store, _live_session_name(store, session_name), target, live_job_ids
+            store,
+            _live_session_name(store, session_name),
+            target,
+            live_job_ids,
+            limit=limit,
+            before=before,
         )
     path = await _resolve_saved_path(session_name)
-    return await asyncio.to_thread(history_payload, path, target, None)
+    return await asyncio.to_thread(
+        history_payload, path, target, None, limit=limit, before=before
+    )

--- a/src/kohakuterrarium/api/routes/persistence/history.py
+++ b/src/kohakuterrarium/api/routes/persistence/history.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from kohakuterrarium.api.deps import get_service
 from kohakuterrarium.api.routes.persistence.live_paths import live_store_entry
+from kohakuterrarium.session.history_paging import DEFAULT_HISTORY_PAGE_LIMIT
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio._runtime import host_engine_or_none
 from kohakuterrarium.studio.persistence.history import (
@@ -28,10 +29,7 @@ from kohakuterrarium.studio.persistence.history import (
     history_index_payload,
     history_payload,
 )
-from kohakuterrarium.studio.persistence.store import (
-    DEFAULT_HISTORY_PAGE_LIMIT,
-    resolve_session_path_default,
-)
+from kohakuterrarium.studio.persistence.store import resolve_session_path_default
 from kohakuterrarium.terrarium.creature_ops import agent_live_job_ids
 from kohakuterrarium.terrarium.service import TerrariumService
 

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
@@ -218,9 +218,9 @@ async def _channel_history_page(
     limit: int,
     before: int | None,
 ) -> dict:
-    """Paged channel history, or the legacy full merge without a local store."""
+    """Paged channel history, or the legacy full merge without a local store/limit."""
     entry = live_store_entry(service, session_id)
-    if entry is not None:
+    if entry is not None and limit > 0:
         _graph_id, store = entry
         page = paged_channel_events(store, channel_name, limit=limit, before=before)
         return {
@@ -236,10 +236,17 @@ async def _channel_history_page(
             "oldest_event_id": page["oldest_event_id"],
             "total": page["total"],
         }
-    try:
-        messages = await service.channel_history(session_id, channel_name)
-    except KeyError:
-        messages = []
+    if entry is not None:
+        # ``limit=0`` is the documented full-payload escape hatch and the
+        # paging helpers only serve bounded pages — read the host-local
+        # store in full instead of paging.
+        _graph_id, store = entry
+        messages = store.get_channel_messages(channel_name)
+    else:
+        try:
+            messages = await service.channel_history(session_id, channel_name)
+        except KeyError:
+            messages = []
     events = [
         {
             "type": "channel_message",

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
@@ -3,10 +3,15 @@
 Service routing sends remote creature operations to their home workers.
 """
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 
 from kohakuterrarium.api.deps import get_service
+from kohakuterrarium.api.routes.persistence.live_paths import live_store_entry
 from kohakuterrarium.api.routes.sessions_v2._helpers import resolve_creature_id
+from kohakuterrarium.session.history_paging import (
+    DEFAULT_HISTORY_PAGE_LIMIT,
+    paged_channel_events,
+)
 from kohakuterrarium.api.schemas import (
     AgentChat,
     BranchMutationResponse,
@@ -144,50 +149,52 @@ async def creature_history(
     session_id: str,
     creature_id: str,
     since_event_id: int | None = None,
+    limit: int = Query(DEFAULT_HISTORY_PAGE_LIMIT, ge=0),
+    before: int | None = Query(None, ge=0),
     service: TerrariumService = Depends(get_service),
 ):
-    """History payload with an optional event cursor.
+    """History payload with cursor paging and an incremental cursor.
 
-    ``since_event_id`` trims ``events`` to those after the cursor so the
-    client can append incrementally instead of re-fetching the whole log
-    after every turn. The full payload remains available (cursor omitted)
-    for the rewind/branch/compact resync path. ``max_event_id`` reports the
-    newest event in the full log so the client can advance its cursor.
+    The response carries the most recent ``limit`` events (400 by default,
+    or ~4MB of event JSON, whichever fills first) plus the paging fields
+    ``has_more`` / ``oldest_event_id`` / ``total``; pass
+    ``oldest_event_id`` back as ``before`` to fetch the next-older page,
+    and ``limit=0`` restores the FULL payload for the rewind/branch/compact
+    resync path that needs the whole log. Paging is applied at the store
+    read (``service.chat_history`` -> ``chat_history_for``), so a 75k-event
+    log costs one key enumeration plus one page of value reads — not the
+    multi-second full build — while still reusing the engine-owned store on
+    the event loop (a second connection to an actively written SQLite file
+    raises ``SQLITE_IOERR`` on POSIX).
+
+    ``since_event_id`` trims the page to events after that id so the client
+    can append incrementally instead of re-fetching. Combined with the
+    default bound the page is the newest ``limit`` events of the log with
+    the already-applied prefix removed; ``has_more`` / ``oldest_event_id``
+    still walk any remainder. Incremental payloads omit the conversation
+    snapshot — it is only valid for the whole conversation and would
+    mislead an appending client. ``max_event_id`` reports the FULL log's
+    true maximum (the session-global counter), never the page maximum,
+    which would desync a client's cursor.
+
+    For ``ch:`` targets the cursor is the per-channel message sequence
+    because channel messages carry no ``event_id``; the page is read from
+    the engine's live store with the same semantics as the saved-session
+    history route. Surfaces without a host-local store (multi-node
+    coordination) keep the legacy full cross-node merge — the merged log
+    has no stable sequence cursor (documented limitation).
     """
     # Channel tabs share this endpoint through the ``ch:`` prefix.
     if creature_id.startswith("ch:"):
-        channel_name = creature_id[3:]
-        try:
-            messages = await service.channel_history(session_id, channel_name)
-        except KeyError:
-            messages = []
-        events = [
-            {
-                "type": "channel_message",
-                "channel": channel_name,
-                "sender": message.get("sender", ""),
-                "content": message.get("content", ""),
-                "ts": message.get("timestamp", message.get("ts", 0)),
-            }
-            for message in messages
-        ]
-        return {
-            "creature_id": creature_id,
-            "session_id": session_id,
-            "messages": [],
-            "events": events,
-            "is_processing": False,
-            # Channel events carry no event_id; report the contract field
-            # explicitly so clients can read it unconditionally.
-            "max_event_id": 0,
-        }
+        return await _channel_history_page(
+            service, session_id, creature_id[3:], limit=limit, before=before
+        )
     cid = await resolve_creature_id(service, creature_id, session_id)
     try:
-        payload = await service.chat_history(cid)
+        payload = await service.chat_history(cid, limit=limit, before=before)
     except KeyError:
         raise HTTPException(404, f"creature {creature_id!r} not found")
     events = payload.get("events") or []
-    max_eid = _history_max_event_id(events)
     if since_event_id is not None:
         payload["events"] = [
             evt
@@ -199,8 +206,61 @@ async def creature_history(
         # Incremental payloads omit the conversation snapshot; it is only
         # valid for the full log and would mislead an appending client.
         payload.pop("messages", None)
-    payload["max_event_id"] = max_eid
+    payload.setdefault("max_event_id", _history_max_event_id(events))
     return payload
+
+
+async def _channel_history_page(
+    service: TerrariumService,
+    session_id: str,
+    channel_name: str,
+    *,
+    limit: int,
+    before: int | None,
+) -> dict:
+    """Paged channel history, or the legacy full merge without a local store."""
+    entry = live_store_entry(service, session_id)
+    if entry is not None:
+        _graph_id, store = entry
+        page = paged_channel_events(store, channel_name, limit=limit, before=before)
+        return {
+            "creature_id": f"ch:{channel_name}",
+            "session_id": session_id,
+            "messages": [],
+            "events": page["events"],
+            "is_processing": False,
+            # Channel events carry no event_id; report the contract field
+            # explicitly so clients can read it unconditionally.
+            "max_event_id": 0,
+            "has_more": page["has_more"],
+            "oldest_event_id": page["oldest_event_id"],
+            "total": page["total"],
+        }
+    try:
+        messages = await service.channel_history(session_id, channel_name)
+    except KeyError:
+        messages = []
+    events = [
+        {
+            "type": "channel_message",
+            "channel": channel_name,
+            "sender": message.get("sender", ""),
+            "content": message.get("content", ""),
+            "ts": message.get("timestamp", message.get("ts", 0)),
+        }
+        for message in messages
+    ]
+    return {
+        "creature_id": f"ch:{channel_name}",
+        "session_id": session_id,
+        "messages": [],
+        "events": events,
+        "is_processing": False,
+        "max_event_id": 0,
+        "has_more": False,
+        "oldest_event_id": None,
+        "total": len(events),
+    }
 
 
 @router.get("/{session_id}/creatures/{creature_id}/events/{event_id}")

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
@@ -527,7 +527,14 @@ class TerrariumRuntimeAdapter:
             case "chat_history":
                 cid = msg.body["creature_id"]
                 self._require_hosted(cid)
-                return {"history": chat_history_for(self._engine, cid)}
+                return {
+                    "history": chat_history_for(
+                        self._engine,
+                        cid,
+                        limit=msg.body.get("limit") or 0,
+                        before=msg.body.get("before"),
+                    )
+                }
 
             case "chat_branches":
                 cid = msg.body["creature_id"]

--- a/src/kohakuterrarium/session/history_paging.py
+++ b/src/kohakuterrarium/session/history_paging.py
@@ -1,0 +1,250 @@
+"""Bounded, cursor-paged history reads shared by saved and live layers.
+
+The paging primitives (sorted-key enumeration, exclusive-cursor binary
+search, dual event-count/byte page budget) live here in the session tier so
+the studio persistence payloads AND the terrarium live creature history page
+through one implementation — the terrarium tier must not import studio, and
+both tiers already depend on ``kohakuterrarium.session``. Cursor semantics
+are therefore identical on every surface: an ``event_id`` cursor for agent
+targets, the per-channel message sequence for ``ch:`` targets.
+
+A page reads at most ``DEFAULT_HISTORY_PAGE_LIMIT`` events or
+``DEFAULT_HISTORY_PAGE_BYTES`` of serialized event JSON, whichever fills
+first. Only page values are read: keys are enumerated and sliced first, so
+the store work stays bounded regardless of log size.
+"""
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from kohakuterrarium.session.history import (
+    dedupe_adjacent_duplicate_events,
+    normalize_resumable_events,
+    normalize_tool_call_events,
+)
+from kohakuterrarium.session.store import SessionStore, iter_kv_keys
+from kohakuterrarium.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Pagination bounds shared by every history page: at most
+# ``DEFAULT_HISTORY_PAGE_LIMIT`` events AND at most this byte budget of
+# serialized event JSON — whichever fills first ends the page.
+DEFAULT_HISTORY_PAGE_LIMIT = 400
+DEFAULT_HISTORY_PAGE_BYTES = 4 * 1024 * 1024
+
+
+def event_id_of(evt: Any) -> int | None:
+    """Extract the session-global ``event_id`` from a raw event value."""
+    if isinstance(evt, dict):
+        eid = evt.get("event_id")
+        if isinstance(eid, int):
+            return eid
+    return None
+
+
+def read_event(store: SessionStore, key: Any) -> dict | None:
+    """Read one raw event value, logging instead of raising on failure."""
+    try:
+        evt = store.events[key]
+    except Exception as e:
+        logger.warning("Failed to read event", error=str(e), exc_info=True)
+        return None
+    return evt if isinstance(evt, dict) else None
+
+
+def cursor_position(store: SessionStore, keys: list[Any], before: int) -> int:
+    """Count events strictly older than cursor ``before`` (page end index).
+
+    Binary search over key positions with one value read per probe —
+    ``O(log n)`` value reads instead of scanning the whole log. Per-agent
+    ``event_id`` grows with key order by construction (both are assigned
+    together in ``append_event``); mirrored events with imported
+    identifiers are the documented exception and may shift a boundary by
+    their displacement.
+    """
+    lo, hi = 0, len(keys)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        eid = event_id_of(read_event(store, keys[mid]))
+        if eid is not None and eid < before:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
+
+
+def page_slice(
+    store: SessionStore,
+    keys: list[Any],
+    *,
+    end: int,
+    limit: int,
+    read: Callable[[SessionStore, Any], dict | None],
+) -> tuple[list[Any], int]:
+    """Walk a page backwards from ``end``, honoring both page bounds.
+
+    Returns the page's ``(values oldest-first, start_index)``. Reading stops
+    after ``limit`` values or once the serialized byte budget is exhausted;
+    at least one value is always read so paging always makes progress. An
+    unreadable value is skipped without consuming the budget.
+    """
+    values: list[Any] = []
+    budget = DEFAULT_HISTORY_PAGE_BYTES
+    start = end
+    while start > 0 and len(values) < limit:
+        start -= 1
+        value = read(store, keys[start])
+        if value is None:
+            continue
+        values.append(value)
+        budget -= len(json.dumps(value, default=str))
+        if budget <= 0:
+            break
+    values.reverse()
+    return values, start
+
+
+def paged_agent_events(
+    store: SessionStore,
+    target: str,
+    *,
+    limit: int,
+    before: int | None,
+    live_job_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    """Build one bounded page of a target's events (oldest-first).
+
+    Only page values are read: keys are enumerated and sliced first, so the
+    store work stays bounded regardless of log size. Cursor metadata comes
+    from the RAW page (before dedupe/normalization) so pages stay anchored
+    to real store events and cannot skip or repeat rows.
+
+    ``live_job_ids`` keeps in-flight work from being synthesized as
+    interrupted on the newest page. Older pages (``before`` set) skip the
+    interrupt synthesis entirely — see the boundary note below.
+    """
+    store.flush()
+    keys = sorted(iter_kv_keys(store.events, prefix=f"{target}:e"))
+    end = len(keys) if before is None else cursor_position(store, keys, before)
+    values, start = page_slice(store, keys, end=end, limit=limit, read=read_event)
+    oldest = event_id_of(values[0]) if values else None
+    events = dedupe_adjacent_duplicate_events(values)
+    if before is None:
+        events = normalize_resumable_events(events, live_job_ids=live_job_ids)
+    else:
+        # PAGE-BOUNDARY TRADEOFF: an older page must not synthesize
+        # "Interrupted by session resume" terminals. A page boundary can
+        # split a tool_call/tool_result pair whose real result lives in a
+        # NEWER page the client may already have rendered — synthesizing
+        # here would fabricate an interrupt bubble that then coexists with
+        # the genuine result. The cost: a job that genuinely died long ago
+        # renders on older pages without its terminal marker until that
+        # page is the newest window. Announcement repair is kept so replay
+        # pairing still works.
+        events = normalize_tool_call_events(events)
+    messages: list[dict[str, Any]] = []
+    if before is None:
+        messages = store.load_conversation(target) or []
+    return {
+        "target": target,
+        "messages": messages,
+        "events": events,
+        "has_more": start > 0 and oldest is not None,
+        "oldest_event_id": oldest,
+        "total": len(keys),
+    }
+
+
+def channel_message_seq(key: Any) -> int | None:
+    """Decode the per-channel sequence from a ``<channel>:mNNNNNN`` key."""
+    text = key.decode() if isinstance(key, bytes) else key
+    if not isinstance(text, str) or ":m" not in text:
+        return None
+    try:
+        return int(text.rsplit(":m", 1)[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def read_channel_message(store: SessionStore, key: Any) -> dict | None:
+    """Read one raw channel message value, logging instead of raising."""
+    try:
+        message = store.channels[key]
+    except Exception as e:
+        logger.warning("Failed to read channel message", error=str(e), exc_info=True)
+        return None
+    return message if isinstance(message, dict) else None
+
+
+def paged_channel_events(
+    store: SessionStore,
+    channel: str,
+    *,
+    limit: int,
+    before: int | None,
+) -> dict[str, Any]:
+    """Build one bounded page of channel messages (oldest-first).
+
+    Channel messages carry no ``event_id``; the cursor is the per-channel
+    message sequence decoded from the key, so cursor positioning needs no
+    value reads at all.
+    """
+    store.channels.flush_cache()
+    keys = sorted(iter_kv_keys(store.channels, prefix=f"{channel}:m"))
+    if before is None:
+        end = len(keys)
+    else:
+        end = sum(
+            1
+            for key in keys
+            if (seq := channel_message_seq(key)) is not None and seq < before
+        )
+    values, start = page_slice(
+        store, keys, end=end, limit=limit, read=read_channel_message
+    )
+    oldest = channel_message_seq(keys[start]) if values else None
+    events = [
+        {
+            "type": "channel_message",
+            "channel": channel,
+            "sender": m.get("sender", ""),
+            "content": m.get("content", ""),
+            "ts": m.get("ts", 0),
+        }
+        for m in values
+    ]
+    return {
+        "target": f"ch:{channel}",
+        "messages": [],
+        "events": events,
+        "has_more": start > 0 and oldest is not None,
+        "oldest_event_id": oldest,
+        "total": len(keys),
+    }
+
+
+def session_max_event_id(store: Any, events: list[dict[str, Any]]) -> int:
+    """Return the FULL log's true maximum ``event_id`` for cursor contracts.
+
+    Prefers the store's monotonic session-global counter (O(1), and mirrored
+    events ratchet it upward); falls back to scanning ``events`` when the
+    store exposes no counter. Callers serving paginated payloads MUST NOT
+    report a page-local maximum: a client advancing its incremental cursor
+    from a page-bounded value would skip or re-fetch events on the next
+    request.
+    """
+    if store is not None:
+        max_fn = getattr(store, "max_event_id", None)
+        if callable(max_fn):
+            try:
+                return int(max_fn(""))
+            except Exception as e:
+                logger.warning("max_event_id read failed", error=str(e))
+    out = 0
+    for evt in events:
+        eid = event_id_of(evt)
+        if eid is not None and eid > out:
+            out = eid
+    return out

--- a/src/kohakuterrarium/studio/persistence/history.py
+++ b/src/kohakuterrarium/studio/persistence/history.py
@@ -53,14 +53,23 @@ def history_from_store(
     session_name: str,
     target: str,
     live_job_ids: set[str] | None = None,
+    *,
+    limit: int = 0,
+    before: int | None = None,
 ) -> dict[str, Any]:
-    """Build validated target history from an already-open store."""
+    """Build validated target history from an already-open store.
+
+    ``limit`` / ``before`` bound and cursor the payload — see
+    :func:`session_history_payload`. The default keeps the full payload.
+    """
     try:
         meta = store.load_meta()
         valid_targets = set(session_targets(store, meta))
         if target not in valid_targets:
             raise NotFoundError(f"Target not found in session: {target}")
-        payload = session_history_payload(store, target, live_job_ids=live_job_ids)
+        payload = session_history_payload(
+            store, target, live_job_ids=live_job_ids, limit=limit, before=before
+        )
         payload["session_name"] = session_name
         payload["meta"] = meta
         return payload
@@ -74,11 +83,16 @@ def history_payload(
     path: Path,
     target: str,
     live_job_ids: set[str] | None = None,
+    *,
+    limit: int = 0,
+    before: int | None = None,
 ) -> dict[str, Any]:
     """Return read-only history for an agent, root, or channel target.
 
     ``live_job_ids`` prevents active work from being synthesized as interrupted.
     Saved sessions omit it because unmatched starts are no longer running.
+    ``limit`` / ``before`` bound and cursor the payload — see
+    :func:`session_history_payload`; the default keeps the full payload.
     Missing sessions and targets retain their typed errors; other failures are
     wrapped in ``SessionError``.
     """
@@ -88,7 +102,9 @@ def history_payload(
     store: SessionStore | None = None
     try:
         store = SessionStore(path)
-        return history_from_store(store, path.stem, target, live_job_ids)
+        return history_from_store(
+            store, path.stem, target, live_job_ids, limit=limit, before=before
+        )
     except (NotFoundError, SessionError):
         raise
     except Exception as e:

--- a/src/kohakuterrarium/studio/persistence/store.py
+++ b/src/kohakuterrarium/studio/persistence/store.py
@@ -7,13 +7,19 @@ deletion, history, and disk usage for individual sessions.
 """
 
 import gc
+import json
 import os
 import time
+from collections.abc import Callable
 from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
-from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.session.history import (
+    dedupe_adjacent_duplicate_events,
+    normalize_resumable_events,
+)
+from kohakuterrarium.session.store import SessionStore, iter_kv_keys
 from kohakuterrarium.session.store_lock import acquire_writer_lock, release_writer_lock
 from kohakuterrarium.studio.persistence.delete_family import (
     detach_file_family,
@@ -222,29 +228,59 @@ def session_history_payload(
     target: str,
     *,
     live_job_ids: set[str] | None = None,
+    limit: int = 0,
+    before: int | None = None,
 ) -> dict[str, Any]:
     """Return history for an agent, root, or channel target.
 
     ``live_job_ids`` identifies work still running in a live session so it is
     not synthesized as interrupted. Saved-session callers omit it because any
     unfinished persisted job is no longer active.
+
+    ``limit`` bounds the payload: with ``limit > 0`` only the most recent
+    page (at most ``limit`` events or ``DEFAULT_HISTORY_PAGE_BYTES`` of
+    event JSON, whichever fills first) is read from the store. ``before``
+    is an exclusive pagination cursor — an ``event_id`` for agent targets,
+    the per-channel message sequence for ``ch:`` targets — so the page
+    contains only events strictly older than it. The default ``limit=0``
+    keeps the full unbounded payload for programmatic callers; the HTTP
+    route supplies its own bounded default. Pages after the newest one
+    omit the conversation snapshot: it describes the whole conversation
+    and belongs to the newest window, so re-sending it per page would
+    duplicate megabytes.
+
+    Every response carries ``has_more``, ``oldest_event_id``, and ``total``
+    so clients can page backwards without gaps or overlap. ``total`` counts
+    stored events for the target; the rendered count can differ slightly
+    after adjacent-duplicate collapse and normalization.
     """
+    if limit and limit > 0:
+        if target.startswith("ch:"):
+            return _paged_channel_events(store, target[3:], limit=limit, before=before)
+        return _paged_agent_events(
+            store, target, limit=limit, before=before, live_job_ids=live_job_ids
+        )
+
     if target.startswith("ch:"):
         channel = target[3:]
         messages = store.get_channel_messages(channel)
+        events = [
+            {
+                "type": "channel_message",
+                "channel": channel,
+                "sender": m.get("sender", ""),
+                "content": m.get("content", ""),
+                "ts": m.get("ts", 0),
+            }
+            for m in messages
+        ]
         return {
             "target": target,
             "messages": [],
-            "events": [
-                {
-                    "type": "channel_message",
-                    "channel": channel,
-                    "sender": m.get("sender", ""),
-                    "content": m.get("content", ""),
-                    "ts": m.get("ts", 0),
-                }
-                for m in messages
-            ],
+            "events": events,
+            "has_more": False,
+            "oldest_event_id": None,
+            "total": len(events),
         }
 
     resumable = getattr(store, "get_resumable_events", None)
@@ -252,10 +288,196 @@ def session_history_payload(
         events = resumable(target, live_job_ids=live_job_ids)
     else:
         events = store.get_events(target)
+    events = list(events)
     return {
         "target": target,
         "messages": store.load_conversation(target) or [],
         "events": events,
+        "has_more": False,
+        "oldest_event_id": _event_id_of(events[0]) if events else None,
+        "total": len(events),
+    }
+
+
+# Pagination bounds shared by every history page: at most
+# ``DEFAULT_HISTORY_PAGE_LIMIT`` events AND at most this byte budget of
+# serialized event JSON — whichever fills first ends the page.
+DEFAULT_HISTORY_PAGE_LIMIT = 400
+DEFAULT_HISTORY_PAGE_BYTES = 4 * 1024 * 1024
+
+
+def _event_id_of(evt: Any) -> int | None:
+    """Extract the session-global ``event_id`` from a raw event value."""
+    if isinstance(evt, dict):
+        eid = evt.get("event_id")
+        if isinstance(eid, int):
+            return eid
+    return None
+
+
+def _read_event(store: SessionStore, key: Any) -> dict | None:
+    """Read one raw event value, logging instead of raising on failure."""
+    try:
+        evt = store.events[key]
+    except Exception as e:
+        logger.warning("Failed to read event", error=str(e), exc_info=True)
+        return None
+    return evt if isinstance(evt, dict) else None
+
+
+def _cursor_position(store: SessionStore, keys: list[Any], before: int) -> int:
+    """Count events strictly older than cursor ``before`` (page end index).
+
+    Binary search over key positions with one value read per probe —
+    ``O(log n)`` value reads instead of scanning the whole log. Per-agent
+    ``event_id`` grows with key order by construction (both are assigned
+    together in ``append_event``); mirrored events with imported
+    identifiers are the documented exception and may shift a boundary by
+    their displacement.
+    """
+    lo, hi = 0, len(keys)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        eid = _event_id_of(_read_event(store, keys[mid]))
+        if eid is not None and eid < before:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
+
+
+def _page_slice(
+    store: SessionStore,
+    keys: list[Any],
+    *,
+    end: int,
+    limit: int,
+    read: Callable[[SessionStore, Any], dict | None],
+) -> tuple[list[Any], int]:
+    """Walk a page backwards from ``end``, honoring both page bounds.
+
+    Returns the page's ``(values oldest-first, start_index)``. Reading stops
+    after ``limit`` values or once the serialized byte budget is exhausted;
+    at least one value is always read so paging always makes progress. An
+    unreadable value is skipped without consuming the budget.
+    """
+    values: list[Any] = []
+    budget = DEFAULT_HISTORY_PAGE_BYTES
+    start = end
+    while start > 0 and len(values) < limit:
+        start -= 1
+        value = read(store, keys[start])
+        if value is None:
+            continue
+        values.append(value)
+        budget -= len(json.dumps(value, default=str))
+        if budget <= 0:
+            break
+    values.reverse()
+    return values, start
+
+
+def _paged_agent_events(
+    store: SessionStore,
+    target: str,
+    *,
+    limit: int,
+    before: int | None,
+    live_job_ids: set[str] | None,
+) -> dict[str, Any]:
+    """Build one bounded page of a target's events (oldest-first).
+
+    Only page values are read: keys are enumerated and sliced first, so the
+    store work stays bounded regardless of log size. Cursor metadata comes
+    from the RAW page (before dedupe/normalization) so pages stay anchored
+    to real store events and cannot skip or repeat rows.
+    """
+    store.flush()
+    keys = sorted(iter_kv_keys(store.events, prefix=f"{target}:e"))
+    end = len(keys) if before is None else _cursor_position(store, keys, before)
+    values, start = _page_slice(store, keys, end=end, limit=limit, read=_read_event)
+    oldest = _event_id_of(values[0]) if values else None
+    events = normalize_resumable_events(
+        dedupe_adjacent_duplicate_events(values), live_job_ids=live_job_ids
+    )
+    messages: list[dict[str, Any]] = []
+    if before is None:
+        messages = store.load_conversation(target) or []
+    return {
+        "target": target,
+        "messages": messages,
+        "events": events,
+        "has_more": start > 0 and oldest is not None,
+        "oldest_event_id": oldest,
+        "total": len(keys),
+    }
+
+
+def _channel_message_seq(key: Any) -> int | None:
+    """Decode the per-channel sequence from a ``<channel>:mNNNNNN`` key."""
+    text = key.decode() if isinstance(key, bytes) else key
+    if not isinstance(text, str) or ":m" not in text:
+        return None
+    try:
+        return int(text.rsplit(":m", 1)[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def _read_channel_message(store: SessionStore, key: Any) -> dict | None:
+    """Read one raw channel message value, logging instead of raising."""
+    try:
+        message = store.channels[key]
+    except Exception as e:
+        logger.warning("Failed to read channel message", error=str(e), exc_info=True)
+        return None
+    return message if isinstance(message, dict) else None
+
+
+def _paged_channel_events(
+    store: SessionStore,
+    channel: str,
+    *,
+    limit: int,
+    before: int | None,
+) -> dict[str, Any]:
+    """Build one bounded page of channel messages (oldest-first).
+
+    Channel messages carry no ``event_id``; the cursor is the per-channel
+    message sequence decoded from the key, so cursor positioning needs no
+    value reads at all.
+    """
+    store.channels.flush_cache()
+    keys = sorted(iter_kv_keys(store.channels, prefix=f"{channel}:m"))
+    if before is None:
+        end = len(keys)
+    else:
+        end = sum(
+            1
+            for key in keys
+            if (seq := _channel_message_seq(key)) is not None and seq < before
+        )
+    values, start = _page_slice(
+        store, keys, end=end, limit=limit, read=_read_channel_message
+    )
+    oldest = _channel_message_seq(keys[start]) if values else None
+    events = [
+        {
+            "type": "channel_message",
+            "channel": channel,
+            "sender": m.get("sender", ""),
+            "content": m.get("content", ""),
+            "ts": m.get("ts", 0),
+        }
+        for m in values
+    ]
+    return {
+        "target": f"ch:{channel}",
+        "messages": [],
+        "events": events,
+        "has_more": start > 0 and oldest is not None,
+        "oldest_event_id": oldest,
+        "total": len(keys),
     }
 
 

--- a/src/kohakuterrarium/studio/persistence/store.py
+++ b/src/kohakuterrarium/studio/persistence/store.py
@@ -7,19 +7,17 @@ deletion, history, and disk usage for individual sessions.
 """
 
 import gc
-import json
 import os
 import time
-from collections.abc import Callable
 from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
-from kohakuterrarium.session.history import (
-    dedupe_adjacent_duplicate_events,
-    normalize_resumable_events,
+from kohakuterrarium.session.history_paging import (
+    paged_agent_events,
+    paged_channel_events,
 )
-from kohakuterrarium.session.store import SessionStore, iter_kv_keys
+from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.session.store_lock import acquire_writer_lock, release_writer_lock
 from kohakuterrarium.studio.persistence.delete_family import (
     detach_file_family,
@@ -256,8 +254,8 @@ def session_history_payload(
     """
     if limit and limit > 0:
         if target.startswith("ch:"):
-            return _paged_channel_events(store, target[3:], limit=limit, before=before)
-        return _paged_agent_events(
+            return paged_channel_events(store, target[3:], limit=limit, before=before)
+        return paged_agent_events(
             store, target, limit=limit, before=before, live_job_ids=live_job_ids
         )
 
@@ -299,13 +297,6 @@ def session_history_payload(
     }
 
 
-# Pagination bounds shared by every history page: at most
-# ``DEFAULT_HISTORY_PAGE_LIMIT`` events AND at most this byte budget of
-# serialized event JSON — whichever fills first ends the page.
-DEFAULT_HISTORY_PAGE_LIMIT = 400
-DEFAULT_HISTORY_PAGE_BYTES = 4 * 1024 * 1024
-
-
 def _event_id_of(evt: Any) -> int | None:
     """Extract the session-global ``event_id`` from a raw event value."""
     if isinstance(evt, dict):
@@ -313,172 +304,6 @@ def _event_id_of(evt: Any) -> int | None:
         if isinstance(eid, int):
             return eid
     return None
-
-
-def _read_event(store: SessionStore, key: Any) -> dict | None:
-    """Read one raw event value, logging instead of raising on failure."""
-    try:
-        evt = store.events[key]
-    except Exception as e:
-        logger.warning("Failed to read event", error=str(e), exc_info=True)
-        return None
-    return evt if isinstance(evt, dict) else None
-
-
-def _cursor_position(store: SessionStore, keys: list[Any], before: int) -> int:
-    """Count events strictly older than cursor ``before`` (page end index).
-
-    Binary search over key positions with one value read per probe —
-    ``O(log n)`` value reads instead of scanning the whole log. Per-agent
-    ``event_id`` grows with key order by construction (both are assigned
-    together in ``append_event``); mirrored events with imported
-    identifiers are the documented exception and may shift a boundary by
-    their displacement.
-    """
-    lo, hi = 0, len(keys)
-    while lo < hi:
-        mid = (lo + hi) // 2
-        eid = _event_id_of(_read_event(store, keys[mid]))
-        if eid is not None and eid < before:
-            lo = mid + 1
-        else:
-            hi = mid
-    return lo
-
-
-def _page_slice(
-    store: SessionStore,
-    keys: list[Any],
-    *,
-    end: int,
-    limit: int,
-    read: Callable[[SessionStore, Any], dict | None],
-) -> tuple[list[Any], int]:
-    """Walk a page backwards from ``end``, honoring both page bounds.
-
-    Returns the page's ``(values oldest-first, start_index)``. Reading stops
-    after ``limit`` values or once the serialized byte budget is exhausted;
-    at least one value is always read so paging always makes progress. An
-    unreadable value is skipped without consuming the budget.
-    """
-    values: list[Any] = []
-    budget = DEFAULT_HISTORY_PAGE_BYTES
-    start = end
-    while start > 0 and len(values) < limit:
-        start -= 1
-        value = read(store, keys[start])
-        if value is None:
-            continue
-        values.append(value)
-        budget -= len(json.dumps(value, default=str))
-        if budget <= 0:
-            break
-    values.reverse()
-    return values, start
-
-
-def _paged_agent_events(
-    store: SessionStore,
-    target: str,
-    *,
-    limit: int,
-    before: int | None,
-    live_job_ids: set[str] | None,
-) -> dict[str, Any]:
-    """Build one bounded page of a target's events (oldest-first).
-
-    Only page values are read: keys are enumerated and sliced first, so the
-    store work stays bounded regardless of log size. Cursor metadata comes
-    from the RAW page (before dedupe/normalization) so pages stay anchored
-    to real store events and cannot skip or repeat rows.
-    """
-    store.flush()
-    keys = sorted(iter_kv_keys(store.events, prefix=f"{target}:e"))
-    end = len(keys) if before is None else _cursor_position(store, keys, before)
-    values, start = _page_slice(store, keys, end=end, limit=limit, read=_read_event)
-    oldest = _event_id_of(values[0]) if values else None
-    events = normalize_resumable_events(
-        dedupe_adjacent_duplicate_events(values), live_job_ids=live_job_ids
-    )
-    messages: list[dict[str, Any]] = []
-    if before is None:
-        messages = store.load_conversation(target) or []
-    return {
-        "target": target,
-        "messages": messages,
-        "events": events,
-        "has_more": start > 0 and oldest is not None,
-        "oldest_event_id": oldest,
-        "total": len(keys),
-    }
-
-
-def _channel_message_seq(key: Any) -> int | None:
-    """Decode the per-channel sequence from a ``<channel>:mNNNNNN`` key."""
-    text = key.decode() if isinstance(key, bytes) else key
-    if not isinstance(text, str) or ":m" not in text:
-        return None
-    try:
-        return int(text.rsplit(":m", 1)[1])
-    except (IndexError, ValueError):
-        return None
-
-
-def _read_channel_message(store: SessionStore, key: Any) -> dict | None:
-    """Read one raw channel message value, logging instead of raising."""
-    try:
-        message = store.channels[key]
-    except Exception as e:
-        logger.warning("Failed to read channel message", error=str(e), exc_info=True)
-        return None
-    return message if isinstance(message, dict) else None
-
-
-def _paged_channel_events(
-    store: SessionStore,
-    channel: str,
-    *,
-    limit: int,
-    before: int | None,
-) -> dict[str, Any]:
-    """Build one bounded page of channel messages (oldest-first).
-
-    Channel messages carry no ``event_id``; the cursor is the per-channel
-    message sequence decoded from the key, so cursor positioning needs no
-    value reads at all.
-    """
-    store.channels.flush_cache()
-    keys = sorted(iter_kv_keys(store.channels, prefix=f"{channel}:m"))
-    if before is None:
-        end = len(keys)
-    else:
-        end = sum(
-            1
-            for key in keys
-            if (seq := _channel_message_seq(key)) is not None and seq < before
-        )
-    values, start = _page_slice(
-        store, keys, end=end, limit=limit, read=_read_channel_message
-    )
-    oldest = _channel_message_seq(keys[start]) if values else None
-    events = [
-        {
-            "type": "channel_message",
-            "channel": channel,
-            "sender": m.get("sender", ""),
-            "content": m.get("content", ""),
-            "ts": m.get("ts", 0),
-        }
-        for m in values
-    ]
-    return {
-        "target": f"ch:{channel}",
-        "messages": [],
-        "events": events,
-        "has_more": start > 0 and oldest is not None,
-        "oldest_event_id": oldest,
-        "total": len(keys),
-    }
 
 
 def _unlink_with_retry(path: Path, attempts: int = 5, base_delay: float = 0.05) -> None:

--- a/src/kohakuterrarium/terrarium/creature_history.py
+++ b/src/kohakuterrarium/terrarium/creature_history.py
@@ -1,0 +1,165 @@
+"""Live per-creature chat-history and branch-metadata reads.
+
+Split out of :mod:`kohakuterrarium.terrarium.creature_ops` (the shared
+agent-read surface) so the history builders own one cohesive area. Every
+function takes the engine + creature id and touches only ``Agent`` +
+``SessionStore`` — same tier rules as creature_ops: no ``studio`` / ``api``
+imports, so the session-tier paging helpers in
+:mod:`kohakuterrarium.session.history_paging` are the shared ground truth
+for saved and live cursors.
+"""
+
+from typing import Any
+
+from kohakuterrarium.session.history import project_branch_metadata
+from kohakuterrarium.session.history_paging import (
+    event_id_of,
+    paged_agent_events,
+    session_max_event_id,
+)
+from kohakuterrarium.terrarium.engine import Terrarium
+
+
+def _resumable_events(
+    store: Any, name: str, live_jobs: set[str]
+) -> list[dict[str, Any]]:
+    if store is None:
+        return []
+    try:
+        return store.get_resumable_events(name, live_job_ids=live_jobs)
+    except Exception:
+        return []
+
+
+def agent_live_job_ids(agent: Any) -> set[str]:
+    """Best-effort union of "still actually running" job ids on an agent.
+
+    ``_direct_job_meta`` only tracks jobs the controller is *currently*
+    awaiting in the foreground turn. A background-promoted sub-agent
+    (or executor-backed background tool) is dropped from
+    ``_direct_job_meta`` the moment it's promoted, even though
+    ``subagent_manager`` / ``executor`` still own its live task. Bug 1
+    surfaces because ``normalize_resumable_events`` synthesised an
+    "Interrupted by session resume" terminal for those background jobs
+    — the frontend then rendered the still-live bubble as interrupted.
+    Union all three sources so the synthesis only fires for genuinely
+    dead jobs.
+    """
+    live: set[str] = set(getattr(agent, "_direct_job_meta", {}).keys())
+    sub_mgr = getattr(agent, "subagent_manager", None)
+    if sub_mgr is not None:
+        try:
+            for status in sub_mgr.get_running_jobs():
+                jid = getattr(status, "job_id", None)
+                if isinstance(jid, str) and jid:
+                    live.add(jid)
+        except Exception:  # pragma: no cover - defensive
+            pass
+    executor = getattr(agent, "executor", None)
+    if executor is not None:
+        get_running = getattr(executor, "get_running_jobs", None)
+        if callable(get_running):
+            try:
+                for status in get_running():
+                    jid = getattr(status, "job_id", None)
+                    if isinstance(jid, str) and jid:
+                        live.add(jid)
+            except Exception:  # pragma: no cover - defensive
+                pass
+    return live
+
+
+def chat_history_for(
+    engine: Terrarium,
+    creature_id: str,
+    *,
+    limit: int = 0,
+    before: int | None = None,
+) -> dict[str, Any]:
+    """Conversation snapshot + event log for one live creature.
+
+    ``limit`` / ``before`` page the event log AT THE STORE READ, with the
+    same cursor contract as the saved-session history route: at most
+    ``limit`` events (or ~4MB of event JSON), ``before`` an exclusive
+    ``event_id`` cursor. Only the page's values are read, so a 75k-event
+    log costs one key enumeration plus one page of reads instead of the
+    multi-second full build. The default ``limit=0`` keeps the full build
+    for branch/rewind resyncs that need the whole log.
+
+    ``max_event_id`` always reports the FULL log's true maximum (the
+    session-global counter) — never the page maximum, which would desync a
+    client's incremental cursor. Older pages (``before`` set) omit the
+    conversation snapshot, mirroring the saved-route contract.
+    """
+    creature = engine.get_creature(creature_id)
+    agent = creature.agent
+    live_jobs = agent_live_job_ids(agent)
+    # Agent-attached store is primary; the engine's lifecycle-attached
+    # store (``_session_stores[graph_id]``) is the fallback for agents
+    # that never got an agent-level attach (older terrarium recipes).
+    agent_store = getattr(agent, "session_store", None)
+    fallback = engine._session_stores.get(creature.graph_id)
+    if limit and limit > 0:
+        store = agent_store if agent_store is not None else fallback
+        if store is None:
+            page: dict[str, Any] = {
+                "events": [],
+                "has_more": False,
+                "oldest_event_id": None,
+                "total": 0,
+            }
+        else:
+            page = paged_agent_events(
+                store,
+                creature.name,
+                limit=limit,
+                before=before,
+                live_job_ids=live_jobs,
+            )
+        return {
+            **page,
+            "creature_id": creature_id,
+            "session_id": creature.graph_id,
+            # Snapshot only on the newest page — it describes the whole
+            # conversation; per-page copies would duplicate megabytes.
+            "messages": (
+                []
+                if before is not None
+                else list(getattr(agent, "conversation_history", []) or [])
+            ),
+            "is_processing": bool(agent.is_processing),
+            "max_event_id": session_max_event_id(store, page["events"]),
+        }
+    events = _resumable_events(agent_store, creature.name, live_jobs)
+    if not events:
+        events = _resumable_events(fallback, creature.name, live_jobs)
+    return {
+        "creature_id": creature_id,
+        "session_id": creature.graph_id,
+        "messages": list(getattr(agent, "conversation_history", []) or []),
+        "events": events,
+        "is_processing": bool(agent.is_processing),
+        "has_more": False,
+        "oldest_event_id": event_id_of(events[0]) if events else None,
+        "total": len(events),
+        "max_event_id": session_max_event_id(
+            agent_store if agent_store is not None else fallback, events
+        ),
+    }
+
+
+def chat_branches_for(engine: Terrarium, creature_id: str) -> list[dict[str, Any]]:
+    creature = engine.get_creature(creature_id)
+    agent = creature.agent
+    live_jobs = agent_live_job_ids(agent)
+    events = _resumable_events(
+        getattr(agent, "session_store", None), creature.name, live_jobs
+    )
+    if not events:
+        fallback = engine._session_stores.get(creature.graph_id)
+        events = _resumable_events(fallback, creature.name, live_jobs)
+    projection = project_branch_metadata(events)
+    return [
+        {"turn_index": turn_index, **metadata}
+        for turn_index, metadata in projection.items()
+    ]

--- a/src/kohakuterrarium/terrarium/creature_ops.py
+++ b/src/kohakuterrarium/terrarium/creature_ops.py
@@ -33,8 +33,16 @@ from kohakuterrarium.core.agent_tool_options import (
 )
 from kohakuterrarium.core.scratchpad import is_reserved_scratchpad_key
 from kohakuterrarium.modules.user_command.base import UserCommandContext
-from kohakuterrarium.session.history import project_branch_metadata
 from kohakuterrarium.terrarium.command_inventory import build_command_inventory
+
+# Live chat-history builders live in their own module; re-exported here so
+# every existing ``creature_ops`` importer (service.py, routes, tests) keeps
+# resolving the same names.
+from kohakuterrarium.terrarium.creature_history import (
+    agent_live_job_ids,
+    chat_branches_for,
+    chat_history_for,
+)
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium.events import EngineEvent, EventKind
 from kohakuterrarium.terrarium.topology import GraphTopology
@@ -596,99 +604,6 @@ async def agent_execute_command(
     if result.data is not None:
         resp["data"] = result.data
     return resp
-
-
-# ---------------------------------------------------------------------------
-# Chat history / branches — touches agent + session_store
-# ---------------------------------------------------------------------------
-
-
-def _resumable_events(
-    store: Any, name: str, live_jobs: set[str]
-) -> list[dict[str, Any]]:
-    if store is None:
-        return []
-    try:
-        return store.get_resumable_events(name, live_job_ids=live_jobs)
-    except Exception:
-        return []
-
-
-def agent_live_job_ids(agent: Any) -> set[str]:
-    """Best-effort union of "still actually running" job ids on an agent.
-
-    ``_direct_job_meta`` only tracks jobs the controller is *currently*
-    awaiting in the foreground turn. A background-promoted sub-agent
-    (or executor-backed background tool) is dropped from
-    ``_direct_job_meta`` the moment it's promoted, even though
-    ``subagent_manager`` / ``executor`` still own its live task. Bug 1
-    surfaces because ``normalize_resumable_events`` synthesised an
-    "Interrupted by session resume" terminal for those background jobs
-    — the frontend then rendered the still-live bubble as interrupted.
-    Union all three sources so the synthesis only fires for genuinely
-    dead jobs.
-    """
-    live: set[str] = set(getattr(agent, "_direct_job_meta", {}).keys())
-    sub_mgr = getattr(agent, "subagent_manager", None)
-    if sub_mgr is not None:
-        try:
-            for status in sub_mgr.get_running_jobs():
-                jid = getattr(status, "job_id", None)
-                if isinstance(jid, str) and jid:
-                    live.add(jid)
-        except Exception:  # pragma: no cover - defensive
-            pass
-    executor = getattr(agent, "executor", None)
-    if executor is not None:
-        get_running = getattr(executor, "get_running_jobs", None)
-        if callable(get_running):
-            try:
-                for status in get_running():
-                    jid = getattr(status, "job_id", None)
-                    if isinstance(jid, str) and jid:
-                        live.add(jid)
-            except Exception:  # pragma: no cover - defensive
-                pass
-    return live
-
-
-def chat_history_for(engine: Terrarium, creature_id: str) -> dict[str, Any]:
-    creature = engine.get_creature(creature_id)
-    agent = creature.agent
-    live_jobs = agent_live_job_ids(agent)
-    # Agent-attached store is primary; the engine's lifecycle-attached
-    # store (``_session_stores[graph_id]``) is the fallback for agents
-    # that never got an agent-level attach (older terrarium recipes).
-    events = _resumable_events(
-        getattr(agent, "session_store", None), creature.name, live_jobs
-    )
-    if not events:
-        fallback = engine._session_stores.get(creature.graph_id)
-        events = _resumable_events(fallback, creature.name, live_jobs)
-    return {
-        "creature_id": creature_id,
-        "session_id": creature.graph_id,
-        "messages": list(getattr(agent, "conversation_history", []) or []),
-        "events": events,
-        "is_processing": bool(agent.is_processing),
-    }
-
-
-def chat_branches_for(engine: Terrarium, creature_id: str) -> list[dict[str, Any]]:
-    creature = engine.get_creature(creature_id)
-    agent = creature.agent
-    live_jobs = agent_live_job_ids(agent)
-    events = _resumable_events(
-        getattr(agent, "session_store", None), creature.name, live_jobs
-    )
-    if not events:
-        fallback = engine._session_stores.get(creature.graph_id)
-        events = _resumable_events(fallback, creature.name, live_jobs)
-    projection = project_branch_metadata(events)
-    return [
-        {"turn_index": turn_index, **metadata}
-        for turn_index, metadata in projection.items()
-    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/kohakuterrarium/terrarium/multi_node_service.py
+++ b/src/kohakuterrarium/terrarium/multi_node_service.py
@@ -572,9 +572,12 @@ class MultiNodeTerrariumService(
     # Per-creature chat / state / mutation / wiring — all route by home.
     # ------------------------------------------------------------------
 
-    async def chat_history(self, creature_id: str) -> dict[str, Any]:
+    async def chat_history(
+        self, creature_id: str, *, limit: int = 0, before: int | None = None
+    ) -> dict[str, Any]:
         return await self._route_per_creature(
-            creature_id, lambda svc: svc.chat_history(creature_id)
+            creature_id,
+            lambda svc: svc.chat_history(creature_id, limit=limit, before=before),
         )
 
     async def chat_branches(self, creature_id: str) -> list[dict[str, Any]]:

--- a/src/kohakuterrarium/terrarium/remote_service.py
+++ b/src/kohakuterrarium/terrarium/remote_service.py
@@ -346,9 +346,14 @@ class RemoteTerrariumService(
     # Per-creature chat ops
     # ------------------------------------------------------------------
 
-    async def chat_history(self, creature_id: str) -> dict[str, Any]:
+    async def chat_history(
+        self, creature_id: str, *, limit: int = 0, before: int | None = None
+    ) -> dict[str, Any]:
         body = _maybe_raise(
-            await self._req("chat_history", {"creature_id": creature_id})
+            await self._req(
+                "chat_history",
+                {"creature_id": creature_id, "limit": limit, "before": before},
+            )
         )
         return body.get("history", {})
 

--- a/src/kohakuterrarium/terrarium/service.py
+++ b/src/kohakuterrarium/terrarium/service.py
@@ -281,8 +281,19 @@ class TerrariumService(DriveServiceProtocol, Protocol):
 
     # === Per-creature chat ops (route-by-home) ===
 
-    async def chat_history(self, creature_id: str) -> dict[str, Any]:
-        """Return conversation snapshot + event log for replay."""
+    async def chat_history(
+        self,
+        creature_id: str,
+        *,
+        limit: int = 0,
+        before: int | None = None,
+    ) -> dict[str, Any]:
+        """Return conversation snapshot + event log for replay.
+
+        ``limit`` / ``before`` page the event log at the store read (same
+        cursor contract as the saved-session history route); the default
+        ``limit=0`` keeps the full build.
+        """
         ...
 
     async def chat_branches(self, creature_id: str) -> list[dict[str, Any]]:
@@ -714,8 +725,10 @@ class LocalTerrariumService(LocalCommandServiceMixin, DriveServiceMixin):
     def _agent(self, creature_id: str):
         return self._engine.get_creature(creature_id).agent
 
-    async def chat_history(self, creature_id: str) -> dict[str, Any]:
-        return _chat_history_for(self._engine, creature_id)
+    async def chat_history(
+        self, creature_id: str, *, limit: int = 0, before: int | None = None
+    ) -> dict[str, Any]:
+        return _chat_history_for(self._engine, creature_id, limit=limit, before=before)
 
     async def chat_event(self, creature_id: str, event_id: int) -> dict[str, Any]:
         """Fetch one persisted event (lazy full-output companion of history)."""

--- a/tests/unit/api/test_creature_chat_history_paging.py
+++ b/tests/unit/api/test_creature_chat_history_paging.py
@@ -348,6 +348,26 @@ class TestLiveChannelPaging:
         finally:
             store.close()
 
+    def test_channel_limit_zero_returns_full_log(self, tmp_path):
+        # ``limit=0`` is the documented full-payload escape hatch; the
+        # channel target must honor it instead of answering with an
+        # empty page (the paging helpers only serve bounded pages).
+        store = _make_store(tmp_path, channel_messages=30)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        client = _client(engine)
+        try:
+            body = client.get(
+                f"/sessions/{GRAPH_ID}/creatures/ch:ops/history",
+                params={"limit": 0},
+            ).json()
+            assert [e["content"] for e in body["events"]] == [
+                f"c{i}" for i in range(30)
+            ]
+            assert body["has_more"] is False
+            assert body["total"] == 30
+        finally:
+            store.close()
+
     def test_channel_without_local_store_keeps_full_merge(self):
         # No host-local store surface on the service: the legacy full
         # cross-node merge answers, with has_more explicitly false because

--- a/tests/unit/api/test_creature_chat_history_paging.py
+++ b/tests/unit/api/test_creature_chat_history_paging.py
@@ -1,0 +1,417 @@
+"""Live history route paging: bounded pages, cursors, and store reuse.
+
+The dashboard loads live creature history through
+``GET /{sid}/creatures/{cid}/history`` after every attach, tab switch, and
+turn; before paging that request built the ENTIRE event log synchronously
+on the event loop (the 331MB problem session measured a ~7s build for a
+123MB response). These tests pin the store-read paging contract: bounded
+by default, ``before`` walks backwards, ``since_event_id`` composes,
+``max_event_id`` stays the full-log truth, and the engine-held store is
+never reopened.
+"""
+
+import types
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from kohakuterrarium.api.deps import get_service
+from kohakuterrarium.api.routes.sessions_v2 import creatures_chat as chat_mod
+from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.terrarium.creature_history import chat_history_for
+from kohakuterrarium.terrarium.service import CreatureInfo
+
+GRAPH_ID = "graph_live1"
+
+
+def _info(cid="cid", name="alice"):
+    return CreatureInfo(
+        creature_id=cid,
+        name=name,
+        graph_id=GRAPH_ID,
+        is_running=True,
+        is_privileged=False,
+        parent_creature_id=None,
+        listen_channels=(),
+        send_channels=(),
+    )
+
+
+class _FakeAgent:
+    def __init__(self, name, store=None):
+        self.name = name
+        self.session_store = store
+        self.conversation_history = [{"role": "user", "content": "snapshot"}]
+        self.is_processing = False
+        self._direct_job_meta = {}
+
+
+class _FakeCreature:
+    def __init__(self, agent, name="alice"):
+        self.agent = agent
+        self.name = name
+        self.graph_id = GRAPH_ID
+        self.is_privileged = False
+
+
+class _FakeEngine:
+    """Minimal engine surface ``chat_history_for`` touches."""
+
+    def __init__(self, creature, store=None):
+        self._creature = creature
+        self._session_stores = {GRAPH_ID: store} if store is not None else {}
+
+    def get_creature(self, cid):
+        return self._creature
+
+
+class _DelegatingService:
+    """Routes ``chat_history`` through the REAL ``chat_history_for`` so the
+    paging contract is exercised end to end from the HTTP layer."""
+
+    def __init__(self, engine):
+        self._engine = engine
+        # ``live_store_entry`` reads this for the ``ch:`` branch.
+        self._session_stores = engine._session_stores
+
+    async def list_creatures(self):
+        return (_info(),)
+
+    async def chat_history(self, creature_id, **kwargs):
+        return chat_history_for(self._engine, creature_id, **kwargs)
+
+
+def _make_store(
+    tmp_path: Path,
+    *,
+    agent: str = "alice",
+    events: int = 0,
+    channel_messages: int = 0,
+    channel: str = "ops",
+) -> SessionStore:
+    path = tmp_path / "alice_3f2a9c11.kohakutr"
+    store = SessionStore(str(path))
+    store.init_meta(
+        agent,
+        "agent",
+        "/p",
+        "/w",
+        [agent],
+        terrarium_channels=[{"name": channel}] if channel_messages else None,
+    )
+    for i in range(events):
+        store.append_event(agent, "user_message", {"content": f"m{i}"})
+    for i in range(channel_messages):
+        store.save_channel_message(channel, {"sender": "a", "content": f"c{i}"})
+    store.flush()
+    return store
+
+
+def _client(engine):
+    app = FastAPI()
+    app.dependency_overrides[get_service] = lambda: _DelegatingService(engine)
+    app.include_router(chat_mod.router, prefix="/sessions")
+    return TestClient(app)
+
+
+# ── agent-target paging ────────────────────────────────────────
+
+
+class TestLiveAgentPaging:
+    def test_default_response_is_bounded(self, tmp_path):
+        store = _make_store(tmp_path, events=450)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        try:
+            body = (
+                _client(engine)
+                .get(f"/sessions/{GRAPH_ID}/creatures/alice/history")
+                .json()
+            )
+            assert len(body["events"]) == 400
+            assert body["has_more"] is True
+            assert body["total"] == 450
+            assert body["oldest_event_id"] == body["events"][0]["event_id"]
+            assert body["events"][-1]["event_id"] == 450
+            # Newest page carries the live conversation snapshot.
+            assert body["messages"] == [{"role": "user", "content": "snapshot"}]
+            assert body["is_processing"] is False
+            # Full-log truth, NOT the page maximum — a client advancing its
+            # incremental cursor from a page-bounded max would re-fetch.
+            assert body["max_event_id"] == 450
+        finally:
+            store.close()
+
+    def test_before_cursor_walks_older_pages(self, tmp_path):
+        store = _make_store(tmp_path, events=10)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        client = _client(engine)
+        try:
+            page1 = client.get(
+                f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                params={"limit": 4},
+            ).json()
+            assert [e["event_id"] for e in page1["events"]] == [7, 8, 9, 10]
+            page2 = client.get(
+                f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                params={"limit": 4, "before": page1["oldest_event_id"]},
+            ).json()
+            assert [e["event_id"] for e in page2["events"]] == [3, 4, 5, 6]
+            # Older pages omit the snapshot — it belongs to the newest
+            # window and would duplicate megabytes per request.
+            assert page2["messages"] == []
+            assert page2["has_more"] is True
+            assert page2["total"] == 10
+            # max_event_id stays the full-log maximum on cursor pages.
+            assert page2["max_event_id"] == 10
+        finally:
+            store.close()
+
+    def test_limit_zero_returns_full_log(self, tmp_path):
+        store = _make_store(tmp_path, events=450)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        try:
+            body = (
+                _client(engine)
+                .get(
+                    f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                    params={"limit": 0},
+                )
+                .json()
+            )
+            assert len(body["events"]) == 450
+            assert body["has_more"] is False
+            assert body["total"] == 450
+            assert body["max_event_id"] == 450
+        finally:
+            store.close()
+
+    def test_since_event_id_composes_with_the_default_bound(self, tmp_path):
+        store = _make_store(tmp_path, events=450)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        try:
+            body = (
+                _client(engine)
+                .get(
+                    f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                    params={"since_event_id": 100},
+                )
+                .json()
+            )
+            ids = [e["event_id"] for e in body["events"]]
+            # Newest page of the log minus the already-applied prefix.
+            assert ids == list(range(101, 451))
+            # Incremental payloads omit the snapshot.
+            assert "messages" not in body
+            assert body["max_event_id"] == 450
+        finally:
+            store.close()
+
+    def test_negative_limit_is_rejected(self, tmp_path):
+        store = _make_store(tmp_path, events=5)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        try:
+            resp = _client(engine).get(
+                f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                params={"limit": -1},
+            )
+            assert resp.status_code == 422
+        finally:
+            store.close()
+
+    def test_live_history_never_reopens_the_store_file(self, tmp_path):
+        store = _make_store(tmp_path, events=10)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+
+        original_init = SessionStore.__init__
+
+        def _bomb(self, *a, **k):
+            raise AssertionError("live history must not open the session file")
+
+        SessionStore.__init__ = _bomb
+        try:
+            client = _client(engine)
+            body = client.get(
+                f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                params={"limit": 3},
+            ).json()
+            assert [e["event_id"] for e in body["events"]] == [8, 9, 10]
+            older = client.get(
+                f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                params={"limit": 3, "before": body["oldest_event_id"]},
+            ).json()
+            assert [e["event_id"] for e in older["events"]] == [5, 6, 7]
+        finally:
+            SessionStore.__init__ = original_init
+            store.close()
+
+
+class TestLivePageBoundaryInterrupt:
+    """A live ``before`` page must not fabricate interrupt terminals.
+
+    The page boundary can end on a ``tool_call`` whose real result lives
+    in a NEWER page the client already rendered; synthesizing an
+    "Interrupted by session resume" bubble there would leave a fake
+    terminal coexisting with the genuine result (P1 review). The newest
+    window keeps the synthesis — a dangling call at the log tail with no
+    live job IS dead.
+    """
+
+    def _tool_store(self, tmp_path: Path) -> SessionStore:
+        store = _make_store(tmp_path)
+        store.append_event("alice", "user_message", {"content": "u1"})  # id 1
+        store.append_event(
+            "alice", "tool_call", {"call_id": "j1", "name": "bash", "args": {}}
+        )  # id 2
+        store.append_event(
+            "alice", "tool_result", {"call_id": "j1", "output": "ok"}
+        )  # id 3
+        store.append_event("alice", "user_message", {"content": "u2"})  # id 4
+        store.append_event(
+            "alice", "tool_call", {"call_id": "j2", "name": "bash", "args": {}}
+        )  # id 5 — dangling, no live job
+        store.flush()
+        return store
+
+    def test_older_page_does_not_synthesize_interrupt(self, tmp_path):
+        store = self._tool_store(tmp_path)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        try:
+            body = (
+                _client(engine)
+                .get(
+                    f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                    params={"limit": 10, "before": 3},
+                )
+                .json()
+            )
+            ids = [e.get("event_id") for e in body["events"]]
+            assert 2 in ids and 3 not in ids  # boundary split the pair
+            assert not any(
+                e.get("_synthetic_resume") or e.get("final_state") == "interrupted"
+                for e in body["events"]
+            )
+        finally:
+            store.close()
+
+    def test_newest_window_still_synthesizes_for_dead_jobs(self, tmp_path):
+        store = self._tool_store(tmp_path)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        try:
+            body = (
+                _client(engine)
+                .get(
+                    f"/sessions/{GRAPH_ID}/creatures/alice/history",
+                    params={"limit": 2},
+                )
+                .json()
+            )
+            synthetic = [
+                e
+                for e in body["events"]
+                if e.get("_synthetic_resume") and e.get("call_id") == "j2"
+            ]
+            assert len(synthetic) == 1
+            assert synthetic[0]["final_state"] == "interrupted"
+        finally:
+            store.close()
+
+
+# ── channel-target paging ──────────────────────────────────────
+
+
+class TestLiveChannelPaging:
+    def test_channel_pages_use_sequence_cursor(self, tmp_path):
+        store = _make_store(tmp_path, channel_messages=30)
+        engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+        client = _client(engine)
+        try:
+            page1 = client.get(
+                f"/sessions/{GRAPH_ID}/creatures/ch:ops/history",
+                params={"limit": 10},
+            ).json()
+            assert [e["content"] for e in page1["events"]] == [
+                f"c{i}" for i in range(20, 30)
+            ]
+            assert page1["has_more"] is True
+            assert page1["total"] == 30
+            assert page1["max_event_id"] == 0
+            page2 = client.get(
+                f"/sessions/{GRAPH_ID}/creatures/ch:ops/history",
+                params={"limit": 10, "before": page1["oldest_event_id"]},
+            ).json()
+            assert [e["content"] for e in page2["events"]] == [
+                f"c{i}" for i in range(10, 20)
+            ]
+            assert page2["has_more"] is True
+        finally:
+            store.close()
+
+    def test_channel_without_local_store_keeps_full_merge(self):
+        # No host-local store surface on the service: the legacy full
+        # cross-node merge answers, with has_more explicitly false because
+        # the merged log has no sequence cursor.
+        class _RemoteService:
+            async def list_creatures(self):
+                return (_info(),)
+
+            async def channel_history(self, gid, name):
+                assert (gid, name) == (GRAPH_ID, "ops")
+                return [{"sender": "a", "content": "x", "timestamp": 1.0}]
+
+        app = FastAPI()
+        app.dependency_overrides[get_service] = lambda: _RemoteService()
+        app.include_router(chat_mod.router, prefix="/sessions")
+        body = (
+            TestClient(app).get(f"/sessions/{GRAPH_ID}/creatures/ch:ops/history").json()
+        )
+        assert [e["content"] for e in body["events"]] == ["x"]
+        assert body["has_more"] is False
+        assert body["total"] == 1
+
+
+# ── chat_history_for paging units ──────────────────────────────
+
+
+class TestChatHistoryForPaging:
+    def test_paged_read_without_store_yields_empty_page(self):
+        # Neither an agent-attached store nor a lifecycle store: the paged
+        # payload degrades to an empty page instead of raising.
+        agent = _FakeAgent("alice", None)
+        engine = _FakeEngine(_FakeCreature(agent))
+        out = chat_history_for(engine, "cid", limit=5, before=None)
+        assert out["events"] == []
+        assert out["total"] == 0
+        assert out["has_more"] is False
+        assert out["messages"] == agent.conversation_history
+        assert out["max_event_id"] == 0
+
+    def test_unreadable_store_counter_falls_back_to_event_scan(self, tmp_path):
+        store = _make_store(tmp_path, events=6)
+        # Simulate a store without the O(1) counter: the payload max must
+        # still be derived rather than reported as 0.
+        counterless = types.SimpleNamespace(
+            flush=store.flush,
+            events=store.events,
+            load_conversation=store.load_conversation,
+        )
+        agent = _FakeAgent("alice", counterless)
+        engine = _FakeEngine(_FakeCreature(agent), store)
+        try:
+            out = chat_history_for(engine, "cid", limit=3, before=None)
+            assert out["max_event_id"] == 6
+        finally:
+            store.close()
+
+
+@pytest.mark.parametrize("event_count,limit,expected", [(2, 5, 2), (0, 5, 0)])
+def test_small_logs_page_without_has_more(tmp_path, event_count, limit, expected):
+    store = _make_store(tmp_path, events=event_count)
+    engine = _FakeEngine(_FakeCreature(_FakeAgent("alice", store)), store)
+    try:
+        out = chat_history_for(engine, "cid", limit=limit, before=None)
+        assert len(out["events"]) == expected
+        assert out["has_more"] is False
+    finally:
+        store.close()

--- a/tests/unit/api/test_creature_chat_route.py
+++ b/tests/unit/api/test_creature_chat_route.py
@@ -96,7 +96,8 @@ class _FakeService:
         if "rewind" in self._raise:
             raise self._raise["rewind"]
 
-    async def chat_history(self, cid):
+    async def chat_history(self, cid, **kw):
+        self.history_kwargs = kw
         if "chat_history" in self._raise:
             raise self._raise["chat_history"]
         return self._history

--- a/tests/unit/api/test_persistence_fork_history_routes.py
+++ b/tests/unit/api/test_persistence_fork_history_routes.py
@@ -371,11 +371,11 @@ class TestHistoryPagination:
             store.close()
 
     def test_byte_budget_caps_page_below_limit(self, monkeypatch, tmp_path):
-        from kohakuterrarium.studio.persistence import store as store_mod
+        from kohakuterrarium.session import history_paging as paging_mod
 
         store = _make_store(tmp_path, events=50, content_size=100)
         try:
-            monkeypatch.setattr(store_mod, "DEFAULT_HISTORY_PAGE_BYTES", 10_000)
+            monkeypatch.setattr(paging_mod, "DEFAULT_HISTORY_PAGE_BYTES", 10_000)
             client = _saved_client(monkeypatch, store)
             body = client.get("/api/sess/history/alice", params={"limit": 400}).json()
             assert 1 <= len(body["events"]) < 50
@@ -496,5 +496,81 @@ class TestHistoryPagination:
             assert len(payload["events"]) == 450
             assert payload["has_more"] is False
             assert payload["total"] == 450
+        finally:
+            store.close()
+
+
+class TestPageBoundaryInterruptSynthesis:
+    """A page boundary must not fabricate "Interrupted by session resume".
+
+    A ``before`` page can end on a ``tool_call`` whose real ``tool_result``
+    lives in a NEWER page; synthesizing an interrupt there would fabricate
+    a terminal that then coexists with the genuine result after the client
+    accumulates both pages (P1). Older pages therefore skip the synthesis;
+    the newest window keeps it (an unfinished call at the log tail IS dead
+    for a saved session).
+    """
+
+    def _tool_store(self, tmp_path: Path) -> SessionStore:
+        path = tmp_path / "alice_3f2a9c11.kohakutr"
+        store = SessionStore(str(path))
+        store.init_meta("alice", "agent", "/p", "/w", ["alice"])
+        store.append_event("alice", "user_message", {"content": "u1"})  # id 1
+        store.append_event(
+            "alice", "tool_call", {"call_id": "j1", "name": "bash", "args": {}}
+        )  # id 2
+        store.append_event(
+            "alice", "tool_result", {"call_id": "j1", "output": "ok"}
+        )  # id 3
+        store.append_event("alice", "user_message", {"content": "u2"})  # id 4
+        store.append_event(
+            "alice", "tool_call", {"call_id": "j2", "name": "bash", "args": {}}
+        )  # id 5 — never finished (genuinely dead)
+        store.flush()
+        return store
+
+    def test_older_page_does_not_synthesize_interrupt(self, monkeypatch, tmp_path):
+        store = self._tool_store(tmp_path)
+        try:
+            monkeypatch.setattr(history_mod, "live_store_entry", lambda svc, n: None)
+            monkeypatch.setattr(
+                history_mod, "resolve_session_path_default", lambda n: Path(store.path)
+            )
+            client = TestClient(_app(history_mod.router))
+            # Page ending exactly between tool_call j1 (id 2) and its
+            # result (id 3): the boundary splits the pair.
+            body = client.get(
+                "/api/sess/history/alice",
+                params={"limit": 10, "before": 3},
+            ).json()
+            ids = [e.get("event_id") for e in body["events"]]
+            assert 2 in ids and 3 not in ids
+            # Announcement repair may inject id-less assistant rows, but no
+            # synthetic interrupt terminal may appear.
+            assert not any(
+                e.get("_synthetic_resume") or e.get("final_state") == "interrupted"
+                for e in body["events"]
+            )
+        finally:
+            store.close()
+
+    def test_newest_page_still_synthesizes_for_dead_jobs(self, monkeypatch, tmp_path):
+        store = self._tool_store(tmp_path)
+        try:
+            monkeypatch.setattr(history_mod, "live_store_entry", lambda svc, n: None)
+            monkeypatch.setattr(
+                history_mod, "resolve_session_path_default", lambda n: Path(store.path)
+            )
+            client = TestClient(_app(history_mod.router))
+            body = client.get("/api/sess/history/alice", params={"limit": 2}).json()
+            # The tail holds tool_call j2 with no result anywhere: the
+            # interrupt synthesis must still fire on the newest window.
+            synthetic = [
+                e
+                for e in body["events"]
+                if e.get("_synthetic_resume") and e.get("call_id") == "j2"
+            ]
+            assert len(synthetic) == 1
+            assert synthetic[0]["final_state"] == "interrupted"
         finally:
             store.close()

--- a/tests/unit/api/test_persistence_fork_history_routes.py
+++ b/tests/unit/api/test_persistence_fork_history_routes.py
@@ -164,7 +164,7 @@ class TestHistoryRoutes:
         monkeypatch.setattr(
             history_mod,
             "history_payload",
-            lambda p, t, j=None: {"target": t, "events": []},
+            lambda p, t, j=None, **k: {"target": t, "events": []},
         )
         client = TestClient(_app(history_mod.router))
         resp = client.get("/api/sess/history/alice")
@@ -178,7 +178,7 @@ class TestHistoryRoutes:
             lambda n: Path("/x/s.kohakutr"),
         )
 
-        def fake_payload(p, t, j=None):
+        def fake_payload(p, t, j=None, **kwargs):
             return {"target": t, "events": []}
 
         monkeypatch.setattr(history_mod, "history_payload", fake_payload)
@@ -199,7 +199,7 @@ class TestHistoryRoutes:
         )
         captured = {}
 
-        def fake_payload(p, t, j=None):
+        def fake_payload(p, t, j=None, **kwargs):
             captured["live"] = j
             return {"target": t, "events": []}
 
@@ -225,7 +225,7 @@ class TestHistoryRoutes:
         )
         captured = {}
 
-        def fake_from_store(store, name, target, j=None):
+        def fake_from_store(store, name, target, j=None, **kwargs):
             captured["store"] = store
             captured["name"] = name
             captured["live"] = j
@@ -270,5 +270,231 @@ class TestHistoryRoutes:
                 assert index.json()["session_name"] == "alice_3f2a9c11"
                 target = client.get(f"/api/{name}/history/alice")
                 assert target.status_code == 200, (name, target.text)
+        finally:
+            store.close()
+
+
+# ── history pagination ──────────────────────────────────────────
+
+
+def _make_store(
+    tmp_path: Path,
+    *,
+    agent: str = "alice",
+    events: int = 0,
+    channel_messages: int = 0,
+    channel: str = "ops",
+    content_size: int = 8,
+) -> SessionStore:
+    """Build a real store with numbered events and/or channel messages."""
+    path = tmp_path / "alice_3f2a9c11.kohakutr"
+    store = SessionStore(str(path))
+    store.init_meta(
+        agent,
+        "agent",
+        "/p",
+        "/w",
+        [agent],
+        terrarium_channels=[{"name": channel}] if channel_messages else None,
+    )
+    for i in range(events):
+        store.append_event(agent, "user_message", {"content": f"m{i}" * content_size})
+    for i in range(channel_messages):
+        store.save_channel_message(channel, {"sender": "a", "content": f"c{i}"})
+    store.flush()
+    return store
+
+
+def _saved_client(monkeypatch, store: SessionStore):
+    """Client that resolves the saved session to ``store``'s file."""
+    monkeypatch.setattr(history_mod, "live_store_entry", lambda svc, n: None)
+    monkeypatch.setattr(
+        history_mod, "resolve_session_path_default", lambda n: Path(store.path)
+    )
+    app = _app(history_mod.router)
+    return TestClient(app)
+
+
+class TestHistoryPagination:
+    def test_default_response_is_bounded(self, monkeypatch, tmp_path):
+        # Without query params the route returns the MOST RECENT page
+        # (≤ DEFAULT_HISTORY_PAGE_LIMIT events), never the full log.
+        store = _make_store(tmp_path, events=450)
+        try:
+            client = _saved_client(monkeypatch, store)
+            resp = client.get("/api/sess/history/alice")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert len(body["events"]) == 400
+            assert body["has_more"] is True
+            assert body["total"] == 450
+            assert body["oldest_event_id"] == body["events"][0]["event_id"]
+            # Chronological order preserved and the newest event is last.
+            assert body["events"][-1]["content"].startswith("m449")
+            assert body["events"][0]["content"].startswith("m50")
+        finally:
+            store.close()
+
+    def test_limit_zero_returns_full_log(self, monkeypatch, tmp_path):
+        store = _make_store(tmp_path, events=450)
+        try:
+            client = _saved_client(monkeypatch, store)
+            resp = client.get("/api/sess/history/alice", params={"limit": 0})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert len(body["events"]) == 450
+            assert body["has_more"] is False
+            assert body["total"] == 450
+        finally:
+            store.close()
+
+    def test_cursor_walk_has_no_gaps_or_duplicates(self, monkeypatch, tmp_path):
+        store = _make_store(tmp_path, events=250)
+        try:
+            client = _saved_client(monkeypatch, store)
+            before = None
+            seen: list[int] = []
+            for _ in range(10):
+                params = {"limit": 100}
+                if before is not None:
+                    params["before"] = before
+                body = client.get("/api/sess/history/alice", params=params).json()
+                ids = [e["event_id"] for e in body["events"]]
+                assert len(ids) <= 100
+                assert ids == sorted(ids)
+                seen = ids + seen
+                if not body["has_more"]:
+                    break
+                before = body["oldest_event_id"]
+            assert seen == list(range(1, 251))
+        finally:
+            store.close()
+
+    def test_byte_budget_caps_page_below_limit(self, monkeypatch, tmp_path):
+        from kohakuterrarium.studio.persistence import store as store_mod
+
+        store = _make_store(tmp_path, events=50, content_size=100)
+        try:
+            monkeypatch.setattr(store_mod, "DEFAULT_HISTORY_PAGE_BYTES", 10_000)
+            client = _saved_client(monkeypatch, store)
+            body = client.get("/api/sess/history/alice", params={"limit": 400}).json()
+            assert 1 <= len(body["events"]) < 50
+            assert body["has_more"] is True
+            # The cursor stays consistent even on a byte-truncated page.
+            before = body["oldest_event_id"]
+            body2 = client.get(
+                "/api/sess/history/alice", params={"limit": 400, "before": before}
+            ).json()
+            ids1 = [e["event_id"] for e in body["events"]]
+            ids2 = [e["event_id"] for e in body2["events"]]
+            assert not set(ids1) & set(ids2)
+            assert max(ids2) < min(ids1)
+        finally:
+            store.close()
+
+    def test_before_older_than_everything_returns_empty_page(
+        self, monkeypatch, tmp_path
+    ):
+        store = _make_store(tmp_path, events=5)
+        try:
+            client = _saved_client(monkeypatch, store)
+            body = client.get(
+                "/api/sess/history/alice", params={"limit": 10, "before": 1}
+            ).json()
+            assert body["events"] == []
+            assert body["has_more"] is False
+            assert body["oldest_event_id"] is None
+            assert body["total"] == 5
+        finally:
+            store.close()
+
+    def test_negative_limit_is_rejected(self, monkeypatch, tmp_path):
+        store = _make_store(tmp_path, events=5)
+        try:
+            client = _saved_client(monkeypatch, store)
+            resp = client.get("/api/sess/history/alice", params={"limit": -1})
+            assert resp.status_code == 422
+        finally:
+            store.close()
+
+    def test_live_path_paginates_without_reopening_store(self, monkeypatch, tmp_path):
+        # The live path keeps using the engine-owned store (SQLITE_IOERR)
+        # and pages from it directly — disk-open entry points stay bombed.
+        store = _make_store(tmp_path, events=10)
+        engine = _FakeEngine(graph=_FakeGraph([]), creatures={})
+        engine._session_stores = {"graph_live1": store}
+
+        def _bomb(*a, **k):
+            raise AssertionError("live history must not open the session file")
+
+        monkeypatch.setattr(history_mod, "resolve_session_path_default", _bomb)
+        monkeypatch.setattr(history_mod, "history_payload", _bomb)
+        app = _app(history_mod.router)
+        app.dependency_overrides[get_service] = lambda: engine
+        client = TestClient(app)
+        try:
+            page1 = client.get(
+                "/api/graph_live1/history/alice", params={"limit": 3}
+            ).json()
+            assert [e["event_id"] for e in page1["events"]] == [8, 9, 10]
+            assert page1["has_more"] is True
+            assert page1["total"] == 10
+            page2 = client.get(
+                "/api/graph_live1/history/alice",
+                params={"limit": 3, "before": page1["oldest_event_id"]},
+            ).json()
+            assert [e["event_id"] for e in page2["events"]] == [5, 6, 7]
+        finally:
+            store.close()
+
+    def test_channel_target_pagination(self, monkeypatch, tmp_path):
+        store = _make_store(tmp_path, channel_messages=30)
+        try:
+            client = _saved_client(monkeypatch, store)
+            page1 = client.get("/api/sess/history/ch:ops", params={"limit": 10}).json()
+            assert len(page1["events"]) == 10
+            assert page1["has_more"] is True
+            assert page1["total"] == 30
+            assert page1["events"][-1]["content"] == "c29"
+            page2 = client.get(
+                "/api/sess/history/ch:ops",
+                params={"limit": 10, "before": page1["oldest_event_id"]},
+            ).json()
+            assert [e["content"] for e in page2["events"]] == [
+                f"c{i}" for i in range(10, 20)
+            ]
+            assert page2["has_more"] is True
+        finally:
+            store.close()
+
+    def test_older_pages_omit_conversation_snapshot(self, monkeypatch, tmp_path):
+        # The conversation snapshot belongs to the newest window; carrying
+        # it on every older page would duplicate megabytes per request.
+        store = _make_store(tmp_path, events=5)
+        try:
+            store.save_conversation("alice", [{"role": "user", "content": "hi"}])
+            store.flush()
+            client = _saved_client(monkeypatch, store)
+            page1 = client.get("/api/sess/history/alice", params={"limit": 2}).json()
+            assert page1["messages"] == [{"role": "user", "content": "hi"}]
+            page2 = client.get(
+                "/api/sess/history/alice",
+                params={"limit": 2, "before": page1["oldest_event_id"]},
+            ).json()
+            assert page2["messages"] == []
+            assert len(page2["events"]) == 2
+        finally:
+            store.close()
+
+    def test_studio_layer_default_stays_full(self, tmp_path):
+        # Programmatic callers (studio facade) rely on the studio-layer
+        # default: full payload, no page bound. Only the HTTP route
+        # defaults to a page.
+        store = _make_store(tmp_path, events=450)
+        try:
+            payload = history_mod.history_payload(Path(store.path), "alice")
+            assert len(payload["events"]) == 450
+            assert payload["has_more"] is False
+            assert payload["total"] == 450
         finally:
             store.close()

--- a/tests/unit/terrarium/test_creature_ops_branches.py
+++ b/tests/unit/terrarium/test_creature_ops_branches.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from kohakuterrarium.terrarium import creature_ops as co
+from kohakuterrarium.terrarium import creature_history as ch
 from kohakuterrarium.terrarium.topology import GraphTopology
 
 # ---------------------------------------------------------------------------
@@ -191,14 +192,14 @@ class TestResumableEventsBranches:
             def get_resumable_events(self, name, live_job_ids=None):
                 raise RuntimeError("store down")
 
-        assert co._resumable_events(_Store(), "alice", set()) == []
+        assert ch._resumable_events(_Store(), "alice", set()) == []
 
     def test_store_returns_events(self):
         class _Store:
             def get_resumable_events(self, name, live_job_ids=None):
                 return [{"e": 1}]
 
-        assert co._resumable_events(_Store(), "alice", set()) == [{"e": 1}]
+        assert ch._resumable_events(_Store(), "alice", set()) == [{"e": 1}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/terrarium/test_multi_node_service.py
+++ b/tests/unit/terrarium/test_multi_node_service.py
@@ -138,7 +138,7 @@ class _FakeService:
     async def promote_job(self, cid, jid):
         return False
 
-    async def chat_history(self, cid):
+    async def chat_history(self, cid, **kw):
         return {"messages": []}
 
     async def chat_branches(self, cid):


### PR DESCRIPTION
> **Draft — feature PR awaiting direction approval.** Per `CONTRIBUTING.md`, behavior/API changes need a maintainer go-ahead before review. This is opened as a **draft** to make the validated implementation visible alongside #295; it is **not requesting review yet** and will be marked ready once (and only if) the direction is approved in the issue.

## Summary

Bounds every session-history response with `limit` / `before` cursor paging — both the saved-session route and the live-creature route — applied at the store read so server cost is bounded too, and integrates the dashboard: latest page first, "load earlier" cursors, incremental post-turn resyncs.

## PR Type

- [ ] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

`GET /{session}/history/{target}` returns every event of a target: on a 331 MB / 75,474-event session that is a 123.7 MB JSON body built in ~7 s server-side — far past the dashboard's 30 s client timeout. The live-creature route `GET /sessions/{id}/creatures/{target}/history` (used by the main chat tab on every tab switch, page refresh, and post-turn resync) had the same problem and additionally blocked the API event loop for its full build. Full analysis and measurements in #295.

## Changes

- New `session/history_paging.py`: shared cursor paging primitives (sorted-key enumeration, read only in-page values, byte-budget cap, exclusive `before` cursor). `SessionStore` public API unchanged.
- Saved route `GET /sessions/{name}/history/{target}`: `limit` (default 400 events / ~4 MB) + `before`; response adds `has_more` / `oldest_event_id` / `total`; `limit=0` keeps the full payload; studio facade default stays full (regression-tested).
- Live route `GET /sessions/{id}/creatures/{target}/history`: same `limit` / `before` (page at the store read; no second SQLite connection to a live store, per the documented POSIX `SQLITE_IOERR` constraint), `since_event_id` incremental semantics unchanged, `max_event_id` still reports the full log, `ch:` channel targets page by their per-channel sequence cursor. Multi-node/remote service signatures updated.
- Older pages (`before` set) skip interrupt-terminal synthesis: a page boundary can split a `tool_call`/`tool_result` pair whose real result is on a newer page, and fabricating an "interrupted" terminal there would coexist with the genuine result (negative-tested).
- Frontend: the chat store loads the latest bounded page first; "Load earlier messages" cursors prepend older pages on both the main tab and the session history viewer; post-turn resyncs fetch incrementally via `since_event_id` (cheaper than the previous full refetch); branch/rewind/compact resyncs keep an explicit full fetch for correctness; a duplicate-sink pair straddling a page boundary is folded on prepend so the paged render matches the full-log render.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/
pytest tests/unit/api tests/unit/studio tests/unit/terrarium -q   # 5383 passed, 4 skipped
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py
pytest tests/unit/test_file_sizes.py -q
cd src/kohakuterrarium-frontend && npm ci && npm run test -- --run src/stores/chat.test.js && npm run format:check && npm run build
```

Reference-session numbers (331 MB / 75,474 events, read-only): saved-route first page 0.10 s / 0.78 MB (was 6.6 s / 123 MB full); live-route single page 0.18 s (was 7.12 s unbounded); full 190-page cursor backwalk with no missing events.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it — the pre-existing issue exists (#295, opened before this PR); **maintainer approval is explicitly pending**, which is why this stays a draft
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow — route docstrings updated; will extend `docs/en/reference/http.md` with the new parameters before marking ready
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Closes #295

## Notes for Reviewers

- The behavior change is the **default** response size of the two history routes (unbounded → latest bounded page). `limit=0` preserves the full payload; the only programmatic caller (studio facade) keeps the full default and is regression-tested.
- Known tradeoffs flagged in #295: branch/rewind resync still fetches the full log; branch `<k/N>` metadata for turns older than the loaded window resolves once that window is loaded via "load earlier".

## Exceptions / Not Run

- Local `pytest tests/e2e/` shows 7 failures; they are identical (same tests) on a clean checkout of this machine without the patch — multinode/subprocess journeys vs. a live local Studio (ports/workers). 73 e2e tests pass.
- Full frontend vitest has a pre-existing flaky subset on this machine (localStorage/timeout); `chat.test.js` (190 tests, incl. all paging tests) is green in isolation.
