### PR TITLE
fix(llm): resolve local image references correctly before Grok edits

### DIFF
--- a/src/kohakuterrarium/builtin_skills/tools/grok_image_gen.md
+++ b/src/kohakuterrarium/builtin_skills/tools/grok_image_gen.md
@@ -14,8 +14,10 @@ Provider-specific image generation for xAI models.
 | Arg | Type | Req | Description |
 | --- | --- | --- | --- |
 | prompt | string | yes | What to produce |
-| images | array | no | Input image paths to edit |
+| action | string | no | `generate` (default) or `edit` |
+| image_url | string | for edit | Source image: HTTP(S), data URL, local `file://` reference, or session artifact URL |
 
 ## Behavior
 
 - Only available when the bound model is an xAI model with image support.
+- Local image references are inlined before editing; unresolved references fail before a request is sent.

--- a/src/kohakuterrarium/llm/artifact_resolve.py
+++ b/src/kohakuterrarium/llm/artifact_resolve.py
@@ -9,7 +9,7 @@ import base64
 import re
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 from urllib.request import url2pathname
 
 from kohakuterrarium.studio.persistence.artifacts import (
@@ -47,7 +47,7 @@ def file_reference_path(url: str) -> Path | None:
     parsed = urlparse(url)
     if parsed.scheme != "file" or parsed.netloc not in ("", "localhost"):
         return None
-    return Path(url2pathname(unquote(parsed.path)))
+    return Path(url2pathname(parsed.path))
 
 
 def _local_media_path(url: str) -> Path | None:

--- a/src/kohakuterrarium/llm/grok_image_gen.py
+++ b/src/kohakuterrarium/llm/grok_image_gen.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from kohakuterrarium.llm.artifact_resolve import resolve_artifact_url
 from kohakuterrarium.llm.grok_media import GrokMediaClient
 from kohakuterrarium.llm.message import ImagePart
 
@@ -39,6 +40,10 @@ class GrokImageClient:
             raise ValueError("prompt is required")
         if not image_url:
             raise ValueError("image_url is required for editing")
+        if image_url.startswith(("file://", "/api/sessions/")):
+            image_url = resolve_artifact_url(image_url)
+            if not image_url.startswith("data:image/"):
+                raise ValueError("image_url could not be resolved to a local image")
         payload = _generation_payload(args, prompt)
         payload["image"] = {"url": image_url, "type": "image_url"}
         response = await self.media.request_json(

--- a/tests/integration/test_llm.py
+++ b/tests/integration/test_llm.py
@@ -29,12 +29,21 @@ Why these collaborators are real:
     reset so resolution is deterministic with no installed packages.
 """
 
+import base64
+import io
+import json
 from typing import Any
 
+import httpx
 import pytest
+from PIL import Image
 
+from kohakuterrarium.builtins.tools.grok_image_gen import GrokImageGenTool
+from kohakuterrarium.builtins.tools.read import ReadTool
 from kohakuterrarium.core.registry import Registry
+from kohakuterrarium.core.tool_output import normalize_tool_result
 from kohakuterrarium.llm import api_keys as ak
+from kohakuterrarium.llm import artifact_resolve
 from kohakuterrarium.llm import backends as backends_mod
 from kohakuterrarium.llm import presets as presets_mod
 from kohakuterrarium.llm.backends import (
@@ -50,6 +59,9 @@ from kohakuterrarium.llm.base import (
     ToolSchema,
 )
 from kohakuterrarium.llm.codex_auth import CodexTokens
+from kohakuterrarium.llm.grok_auth import GrokToken, GrokTokens
+from kohakuterrarium.llm.grok_image_gen import GrokImageClient
+from kohakuterrarium.llm.grok_media import GrokMediaClient
 from kohakuterrarium.llm.message import (
     AssistantMessage,
     FilePart,
@@ -88,7 +100,13 @@ from kohakuterrarium.llm.variations import (
     normalize_variation_selections,
     parse_variation_selector,
 )
-from kohakuterrarium.modules.tool.base import BaseTool, ExecutionMode, ToolResult
+from kohakuterrarium.modules.tool.base import (
+    BaseTool,
+    ExecutionMode,
+    ToolContext,
+    ToolResult,
+)
+from kohakuterrarium.session.store import SessionStore
 
 pytestmark = pytest.mark.timeout(30)
 
@@ -963,7 +981,7 @@ class TestLlmIntegration:
         bad_call = NativeToolCall(id="c2", name="read", arguments="{not json")
         assert bad_call.parsed_arguments() == {"_raw": "{not json"}
 
-    async def test_multimodal_message_round_trip_workflow(self):
+    async def test_multimodal_message_round_trip_workflow(self, tmp_path, monkeypatch):
         """Build a full multimodal conversation and assert exact wire shape.
 
         The controller assembles ``Message`` objects (system + multimodal
@@ -1226,6 +1244,63 @@ class TestLlmIntegration:
         # The provider-native metadata the agent-start validator reads.
         assert provider.provider_name == "minimal"
         assert provider.provider_native_tools == frozenset({"image_gen"})
+
+        image_buffer = io.BytesIO()
+        Image.new("RGB", (2, 2), "red").save(image_buffer, format="PNG")
+        image_bytes = image_buffer.getvalue()
+        encoded = base64.b64encode(image_bytes).decode("ascii")
+        source = tmp_path / "image%20name.png"
+        source.write_bytes(image_bytes)
+        (tmp_path / "image name.png").write_bytes(b"wrong file")
+        context = ToolContext(agent_name="vision", session=None, working_dir=tmp_path)
+        read_result = await ReadTool().execute({"path": source.name}, context=context)
+        assert read_result.success
+        file_reference = read_result.output[1].url
+        assert file_reference == source.resolve().as_uri()
+
+        requests = []
+
+        def respond(request):
+            requests.append((request.url.path, json.loads(request.content)))
+            return httpx.Response(
+                200, json={"data": [{"b64_json": encoded, "mime_type": "image/png"}]}
+            )
+
+        async def no_refresh(**kwargs):
+            return None
+
+        monkeypatch.setattr(GrokTokens, "ensure_fresh_cli", no_refresh)
+        monkeypatch.setattr(
+            GrokTokens,
+            "load_candidates",
+            lambda: [GrokToken(access_token="test", source="test")],
+        )
+        monkeypatch.setattr(artifact_resolve, "_session_dir", lambda: tmp_path)
+        media = GrokMediaClient(transport=httpx.MockTransport(respond))
+        tool = GrokImageGenTool(client=GrokImageClient(media=media))
+        generated = await tool.execute({"prompt": "a red square"})
+        assert generated.success
+        store = SessionStore(tmp_path / "media.kohakutr")
+        try:
+            normalized, _ = normalize_tool_result(
+                tool, generated, max_output=0, artifact_store=store
+            )
+            artifact_reference = normalized.output[0].url
+            assert artifact_reference.startswith("/api/sessions/media/artifacts/")
+            for reference in (file_reference, artifact_reference):
+                edited = await tool.execute(
+                    {"prompt": "add a border", "action": "edit", "image_url": reference}
+                )
+                assert edited.success
+                assert edited.output[0].url == f"data:image/png;base64,{encoded}"
+                assert requests[-1][0] == "/v1/images/edits"
+                assert requests[-1][1]["image"] == {
+                    "url": f"data:image/png;base64,{encoded}",
+                    "type": "image_url",
+                }
+        finally:
+            store.close()
+        assert len(requests) == 3
 
     def test_api_key_storage_and_resolution_workflow(self):
         """Store + retrieve an API key, then assert the resolver override.

--- a/tests/unit/llm/test_artifact_resolve.py
+++ b/tests/unit/llm/test_artifact_resolve.py
@@ -9,6 +9,8 @@ identity no-op when nothing needs resolving (the common hot path).
 
 import base64
 
+import pytest
+
 from kohakuterrarium.llm import artifact_resolve
 from kohakuterrarium.llm.artifact_resolve import (
     file_reference_path,
@@ -54,6 +56,35 @@ class TestResolveArtifactUrl:
 
 
 class TestFileReferences:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "image%20name.png",
+            "image%25name.png",
+            "image%2Fname.png",
+            "a b.png",
+            "图片.png",
+        ],
+    )
+    def test_file_reference_preserves_exact_filename(self, tmp_path, name):
+        pic = tmp_path / name
+        pic.write_bytes(b"expected image")
+        url = pic.resolve().as_uri()
+
+        assert file_reference_path(url) == pic.resolve()
+        assert resolve_artifact_url(url) == (
+            "data:image/png;base64," + base64.b64encode(b"expected image").decode()
+        )
+
+    def test_file_reference_does_not_read_decoded_neighbor(self, tmp_path):
+        pic = tmp_path / "image%20name.png"
+        pic.write_bytes(b"expected image")
+        (tmp_path / "image name.png").write_bytes(b"wrong image")
+
+        assert resolve_artifact_url(pic.resolve().as_uri()) == (
+            "data:image/png;base64," + base64.b64encode(b"expected image").decode()
+        )
+
     def test_file_reference_inlined_from_disk(self, tmp_path):
         pic = tmp_path / "a b.png"
         pic.write_bytes(b"PNGDATA")

--- a/tests/unit/llm/test_grok_image_gen.py
+++ b/tests/unit/llm/test_grok_image_gen.py
@@ -4,6 +4,7 @@ import base64
 
 import pytest
 
+from kohakuterrarium.llm import artifact_resolve
 from kohakuterrarium.llm.grok_auth import GrokToken
 from kohakuterrarium.llm.grok_image_gen import GrokImageClient
 from kohakuterrarium.llm.grok_media import GrokMediaResponse
@@ -30,6 +31,85 @@ class _Media:
 
 
 class TestGrokImageClient:
+    @pytest.mark.parametrize("reference_kind", ["file", "artifact"])
+    async def test_edit_inlines_local_image(
+        self, tmp_path, monkeypatch, reference_kind
+    ):
+        data = b"local image"
+        if reference_kind == "file":
+            image = tmp_path / "image%20name.png"
+            reference = image.resolve().as_uri()
+        else:
+            image = tmp_path / "sid.artifacts" / "source.png"
+            reference = "/api/sessions/sid/artifacts/source.png"
+        image.parent.mkdir(parents=True, exist_ok=True)
+        image.write_bytes(data)
+        monkeypatch.setattr(artifact_resolve, "_session_dir", lambda: tmp_path)
+        media = _Media()
+        args = {"prompt": "add a hat", "image_url": reference}
+
+        parts = await GrokImageClient(media=media).edit(args)
+
+        assert media.calls[0][1] == "images/edits"
+        assert media.calls[0][2]["image"] == {
+            "url": "data:image/png;base64," + base64.b64encode(data).decode(),
+            "type": "image_url",
+        }
+        assert (
+            parts[0].url
+            == "data:image/jpeg;base64," + base64.b64encode(b"jpeg").decode()
+        )
+        assert args["image_url"] == reference
+
+    @pytest.mark.parametrize(
+        "reference",
+        ["file://remote/share/source.png", "/api/sessions/sid/artifacts/missing.png"],
+    )
+    async def test_edit_rejects_unresolved_local_reference(
+        self, tmp_path, monkeypatch, reference
+    ):
+        monkeypatch.setattr(artifact_resolve, "_session_dir", lambda: tmp_path)
+        media = _Media()
+
+        with pytest.raises(ValueError, match="image_url"):
+            await GrokImageClient(media=media).edit(
+                {"prompt": "edit", "image_url": reference}
+            )
+        assert media.calls == []
+
+    async def test_edit_rejects_missing_local_file(self, tmp_path):
+        media = _Media()
+        reference = (tmp_path / "missing.png").resolve().as_uri()
+
+        with pytest.raises(ValueError, match="image_url"):
+            await GrokImageClient(media=media).edit(
+                {"prompt": "edit", "image_url": reference}
+            )
+        assert media.calls == []
+
+    async def test_edit_rejects_non_image_local_file(self, tmp_path):
+        source = tmp_path / "source.txt"
+        source.write_text("not an image", encoding="utf-8")
+        media = _Media()
+
+        with pytest.raises(ValueError, match="image_url"):
+            await GrokImageClient(media=media).edit(
+                {"prompt": "edit", "image_url": source.resolve().as_uri()}
+            )
+        assert media.calls == []
+
+    @pytest.mark.parametrize(
+        "reference", ["https://img.test/a", "data:image/png;base64,QUJD"]
+    )
+    async def test_edit_preserves_remote_and_inline_images(self, reference):
+        media = _Media()
+
+        await GrokImageClient(media=media).edit(
+            {"prompt": "edit", "image_url": reference}
+        )
+
+        assert media.calls[0][2]["image"]["url"] == reference
+
     @pytest.mark.asyncio
     async def test_generation_uses_images_endpoint_and_returns_image_part(self):
         media = _Media()


### PR DESCRIPTION
## Summary

Grok image edits now inline local file and session artifact images before sending the request, and reject unresolved local references before contacting the provider. Shared file-URI resolution now decodes percent escapes exactly once, so a file named `image%20name.png` cannot silently resolve to its `image name.png` neighbor.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

The read tool returns file URIs, and normalized generated images use session artifact URLs. Passing either reference to Grok editing previously sent a machine-local reference to the remote API. The shared resolver also decoded file paths twice, corrupting literal percent escapes and potentially reading the wrong existing file.

Both issues were reproduced before the production changes.

## Changes

- Remove redundant `unquote` before `url2pathname`.
- Reuse the existing artifact resolver at the Grok edit boundary; reject unresolved/non-image local references before a media request. Preserve HTTP(S)/data inputs and the caller's arguments.
- Correct the Grok tool documentation to describe the existing `action` and `image_url` arguments.
- Add unit regression guards and extend the existing multimodal integration workflow with real ReadTool, image tool/client, session artifact persistence, and an HTTP transport boundary.
- Keep the fixes in two commits, one per issue.

## Validation

### Upstream PR CI (authoritative)

[CI run 34177367249](https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/34177367249) finished for head `f3fabc92cfed4a733305dc17a5e0379f8bf49723`: **12 jobs passed, 1 failed**. This PR is ready for review at the requester's explicit direction; it is **not claimed CI-green**.

- Passed: lint (including standard repository-wide Black), dependency graph, file-size guards, frontend, wheel/install, all six Linux/macOS test combinations, and Windows/Python 3.13.
- Windows/Python 3.13: **12,906 unit tests passed, 17 skipped; 175 integration tests passed**, including the extended multimodal workflow.
- [Windows/Python 3.12 failure](https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/34177367249/job/101909345928): **1 failed, 12,905 passed, 17 skipped**. The only failure is `tests/unit/cli/test_aio_entrypoint.py::TestWaitForPort::test_returns_true_when_port_opens_mid_wait`; `_wait_for_port(..., timeout_s=3.0)` returned false. All new local-image unit regressions passed; integration was skipped after the unit-stage failure.
- The identical port-wait assertion also failed in the [preceding merged PR #292 CI](https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/34070364836/job/101586446568), on Windows/Python 3.13. That code and test are unchanged here. This is evidence of an existing timing-sensitive failure, not a passing CI result.
- A failed-jobs-only rerun was attempted once through the integration, then through the GitHub CLI. GitHub denied both: `Resource not accessible by integration` and `Must have admin rights to Repository`. **A maintainer needs to rerun the failed job.** No unrelated test or workflow was changed to bypass it.

### Local validation

Local environment: Windows, Python 3.12.10; baseline `d70788e4`.

Before the production fix, the new unit checks produced **10 failures / 18 passes**, and the extended integration workflow failed because the outgoing image was still a file URI.

After the fix:

```bash
python -m pytest tests/unit/llm/test_artifact_resolve.py tests/unit/llm/test_grok_image_gen.py tests/integration/test_llm.py -q -p no:cacheprovider --tb=short
# 33 passed

python -m pytest tests/unit/llm tests/unit/builtins/test_grok_image_gen.py tests/unit/builtins/test_video_gen.py tests/unit/builtins/tools/test_read.py tests/unit/test_tool_doc_shape.py tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py tests/integration/test_llm.py -q -p no:cacheprovider --tb=short
# 2934 passed, 9 skipped, 2 failed (both reproduced on the unchanged baseline)

python -m ruff check src/ tests/
# passed

python -m black --check --no-cache --target-version py312 --workers 1 src/ tests/
# 1604 files would be left unchanged

git diff --check origin/main...HEAD
# passed
```

Also ran `python -m black --check --no-cache <file>` individually on all five changed Python files with the project defaults; all passed.

The two failures reproduced at the unchanged baseline are:

- `tests/unit/llm/test_grok_auth.py::TestGrokTokens::test_grok_cli_is_preferred_and_secret_repr_is_redacted`: the installed CLI reports `1.0.13`, while the test expects `1.0.5`.
- `tests/unit/test_tool_doc_shape.py::test_every_schema_has_a_doc_and_every_doc_has_a_tool`: existing group/channel tool documents are absent from the collected registry.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Fixes #300
Fixes #301

## Notes for Reviewers

The post-fix audit checked exact file bytes, percent-encoded filenames, both tool-produced reference forms, rejection before network activity, unchanged remote/data inputs, and input argument preservation. No additional actionable defect was found in the scoped diff.

This reuses existing MIME/path resolution rather than adding a new resolver or attempting image pixel validation. HTTP is mocked at the transport boundary; no paid Grok request was made.

## Screenshots / Logs (if applicable)

No UI changes.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- The requester explicitly asked to open a **Draft PR after local review and use upstream PR CI as the acceptance authority**. This bypasses a separate fork-CI gate; the workflow does not trigger for pushes to this feature branch.
- Marked ready for review at the requester's explicit direction after disclosure of the CI result. The existing Windows port-wait failure above still needs a maintainer-triggered rerun. This account cannot rerun upstream Actions jobs.
- The full repository unit/integration matrices were not run locally; local validation covered the affected LLM suite, adjacent tools and architecture/file/document guards. The two baseline failures above are recorded rather than folded into this scoped fix.
- The global Black check used an explicit Python 3.12 target for the local interpreter. Each changed Python file also passed with project defaults; the standard repository-wide check has now passed in upstream PR CI.
- No frontend files changed, so frontend formatting/build were not run locally. No multi-node/Studio/serving behavior changed, so e2e was not run locally.
