### PR TITLE
fix(codex): recover oauth refresh after token invalidation

### DIFF
--- a/src/kohakuterrarium/llm/codex_auth.py
+++ b/src/kohakuterrarium/llm/codex_auth.py
@@ -38,7 +38,7 @@ CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 REDIRECT_PORT = 1455
 REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/auth/callback"
 DEVICE_REDIRECT_URI = f"{ISSUER}/deviceauth/callback"
-SCOPE = "openid email profile"
+SCOPE = "openid email profile offline_access"
 AUDIENCE = "https://api.openai.com/v1"
 
 CODEX_CLI_TOKEN_PATH = Path.home() / ".codex" / "auth.json"

--- a/src/kohakuterrarium/llm/codex_provider.py
+++ b/src/kohakuterrarium/llm/codex_provider.py
@@ -108,6 +108,7 @@ class CodexOAuthProvider(BaseLLMProvider):
         self._websocket_mode = bool(websocket_mode)
         self._ws_session: ResponsesWSSession | None = None
         self._tokens: CodexTokens | None = None
+        self._token_lock = asyncio.Lock()
         self._client: Any = None  # AsyncOpenAI
         self._last_tool_calls: list[NativeToolCall] = []
         self._last_usage: dict[str, int] = {}
@@ -159,16 +160,30 @@ class CodexOAuthProvider(BaseLLMProvider):
         )
 
     async def _ensure_valid_token(self) -> None:
-        """Refresh token if expired and rebuild client (OAuth mode only)."""
+        """Adopt a newer on-disk login or refresh the expired access token."""
         if self._api_key:
             if not self._client:
                 self._rebuild_client()
             return
-        if not self._tokens:
-            await self.ensure_authenticated()
-            return
-        if self._tokens.is_expired():
-            self._tokens = await refresh_tokens(self._tokens)
+        async with self._token_lock:
+            if not self._tokens:
+                await self.ensure_authenticated()
+                await self._reset_ws_session()
+                return
+            if not self._tokens.is_expired():
+                return
+            reloaded = CodexTokens.load()
+            if reloaded is not None and not reloaded.is_expired():
+                self._tokens = reloaded
+            else:
+                try:
+                    self._tokens = await refresh_tokens(self._tokens)
+                except Exception:
+                    reloaded = CodexTokens.load()
+                    if reloaded is None or reloaded.is_expired():
+                        raise
+                    self._tokens = reloaded
+            await self._reset_ws_session()
             self._rebuild_client()
 
     @property
@@ -201,6 +216,7 @@ class CodexOAuthProvider(BaseLLMProvider):
             websocket_mode=self._websocket_mode,
         )
         clone._tokens = self._tokens
+        clone._token_lock = self._token_lock
         clone._client = self._client
         clone._retry_policy = self._retry_policy
         clone._emergency_drop_callbacks = list(self._emergency_drop_callbacks)
@@ -506,11 +522,16 @@ class CodexOAuthProvider(BaseLLMProvider):
         if part is not None:
             self._last_assistant_parts.append(part)
 
+    async def _reset_ws_session(self) -> None:
+        """Drop the WebSocket session so the next turn reconnects with fresh auth."""
+        session = self._ws_session
+        self._ws_session = None
+        if session is not None:
+            await session.close()
+
     async def close(self) -> None:
         """Close the WebSocket session and the underlying SDK client."""
-        if self._ws_session is not None:
-            await self._ws_session.close()
-            self._ws_session = None
+        await self._reset_ws_session()
         if self._client:
             await self._client.close()
         self._client = None

--- a/src/kohakuterrarium/llm/codex_provider.py
+++ b/src/kohakuterrarium/llm/codex_provider.py
@@ -186,6 +186,37 @@ class CodexOAuthProvider(BaseLLMProvider):
             await self._reset_ws_session()
             self._rebuild_client()
 
+    @staticmethod
+    def _is_unauthorized_error(exc: BaseException) -> bool:
+        """Return whether the server rejected the cached access token."""
+        return getattr(exc, "status_code", None) == 401
+
+    async def _recover_unauthorized(self) -> bool:
+        """Reload or refresh credentials after a server 401, then rebuild the client."""
+        async with self._token_lock:
+            if self._tokens is None:
+                return False
+            previous_access = self._tokens.access_token
+            reloaded = CodexTokens.load()
+            if reloaded is not None:
+                self._tokens = reloaded
+            if (
+                self._tokens.is_expired()
+                or self._tokens.access_token == previous_access
+            ):
+                try:
+                    self._tokens = await refresh_tokens(self._tokens)
+                except Exception:
+                    recovered = CodexTokens.load()
+                    if recovered is None or recovered.access_token == previous_access:
+                        return False
+                    self._tokens = recovered
+            if self._tokens.access_token == previous_access:
+                return False
+            await self._reset_ws_session()
+            self._rebuild_client()
+            return True
+
     @property
     def last_tool_calls(self) -> list[NativeToolCall]:
         return self._last_tool_calls
@@ -238,8 +269,10 @@ class CodexOAuthProvider(BaseLLMProvider):
         """Stream with classified retries and two-stage overflow recovery."""
         current = messages
         attempt = 0
+        auth_retry = False
         overflow_state = OverflowRecoveryState()
         while True:
+            emitted = False
             try:
                 async for chunk in self._raw_stream_chat(
                     current,
@@ -247,10 +280,24 @@ class CodexOAuthProvider(BaseLLMProvider):
                     provider_native_tools=provider_native_tools,
                     **kwargs,
                 ):
+                    emitted = True
                     yield chunk
                 return
             except Exception as exc:
                 cls = classify_openai_error(exc)
+                if (
+                    not auth_retry
+                    and not emitted
+                    and not self._api_key
+                    and self._is_unauthorized_error(exc)
+                ):
+                    auth_retry = True
+                    if await self._recover_unauthorized():
+                        logger.warning(
+                            "Codex credential rejected; retrying with refreshed token",
+                            error_class=cls.value,
+                        )
+                        continue
                 if cls is ErrorClass.OVERFLOW:
                     replacement = await self._recover_from_overflow(
                         current, overflow_state

--- a/tests/unit/llm/test_codex_auth.py
+++ b/tests/unit/llm/test_codex_auth.py
@@ -17,6 +17,7 @@ from urllib.parse import parse_qs, urlparse
 from kohakuterrarium.llm.codex_auth import (
     CLIENT_ID,
     REDIRECT_URI,
+    SCOPE,
     CodexTokens,
     _build_auth_url,
     _generate_pkce,
@@ -130,6 +131,8 @@ class TestBuildAuthURL:
         assert qs["state"] == ["state456"]
         assert qs["redirect_uri"] == [REDIRECT_URI]
         assert qs["response_type"] == ["code"]
+        assert qs["scope"] == [SCOPE]
+        assert "offline_access" in SCOPE
 
 
 class TestIsHeadless:

--- a/tests/unit/llm/test_codex_provider.py
+++ b/tests/unit/llm/test_codex_provider.py
@@ -4,14 +4,18 @@ Behavior-first: the Codex provider is the OpenAI Responses-API transport.
 With an explicit ``api_key`` it authenticates against a custom ``base_url``
 using API-key auth and MUST skip the Codex OAuth login; with no key it
 falls back to the ChatGPT-subscription OAuth flow (tokens). These tests
-pin the client-construction + mode-selection without any network/OAuth.
+pin the client-construction, mode-selection, and token-reload paths
+without any network/OAuth.
 """
 
+import asyncio
+import time
 from dataclasses import dataclass
 
 import pytest
 
 from kohakuterrarium.llm import codex_provider as cp
+from kohakuterrarium.llm.codex_auth import CodexTokens
 from kohakuterrarium.llm.codex_provider import CODEX_BASE_URL, CodexOAuthProvider
 
 pytestmark = pytest.mark.skipif(not cp.HAS_OPENAI, reason="openai SDK not installed")
@@ -58,6 +62,7 @@ class TestApiKeyMode:
         clone = p.with_model("b")
         assert clone._api_key == "sk-custom"
         assert clone._base_url == "https://my.host/v1"
+        assert clone._token_lock is p._token_lock
 
 
 class TestOAuthMode:
@@ -78,6 +83,165 @@ class TestOAuthMode:
         assert p._api_key is None
         assert isinstance(p._tokens, _FakeTokens)
         assert str(p._client.base_url).rstrip("/") == CODEX_BASE_URL.rstrip("/")
+
+
+class TestTokenReload:
+    async def test_expired_token_reloads_newer_disk_login(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="", expires_at=time.time() - 60
+        )
+        fresh = CodexTokens(
+            access_token="fresh", refresh_token="rotated", expires_at=time.time() + 3600
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        rebuilds: list[bool] = []
+        p._rebuild_client = lambda: rebuilds.append(True)
+
+        async def _boom(*args, **kwargs):
+            raise AssertionError(
+                "refresh_tokens must not run when disk has a fresh login"
+            )
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: fresh)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _boom)
+
+        await p._ensure_valid_token()
+
+        assert p._tokens is fresh
+        assert rebuilds == [True]
+
+    async def test_refresh_failure_recovers_from_newer_disk_login(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="old", expires_at=time.time() - 60
+        )
+        fresh = CodexTokens(
+            access_token="fresh", refresh_token="new", expires_at=time.time() + 3600
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+        loads = iter([stale, fresh])
+        refresh_calls: list[CodexTokens] = []
+
+        def _load(cls, path=None):
+            return next(loads)
+
+        async def _refresh(tokens):
+            refresh_calls.append(tokens)
+            raise RuntimeError("invalid_grant")
+
+        monkeypatch.setattr(cp.CodexTokens, "load", classmethod(_load))
+        monkeypatch.setattr(cp, "refresh_tokens", _refresh)
+
+        await p._ensure_valid_token()
+
+        assert p._tokens is fresh
+        assert refresh_calls == [stale]
+
+    async def test_refresh_failure_without_new_login_propagates(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="", expires_at=time.time() - 60
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+
+        async def _refresh(tokens):
+            raise RuntimeError("No refresh token available - please re-authenticate")
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: stale)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _refresh)
+
+        with pytest.raises(RuntimeError, match="No refresh token available"):
+            await p._ensure_valid_token()
+
+    async def test_refresh_success_rebuilds_client(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="old", expires_at=time.time() - 60
+        )
+        fresh = CodexTokens(
+            access_token="fresh", refresh_token="new", expires_at=time.time() + 3600
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        rebuilds: list[bool] = []
+        p._rebuild_client = lambda: rebuilds.append(True)
+
+        async def _refresh(tokens):
+            return fresh
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: stale)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _refresh)
+
+        await p._ensure_valid_token()
+
+        assert p._tokens is fresh
+        assert rebuilds == [True]
+
+    async def test_concurrent_refresh_runs_once(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="old", expires_at=time.time() - 60
+        )
+        fresh = CodexTokens(
+            access_token="fresh", refresh_token="new", expires_at=time.time() + 3600
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+        refresh_calls = 0
+
+        async def _refresh(tokens):
+            nonlocal refresh_calls
+            refresh_calls += 1
+            await asyncio.sleep(0)
+            return fresh
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: stale)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _refresh)
+
+        await asyncio.gather(p._ensure_valid_token(), p._ensure_valid_token())
+
+        assert p._tokens is fresh
+        assert refresh_calls == 1
+
+    async def test_token_reload_resets_ws_session(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="", expires_at=time.time() - 60
+        )
+        fresh = CodexTokens(
+            access_token="fresh", refresh_token="new", expires_at=time.time() + 3600
+        )
+
+        class _FakeWSSession:
+            def __init__(self):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+        p = CodexOAuthProvider(model="gpt-x", websocket_mode=True)
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+        session = _FakeWSSession()
+        p._ws_session = session
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: fresh)
+        )
+
+        await p._ensure_valid_token()
+
+        assert session.closed is True
+        assert p._ws_session is None
 
 
 class _FakeResponses:

--- a/tests/unit/llm/test_codex_provider.py
+++ b/tests/unit/llm/test_codex_provider.py
@@ -221,13 +221,6 @@ class TestTokenReload:
             access_token="fresh", refresh_token="new", expires_at=time.time() + 3600
         )
 
-        class _FakeWSSession:
-            def __init__(self):
-                self.closed = False
-
-            async def close(self):
-                self.closed = True
-
         p = CodexOAuthProvider(model="gpt-x", websocket_mode=True)
         p._tokens = stale
         p._rebuild_client = lambda: None
@@ -261,6 +254,209 @@ class _FakeResponses:
 class _FakeClient:
     def __init__(self):
         self.responses = _FakeResponses()
+
+
+class _TokenExpiredError(Exception):
+    def __init__(self):
+        super().__init__("Error code: 401 - Provided authentication token is expired.")
+        self.status_code = 401
+        self.body = {
+            "error": {
+                "code": "token_expired",
+                "message": "Provided authentication token is expired.",
+            }
+        }
+
+
+async def _empty_stream():
+    if False:  # pragma: no cover - make this an async generator
+        yield
+
+
+class _ScriptedResponses:
+    def __init__(self, outcomes):
+        self._outcomes = list(outcomes)
+        self.calls = 0
+
+    async def create(self, **kwargs):
+        self.calls += 1
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome()
+
+
+class _ScriptedClient:
+    def __init__(self, outcomes):
+        self.responses = _ScriptedResponses(outcomes)
+
+
+class _FakeWSSession:
+    def __init__(self):
+        self.closed = False
+
+    def invalidate(self):
+        pass
+
+    async def close(self):
+        self.closed = True
+
+
+class TestUnauthorizedRecovery:
+    async def _drive(self, provider):
+        return [
+            chunk
+            async for chunk in provider._stream_chat(
+                [{"role": "user", "content": "hi"}]
+            )
+        ]
+
+    async def test_server_401_reloads_disk_login_and_retries(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="old", expires_at=time.time() + 3600
+        )
+        fresh = CodexTokens(
+            access_token="fresh", refresh_token="new", expires_at=time.time() + 3600
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+        p._client = _ScriptedClient([_TokenExpiredError(), _empty_stream])
+        session = _FakeWSSession()
+        p._ws_session = session
+
+        async def _boom(*args, **kwargs):
+            raise AssertionError(
+                "refresh_tokens must not run when disk has a fresh login"
+            )
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: fresh)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _boom)
+
+        chunks = await self._drive(p)
+
+        assert chunks == []
+        assert p._tokens is fresh
+        assert p._client.responses.calls == 2
+        assert session.closed is True
+        assert p._ws_session is None
+
+    async def test_server_401_refreshes_cached_token_and_retries(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="old", expires_at=time.time() + 3600
+        )
+        fresh = CodexTokens(
+            access_token="fresh", refresh_token="new", expires_at=time.time() + 3600
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+        p._client = _ScriptedClient([_TokenExpiredError(), _empty_stream])
+        refresh_calls: list[CodexTokens] = []
+
+        async def _refresh(tokens):
+            refresh_calls.append(tokens)
+            return fresh
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: stale)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _refresh)
+
+        chunks = await self._drive(p)
+
+        assert chunks == []
+        assert p._tokens is fresh
+        assert refresh_calls == [stale]
+        assert p._client.responses.calls == 2
+
+    async def test_server_401_retries_credentials_once(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="old", expires_at=time.time() + 3600
+        )
+        fresh = CodexTokens(
+            access_token="fresh", refresh_token="new", expires_at=time.time() + 3600
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+        p._client = _ScriptedClient([_TokenExpiredError(), _TokenExpiredError()])
+        refresh_calls = 0
+
+        async def _refresh(tokens):
+            nonlocal refresh_calls
+            refresh_calls += 1
+            return fresh
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: stale)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _refresh)
+
+        with pytest.raises(_TokenExpiredError):
+            await self._drive(p)
+
+        assert p._client.responses.calls == 2
+        assert refresh_calls == 1
+
+    async def test_server_401_without_recoverable_credentials_reraises(
+        self, monkeypatch
+    ):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="old", expires_at=time.time() + 3600
+        )
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+        p._client = _ScriptedClient([_TokenExpiredError()])
+        refresh_calls: list[CodexTokens] = []
+
+        async def _refresh(tokens):
+            refresh_calls.append(tokens)
+            raise RuntimeError("invalid_grant")
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: stale)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _refresh)
+
+        with pytest.raises(_TokenExpiredError):
+            await self._drive(p)
+
+        assert p._client.responses.calls == 1
+        assert refresh_calls == [stale]
+
+    async def test_server_401_after_output_does_not_retry(self, monkeypatch):
+        stale = CodexTokens(
+            access_token="stale", refresh_token="old", expires_at=time.time() + 3600
+        )
+
+        async def _chunk_then_401():
+            yield _Ev(type="response.output_text.delta", delta="hello")
+            raise _TokenExpiredError()
+
+        p = CodexOAuthProvider(model="gpt-x")
+        p._tokens = stale
+        p._rebuild_client = lambda: None
+        p._client = _ScriptedClient([_chunk_then_401])
+
+        async def _boom(*args, **kwargs):
+            raise AssertionError("recovery must not run after output was emitted")
+
+        monkeypatch.setattr(
+            cp.CodexTokens, "load", classmethod(lambda cls, path=None: stale)
+        )
+        monkeypatch.setattr(cp, "refresh_tokens", _boom)
+
+        chunks: list[str] = []
+        with pytest.raises(_TokenExpiredError):
+            async for chunk in p._stream_chat([{"role": "user", "content": "hi"}]):
+                chunks.append(chunk)
+
+        assert chunks == ["hello"]
+        assert p._client.responses.calls == 1
 
 
 class TestSessionIdHeaderGating:


### PR DESCRIPTION
## Summary

Fixes Codex OAuth sessions becoming permanently blocked after the access token expires. The login now requests `offline_access`, and the running provider re-reads/refreshes the on-disk credential when the cached access token is expired **or when the server rejects it with 401**. The WebSocket session is reset when credentials change so the next turn reconnects with the new token.

Fixes #303

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

See #303. Two issues combined:

1. `kt login codex` requested only `openid email profile`, so OpenAI did not issue a refresh token. The stored `refresh_token` was empty, and the access token only lasts about 10 days.
2. `CodexOAuthProvider` cached `self._tokens` in memory. Re-running `kt login codex` in another process wrote a new credential file, but the running session kept using the stale cached token until it was stopped and resumed.

A follow-up production report showed the same class of failure when the server invalidated the access token before its local `expires_at`: requests returned `401 token_expired`, `_stream_chat()` classified it as a non-retryable user error, and the provider never re-read the file that `kt login codex` had just updated. Switching providers or resuming rebuilt the provider and worked.

## Changes

- Add `offline_access` to the Codex OAuth scope.
- In `CodexOAuthProvider._ensure_valid_token()`, serialize token checks with a per-provider lock, reload the credential file before refreshing, and reload again after a refresh failure to adopt a newer login written by another process.
- Share the token lock with `with_model()` clones.
- On a pre-output HTTP 401, recover credentials once: reload the on-disk login, or refresh the current token, then reset the WebSocket session and retry the request.
- Reset the WebSocket session when credentials change so the next turn reconnects with the new token.
- Add regression tests for refresh success, concurrent refresh, disk recovery, server-side 401 recovery, one-shot recovery, and WebSocket reset.

## Validation

```bash
ruff check src/ tests/
black --check src/ tests/

pytest tests/unit/llm/test_codex_auth.py \
       tests/unit/llm/test_codex_provider.py \
       tests/unit/studio/test_codex_oauth.py \
       tests/integration/test_llm.py -q
pytest tests/unit/test_file_sizes.py -q
```

Results:

- `ruff check src/ tests/` — passed
- `black --check src/ tests/` — passed
- Targeted Codex + LLM integration tests — 64 passed
- `pytest tests/unit/llm -q` — 811 passed, 1 environment-specific failure:
  - `tests/unit/llm/test_grok_auth.py` expects local Grok CLI metadata `1.0.5`; this machine has `1.0.24`
- File-size guard — 1758 passed
- Upstream CI: all non-Windows jobs and lint/package/format checks pass. The Windows 3.12 unit job is failing on unrelated, flaky tests (`test_aio_entrypoint`, `test_session` TUI scrollbar, `test_hooks` debounce); the same job passed on the previous run for this branch and the failing tests do not touch this PR. Windows 3.13, macOS, Ubuntu, and all lint/format/package jobs are green.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [ ] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Fixes #303

## Notes for Reviewers

This is a bug fix, not a feature. The issue was opened before the PR. The only user-visible behavior change is that a new Codex login now requests `offline_access`, which enables automatic refresh; existing cached credentials need one re-login to gain a refresh token. No docs update: the CLI flow and config shape are unchanged.

The 401 recovery path intentionally retries credentials only once and only before any output is emitted, so a mid-stream failure cannot duplicate text.

## Screenshots / Logs (if applicable)

N/A

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- `tests/unit/llm/test_grok_auth.py` has one environment-specific failure on this machine (Grok CLI version), unrelated to this PR.
- Fork CI could not be triggered because `SLAPaper/KohakuTerrarium` main is stale relative to upstream; upstream CI runs on this PR instead.
- Windows 3.12 CI currently fails on unrelated flaky tests; see the validation note above.
