### PR TITLE
perf(history): bound session history with paged cursors and a layered viewport

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.historyPaging.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.historyPaging.test.js
@@ -503,7 +503,8 @@ describe("connected paged history and reset", () => {
       .spyOn(terrariumAPI, "getHistoryPage")
       .mockResolvedValueOnce(page(800, 200))
       .mockResolvedValueOnce(page(400, 400))
-      .mockResolvedValueOnce(page(0, 400, false))
+      .mockResolvedValueOnce(page(0, 400, true))
+      .mockResolvedValueOnce(page(-400, 400, false))
     await mountPage()
     const vp = wrapper.get(".chat-messages-viewport").element
     const top = vp.scrollTop
@@ -547,6 +548,32 @@ describe("connected paged history and reset", () => {
     vp.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
     await flushPromises()
     expect(ids()).toHaveLength(400)
+    // Render every loaded row, so the next upward step needs a fetch.
+    for (let step = 0; step < 6 && ids().length < chat.messagesByTab.root.length; step += 1) {
+      vp.scrollTop = 0
+      vp.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+      await flushPromises()
+    }
+    expect(ids()).toHaveLength(chat.messagesByTab.root.length)
+    const calls = api.mock.calls.length
+    const loaded = chat.messagesByTab.root.length
+    // A live turn refuses the fetch instead of spending a discarded request.
+    chat.processingByTab.root = true
+    await flushPromises()
+    expect(wrapper.find("[data-history-generating]").exists()).toBe(true)
+    vp.scrollTop = 0
+    vp.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+    await flushPromises()
+    expect(api).toHaveBeenCalledTimes(calls)
+    expect(chat.messagesByTab.root).toHaveLength(loaded)
+    chat.processingByTab.root = false
+    await flushPromises()
+    expect(wrapper.find("[data-history-generating]").exists()).toBe(false)
+    vp.scrollTop = 0
+    vp.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+    await flushPromises()
+    expect(api).toHaveBeenCalledTimes(calls + 1)
+    expect(chat.messagesByTab.root.length).toBeGreaterThan(loaded)
   })
 
   it.each(["tail", "switch", "unmount"])(

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.historyPaging.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.historyPaging.test.js
@@ -569,9 +569,7 @@ describe("connected paged history and reset", () => {
     chat.processingByTab.root = false
     await flushPromises()
     expect(wrapper.find("[data-history-generating]").exists()).toBe(false)
-    vp.scrollTop = 0
-    vp.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
-    await flushPromises()
+    // The refused fetch resumes on its own once the turn ends.
     expect(api).toHaveBeenCalledTimes(calls + 1)
     expect(chat.messagesByTab.root.length).toBeGreaterThan(loaded)
   })

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.historyPaging.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.historyPaging.test.js
@@ -1,0 +1,592 @@
+import { flushPromises, mount } from "@vue/test-utils"
+import { createPinia, setActivePinia } from "pinia"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import ChatPanel from "./ChatPanel.vue"
+import { useChatStore } from "@/stores/chat"
+import { sessionAPI, terrariumAPI } from "@/utils/api"
+
+let wrapper, chat, frames, idle
+const height = (element) =>
+  30 + (Number(element.getAttribute("data-message-id")?.split(":").pop()) % 3 || 0) * 17
+function geometry(element) {
+  const vp = element.closest?.(".chat-messages-viewport")
+  if (!vp || element === vp) return { top: 0, bottom: 120, height: 120 }
+  let top = 30 - vp.scrollTop
+  for (const row of vp.querySelectorAll("[data-message-id]")) {
+    if (row === element) return { top, bottom: top + height(row), height: height(row) }
+    top += height(row)
+  }
+  return { top: 0, bottom: 0, height: 0 }
+}
+function page(start, count, older = true, overrides = {}) {
+  const events = Array.from({ length: count }, (_, i) => ({
+    type: "user_message",
+    event_id: start + i,
+    content: `message ${start + i}`,
+    _history_key: `e:${start + i}`,
+  }))
+  return {
+    events,
+    messages: [],
+    live_job_ids: [],
+    is_processing: false,
+    history_page: {
+      version: 1,
+      stream: "events",
+      history_id: "history",
+      before: `b${start}`,
+      after: `a${start + count - 1}`,
+      has_older: older,
+      has_newer: false,
+      reset_required: false,
+    },
+    ...overrides,
+  }
+}
+const ids = () =>
+  wrapper.findAll("[data-message-id]").map((row) => row.attributes("data-message-id"))
+const button = () => wrapper.get("button.self-center")
+function visibleAnchor() {
+  const vp = wrapper.get(".chat-messages-viewport").element
+  const row = [...vp.querySelectorAll("[data-message-id]")].find(
+    (el) => el.getBoundingClientRect().bottom > 0,
+  )
+  return { key: row.getAttribute("data-message-id"), top: row.getBoundingClientRect().top }
+}
+async function scroll(top) {
+  const vp = wrapper.get(".chat-messages-viewport").element
+  vp.scrollTop = Math.max(0, top)
+  vp.dispatchEvent(new Event("scroll"))
+  for (const [id, callback] of [...frames]) {
+    frames.delete(id)
+    callback()
+  }
+  await flushPromises()
+}
+beforeEach(() => {
+  setActivePinia(createPinia())
+  frames = new Map()
+  idle = new Map()
+  let sequence = 0
+  vi.stubGlobal("requestAnimationFrame", (cb) => {
+    const id = ++sequence
+    frames.set(id, cb)
+    return id
+  })
+  vi.stubGlobal("cancelAnimationFrame", (id) => frames.delete(id))
+  vi.stubGlobal("requestIdleCallback", (cb) => {
+    const id = ++sequence
+    idle.set(id, cb)
+    return id
+  })
+  vi.stubGlobal("cancelIdleCallback", (id) => idle.delete(id))
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function () {
+    return geometry(this)
+  })
+  chat = useChatStore("graph")
+  chat._instanceId = "graph"
+  chat._instanceGraphId = "graph"
+  chat.activeTab = "root"
+  chat.tabs = ["root", "other"]
+  chat.messagesByTab.other = [{ id: "other", role: "user", content: "other tab" }]
+  chat.commandInventoryByTab.root = { commands: [], skills: [] }
+  chat._commandInventoryFetchedAtByTab.root = Date.now()
+})
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = null
+  chat._cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+async function mountPage(kind = "live") {
+  if (kind === "live") await chat._loadHistory("root")
+  else await chat.initHistoryPage("root", { kind: "saved", sessionName: "saved" })
+  await mountPanel(kind)
+}
+async function mountPanel(kind = "live") {
+  wrapper = mount(ChatPanel, {
+    attachTo: document.body,
+    props: {
+      instance: { id: "graph", graph_id: "graph", creatures: [{ name: "root", status: "idle" }] },
+      readOnly: kind === "saved",
+    },
+    global: {
+      stubs: {
+        ChatMessage: {
+          props: ["message"],
+          template:
+            '<div>{{ message.content || message.parts?.map(p => p.content).join("") }}</div>',
+        },
+        ModelSwitcher: true,
+        SiteChip: true,
+        StatusDot: true,
+      },
+    },
+  })
+  await flushPromises()
+  const vp = wrapper.get(".chat-messages-viewport").element
+  Object.defineProperty(vp, "clientHeight", { configurable: true, value: 120 })
+  Object.defineProperty(vp, "scrollHeight", {
+    configurable: true,
+    get: () =>
+      30 + [...vp.querySelectorAll("[data-message-id]")].reduce((sum, row) => sum + height(row), 0),
+  })
+  await scroll(vp.scrollHeight - 120)
+}
+
+async function runIdle() {
+  for (const [id, callback] of [...idle]) {
+    idle.delete(id)
+    callback()
+  }
+  await flushPromises()
+}
+
+describe("bounded initial tail fill, source currency, and scroll intent", () => {
+  it("does not turn initial fill into multi-page head catchup after a live mutation", async () => {
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page(150, 50))
+      .mockResolvedValue(page(200, 1))
+    await mountPage()
+    chat._appendStreamChunk("root", "live")
+    await runIdle()
+    expect(api).toHaveBeenCalledTimes(1)
+  })
+
+  it("stops scheduling once successive small pages reach the tail message budget", async () => {
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page(150, 50))
+      .mockResolvedValueOnce(page(100, 50))
+      .mockResolvedValueOnce(page(50, 50))
+      .mockResolvedValueOnce(page(0, 50))
+    await mountPage()
+    await runIdle()
+    await runIdle()
+    await runIdle()
+    await runIdle()
+    expect(ids()).toHaveLength(200)
+    expect(api).toHaveBeenCalledTimes(4)
+    const vp = wrapper.get(".chat-messages-viewport").element
+    expect(vp.scrollTop).toBeGreaterThanOrEqual(vp.scrollHeight - vp.clientHeight)
+    await scroll(vp.scrollHeight - vp.clientHeight)
+    await runIdle()
+    expect(ids()).toHaveLength(200)
+    expect(api).toHaveBeenCalledTimes(4)
+  })
+
+  it("does not start a queued fill after its scheduling deadline", async () => {
+    let now = 100
+    vi.spyOn(Date, "now").mockImplementation(() => now)
+    const api = vi.spyOn(terrariumAPI, "getHistoryPage").mockResolvedValueOnce(page(100, 50))
+    await mountPage()
+    now += 1501
+    await runIdle()
+    expect(api).toHaveBeenCalledTimes(1)
+    expect(ids()).toHaveLength(50)
+  })
+
+  it("ignores compensation-generated scroll but accepts the next upward inertia movement", async () => {
+    const text = (id) => ({
+      type: "text",
+      content: `text${id}`,
+      event_id: id,
+      _history_key: `e:${id}`,
+    })
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page(401, 50, true, { events: [text(400), ...page(401, 50).events] }))
+      .mockResolvedValueOnce(page(300, 1, true, { events: [text(300)] }))
+      .mockResolvedValueOnce(page(200, 1, false, { events: [text(200)] }))
+    await mountPage()
+    const vp = wrapper.get(".chat-messages-viewport").element
+    vp.scrollTop = 20
+    await button().trigger("click")
+    await flushPromises()
+    const keys = ids()
+    await scroll(vp.scrollTop)
+    expect(ids()).toEqual(keys)
+    expect(api).toHaveBeenCalledTimes(2)
+    await scroll(10)
+    expect(api).toHaveBeenCalledTimes(3)
+    expect(wrapper.text()).toContain("text200text300text400")
+  })
+
+  it("claims fill once across two panels and never rearms on manual reset", async () => {
+    let release
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page(400, 50))
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            release = r
+          }),
+      )
+    await mountPage()
+    const first = wrapper
+    await mountPanel()
+    await runIdle()
+    expect(api).toHaveBeenCalledTimes(2)
+    release(page(350, 50, false))
+    await flushPromises()
+    await runIdle()
+    expect(ids()).toHaveLength(100)
+    expect(first.findAll("[data-message-id]")).toHaveLength(100)
+    api.mockResolvedValueOnce(page(400, 50))
+    await chat.initHistoryPage("root")
+    await flushPromises()
+    await runIdle()
+    expect(api).toHaveBeenCalledTimes(3)
+    first.unmount()
+  })
+
+  it("keeps pre-first-page reading intent cancelled when history becomes ready", async () => {
+    let release
+    const api = vi.spyOn(terrariumAPI, "getHistoryPage").mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          release = r
+        }),
+    )
+    await mountPanel()
+    const load = chat._loadHistory("root")
+    await flushPromises()
+    wrapper
+      .get(".chat-messages-viewport")
+      .element.dispatchEvent(new WheelEvent("wheel", { deltaY: -10 }))
+    release(page(400, 50))
+    await load
+    await flushPromises()
+    await runIdle()
+    expect(api).toHaveBeenCalledTimes(1)
+    expect(ids()).toHaveLength(50)
+  })
+
+  it("starts only after a mounted empty panel receives its first page", async () => {
+    let release
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            release = r
+          }),
+      )
+      .mockResolvedValueOnce(page(0, 200, false))
+    await mountPanel()
+    const load = chat._loadHistory("root")
+    await flushPromises()
+    release(page(200, 1))
+    await load
+    await flushPromises()
+    expect(ids()).toHaveLength(1)
+    expect(api).toHaveBeenCalledTimes(1)
+    await runIdle()
+    expect(ids()).toHaveLength(200)
+    expect(api).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(["live", "saved"])(
+    "shows %s first page before delayed fill and fills the same tail budget as return-to-bottom",
+    async (kind) => {
+      let release
+      const api = vi
+        .spyOn(kind === "live" ? terrariumAPI : sessionAPI, "getHistoryPage")
+        .mockResolvedValueOnce(page(400, 50))
+        .mockImplementationOnce(
+          () =>
+            new Promise((r) => {
+              release = r
+            }),
+        )
+      await mountPage(kind)
+      expect(ids()).toHaveLength(50)
+      expect(api).toHaveBeenCalledTimes(1)
+      await runIdle()
+      expect(api).toHaveBeenCalledTimes(2)
+      expect(ids()).toHaveLength(50)
+      release(page(0, 400, false))
+      await flushPromises()
+      await runIdle()
+      expect(ids()).toHaveLength(200)
+      const filled = ids()
+      const vp = wrapper.get(".chat-messages-viewport").element
+      await scroll(vp.scrollHeight - 120)
+      expect(ids()).toEqual(filled)
+      await runIdle()
+      expect(api).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it("stops at three extra pages even when many events merge into one row", async () => {
+    const textPage = (n) =>
+      page(n, 400, true, {
+        events: Array.from({ length: 400 }, (_, i) => ({
+          type: "text",
+          content: "x",
+          event_id: n + i,
+          _history_key: `e:${n + i}`,
+        })),
+      })
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(textPage(1200))
+      .mockResolvedValueOnce(textPage(800))
+      .mockResolvedValueOnce(textPage(400))
+      .mockResolvedValueOnce(textPage(0))
+    await mountPage()
+    await runIdle()
+    await runIdle()
+    await runIdle()
+    await runIdle()
+    expect(api).toHaveBeenCalledTimes(4)
+    expect(chat.messagesByTab.root).toHaveLength(1)
+    expect(chat.messagesByTab.root[0]._historyKeys).toHaveLength(1600)
+    await scroll(0)
+    await runIdle()
+    expect(api).toHaveBeenCalledTimes(4)
+  })
+
+  it.each(["up", "tab", "unmount", "deadline"])(
+    "keeps a late initial-fill response cache-only after %s",
+    async (reason) => {
+      let release,
+        now = 100
+      vi.spyOn(Date, "now").mockImplementation(() => now)
+      const api = vi
+        .spyOn(terrariumAPI, "getHistoryPage")
+        .mockResolvedValueOnce(page(400, 50))
+        .mockImplementationOnce(
+          () =>
+            new Promise((r) => {
+              release = r
+            }),
+        )
+      await mountPage()
+      await runIdle()
+      expect(api).toHaveBeenCalledTimes(2)
+      if (reason === "up")
+        wrapper
+          .get(".chat-messages-viewport")
+          .element.dispatchEvent(new WheelEvent("wheel", { deltaY: -10 }))
+      if (reason === "tab") {
+        chat.activeTab = "other"
+        await flushPromises()
+      }
+      if (reason === "unmount") {
+        wrapper.unmount()
+        wrapper = null
+      }
+      if (reason === "deadline") now += 1501
+      release(page(0, 400))
+      await flushPromises()
+      await runIdle()
+      expect(chat.messagesByTab.root).toHaveLength(50)
+      expect(chat.historyPageByTab.root.hasCachedOlder).toBe(true)
+      expect(api).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it("does not fetch when the render-unit budget is full despite few rows", async () => {
+    const messages = Array.from({ length: 3 }, (_, i) => ({
+      role: "assistant",
+      content: "row",
+      _history_key: `s:${i}`,
+      tool_calls: Array.from({ length: 500 }, (_, j) => ({
+        id: `${i}:${j}`,
+        function: { name: "read", arguments: "{}" },
+      })),
+    }))
+    const payload = page(0, 0, true, { messages })
+    payload.history_page.stream = "snapshot"
+    const api = vi.spyOn(terrariumAPI, "getHistoryPage").mockResolvedValueOnce(payload)
+    await mountPage()
+    await runIdle()
+    expect(ids()).toHaveLength(2)
+    expect(api).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("connected paged history and reset", () => {
+  it("offers bounded recovery after an older response invalidates the source", async () => {
+    const reset = page(0, 0)
+    reset.history_page.reset_required = true
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page(400, 50))
+      .mockResolvedValueOnce(reset)
+      .mockResolvedValueOnce(page(600, 50))
+    await mountPage()
+    await button().trigger("click")
+    await flushPromises()
+    expect(chat.messagesByTab.root).toHaveLength(50)
+    await wrapper.get("[data-history-reset]").trigger("click")
+    await flushPromises()
+    expect(api.mock.calls[2][2]).toEqual({ limit: 400 })
+    expect(wrapper.text()).toContain("message 600")
+    expect(wrapper.find("[data-history-reset]").exists()).toBe(false)
+    expect(button().exists()).toBe(true)
+  })
+
+  it("loads the full saved channel record from its visible preview control", async () => {
+    const record = {
+      content: "preview",
+      sender: "worker",
+      _history_key: "c:1",
+      _history_truncated: true,
+      _history_detail: "opaque",
+    }
+    const payload = page(0, 0, false)
+    payload.history_page.stream = "channel"
+    payload.messages = [record]
+    vi.spyOn(sessionAPI, "getHistoryPage").mockResolvedValue(payload)
+    const detail = vi.spyOn(sessionAPI, "getHistoryDetail").mockResolvedValue({
+      record: { ...record, content: "complete channel message", _history_truncated: false },
+      history_page: payload.history_page,
+    })
+    await mountPage("saved")
+    expect(wrapper.text()).toContain("preview")
+    await wrapper.get('[data-history-detail="c:1"]').trigger("click")
+    await flushPromises()
+    expect(detail).toHaveBeenCalledWith("saved", "root", {
+      stream: "channel",
+      history_id: "history",
+      ref: "opaque",
+    })
+    expect(wrapper.text()).toContain("complete channel message")
+    expect(wrapper.find('[data-history-detail="c:1"]').exists()).toBe(false)
+  })
+  it.each(["live", "saved"])(
+    "bounds %s initial load, preserves current anchor after delayed manual fetch, and uses local rows first",
+    async (kind) => {
+      let release
+      const api = vi
+        .spyOn(kind === "live" ? terrariumAPI : sessionAPI, "getHistoryPage")
+        .mockResolvedValueOnce(page(400, 50))
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              release = resolve
+            }),
+        )
+      await mountPage(kind)
+      expect(ids()).toHaveLength(50)
+      expect(api.mock.calls[0][2]).toMatchObject({ limit: 400 })
+      await button().trigger("click")
+      await flushPromises()
+      expect(api.mock.calls[1][2]).toMatchObject({ before: "b400", stream: "events" })
+      expect(ids()).toHaveLength(50)
+      const vp = wrapper.get(".chat-messages-viewport").element
+      vp.scrollTop = 55
+      const anchor = visibleAnchor()
+      release(page(0, 400, false))
+      await flushPromises()
+      expect(ids()).toHaveLength(250)
+      expect(
+        wrapper.get(`[data-message-id="${anchor.key}"]`).element.getBoundingClientRect().top,
+      ).toBe(anchor.top)
+      await button().trigger("click")
+      await flushPromises()
+      expect(api).toHaveBeenCalledTimes(2)
+      expect(ids()).toHaveLength(450)
+      await scroll(vp.scrollHeight - 120)
+      expect(ids()).toHaveLength(200)
+      expect(chat.messagesByTab.root).toHaveLength(450)
+    },
+  )
+
+  it("keeps a completed prefetch cache-only and traverses multiple pages via upward scroll", async () => {
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page(800, 200))
+      .mockResolvedValueOnce(page(400, 400))
+      .mockResolvedValueOnce(page(0, 400, false))
+    await mountPage()
+    const vp = wrapper.get(".chat-messages-viewport").element
+    const top = vp.scrollTop
+    await chat.prefetchOlderHistory("root")
+    expect(ids()).toHaveLength(200)
+    expect(chat.messagesByTab.root).toHaveLength(200)
+    expect(vp.scrollTop).toBe(top)
+    await scroll(0)
+    expect(ids()).toHaveLength(300)
+    expect(api).toHaveBeenCalledTimes(2)
+    await scroll(0)
+    await scroll(0)
+    await scroll(0)
+    expect(ids()).toHaveLength(600)
+    expect(api).toHaveBeenCalledTimes(2)
+    const beforeIdle = vp.scrollTop
+    for (const [id, callback] of [...idle]) {
+      idle.delete(id)
+      callback()
+    }
+    await flushPromises()
+    expect(api).toHaveBeenCalledTimes(3)
+    expect(ids()).toHaveLength(600)
+    expect(chat.messagesByTab.root).toHaveLength(600)
+    expect(vp.scrollTop).toBe(beforeIdle)
+    await scroll(0)
+    expect(ids()).toHaveLength(700)
+    expect(api).toHaveBeenCalledTimes(3)
+    await scroll(vp.scrollHeight - 120)
+    expect(ids()).toHaveLength(200)
+    expect(idle.size).toBe(0)
+  })
+
+  it.each(["tail", "switch", "unmount"])(
+    "does not materialize when %s invalidates a pending viewport continuation",
+    async (action) => {
+      let release
+      vi.spyOn(terrariumAPI, "getHistoryPage")
+        .mockResolvedValueOnce(page(400, 50))
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              release = resolve
+            }),
+        )
+      await mountPage()
+      await button().trigger("click")
+      await flushPromises()
+      if (action === "tail") {
+        const vp = wrapper.get(".chat-messages-viewport").element
+        await scroll(vp.scrollHeight - 120)
+      } else if (action === "switch") {
+        chat.activeTab = "other"
+        await flushPromises()
+      } else {
+        wrapper.unmount()
+        wrapper = null
+      }
+      release(page(0, 400, false))
+      await flushPromises()
+      expect(chat.messagesByTab.root).toHaveLength(50)
+      expect(chat.historyPageByTab.root.hasCachedOlder).toBe(true)
+      if (action === "switch") expect(ids()).toEqual(["other"])
+      expect(idle.size).toBe(0)
+    },
+  )
+
+  it("resolves the current row containing the old text key after a boundary merge", async () => {
+    const text = (id, content) => ({ type: "text", event_id: id, content, _history_key: `e:${id}` })
+    vi.spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page(400, 1, true, { events: [text(400, "later")] }))
+      .mockResolvedValueOnce(page(0, 1, false, { events: [text(0, "earlier ")] }))
+    await mountPage()
+    const vp = wrapper.get(".chat-messages-viewport").element
+    vp.scrollTop = 10
+    const anchor = visibleAnchor()
+    await button().trigger("click")
+    await flushPromises()
+    expect(wrapper.text()).toContain("earlier later")
+    expect(chat.messagesByTab.root[0]._historyKeys).toEqual(["e:0", "e:400"])
+    expect(ids()).toEqual(["h_e:0"])
+    expect(wrapper.get('[data-message-id="h_e:0"]').element.getBoundingClientRect().top).toBe(
+      anchor.top,
+    )
+  })
+})

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.historyPaging.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.historyPaging.test.js
@@ -535,6 +535,18 @@ describe("connected paged history and reset", () => {
     await scroll(vp.scrollHeight - 120)
     expect(ids()).toHaveLength(200)
     expect(idle.size).toBe(0)
+    // A viewport pinned at the top receives no further scroll delta, so the
+    // gesture itself must still be able to request the next batch.
+    await scroll(0)
+    expect(ids()).toHaveLength(300)
+    vp.scrollTop = 0
+    vp.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+    await flushPromises()
+    expect(ids()).toHaveLength(400)
+    vp.scrollTop = vp.scrollHeight - 120
+    vp.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+    await flushPromises()
+    expect(ids()).toHaveLength(400)
   })
 
   it.each(["tail", "switch", "unmount"])(

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -81,9 +81,10 @@
               <p class="text-warm-300 dark:text-warm-600 text-xs mt-1">{{ resolvedEmptySubtitle }}</p>
             </div>
           </template>
-          <button v-if="windowStart > 0 || hasOlderHistory" class="self-center text-xs text-iolite dark:text-iolite-light hover:underline" @click="loadEarlierMessages">
+          <button v-if="!historyFetchBlocked && (windowStart > 0 || hasOlderHistory)" class="self-center text-xs text-iolite dark:text-iolite-light hover:underline" @click="loadEarlierMessages">
             {{ windowStart ? t("chat.showEarlier", { count: windowStart }) : t("sessionViewer.trace.turn.loadMore") }}
           </button>
+          <p v-else-if="historyFetchBlocked" data-history-generating class="self-center text-xs text-warm-400 dark:text-warm-500">{{ t("chat.loadEarlierGenerating") }}</p>
           <p v-if="historyDetailError" role="alert" class="text-xs text-coral">{{ historyDetailError }}</p>
           <div v-for="(msg, idx) in windowMessages" :key="msg.id" :data-message-id="msg.id" class="flex flex-col">
             <button v-for="key in msg._historyDetails || []" :key="key" :data-history-detail="key" :disabled="historyDetailPending !== null" class="self-start text-xs text-iolite hover:underline" @click="loadHistoryDetail(key)">{{ t("sessionViewer.detail.title") }}</button>
@@ -561,6 +562,11 @@ const hasOlderHistory = computed(() => {
   return tab ? !!chat.historyPageByTab?.[tab]?.hasOlder : false
 })
 
+// A live turn keeps mutating the projected range, so an older page cannot be
+// merged until it finishes. Surface that instead of spending a request that
+// the source would discard.
+const historyFetchBlocked = computed(() => viewProcessing.value && windowStart.value === 0 && hasOlderHistory.value)
+
 // The single shared viewport/history coordinator. The "show earlier"
 // button (manual) and continuous upward scrolling (automatic) both run
 // through one expansion transaction: consume local unrendered rows first,
@@ -598,6 +604,7 @@ const historyExpander = createChatHistoryExpander({
     // the source reports older data. The store fetches/caches but does not
     // replay or touch the DOM until the synchronous materialize.
     if (!hasOlderHistory.value) return false
+    if (viewProcessing.value) return false
     const context = getScrollKey()
     const epoch = readingEpoch
     const prefetched = await chat.prefetchOlderHistory(tab)

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -801,14 +801,6 @@ watch(
   },
 )
 
-// The refused older-page fetch resumes on its own once the turn ends, so a
-// reader parked at the top does not have to gesture again.
-watch(viewProcessing, (processing) => {
-  if (processing || !isHistoryMode.value) return
-  const el = messagesEl.value
-  if (el && el.scrollTop <= CHAT_AUTO_EXPAND_TOP_PX) historyExpander.maybeExpandAtTop(el.scrollTop)
-})
-
 watch(
   scrollScope,
   (scope, previousScope) => {
@@ -835,6 +827,14 @@ watch(
   },
   { immediate: true },
 )
+
+// The refused older-page fetch resumes on its own once the turn ends, so a
+// reader parked at the top does not have to gesture again.
+watch(viewProcessing, (processing) => {
+  if (processing || !isHistoryMode.value) return
+  const el = messagesEl.value
+  if (el && el.scrollTop <= CHAT_AUTO_EXPAND_TOP_PX) historyExpander.maybeExpandAtTop(el.scrollTop)
+})
 
 watch(
   () => [scrollScope.value, chat._instanceGeneration, chat.historyPageByTab?.[viewActiveTab.value]?.historyId],

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -67,8 +67,11 @@
         <div class="px-4 py-2 rounded-lg bg-white dark:bg-warm-900 border border-iolite/40 shadow-lg text-sm text-iolite dark:text-iolite-light font-medium"><span class="i-carbon-upload mr-1" /> {{ t("chat.dropToAttach") }}</div>
       </div>
 
-      <div ref="messagesEl" class="chat-messages-viewport flex-1 overflow-y-auto px-5 py-4" @scroll="onMessagesScroll">
+      <div ref="messagesEl" class="chat-messages-viewport flex-1 overflow-y-auto px-5 py-4" @scroll="onMessagesScroll" @wheel.passive="onMessagesWheel" @keydown="onMessagesKeydown" @touchstart.passive="onMessagesTouchStart" @touchmove.passive="onMessagesTouchMove">
         <div class="flex flex-col gap-3">
+          <p v-if="chat.tokenUsage[viewActiveTab]?.partial" data-history-partial class="text-xs text-warm-400">{{ viewActiveTab }} — Loaded history / partial statistics (including loaded sub-agent usage)</p>
+          <button v-if="chat.historyPageByTab[viewActiveTab]?.hasNewer" data-history-newer class="self-center text-xs text-iolite" @click="reloadHistoryPage">Newer messages pending — {{ t("common.refresh") }}</button>
+          <button v-if="chat.historyPageByTab[viewActiveTab]?.resetRequired" data-history-reset class="self-center text-xs text-iolite" @click="reloadHistoryPage">{{ t("common.refresh") }}</button>
           <template v-if="viewMessages.length === 0">
             <div class="text-center py-16">
               <div class="w-12 h-12 rounded-2xl bg-gradient-to-br from-iolite/10 to-amber/10 dark:from-iolite/5 dark:to-amber/5 flex items-center justify-center mx-auto mb-3">
@@ -78,10 +81,12 @@
               <p class="text-warm-300 dark:text-warm-600 text-xs mt-1">{{ resolvedEmptySubtitle }}</p>
             </div>
           </template>
-          <button v-if="windowStart > 0" class="self-center text-xs text-iolite dark:text-iolite-light hover:underline" @click="loadEarlierMessages">
-            {{ t("chat.showEarlier", { count: windowStart }) }}
+          <button v-if="windowStart > 0 || hasOlderHistory" class="self-center text-xs text-iolite dark:text-iolite-light hover:underline" @click="loadEarlierMessages">
+            {{ windowStart ? t("chat.showEarlier", { count: windowStart }) : t("sessionViewer.trace.turn.loadMore") }}
           </button>
+          <p v-if="historyDetailError" role="alert" class="text-xs text-coral">{{ historyDetailError }}</p>
           <div v-for="(msg, idx) in windowMessages" :key="msg.id" :data-message-id="msg.id" class="flex flex-col">
+            <button v-for="key in msg._historyDetails || []" :key="key" :data-history-detail="key" :disabled="historyDetailPending !== null" class="self-start text-xs text-iolite hover:underline" @click="loadHistoryDetail(key)">{{ t("sessionViewer.detail.title") }}</button>
             <ChatMessage :message="msg" :prev-message="windowStart + idx > 0 ? viewMessages[windowStart + idx - 1] : null" :is-first="windowStart + idx === 0" :message-idx="windowStart + idx" :is-last-assistant="msg.role === 'assistant' && windowStart + idx === viewMessages.length - 1" :tab-id="viewActiveTab" />
           </div>
           <div v-if="showKohakUwUingIndicator" class="flex items-center gap-2.5 py-2 pl-1">
@@ -194,8 +199,8 @@ import { inject } from "vue"
 
 import StatusDot from "@/components/common/StatusDot.vue"
 import ChatMessage from "@/components/chat/ChatMessage.vue"
-import { useChatRenderWindow, CHAT_RENDER_EXPAND_MESSAGE_LIMIT, CHAT_RENDER_EXPAND_UNIT_BUDGET } from "@/components/chat/chatRenderWindow"
-import { createChatHistoryExpander, captureViewportAnchor, restoreViewportAnchor } from "@/components/chat/chatHistoryExpand"
+import { isTailRenderBudgetFull, useChatRenderWindow, CHAT_RENDER_EXPAND_MESSAGE_LIMIT, CHAT_RENDER_EXPAND_UNIT_BUDGET, CHAT_RENDER_MESSAGE_LIMIT, CHAT_RENDER_UNIT_BUDGET } from "@/components/chat/chatRenderWindow"
+import { createChatHistoryExpander, captureSemanticAnchor } from "@/components/chat/chatHistoryExpand"
 import { createChatScrollScheduler } from "@/components/chat/chatScrollScheduler"
 import SlashCommandMenu from "@/components/chat/SlashCommandMenu.vue"
 import ModelSwitcher from "@/components/chrome/ModelSwitcher.vue"
@@ -538,23 +543,114 @@ function getScrollKey(instanceId = props.instance?.id || chat._instanceId, tab =
 // Live tail is selected by an estimated render-unit budget. An explicit
 // start marks history-reading mode: its top stays fixed while the open
 // end keeps newly arriving messages reachable.
-const { enterHistoryAt, expandHistory, isHistoryMode, leaveHistory, restoreHistory, windowMessages, windowStart } = useChatRenderWindow(viewMessages, () => getScrollKey())
+// A monotonically-increasing reading epoch invalidates a pending page
+// fetch when the reading intent changes: return-to-tail, scope switch, or
+// unmount. The store's source already fences request data by
+// source-key/instance/mutation generation; this guards the viewport
+// continuation (no stale scroll/replay) against those same transitions.
+let readingEpoch = 0
+const { enterHistoryAt, expandHistory, isHistoryMode, leaveHistory: _leaveHistory, restoreHistory, windowMessages, windowStart } = useChatRenderWindow(viewMessages, () => getScrollKey())
+const leaveHistory = () => {
+  readingEpoch += 1
+  historyExpander.cancelIdleExpand()
+  _leaveHistory()
+}
 
-// Continuous upward scrolling: reaching the top of the rendered window
-// expands it one small step, and an idle lookahead pre-mounts the next
-// step so back-to-back expansions never stall the scroll interaction.
+const hasOlderHistory = computed(() => {
+  const tab = viewActiveTab.value
+  return tab ? !!chat.historyPageByTab?.[tab]?.hasOlder : false
+})
+
+// The single shared viewport/history coordinator. The "show earlier"
+// button (manual) and continuous upward scrolling (automatic) both run
+// through one expansion transaction: consume local unrendered rows first,
+// fetch an older raw page only when those are exhausted. A scope switch,
+// return-to-tail, or unmount invalidates the continuation.
+let isPanelDisposed = false
 const historyExpander = createChatHistoryExpander({
-  canExpand: () => isHistoryMode.value && windowStart.value > 0,
-  expand: () => expandHistory({ unitBudget: CHAT_RENDER_EXPAND_UNIT_BUDGET, messageLimit: CHAT_RENDER_EXPAND_MESSAGE_LIMIT }),
+  initialFill: {
+    owner: () => chat,
+    generation: () => chat._instanceGeneration,
+    key: () => viewActiveTab.value,
+    ready: () => !!messagesEl.value && !!chat.historyPageByTab?.[viewActiveTab.value]?.historyId,
+    atTail: () => isNearBottom.value && !isHistoryMode.value,
+    needsMore: () => {
+      const state = chat.historyPageByTab?.[viewActiveTab.value]
+      return state?.hasOlder && !state.pending && !state.hasNewer && chat._controllerForTab(viewActiveTab.value)?.isCurrent() && !isTailRenderBudgetFull(viewMessages.value)
+    },
+    prefetch: () => chat.prefetchOlderHistory(viewActiveTab.value),
+    materialize: () => chat.materializeOlderHistory(viewActiveTab.value),
+    scroll: () => scrollToBottom(),
+  },
+  onCompensated: () => {
+    lastObservedScrollTop = messagesEl.value?.scrollTop || 0
+  },
+  canExpand: () => isHistoryMode.value && (windowStart.value > 0 || hasOlderHistory.value),
+  expand: async (step, { idle = false } = {}) => {
+    const tab = viewActiveTab.value
+    if (!tab) return false
+    // Local unrendered rows exist: expand the render window, no fetch.
+    if (windowStart.value > 0) {
+      expandHistory(step)
+      return true
+    }
+    // Local unrendered rows exhausted: fetch/cache an older page only when
+    // the source reports older data. The store fetches/caches but does not
+    // replay or touch the DOM until the synchronous materialize.
+    if (!hasOlderHistory.value) return false
+    const context = getScrollKey()
+    const epoch = readingEpoch
+    const prefetched = await chat.prefetchOlderHistory(tab)
+    // Validate scope/reading intent before the synchronous apply: a valid
+    // cache response does not authorize a stale scroll/replay. Returning to
+    // the tail (leaveHistory), a scope switch, or an unmount all bump the
+    // reading epoch and must discard this continuation.
+    if (isPanelDisposed || readingEpoch !== epoch || getScrollKey() !== context || prefetched?.discarded || idle) return false
+    const anchor = captureSemanticAnchor(
+      () => messagesEl.value,
+      () => viewMessages.value,
+    )
+    const applied = chat.materializeOlderHistory(tab, () => enterHistoryAt(windowStart.value))
+    if (!applied?.applied) return false
+    expandHistory(step)
+    return anchor || true
+  },
   getViewportEl: () => messagesEl.value,
-  getContext: () => getScrollKey(),
+  getMessages: () => viewMessages.value,
+  getContext: () => `${getScrollKey()}:${readingEpoch}`,
+  autoStep: { unitBudget: CHAT_RENDER_EXPAND_UNIT_BUDGET, messageLimit: CHAT_RENDER_EXPAND_MESSAGE_LIMIT },
+  manualStep: { unitBudget: CHAT_RENDER_UNIT_BUDGET, messageLimit: CHAT_RENDER_MESSAGE_LIMIT },
 })
 
 async function loadEarlierMessages() {
-  const anchor = captureViewportAnchor(() => messagesEl.value)
-  expandHistory()
-  await nextTick()
-  restoreViewportAnchor(() => messagesEl.value, anchor)
+  await historyExpander.expandManual()
+}
+
+async function reloadHistoryPage() {
+  historyExpander.cancelInitialFill(true)
+  try {
+    if (chat.historyPageByTab[viewActiveTab.value]?.hasNewer) await chat.refreshHistoryHead(viewActiveTab.value)
+    else await chat.initHistoryPage(viewActiveTab.value)
+  } catch (error) {
+    historyDetailError.value = error.message
+  }
+}
+
+const historyDetailPending = ref(null)
+const historyDetailError = ref("")
+async function loadHistoryDetail(key) {
+  if (historyDetailPending.value !== null) return
+  const context = getScrollKey()
+  historyDetailPending.value = key
+  historyDetailError.value = ""
+  try {
+    const result = await chat.loadHistoryRecord(viewActiveTab.value, key)
+    if (!result.applied && context === getScrollKey()) historyDetailError.value = t("common.refresh")
+  } catch (error) {
+    if (context === getScrollKey()) historyDetailError.value = error?.response?.data?.detail || error.message || t("common.status.error")
+  } finally {
+    historyDetailPending.value = null
+  }
 }
 
 let lastObservedScrollTop = 0
@@ -588,9 +684,27 @@ function restoreScrollPosition(instanceId = props.instance?.id || chat._instance
 }
 
 let scrollStateFrame = null
+let scrolledUp = false
+let touchY = null
+function onMessagesWheel(event) {
+  if (event.deltaY < 0) historyExpander.cancelInitialFill(true)
+}
+function onMessagesKeydown(event) {
+  if (["ArrowUp", "PageUp", "Home"].includes(event.key)) historyExpander.cancelInitialFill(true)
+}
+function onMessagesTouchStart(event) {
+  touchY = event.touches[0]?.clientY ?? null
+}
+function onMessagesTouchMove(event) {
+  const y = event.touches[0]?.clientY
+  if (touchY != null && y > touchY) historyExpander.cancelInitialFill(true)
+  touchY = y
+}
 function onMessagesScroll() {
   const el = messagesEl.value
   if (el && el.scrollTop < lastObservedScrollTop) {
+    scrolledUp = true
+    historyExpander.cancelInitialFill(true)
     if (!isHistoryMode.value) enterHistoryAt(windowStart.value)
     isNearBottom.value = false
     scrollScheduler.suppress()
@@ -603,9 +717,10 @@ function onMessagesScroll() {
     if (isNearBottom.value) {
       leaveHistory()
       scrollScheduler.resume()
-    } else if (el) {
+    } else if (el && scrolledUp) {
       historyExpander.maybeExpandAtTop(el.scrollTop)
     }
+    scrolledUp = false
     saveScrollPosition()
   })
 }
@@ -666,6 +781,9 @@ watch(
 watch(
   scrollScope,
   (scope, previousScope) => {
+    readingEpoch += 1
+    historyExpander.cancelInitialFill()
+    scrolledUp = false
     scrollScheduler.invalidate()
     scrollScheduler.resume()
     historyExpander.cancelIdleExpand()
@@ -685,6 +803,15 @@ watch(
     })
   },
   { immediate: true },
+)
+
+watch(
+  () => [scrollScope.value, chat._instanceGeneration, chat.historyPageByTab?.[viewActiveTab.value]?.historyId],
+  () => {
+    if (!chat.historyPageByTab?.[viewActiveTab.value]?.historyId) historyExpander.cancelInitialFill()
+    else nextTick(() => historyExpander.startInitialFill())
+  },
+  { flush: "post" },
 )
 
 watch(inputText, () => {
@@ -999,8 +1126,13 @@ function onGlobalKeydown(e) {
     chat.interrupt(viewActiveTab.value)
   }
 }
-onMounted(() => window.addEventListener("keydown", onGlobalKeydown))
+onMounted(() => {
+  window.addEventListener("keydown", onGlobalKeydown)
+  nextTick(() => historyExpander.startInitialFill())
+})
 onUnmounted(() => {
+  isPanelDisposed = true
+  readingEpoch += 1
   window.removeEventListener("keydown", onGlobalKeydown)
   scrollScheduler.dispose()
   historyExpander.dispose()

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -200,7 +200,7 @@ import { inject } from "vue"
 import StatusDot from "@/components/common/StatusDot.vue"
 import ChatMessage from "@/components/chat/ChatMessage.vue"
 import { isTailRenderBudgetFull, useChatRenderWindow, CHAT_RENDER_EXPAND_MESSAGE_LIMIT, CHAT_RENDER_EXPAND_UNIT_BUDGET, CHAT_RENDER_MESSAGE_LIMIT, CHAT_RENDER_UNIT_BUDGET } from "@/components/chat/chatRenderWindow"
-import { createChatHistoryExpander, captureSemanticAnchor } from "@/components/chat/chatHistoryExpand"
+import { createChatHistoryExpander, captureSemanticAnchor, CHAT_AUTO_EXPAND_TOP_PX } from "@/components/chat/chatHistoryExpand"
 import { createChatScrollScheduler } from "@/components/chat/chatScrollScheduler"
 import SlashCommandMenu from "@/components/chat/SlashCommandMenu.vue"
 import ModelSwitcher from "@/components/chrome/ModelSwitcher.vue"
@@ -686,18 +686,35 @@ function restoreScrollPosition(instanceId = props.instance?.id || chat._instance
 let scrollStateFrame = null
 let scrolledUp = false
 let touchY = null
+// An expansion whose anchor cannot be restored leaves the viewport pinned
+// at the top, where no further scroll delta arrives. The gesture itself
+// must still be able to ask for the next batch.
+function nudgeHistoryAtTop() {
+  const el = messagesEl.value
+  if (!el || !isHistoryMode.value || el.scrollTop > CHAT_AUTO_EXPAND_TOP_PX) return
+  historyExpander.maybeExpandAtTop(el.scrollTop)
+}
 function onMessagesWheel(event) {
-  if (event.deltaY < 0) historyExpander.cancelInitialFill(true)
+  if (event.deltaY < 0) {
+    historyExpander.cancelInitialFill(true)
+    nudgeHistoryAtTop()
+  }
 }
 function onMessagesKeydown(event) {
-  if (["ArrowUp", "PageUp", "Home"].includes(event.key)) historyExpander.cancelInitialFill(true)
+  if (["ArrowUp", "PageUp", "Home"].includes(event.key)) {
+    historyExpander.cancelInitialFill(true)
+    nudgeHistoryAtTop()
+  }
 }
 function onMessagesTouchStart(event) {
   touchY = event.touches[0]?.clientY ?? null
 }
 function onMessagesTouchMove(event) {
   const y = event.touches[0]?.clientY
-  if (touchY != null && y > touchY) historyExpander.cancelInitialFill(true)
+  if (touchY != null && y > touchY) {
+    historyExpander.cancelInitialFill(true)
+    nudgeHistoryAtTop()
+  }
   touchY = y
 }
 function onMessagesScroll() {

--- a/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/chat/ChatPanel.vue
@@ -562,9 +562,8 @@ const hasOlderHistory = computed(() => {
   return tab ? !!chat.historyPageByTab?.[tab]?.hasOlder : false
 })
 
-// A live turn keeps mutating the projected range, so an older page cannot be
-// merged until it finishes. Surface that instead of spending a request that
-// the source would discard.
+// A live turn mutates the projected range, so an older page cannot merge
+// until it finishes; say so instead of spending a request it would discard.
 const historyFetchBlocked = computed(() => viewProcessing.value && windowStart.value === 0 && hasOlderHistory.value)
 
 // The single shared viewport/history coordinator. The "show earlier"
@@ -801,6 +800,14 @@ watch(
     if (scope === previous?.[0] && val) scheduleScrollToBottom()
   },
 )
+
+// The refused older-page fetch resumes on its own once the turn ends, so a
+// reader parked at the top does not have to gesture again.
+watch(viewProcessing, (processing) => {
+  if (processing || !isHistoryMode.value) return
+  const el = messagesEl.value
+  if (el && el.scrollTop <= CHAT_AUTO_EXPAND_TOP_PX) historyExpander.maybeExpandAtTop(el.scrollTop)
+})
 
 watch(
   scrollScope,

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.js
@@ -1,35 +1,67 @@
 import { nextTick } from "vue"
+import { indexOfSemanticKey, semanticKey } from "./chatRenderWindow"
 
 // Distance (px) from the top of the viewport at which continuous
 // upward scrolling expands the render window without a click on
 // "show earlier".
 export const CHAT_AUTO_EXPAND_TOP_PX = 48
 
-// Reading-position anchor for prepending content. The first message
-// wrapper visible at the viewport top is captured before the DOM
-// changes; after the commit its viewport-relative position is restored
-// via an absolute delta on its live rect. Unlike a scrollHeight delta
-// this is self-correcting when the browser's native scroll anchoring
-// already adjusted scrollTop for the insertion (the anchor delta then
-// reads ~0, so no double compensation).
-export function captureViewportAnchor(getViewportEl) {
+// Automatic (scroll / idle) expansion uses a smaller step than explicit
+// (button) expansion so a scroll gesture never mounts a whole page at
+// once. These mirror the render budgets in chatRenderWindow.js.
+export const CHAT_HISTORY_AUTO_STEP = { unitBudget: 500, messageLimit: 100 }
+export const CHAT_HISTORY_MANUAL_STEP = { unitBudget: 1000, messageLimit: 200 }
+
+// Capture the first visible row's physical key and viewport offset.
+export function captureSemanticAnchor(getViewportEl, getMessages) {
   const el = getViewportEl()
   if (!el) return null
   const viewportTop = el.getBoundingClientRect().top
   for (const wrapper of el.querySelectorAll("[data-message-id]")) {
     if (wrapper.getBoundingClientRect().bottom > viewportTop) {
-      return { element: wrapper, offset: wrapper.getBoundingClientRect().top - viewportTop }
+      let key = null
+      if (getMessages) {
+        const id =
+          typeof wrapper.getAttribute === "function"
+            ? wrapper.getAttribute("data-message-id")
+            : null
+        const message = getMessages().find((m) => m != null && String(m.id) === String(id))
+        key = semanticKey(message)
+      }
+      return { element: wrapper, offset: wrapper.getBoundingClientRect().top - viewportTop, key }
     }
   }
   return null
 }
 
-export function restoreViewportAnchor(getViewportEl, anchor) {
-  if (!anchor || !anchor.element.isConnected) return
+// Resolve the current semantic row after the DOM commit.
+export function restoreSemanticAnchor(getViewportEl, getMessages, anchor) {
+  if (!anchor) return
+  let element = anchor.key == null && anchor.element?.isConnected ? anchor.element : null
+  if (getMessages && anchor.key != null) {
+    const messages = getMessages()
+    const index = indexOfSemanticKey(messages, anchor.key)
+    if (index >= 0) {
+      const id = messages[index]?.id
+      const vp = getViewportEl()
+      if (vp) {
+        for (const wrapper of vp.querySelectorAll("[data-message-id]")) {
+          if (
+            typeof wrapper.getAttribute === "function" &&
+            String(wrapper.getAttribute("data-message-id")) === String(id)
+          ) {
+            element = wrapper
+            break
+          }
+        }
+      }
+    }
+  }
+  if (!element) return
   const el = getViewportEl()
   if (!el) return
   const viewportTop = el.getBoundingClientRect().top
-  el.scrollTop += anchor.element.getBoundingClientRect().top - viewportTop - anchor.offset
+  el.scrollTop += element.getBoundingClientRect().top - viewportTop - anchor.offset
 }
 
 function defaultScheduleIdle(callback) {
@@ -47,41 +79,111 @@ function defaultCancelIdle(handle) {
   }
 }
 
-// Drives automatic history expansion on top of useChatRenderWindow:
-// - ``maybeExpandAtTop`` grows the window one small step when scrolling
-//   reaches the top of the rendered range, compensating scrollTop after
-//   the DOM commit so reading position never jumps.
-// - ``scheduleIdleExpand`` pre-mounts the next step off the interaction
-//   path. It never chains: at most one batch lives ahead of the
-//   viewport, so idle expansion cannot walk the whole history.
+const initialFills = new WeakMap()
+
+// Coordinate manual, scroll, and idle expansion with semantic compensation.
 export function createChatHistoryExpander({
   canExpand,
   expand,
   getViewportEl,
+  getMessages,
   getContext,
+  initialFill,
+  onCompensated,
+  autoStep = CHAT_HISTORY_AUTO_STEP,
+  manualStep = CHAT_HISTORY_MANUAL_STEP,
   scheduleIdle = defaultScheduleIdle,
   cancelIdle = defaultCancelIdle,
 }) {
   let idleHandle = null
   let expanding = false
   let disposed = false
+  let fillState = null
+  let fillHandle = null
 
-  async function expandAndCompensate() {
-    const context = getContext?.()
-    const anchor = captureViewportAnchor(getViewportEl)
-    expand()
-    await nextTick()
-    // A scope switch during the DOM commit means the prepended content
-    // no longer belongs to the mounted list — don't shift the new
-    // scope's restored scroll position by a stale delta.
-    if (getContext && getContext() !== context) return
-    restoreViewportAnchor(getViewportEl, anchor)
+  function getFillState() {
+    const owner = initialFill.owner()
+    const generation = initialFill.generation()
+    let session = initialFills.get(owner)
+    if (!session || session.generation !== generation) {
+      session = { generation, tabs: new Map() }
+      initialFills.set(owner, session)
+    }
+    const key = initialFill.key()
+    let state = session.tabs.get(key)
+    if (!state) session.tabs.set(key, (state = { claimed: false, cancelled: false }))
+    return state
   }
 
-  async function runExpand() {
+  function cancelInitialFill(recordIntent = false) {
+    const state = recordIntent && initialFill ? getFillState() : fillState
+    if (state) {
+      state.claimed = true
+      state.cancelled = true
+    }
+    if (fillHandle !== null) cancelIdle(fillHandle)
+    fillHandle = null
+  }
+
+  function startInitialFill() {
+    if (disposed || !initialFill?.ready()) return
+    const owner = initialFill.owner()
+    const key = initialFill.key()
+    const generation = initialFill.generation()
+    const state = getFillState()
+    if (state.claimed) return
+    fillState = state
+    state.claimed = true
+    const deadline = Date.now() + 1500
+    let pages = 0
+    const current = () =>
+      !disposed &&
+      !state.cancelled &&
+      initialFill.owner() === owner &&
+      initialFill.key() === key &&
+      initialFill.generation() === generation &&
+      initialFill.atTail() &&
+      Date.now() < deadline
+    const schedule = () => {
+      if (!current() || pages >= 3 || !initialFill.needsMore()) return
+      fillHandle = scheduleIdle(async () => {
+        fillHandle = null
+        if (!current() || !initialFill.needsMore()) return
+        pages += 1
+        try {
+          const result = await initialFill.prefetch()
+          if (!current() || result?.discarded || !initialFill.needsMore()) return
+          if (!initialFill.materialize()?.applied) return
+          await nextTick()
+          if (!current()) return
+          initialFill.scroll()
+          schedule()
+        } catch (error) {
+          console.warn("[chat] initial history fill failed", error)
+        }
+      })
+    }
+    schedule()
+  }
+
+  async function expandAndCompensate(step, intent) {
+    const context = getContext?.()
+    const preAnchor = captureSemanticAnchor(getViewportEl, getMessages)
+
+    const result = await expand(step, intent)
+    await nextTick()
+
+    if (getContext && getContext() !== context) return
+    if (result === false) return
+    const anchor = result && typeof result === "object" ? result : preAnchor
+    restoreSemanticAnchor(getViewportEl, getMessages, anchor)
+    onCompensated?.()
+  }
+
+  async function runExpand(step, intent = { idle: false }) {
     expanding = true
     try {
-      await expandAndCompensate()
+      await expandAndCompensate(step, intent)
     } catch (error) {
       // Scroll-handler-originated work must never surface as an
       // unhandled rejection.
@@ -92,14 +194,15 @@ export function createChatHistoryExpander({
   }
 
   function maybeExpandAtTop(scrollTop) {
+    cancelInitialFill()
     if (disposed || expanding || !canExpand() || scrollTop > CHAT_AUTO_EXPAND_TOP_PX) return false
-    // The interactive step mounts the batch a pending lookahead was
-    // going to pre-mount, so supersede it: keeps at most one batch
-    // ahead of the reading position, and keeps the setTimeout fallback
-    // from firing a stale expansion mid-gesture.
+    // The interactive step mounts the batch a pending lookahead was going
+    // to pre-mount, so supersede it: keeps at most one batch ahead of the
+    // reading position, and keeps the setTimeout fallback from firing a
+    // stale expansion mid-gesture.
     cancelIdleExpand()
     const context = getContext?.()
-    runExpand().then(() => {
+    runExpand(autoStep).then(() => {
       // A scope switch or disposal during the in-flight expansion
       // invalidates the continuation: never re-arm the lookahead for a
       // scope the user did not scroll in.
@@ -114,7 +217,7 @@ export function createChatHistoryExpander({
     idleHandle = scheduleIdle(() => {
       idleHandle = null
       if (disposed || !canExpand()) return
-      runExpand()
+      runExpand(autoStep, { idle: true })
     })
   }
 
@@ -124,14 +227,28 @@ export function createChatHistoryExpander({
     idleHandle = null
   }
 
+  // Explicit "show earlier" button expansion. Shares the coordinator with
+  // automatic expansion but uses the larger manual budget.
+  function expandManual() {
+    cancelInitialFill(true)
+    if (disposed) return Promise.resolve()
+    cancelIdleExpand()
+    if (expanding) return Promise.resolve()
+    return runExpand(manualStep)
+  }
+
   function dispose() {
     disposed = true
+    cancelInitialFill()
     cancelIdleExpand()
   }
 
   return {
+    startInitialFill,
+    cancelInitialFill,
     cancelIdleExpand,
     dispose,
+    expandManual,
     maybeExpandAtTop,
     scheduleIdleExpand,
   }

--- a/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatHistoryExpand.test.js
@@ -1,9 +1,66 @@
 import { flushPromises } from "@vue/test-utils"
 import { describe, expect, it, vi } from "vitest"
 
-import { CHAT_AUTO_EXPAND_TOP_PX, createChatHistoryExpander } from "./chatHistoryExpand"
+import {
+  CHAT_AUTO_EXPAND_TOP_PX,
+  createChatHistoryExpander,
+  restoreSemanticAnchor,
+} from "./chatHistoryExpand"
 
-describe("chat history auto expansion", () => {
+describe("chat history auto expansion and initial-fill lifecycle", () => {
+  it("isolates generation claims from disposal of an older panel", async () => {
+    const owner = {}
+    let generation = 0
+    const initialFill = {
+      owner: () => owner,
+      generation: () => generation,
+      key: () => "root",
+      ready: () => true,
+      atTail: () => true,
+      needsMore: () => true,
+      prefetch: vi.fn(async () => ({ cached: true })),
+      materialize: vi.fn(() => ({ applied: false })),
+      scroll: vi.fn(),
+    }
+    const old = createExpander({ initialFill })
+    old.expander.startInitialFill()
+    generation++
+    const current = createExpander({ initialFill })
+    current.expander.startInitialFill()
+    old.expander.startInitialFill()
+    old.expander.dispose()
+    current.idle.runNext()
+    await flushPromises()
+    expect(initialFill.prefetch).toHaveBeenCalledTimes(1)
+    expect(initialFill.materialize).toHaveBeenCalledTimes(1)
+    current.expander.dispose()
+  })
+
+  it("resolves semantic identity instead of a connected recycled node", () => {
+    const stale = { isConnected: true, getBoundingClientRect: () => ({ top: 500 }) }
+    const row = { getAttribute: () => "merged", getBoundingClientRect: () => ({ top: 80 }) }
+    const viewport = {
+      scrollTop: 10,
+      getBoundingClientRect: () => ({ top: 0 }),
+      querySelectorAll: () => [row],
+    }
+    restoreSemanticAnchor(
+      () => viewport,
+      () => [{ id: "merged", _historyKeys: ["old", "new"] }],
+      { element: stale, key: "old", offset: 20 },
+    )
+    expect(viewport.scrollTop).toBe(70)
+  })
+
+  it("passes idle intent separately from interactive expansion", async () => {
+    const expand = vi.fn()
+    const { idle, expander } = createExpander({ expand })
+    expander.scheduleIdleExpand()
+    idle.runNext()
+    await flushPromises()
+    expect(expand).toHaveBeenCalledWith(expect.any(Object), { idle: true })
+  })
+
   function createIdleHarness() {
     const scheduled = []
     const cancelled = new Set()

--- a/src/kohakuterrarium-frontend/src/components/chat/chatRenderWindow.js
+++ b/src/kohakuterrarium-frontend/src/components/chat/chatRenderWindow.js
@@ -50,10 +50,77 @@ export function findRenderWindowStart(
   return start
 }
 
+export function isTailRenderBudgetFull(messages) {
+  if (findRenderWindowStart(messages) > 0 || messages.length >= CHAT_RENDER_MESSAGE_LIMIT)
+    return true
+  return (
+    messages.length >= CHAT_RENDER_MIN_MESSAGES &&
+    messages.reduce((units, message) => units + messageRenderUnits(message), 0) >=
+      CHAT_RENDER_UNIT_BUDGET
+  )
+}
+
+// A projected row's stable semantic anchor. The window boundary is keyed
+// by a physical record identity (``_historyKeys``), not the positional
+// ``id``, so a row whose id changes when older text/tool events merge in
+// still resolves to the same DOM position after a page materializes.
+export function semanticKey(message) {
+  if (!message) return null
+  if (Array.isArray(message._historyKeys) && message._historyKeys.length) {
+    return String(message._historyKeys[0])
+  }
+  if (Array.isArray(message._historyKey) && message._historyKey.length) {
+    return String(message._historyKey[0])
+  }
+  return message.id != null ? String(message.id) : null
+}
+
+// Resolve a semantic key to the current array index. A row is found by
+// exact ``id`` match OR by key containment (a merged row whose
+// ``_historyKeys`` include the recorded boundary key).
+export function indexOfSemanticKey(messages, key) {
+  if (key == null) return -1
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i]
+    if (message?.id === key) return i
+    const keys = Array.isArray(message?._historyKeys)
+      ? message._historyKeys
+      : Array.isArray(message?._historyKey)
+        ? message._historyKey
+        : []
+    if (keys.includes(key)) return i
+  }
+  return -1
+}
+
 export function useChatRenderWindow(messages, getScopeKey) {
   const activeAnchorId = ref(null)
   const windowStarts = new Map()
   const tailWindowStart = computed(() => findRenderWindowStart(messages.value))
+
+  // Resolve an anchor to a row index. The anchor is a stable semantic key
+  // (a physical ``_history_key``) so a row that survives page-boundary
+  // merging or cross-page duplicate collapse is still found by key
+  // containment, even when its generated ``id`` changed. Falls back to the
+  // legacy stable ``id`` match for rows without a physical key.
+  function findAnchorIndex(anchor) {
+    const list = messages.value
+    if (anchor == null) return -1
+    const byId = list.findIndex((message) => message.id === anchor)
+    if (byId >= 0) return byId
+    return list.findIndex((message) => {
+      const keys = Array.isArray(message?._historyKeys)
+        ? message._historyKeys
+        : Array.isArray(message?._historyKey)
+          ? message._historyKey
+          : []
+      return keys.includes(anchor)
+    })
+  }
+
+  function rowAnchorKey(message) {
+    return semanticKey(message)
+  }
 
   function leaveHistory(key = getScopeKey()) {
     activeAnchorId.value = null
@@ -62,7 +129,7 @@ export function useChatRenderWindow(messages, getScopeKey) {
 
   const windowStart = computed(() => {
     if (!activeAnchorId.value) return tailWindowStart.value
-    const index = messages.value.findIndex((message) => message.id === activeAnchorId.value)
+    const index = findAnchorIndex(activeAnchorId.value)
     if (index < 0) {
       leaveHistory()
       return tailWindowStart.value
@@ -73,14 +140,15 @@ export function useChatRenderWindow(messages, getScopeKey) {
   const isHistoryMode = computed(() => activeAnchorId.value != null)
 
   function enterHistoryAt(index) {
-    const messageId = messages.value[index]?.id
-    if (!messageId) {
+    const message = messages.value[index]
+    const anchor = rowAnchorKey(message)
+    if (!anchor) {
       leaveHistory()
       return
     }
-    activeAnchorId.value = messageId
+    activeAnchorId.value = anchor
     const key = getScopeKey()
-    if (key) windowStarts.set(key, messageId)
+    if (key) windowStarts.set(key, anchor)
   }
 
   function expandHistory(step = {}) {
@@ -88,17 +156,17 @@ export function useChatRenderWindow(messages, getScopeKey) {
   }
 
   function restoreHistory(key = getScopeKey()) {
-    const messageId = windowStarts.get(key)
-    if (!messageId) {
+    const anchor = windowStarts.get(key)
+    if (!anchor) {
       activeAnchorId.value = null
       return false
     }
-    if (!messages.value.some((message) => message.id === messageId)) {
+    if (findAnchorIndex(anchor) < 0) {
       windowStarts.delete(key)
       activeAnchorId.value = null
       return false
     }
-    activeAnchorId.value = messageId
+    activeAnchorId.value = anchor
     return true
   }
 

--- a/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.test.js
@@ -107,6 +107,14 @@ it("loads saved history through its scoped bounded source and refreshes without 
   await flushPromises()
   expect(current.tabs).toEqual(["root"])
   expect(current.messagesByTab.root[0].content).toBe("keep current")
+  // A refresh that cannot apply (history changed on disk) must surface.
+  api.mockResolvedValueOnce({
+    messages: [],
+    history_page: { ...metadata, reset_required: true },
+  })
+  useSessionDetailStore().reloadKey += 1
+  await flushPromises()
+  expect(wrapper.text()).toContain("History changed on disk")
 })
 
 it("re-derives the fallback reasoning panel across a materialized older page", async () => {

--- a/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.test.js
+++ b/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.test.js
@@ -1,0 +1,193 @@
+import { mount, flushPromises } from "@vue/test-utils"
+import { createPinia, setActivePinia } from "pinia"
+import { defineComponent, h } from "vue"
+import { createMemoryHistory, createRouter, useRoute, useRouter } from "vue-router"
+import { afterEach, expect, it, vi } from "vitest"
+import SessionHistoryViewer from "./SessionHistoryViewer.vue"
+import { useChatStore } from "@/stores/chat"
+import { sessionAPI } from "@/utils/api"
+import { useSessionDetailStore } from "@/stores/sessionDetail"
+
+let wrapper
+afterEach(() => {
+  wrapper?.unmount()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+it("loads saved history through its scoped bounded source and refreshes without dropping older pages", async () => {
+  vi.stubGlobal("useRoute", useRoute)
+  vi.stubGlobal("useRouter", useRouter)
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: "/sessions/:name", component: SessionHistoryViewer }],
+  })
+  await router.push("/sessions/saved-one")
+  await router.isReady()
+  vi.spyOn(sessionAPI, "getHistoryIndex").mockResolvedValue({ meta: {}, targets: ["root"] })
+  const full = vi.spyOn(sessionAPI, "getHistory").mockResolvedValue({ messages: [], events: [] })
+  const api = vi.spyOn(sessionAPI, "getHistoryPage").mockResolvedValue({
+    messages: [{ role: "user", content: "bounded saved", _history_key: "s20" }],
+    events: [],
+    history_page: {
+      version: 1,
+      stream: "snapshot",
+      history_id: "h1",
+      before: "s20",
+      after: "s20",
+      has_older: true,
+      has_newer: false,
+      reset_required: false,
+    },
+    live_job_ids: [],
+  })
+  const Panel = defineComponent({
+    props: ["instance"],
+    setup(props) {
+      const chat = useChatStore(props.instance.id)
+      return () =>
+        h(
+          "div",
+          { "data-test": "transcript" },
+          (chat.messagesByTab.root || []).map((m) => m.content).join("|"),
+        )
+    },
+  })
+  wrapper = mount(SessionHistoryViewer, {
+    attachTo: document.body,
+    global: { plugins: [pinia, router], stubs: { ChatPanel: Panel } },
+  })
+  await flushPromises()
+  expect(full).not.toHaveBeenCalled()
+  expect(api).toHaveBeenCalledWith("saved-one", "root", expect.objectContaining({ limit: 400 }))
+  expect(wrapper.get('[data-test="transcript"]').text()).toBe("bounded saved")
+  const chat = useChatStore("session:saved-one")
+  expect(chat.historyPageByTab.root.hasOlder).toBe(true)
+  expect(chat.runningJobs).toEqual({})
+  const metadata = {
+    version: 1,
+    stream: "snapshot",
+    history_id: "h1",
+    before: "s10",
+    after: "s20",
+    has_older: false,
+    has_newer: false,
+  }
+  api.mockResolvedValueOnce({
+    messages: [{ role: "user", content: "older", _history_key: "s10" }],
+    history_page: metadata,
+  })
+  await chat.prefetchOlderHistory("root")
+  chat.materializeOlderHistory("root")
+  await flushPromises()
+  expect(wrapper.get('[data-test="transcript"]').text()).toBe("older|bounded saved")
+  api.mockResolvedValueOnce({
+    messages: [{ role: "user", content: "newer", _history_key: "s30" }],
+    history_page: { ...metadata, after: "s30" },
+  })
+  useSessionDetailStore().reloadKey += 1
+  await flushPromises()
+  expect(api.mock.calls.at(-1)[2]).toMatchObject({ after: "s20", stream: "snapshot" })
+  expect(wrapper.get('[data-test="transcript"]').text()).toBe("older|bounded saved|newer")
+  let release
+  vi.mocked(sessionAPI.getHistoryIndex).mockImplementationOnce(
+    () =>
+      new Promise((r) => {
+        release = r
+      }),
+  )
+  await router.push("/sessions/delayed")
+  await flushPromises()
+  await router.push("/sessions/current")
+  await flushPromises()
+  const current = useChatStore("session:current")
+  current.messagesByTab.root = [{ role: "user", content: "keep current" }]
+  release({ meta: {}, targets: ["stale"] })
+  await flushPromises()
+  expect(current.tabs).toEqual(["root"])
+  expect(current.messagesByTab.root[0].content).toBe("keep current")
+})
+
+it("re-derives the fallback reasoning panel across a materialized older page", async () => {
+  vi.stubGlobal("useRoute", useRoute)
+  vi.stubGlobal("useRouter", useRouter)
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: "/sessions/:name", component: SessionHistoryViewer }],
+  })
+  await router.push("/sessions/reason-one")
+  await router.isReady()
+  const index = vi
+    .spyOn(sessionAPI, "getHistoryIndex")
+    .mockResolvedValue({ meta: {}, targets: ["root"] })
+  const api = vi.spyOn(sessionAPI, "getHistoryPage").mockResolvedValue({
+    messages: [
+      { role: "assistant", content: "head", reasoning_content: "head-think", _history_key: "s20" },
+    ],
+    events: [],
+    history_page: {
+      version: 1,
+      stream: "snapshot",
+      history_id: "h1",
+      before: "s20",
+      after: "s20",
+      has_older: true,
+      has_newer: false,
+      reset_required: false,
+    },
+    live_job_ids: [],
+  })
+  const Panel = defineComponent({
+    props: ["instance"],
+    setup(props) {
+      return () => h("div", { "data-test": "transcript" })
+    },
+  })
+  wrapper = mount(SessionHistoryViewer, {
+    attachTo: document.body,
+    global: { plugins: [pinia, router], stubs: { ChatPanel: Panel } },
+  })
+  await flushPromises()
+  expect(index).toHaveBeenCalledWith("reason-one")
+  // Snapshot head reasoning surfaces in the fallback panel.
+  expect(wrapper.text()).toContain("chain-of-thought (1)")
+  const reasoningToggle = wrapper
+    .findAll("button")
+    .find((b) => b.text().includes("chain-of-thought"))
+  await reasoningToggle.trigger("click")
+  expect(wrapper.text()).toContain("head-think")
+  const chat = useChatStore("session:reason-one")
+  const olderPage = {
+    messages: [
+      {
+        role: "assistant",
+        content: "older",
+        reasoning_content: "older-think",
+        _history_key: "s10",
+      },
+    ],
+    events: [],
+    history_page: {
+      version: 1,
+      stream: "snapshot",
+      history_id: "h1",
+      before: "s10",
+      after: "s20",
+      has_older: false,
+      has_newer: false,
+      reset_required: false,
+    },
+    live_job_ids: [],
+  }
+  api.mockResolvedValueOnce(olderPage)
+  await chat.prefetchOlderHistory("root")
+  chat.materializeOlderHistory("root")
+  await flushPromises()
+  // Materializing the older page must surface the older reasoning in the
+  // reactive fallback panel instead of leaving it stale at the head count.
+  expect(wrapper.text()).toContain("chain-of-thought (2)")
+  expect(wrapper.text()).toContain("older-think")
+})

--- a/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
@@ -178,7 +178,8 @@ async function loadTarget(tab) {
   const store = _chatStoreRef.value
   const name = sessionName.value
   const result = store.historyPageByTab[tab]?.historyId ? await store.refreshHistoryHead(tab) : await store.initHistoryPage(tab, { kind: "saved", sessionName: name })
-  if (!result.applied || store !== _chatStoreRef.value || name !== sessionName.value) return
+  if (store !== _chatStoreRef.value || name !== sessionName.value) return
+  if (!result.applied) error.value = "History changed on disk — reopen the session"
 }
 
 let loadSequence = 0

--- a/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
+++ b/src/kohakuterrarium-frontend/src/components/sessions/SessionHistoryViewer.vue
@@ -60,10 +60,9 @@
 <script setup>
 import ChatPanel from "@/components/chat/ChatPanel.vue"
 import { useDensity } from "@/composables/useDensity"
-import { useChatStore, _convertHistory, _replayEvents } from "@/stores/chat"
+import { useChatStore } from "@/stores/chat"
 import { useSessionDetailStore } from "@/stores/sessionDetail"
 import { sessionAPI } from "@/utils/api"
-import { extractReasoning } from "@/utils/chatReasoning"
 
 const props = defineProps({
   embedded: { type: Boolean, default: false },
@@ -128,9 +127,8 @@ const loading = ref(false)
 const error = ref("")
 const viewerMeta = ref(null)
 const historyTargets = ref([])
-const reasoningEntriesByTab = reactive({})
 const showReasoning = ref(false)
-const activeReasoningEntries = computed(() => reasoningEntriesByTab[chat.activeTab] || [])
+const activeReasoningEntries = computed(() => (chat.messagesByTab?.[chat.activeTab] || []).flatMap((message, messageIndex) => (message._fallbackReasoning || []).map((entry) => ({ messageIndex, ...entry }))))
 
 const viewerInstance = computed(() => {
   const meta = viewerMeta.value || {}
@@ -149,9 +147,6 @@ function goBack() {
 }
 
 function resetViewer() {
-  for (const key of Object.keys(reasoningEntriesByTab)) {
-    delete reasoningEntriesByTab[key]
-  }
   showReasoning.value = false
   chat._cleanup()
   chat._instanceId = `session:${sessionName.value}`
@@ -180,33 +175,21 @@ function ensureTabs(tabs) {
 
 async function loadTarget(tab) {
   if (!tab) return
-  const entries = []
-  const data = await sessionAPI.getHistory(sessionName.value, tab)
-  for (const [messageIndex, message] of (data.messages || []).entries()) {
-    // New sessions render segments inline through ChatMessage; the
-    // fallback panel only serves old snapshots without ordered segments.
-    if (Array.isArray(message?._kt_assistant_segments)) continue
-    for (const entry of extractReasoning(message)) {
-      entries.push({ messageIndex, ...entry })
-    }
-  }
-  reasoningEntriesByTab[tab] = entries
-  if (data.events?.length) {
-    // Read-only saved history: never populate ``runningJobs`` — a frozen
-    // session has no live work, and its unfinished jobs already replay as
-    // ``interrupted`` via the backend's synthetic terminals (UXI-04).
-    const { messages } = _replayEvents(data.messages || [], data.events)
-    chat.messagesByTab[tab] = messages
-  } else {
-    chat.messagesByTab[tab] = _convertHistory(data.messages || [])
-  }
+  const store = _chatStoreRef.value
+  const name = sessionName.value
+  const result = store.historyPageByTab[tab]?.historyId ? await store.refreshHistoryHead(tab) : await store.initHistoryPage(tab, { kind: "saved", sessionName: name })
+  if (!result.applied || store !== _chatStoreRef.value || name !== sessionName.value) return
 }
 
+let loadSequence = 0
 async function loadSession() {
+  const sequence = ++loadSequence
+  const name = sessionName.value
   loading.value = true
   error.value = ""
   try {
-    const index = await sessionAPI.getHistoryIndex(sessionName.value)
+    const index = await sessionAPI.getHistoryIndex(name)
+    if (sequence !== loadSequence || name !== sessionName.value) return
     viewerMeta.value = index.meta || {}
     historyTargets.value = index.targets || []
     resetViewer()
@@ -215,9 +198,9 @@ async function loadSession() {
       await loadTarget(chat.activeTab)
     }
   } catch (err) {
-    error.value = err?.response?.data?.detail || err?.message || String(err)
+    if (sequence === loadSequence && name === sessionName.value) error.value = err?.response?.data?.detail || err?.message || String(err)
   } finally {
-    loading.value = false
+    if (sequence === loadSequence) loading.value = false
   }
 }
 
@@ -265,6 +248,7 @@ watch(
 // the previous session's frozen history while ``initForInstance`` is
 // still awaiting its ``fetchOne`` round-trip.
 onUnmounted(() => {
+  loadSequence += 1
   chat.resetForRouteSwitch()
 })
 </script>

--- a/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
@@ -91,9 +91,17 @@ describe("paged history consumers", () => {
     await chat._resyncHistory("root", { full: true })
     expect(chat.tokenUsage.root.partial).toBe(false)
     expect(full).toHaveBeenCalledTimes(1)
+    full.mockResolvedValueOnce({ messages: [{ role: "user", content: "snapshot only" }] })
+    chat.tokenUsage.root.partial = true
+    await chat._resyncHistory("root", { full: true })
+    expect(chat.tokenUsage.root.partial).toBe(false)
+    full.mockResolvedValueOnce({ events: [] })
+    chat.tokenUsage.root.partial = true
+    await chat._resyncHistory("root", { full: true, initialLoad: true })
+    expect(chat.tokenUsage.root.partial).toBe(false)
     api.mockResolvedValueOnce(page([event(50)]))
     await chat._resyncHistory("root")
-    expect(full).toHaveBeenCalledTimes(1)
+    expect(full).toHaveBeenCalledTimes(3)
     expect(content(chat)).toEqual(["50"])
     expect(chat.historyPageByTab.root.hasOlder).toBe(true)
   })
@@ -228,6 +236,24 @@ describe("paged history consumers", () => {
     expect(chat.materializeOlderHistory("root").applied).toBe(true)
     expect(content(chat)[0]).toBe("older")
     expect(anchors.map((key) => indexOfSemanticKey(chat.messagesByTab.root, key))).not.toContain(-1)
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce(
+      page([
+        event(80, "user_message"),
+        event(81, "text", {
+          content: "preview",
+          _history_truncated: true,
+          _history_detail: "opaque",
+        }),
+      ]),
+    )
+    vi.spyOn(terrariumAPI, "getHistoryDetail").mockResolvedValueOnce({
+      record: { _history_key: "e:81", _history_truncated: false, content: "full" },
+      history_page: { version: 1, stream: "events", history_id: "h1" },
+    })
+    await chat.initHistoryPage("root")
+    chat.processingByTab.root = true
+    expect((await chat.loadHistoryRecord("root", "e:81")).applied).toBe(true)
+    expect(chat.processingByTab.root).toBe(true)
   })
 
   it("treats live job ids as authoritative and retains result-first tools across page boundaries", async () => {

--- a/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
@@ -1,0 +1,253 @@
+import { createPinia, setActivePinia } from "pinia"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useChatStore } from "./chat"
+import { sessionAPI, terrariumAPI } from "@/utils/api"
+
+function event(id, type = "user_message", extra = {}) {
+  return {
+    type,
+    event_id: id,
+    turn_index: id,
+    branch_id: 0,
+    content: String(id),
+    _history_key: `e:${id}`,
+    ...extra,
+  }
+}
+function page(
+  events,
+  { before = "b20", after = "a30", older = true, stream = "events", ...extra } = {},
+) {
+  return {
+    events: stream === "events" ? events : [],
+    messages: stream === "events" ? [] : events,
+    history_page: {
+      version: 1,
+      stream,
+      history_id: "h1",
+      before,
+      after,
+      has_older: older,
+      has_newer: false,
+      reset_required: false,
+    },
+    live_job_ids: [],
+    is_processing: false,
+    ...extra,
+  }
+}
+const content = (chat) =>
+  (chat.messagesByTab.root || []).map(
+    (m) => m.content || m.parts?.map((p) => p.content || p.result).join(""),
+  )
+let chat
+beforeEach(() => {
+  setActivePinia(createPinia())
+  chat = useChatStore()
+  chat._instanceId = "instance"
+  chat._instanceGraphId = "graph"
+  chat.activeTab = "root"
+})
+afterEach(() => {
+  chat._cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("paged history consumers", () => {
+  it("loads the real live entry point with a bounded request and refreshes after the loaded head", async () => {
+    const full = vi.spyOn(terrariumAPI, "getHistory").mockResolvedValue({ events: [] })
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page([event(20), event(21)]))
+      .mockResolvedValueOnce(page([event(10)], { before: "b10", after: "a10", older: false }))
+      .mockResolvedValueOnce(page([event(22)], { before: "b22", after: "a22", older: true }))
+    expect(await chat._loadHistory("root")).toBe(true)
+    expect(full).not.toHaveBeenCalled()
+    expect(api).toHaveBeenCalledWith("graph", "root", expect.objectContaining({ limit: 400 }))
+    expect(content(chat)).toEqual(["20", "21"])
+    expect(chat.tokenUsage.root.partial).toBe(true)
+    chat._restoreTokenUsage("root", [
+      event(1, "token_usage", { total_tokens: 900 }),
+      event(2, "subagent_result", { job_id: "old-agent", total_tokens: 300 }),
+    ])
+    expect(chat.historyPageByTab.root.hasOlder).toBe(true)
+    await chat.prefetchOlderHistory("root")
+    expect(content(chat)).toEqual(["20", "21"])
+    expect(chat.materializeOlderHistory("root").applied).toBe(true)
+    expect(content(chat)).toEqual(["10", "20", "21"])
+    expect(chat.tokenUsage.root.total).toBe(900)
+    expect(chat.tokenUsage.root.partial).toBeUndefined()
+    chat._appendStreamChunk("root", "live")
+    await chat._resyncHistory("root")
+    expect(full).not.toHaveBeenCalled()
+    expect(api.mock.calls[2][2]).toMatchObject({ after: "a30", history_id: "h1" })
+    expect(content(chat)).toEqual(["10", "20", "21", "22"])
+    expect(chat.historyPageByTab.root.hasOlder).toBe(false)
+    full.mockResolvedValueOnce({ events: [event(40)] })
+    await chat._resyncHistory("root", { full: true })
+    expect(full).toHaveBeenCalledTimes(1)
+    api.mockResolvedValueOnce(page([event(50)]))
+    await chat._resyncHistory("root")
+    expect(full).toHaveBeenCalledTimes(1)
+    expect(content(chat)).toEqual(["50"])
+    expect(chat.historyPageByTab.root.hasOlder).toBe(true)
+  })
+
+  it("keeps a delayed older response cache-only and rejects materialization after history mutation", async () => {
+    let release
+    vi.spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page([event(20)]))
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            release = r
+          }),
+      )
+    await chat.initHistoryPage("root")
+    const pending = chat.prefetchOlderHistory("root")
+    release(page([event(10)], { before: "b10", older: false }))
+    await pending
+    expect(content(chat)).toEqual(["20"])
+    chat._appendStreamChunk("root", "live")
+    expect(chat.materializeOlderHistory("root").applied).toBe(false)
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce(page([event(30)]))
+    const before = content(chat)
+    await chat.prefetchOlderHistory("root")
+    expect(content(chat)).toEqual(before)
+    expect(chat.materializeOlderHistory("root").applied).toBe(true)
+    expect(content(chat)).toEqual(["10", "20", "30"])
+    const pin = vi.fn()
+    chat.materializeOlderHistory("root", pin)
+    expect(pin).not.toHaveBeenCalled()
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce({
+      ...page([]),
+      history_page: { ...page([]).history_page, reset_required: true },
+    })
+    await chat.initHistoryPage("root")
+    expect(chat.historyPageByTab.root.resetRequired).toBe(true)
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce(page([event(60)]))
+    await chat.initHistoryPage("root")
+    expect(chat.historyPageByTab.root.resetRequired).toBe(false)
+    expect(content(chat)).toEqual(["60"])
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce(
+      page([
+        event(70, "ask_text", {
+          ui_event_id: "prompt",
+          interactive: true,
+          surface: "chat",
+          payload: { prompt: "Reply" },
+        }),
+      ]),
+    )
+    await chat.initHistoryPage("root")
+    expect(chat.attentionByTab.root.pending).toEqual(new Set(["prompt"]))
+    expect(chat._appliedMaxEventIdByTab.root).toBe(70)
+  })
+
+  it("reuses the saved source for older reads, maps channel messages, and never starts saved jobs", async () => {
+    const api = vi
+      .spyOn(sessionAPI, "getHistoryPage")
+      .mockResolvedValueOnce(
+        page([{ _history_key: "c20", sender: "a", content: "new" }], { stream: "channel" }),
+      )
+      .mockResolvedValueOnce(
+        page([{ _history_key: "c10", sender: "b", content: "old" }], {
+          stream: "channel",
+          older: false,
+        }),
+      )
+    const live = vi.spyOn(terrariumAPI, "getHistoryPage")
+    await chat.initHistoryPage("root", { kind: "saved", sessionName: "saved-one" })
+    await chat.prefetchOlderHistory("root")
+    chat.materializeOlderHistory("root")
+    expect(content(chat)).toEqual(["old", "new"])
+    expect(chat.messagesByTab.root.map((m) => m.id)).toEqual(["ch_c10", "ch_c20"])
+    expect(api.mock.calls[1].slice(0, 2)).toEqual(["saved-one", "root"])
+    expect(live).not.toHaveBeenCalled()
+    expect(chat.runningJobs).toEqual({})
+  })
+
+  it("uses explicit snapshot fallback only for an empty event source", async () => {
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page([], { before: null, after: null, older: false }))
+      .mockResolvedValueOnce(
+        page([{ role: "user", content: "snapshot", _history_key: "s1" }], {
+          stream: "snapshot",
+          older: false,
+        }),
+      )
+    await chat.initHistoryPage("root")
+    expect(api.mock.calls[1][2]).toMatchObject({ stream: "snapshot", limit: 400 })
+    expect(content(chat)).toEqual(["snapshot"])
+  })
+
+  it("preserves duplicate provenance and remaps an assistant boundary after older text merges", async () => {
+    vi.spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page([event(20, "text", { content: "later" })]))
+      .mockResolvedValueOnce(page([event(10, "text", { content: "earlier " })], { older: false }))
+    await chat.initHistoryPage("root")
+    await chat.prefetchOlderHistory("root")
+    chat.materializeOlderHistory("root")
+    expect(content(chat)).toEqual(["earlier later"])
+    expect(chat.messagesByTab.root[0]._historyKeys).toEqual(["e:10", "e:20"])
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce(
+      page([event(30, "user_input"), event(31, "user_message", { turn_index: 30 })]),
+    )
+    await chat.initHistoryPage("root")
+    expect(chat.messagesByTab.root[0]._historyKeys).toEqual(["e:30", "e:31"])
+  })
+
+  it("treats live job ids as authoritative and retains result-first tools across page boundaries", async () => {
+    const call = event(20, "tool_call", { name: "read", call_id: "job", args: {} })
+    const api = vi
+      .spyOn(terrariumAPI, "getHistoryPage")
+      .mockResolvedValueOnce(page([call], { live_job_ids: ["job"], is_processing: true }))
+      .mockResolvedValueOnce(page([], { live_job_ids: [] }))
+    await chat.initHistoryPage("root")
+    expect(chat.messagesByTab.root[0].parts[0].status).toBe("running")
+    expect(chat.runningJobs.job).toBeDefined()
+    await chat.refreshHistoryHead("root")
+    expect(chat.messagesByTab.root[0].parts[0].status).toBe("interrupted")
+    expect(chat.runningJobs.job).toBeUndefined()
+    expect(chat.processingByTab.root).toBe(false)
+    chat.eventsByTab.root.push(
+      event(25, "tool_call", { name: "read", call_id: "new-job", args: {} }),
+    )
+    chat._rebuildMessages("root")
+    expect(
+      chat.messagesByTab.root.flatMap((m) => m.parts || []).find((p) => p.jobId === "new-job")
+        .status,
+    ).toBe("running")
+    expect(
+      chat.messagesByTab.root.flatMap((m) => m.parts || []).find((p) => p.jobId === "job").status,
+    ).toBe("interrupted")
+    api.mockResolvedValueOnce(
+      page([event(21, "tool_result", { name: "read", call_id: "job", output: "done" })]),
+    )
+    api.mockResolvedValueOnce(page([call], { older: false }))
+    await chat.initHistoryPage("root")
+    expect(chat.messagesByTab.root[0].parts[0].result).toBe("done")
+    await chat.prefetchOlderHistory("root")
+    chat.materializeOlderHistory("root")
+    expect(
+      chat.messagesByTab.root.flatMap((m) => m.parts || []).filter((p) => p.type === "tool"),
+    ).toHaveLength(1)
+    expect(chat.messagesByTab.root[0]._historyKeys).toEqual(["e:20", "e:21"])
+    api.mockResolvedValueOnce(page([call], { live_job_ids: ["job"], is_processing: true }))
+    await chat.initHistoryPage("root")
+    let cursor = 100
+    api.mockImplementation(async () => {
+      const result = page([event(cursor++)], { after: `a${cursor}` })
+      result.history_page.has_newer = true
+      return result
+    })
+    const attention = chat.attentionByTab.root
+    expect((await chat.refreshHistoryHead("root")).catchingUp).toBe(true)
+    expect(chat.messagesByTab.root[0].parts[0].status).toBe("running")
+    expect(chat.runningJobs.job).toBeDefined()
+    expect(chat.processingByTab.root).toBe(true)
+    expect(chat.attentionByTab.root).toBe(attention)
+    expect(chat.historyPageByTab.root.hasNewer).toBe(true)
+  })
+})

--- a/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
@@ -79,7 +79,8 @@ describe("paged history consumers", () => {
     expect(content(chat)).toEqual(["10", "20", "21"])
     expect(chat.processingByTab.root).toBe(true)
     expect(chat.tokenUsage.root.total).toBe(900)
-    expect(chat.tokenUsage.root.partial).toBeUndefined()
+    // The oldest page is loaded, so the totals are no longer partial.
+    expect(chat.tokenUsage.root.partial).toBe(false)
     chat._appendStreamChunk("root", "live")
     await chat._resyncHistory("root")
     expect(full).not.toHaveBeenCalled()
@@ -104,6 +105,16 @@ describe("paged history consumers", () => {
     expect(full).toHaveBeenCalledTimes(3)
     expect(content(chat)).toEqual(["50"])
     expect(chat.historyPageByTab.root.hasOlder).toBe(true)
+    // A reconnect resync keeps the materialized older range instead of
+    // resetting to the newest page.
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce(page([event(60)]))
+    await chat.prefetchOlderHistory("root")
+    expect(chat.materializeOlderHistory("root").applied).toBe(true)
+    const merged = chat.messagesByTab.root.length
+    expect(merged).toBeGreaterThan(1)
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce(page([], { after: "a60" }))
+    await chat._resyncHistory("root", { initialLoad: true })
+    expect(chat.messagesByTab.root.length).toBe(merged)
   })
 
   it("keeps a delayed older response cache-only and rejects materialization after history mutation", async () => {
@@ -253,6 +264,13 @@ describe("paged history consumers", () => {
     await chat.initHistoryPage("root")
     chat.processingByTab.root = true
     expect((await chat.loadHistoryRecord("root", "e:81")).applied).toBe(true)
+    expect(chat.processingByTab.root).toBe(true)
+    vi.mocked(terrariumAPI.getHistoryPage).mockResolvedValueOnce({
+      events: [event(90, "user_message")],
+      is_processing: true,
+    })
+    chat.processingByTab.root = false
+    await chat.initHistoryPage("root")
     expect(chat.processingByTab.root).toBe(true)
   })
 

--- a/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from "pinia"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { useChatStore } from "./chat"
+import { indexOfSemanticKey, semanticKey } from "@/components/chat/chatRenderWindow"
 import { sessionAPI, terrariumAPI } from "@/utils/api"
 
 function event(id, type = "user_message", extra = {}) {
@@ -196,6 +197,33 @@ describe("paged history consumers", () => {
     )
     await chat.initHistoryPage("root")
     expect(chat.messagesByTab.root[0]._historyKeys).toEqual(["e:30", "e:31"])
+    vi.mocked(terrariumAPI.getHistoryPage)
+      .mockResolvedValueOnce(
+        page([
+          event(40, "processing_start"),
+          event(41, "subagent_tool", {
+            activity: "tool_start",
+            tool_name: "bash",
+            subagent: "worker",
+            job_id: "sa",
+            detail: "cmd",
+          }),
+          event(42, "background_result", { job_id: "sa", label: "worker" }),
+          event(43, "processing_error", { error: "boom" }),
+        ]),
+      )
+      .mockResolvedValueOnce(
+        page([event(39, "user_input", { content: "older" })], { older: false }),
+      )
+    await chat.initHistoryPage("root")
+    expect(chat.messagesByTab.root.map((m) => m.role)).toEqual(["assistant", "bg_result", "error"])
+    expect(chat.messagesByTab.root.every((m) => m._historyKeys?.length)).toBe(true)
+    const anchors = chat.messagesByTab.root.map((m) => semanticKey(m))
+    expect(anchors).toEqual(["e:40", "e:42", "e:43"])
+    await chat.prefetchOlderHistory("root")
+    expect(chat.materializeOlderHistory("root").applied).toBe(true)
+    expect(content(chat)[0]).toBe("older")
+    expect(anchors.map((key) => indexOfSemanticKey(chat.messagesByTab.root, key))).not.toContain(-1)
   })
 
   it("treats live job ids as authoritative and retains result-first tools across page boundaries", async () => {

--- a/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.historyPage.integration.test.js
@@ -72,10 +72,12 @@ describe("paged history consumers", () => {
       event(2, "subagent_result", { job_id: "old-agent", total_tokens: 300 }),
     ])
     expect(chat.historyPageByTab.root.hasOlder).toBe(true)
+    chat.processingByTab.root = true
     await chat.prefetchOlderHistory("root")
     expect(content(chat)).toEqual(["20", "21"])
     expect(chat.materializeOlderHistory("root").applied).toBe(true)
     expect(content(chat)).toEqual(["10", "20", "21"])
+    expect(chat.processingByTab.root).toBe(true)
     expect(chat.tokenUsage.root.total).toBe(900)
     expect(chat.tokenUsage.root.partial).toBeUndefined()
     chat._appendStreamChunk("root", "live")
@@ -85,7 +87,9 @@ describe("paged history consumers", () => {
     expect(content(chat)).toEqual(["10", "20", "21", "22"])
     expect(chat.historyPageByTab.root.hasOlder).toBe(false)
     full.mockResolvedValueOnce({ events: [event(40)] })
+    chat.tokenUsage.root.partial = true
     await chat._resyncHistory("root", { full: true })
+    expect(chat.tokenUsage.root.partial).toBe(false)
     expect(full).toHaveBeenCalledTimes(1)
     api.mockResolvedValueOnce(page([event(50)]))
     await chat._resyncHistory("root")

--- a/src/kohakuterrarium-frontend/src/stores/chat.historyPage.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.historyPage.test.js
@@ -1,6 +1,7 @@
+import { createPinia, setActivePinia } from "pinia"
 import { describe, expect, it } from "vitest"
 
-import { _convertHistory } from "./chat"
+import { _convertHistory, useChatStore } from "./chat"
 
 describe("_convertHistory paged snapshot mode", () => {
   it("defaults to the legacy positional ids", () => {
@@ -25,5 +26,32 @@ describe("_convertHistory paged snapshot mode", () => {
   it("falls back to an absolute index when a paged record has no stable key", () => {
     const out = _convertHistory([{ role: "user", content: "q" }], { paged: true })
     expect(out[0]._historyKey).toEqual(["abs_0"])
+  })
+})
+
+describe("per-store maps keyed by the store, not the action receiver", () => {
+  it("resolves one paged controller per tab for any receiver", () => {
+    setActivePinia(createPinia())
+    const chat = useChatStore("receivers")
+    const opts = { kind: "saved", sessionName: "saved" }
+    const first = chat._controllerForTab("root", opts)
+    // Pinia's devtools plugin invokes options-API actions with a fresh
+    // Proxy of the store as ``this``; ownership must not follow it.
+    const proxy = new Proxy(chat, {})
+    expect(chat._controllerForTab.call(proxy, "root", opts)).toBe(first)
+    chat.historyPageByTab.root = { historyId: "h1" }
+    chat._disposeHistoryPageControllers.call(proxy)
+    expect(chat.historyPageByTab).toEqual({})
+    expect(chat._controllerForTab("root", opts)).not.toBe(first)
+    chat._cleanup()
+  })
+
+  it("keeps the tool index visible to later actions", () => {
+    setActivePinia(createPinia())
+    const chat = useChatStore("tool-index")
+    const part = { type: "tool", jobId: "job-1", name: "read", status: "running", id: "tool_1" }
+    chat._indexToolPart("root", part)
+    expect(chat._findToolPart.call(new Proxy(chat, {}), "root", [], "read", "job-1")).toBe(part)
+    chat._cleanup()
   })
 })

--- a/src/kohakuterrarium-frontend/src/stores/chat.historyPage.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.historyPage.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { _convertHistory } from "./chat"
+
+describe("_convertHistory paged snapshot mode", () => {
+  it("defaults to the legacy positional ids", () => {
+    const out = _convertHistory([{ role: "user", content: "q" }])
+    expect(out[0].id).toBe("h_0")
+    expect(out[0]._historyKey).toBeUndefined()
+  })
+
+  it("keys a paged snapshot row by its stable _history_key, not position", () => {
+    const out = _convertHistory(
+      [
+        { role: "user", content: "q", _history_key: "abs_10" },
+        { role: "assistant", content: "a", _history_key: "abs_11" },
+      ],
+      { paged: true },
+    )
+    expect(out[0].id).toBe("abs_10")
+    expect(out[0]._historyKey).toEqual(["abs_10"])
+    expect(out[1].id).toBe("abs_11")
+  })
+
+  it("falls back to an absolute index when a paged record has no stable key", () => {
+    const out = _convertHistory([{ role: "user", content: "q" }], { paged: true })
+    expect(out[0]._historyKey).toEqual(["abs_0"])
+  })
+})

--- a/src/kohakuterrarium-frontend/src/stores/chat.historyPage.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.historyPage.test.js
@@ -46,6 +46,19 @@ describe("per-store maps keyed by the store, not the action receiver", () => {
     chat._cleanup()
   })
 
+  it("drops a closed tab's paged controller and its published state", () => {
+    setActivePinia(createPinia())
+    const chat = useChatStore("drop")
+    chat.tabs = ["a", "b"]
+    chat.activeTab = "a"
+    const first = chat._controllerForTab("a", { kind: "saved", sessionName: "saved" })
+    chat.historyPageByTab.a = { historyId: "h1" }
+    chat.closeTab("a")
+    expect(chat.historyPageByTab.a).toBeUndefined()
+    expect(chat._controllerForTab("a", { kind: "saved", sessionName: "saved" })).not.toBe(first)
+    chat._cleanup()
+  })
+
   it("keeps the tool index visible to later actions", () => {
     setActivePinia(createPinia())
     const chat = useChatStore("tool-index")

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -1,5 +1,5 @@
 import { ElMessage } from "element-plus"
-import { getCurrentInstance, markRaw } from "vue"
+import { getCurrentInstance, markRaw, toRaw } from "vue"
 import { extractReasoning } from "@/utils/chatReasoning"
 
 import { injectScope, registerScopeDisposer, scopeOfStoreId } from "@/composables/useScope"
@@ -216,11 +216,19 @@ function contentSignature(content) {
 // after the user switched tab, session, or mutated history is discarded.
 const _historyPageControllers = new WeakMap()
 
+// Pinia's devtools plugin invokes every action with a fresh Proxy of the
+// store as ``this``, so a receiver must never be used as a persistent
+// key. ``toRaw`` resolves any wrapper to the one store instance.
+function _storeKey(store) {
+  return toRaw(store)
+}
+
 function _historyPageMap(store) {
-  let map = _historyPageControllers.get(store)
+  const key = _storeKey(store)
+  let map = _historyPageControllers.get(key)
   if (!map) {
     map = new Map()
-    _historyPageControllers.set(store, map)
+    _historyPageControllers.set(key, map)
   }
   return map
 }
@@ -228,10 +236,11 @@ function _historyPageMap(store) {
 const _indexesByStore = new WeakMap()
 
 function _tabIndexes(store, tab) {
-  let byTab = _indexesByStore.get(store)
+  const key = _storeKey(store)
+  let byTab = _indexesByStore.get(key)
   if (!byTab) {
     byTab = new Map()
-    _indexesByStore.set(store, byTab)
+    _indexesByStore.set(key, byTab)
   }
   let idx = byTab.get(tab)
   if (!idx) {
@@ -722,6 +731,23 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
     if (!target._historyKeys.includes(k)) target._historyKeys.push(k)
   }
 
+  // A rendered row owns the parts it holds. Tool and sub-agent updates
+  // arrive on later events and must key the owning row, which is not
+  // always ``cur`` (the row may already be closed).
+  const _rowOfPart = new WeakMap()
+
+  function pushKeyed(row, evt) {
+    addHistoryKey(row, evt)
+    result.push(row)
+    return row
+  }
+
+  function keyOwningRow(part, evt) {
+    const owner = (part && _rowOfPart.get(part)) || cur
+    if (owner) addHistoryKey(owner, evt)
+    return owner
+  }
+
   function ensureCur() {
     if (!cur) {
       cur = {
@@ -732,6 +758,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         _historyKeys: [],
       }
       result.push(cur)
+      _rowOfPart.set(cur, cur)
     }
     return cur
   }
@@ -791,6 +818,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
     // must not reset the visible elapsed timer to 0.
     if (startedTs) tool.startedAt = startedTs
     c.parts.push(tool)
+    _rowOfPart.set(tool, c)
     if (jobId) startedJobs[jobId] = tool
     return tool
   }
@@ -848,6 +876,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       }
       if (!sa.children) sa.children = []
       sa.children.push(tool)
+      _rowOfPart.set(tool, _rowOfPart.get(sa) || cur)
       return tool
     }
     return addTool(name, "tool", args)
@@ -863,10 +892,10 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         tc.resultParts = payload.resultParts
         tc.resultMeta = payload.resultMeta
         if (opts?.error) tc.status = "error"
-        return
+        return tc
       }
     }
-    updateTool(name, result, opts)
+    return updateTool(name, result, opts)
   }
 
   function findToolByJobId(jobId) {
@@ -927,6 +956,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       if (tc.jobId) completedJobs.add(tc.jobId)
       if (jobId) completedJobs.add(jobId)
     }
+    return tc
   }
 
   function findCompactMessage(round, preferRunning = false) {
@@ -1078,6 +1108,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         repliedActionId: "",
         repliedValues: null,
       }
+      addHistoryKey(message, evt)
       result.push(message)
       interactiveMessages.set(uiEventId, message)
     } else if (t === "ui_supersede" || t === "timeout") {
@@ -1099,6 +1130,8 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         _historyKeys: [],
       }
       result.push(cur)
+      _rowOfPart.set(cur, cur)
+      addHistoryKey(cur, evt)
     } else if (t === "text" || t === "text_chunk") {
       // text_chunk is the Wave C per-chunk streaming format; replay
       // collapses consecutive chunks into one assistant text part.
@@ -1121,39 +1154,48 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         cur = null
         const ch = evt.channel || ""
         const sender = evt.sender || ""
-        result.push({
-          id: stableId("h_"),
-          role: "trigger",
-          content: ch ? `channel: ${ch}${sender ? ` from ${sender}` : ""}` : evt.name,
-          triggerContent: evt.content || "",
-          channel: ch,
-          sender,
-          timestamp: "",
-        })
+        pushKeyed(
+          {
+            id: stableId("h_"),
+            role: "trigger",
+            content: ch ? `channel: ${ch}${sender ? ` from ${sender}` : ""}` : evt.name,
+            triggerContent: evt.content || "",
+            channel: ch,
+            sender,
+            timestamp: "",
+          },
+          evt,
+        )
       } else if (at === "drive_turn") {
         cur = null
-        result.push(_driveTurnMessage(evt, stableId("drv_"), ""))
+        pushKeyed(_driveTurnMessage(evt, stableId("drv_"), ""), evt)
       } else if (at === "token_usage") {
         if (cur) cur._pendingReasoningCursor = cur.parts.length
       } else if (at === "processing_complete") {
         // skip
       } else if (at === "context_cleared") {
         cur = null
-        result.push({
-          id: stableId("clear_"),
-          role: "clear",
-          messagesCleared: evt.messages_cleared || 0,
-          timestamp: "",
-        })
+        pushKeyed(
+          {
+            id: stableId("clear_"),
+            role: "clear",
+            messagesCleared: evt.messages_cleared || 0,
+            timestamp: "",
+          },
+          evt,
+        )
       } else if (at === "processing_error") {
         cur = null
-        result.push({
-          id: stableId("err_"),
-          role: "error",
-          errorType: evt.error_type || "Error",
-          content: evt.error || evt.detail || "Unknown error",
-          timestamp: "",
-        })
+        pushKeyed(
+          {
+            id: stableId("err_"),
+            role: "error",
+            errorType: evt.error_type || "Error",
+            content: evt.error || evt.detail || "Unknown error",
+            timestamp: "",
+          },
+          evt,
+        )
       } else if (at === "subagent_start") {
         const tool = addTool(
           evt.name,
@@ -1164,24 +1206,28 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         )
         tool.llm_name = evt.llm_name || ""
         tool.model = evt.model || ""
+        keyOwningRow(tool, evt)
       } else if (at === "subagent_done") {
         const tool =
           findSubagent(evt.name, evt.job_id) ||
           addTool(evt.name, "subagent", {}, evt.job_id, _evtStartedTs(evt))
         tool.llm_name = evt.llm_name || tool.llm_name || ""
         tool.model = evt.model || tool.model || ""
-        updateTool(
-          evt.name,
-          evt.result || evt.detail,
-          {
-            tools_used: evt.tools_used,
-            turns: evt.turns,
-            duration: evt.duration,
-            total_tokens: evt.total_tokens,
-            prompt_tokens: evt.prompt_tokens,
-            completion_tokens: evt.completion_tokens,
-          },
-          evt.job_id,
+        keyOwningRow(
+          updateTool(
+            evt.name,
+            evt.result || evt.detail,
+            {
+              tools_used: evt.tools_used,
+              turns: evt.turns,
+              duration: evt.duration,
+              total_tokens: evt.total_tokens,
+              prompt_tokens: evt.prompt_tokens,
+              completion_tokens: evt.completion_tokens,
+            },
+            evt.job_id,
+          ) || tool,
+          evt,
         )
       } else if (at === "subagent_error") {
         const tool =
@@ -1189,41 +1235,59 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
           addTool(evt.name, "subagent", {}, evt.job_id, _evtStartedTs(evt))
         tool.llm_name = evt.llm_name || tool.llm_name || ""
         tool.model = evt.model || tool.model || ""
-        updateTool(
-          evt.name,
-          evt.result || evt.error || evt.detail,
-          {
-            error: true,
-            interrupted: !!evt.interrupted,
-            finalState: evt.final_state,
-            tools_used: evt.tools_used,
-            turns: evt.turns,
-            duration: evt.duration,
-            total_tokens: evt.total_tokens,
-            prompt_tokens: evt.prompt_tokens,
-            completion_tokens: evt.completion_tokens,
-          },
-          evt.job_id,
+        keyOwningRow(
+          updateTool(
+            evt.name,
+            evt.result || evt.error || evt.detail,
+            {
+              error: true,
+              interrupted: !!evt.interrupted,
+              finalState: evt.final_state,
+              tools_used: evt.tools_used,
+              turns: evt.turns,
+              duration: evt.duration,
+              total_tokens: evt.total_tokens,
+              prompt_tokens: evt.prompt_tokens,
+              completion_tokens: evt.completion_tokens,
+            },
+            evt.job_id,
+          ) || tool,
+          evt,
         )
       } else if (at === "tool_start") {
-        addTool(evt.name, "tool", evt.args || { info: evt.detail }, evt.job_id, _evtStartedTs(evt))
+        keyOwningRow(
+          addTool(
+            evt.name,
+            "tool",
+            evt.args || { info: evt.detail },
+            evt.job_id,
+            _evtStartedTs(evt),
+          ),
+          evt,
+        )
       } else if (at === "tool_done") {
-        updateTool(
-          evt.name,
-          evt.result || evt.output || evt.detail,
-          { tools_used: evt.tools_used, canvas_preview: evt.canvas_preview },
-          evt.job_id,
+        keyOwningRow(
+          updateTool(
+            evt.name,
+            evt.result || evt.output || evt.detail,
+            { tools_used: evt.tools_used, canvas_preview: evt.canvas_preview },
+            evt.job_id,
+          ),
+          evt,
         )
       } else if (at === "tool_error") {
-        updateTool(
-          evt.name,
-          evt.result || evt.error || evt.detail,
-          {
-            error: true,
-            interrupted: !!evt.interrupted,
-            finalState: evt.final_state,
-          },
-          evt.job_id,
+        keyOwningRow(
+          updateTool(
+            evt.name,
+            evt.result || evt.error || evt.detail,
+            {
+              error: true,
+              interrupted: !!evt.interrupted,
+              finalState: evt.final_state,
+            },
+            evt.job_id,
+          ),
+          evt,
         )
       } else if (at?.startsWith("subagent_tool_")) {
         const subAct = at.replace("subagent_", "")
@@ -1231,11 +1295,14 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         const saName = evt.subagent || ""
         const saJobId = evt.job_id || ""
         if (subAct === "tool_start") {
-          addSubagentTool(toolName, { info: evt.detail || "" }, saName, saJobId)
+          keyOwningRow(addSubagentTool(toolName, { info: evt.detail || "" }, saName, saJobId), evt)
         } else if (subAct === "tool_done") {
-          updateSubagentTool(toolName, evt.detail || "", null, saName, saJobId)
+          keyOwningRow(updateSubagentTool(toolName, evt.detail || "", null, saName, saJobId), evt)
         } else if (subAct === "tool_error") {
-          updateSubagentTool(toolName, evt.detail || "", { error: true }, saName, saJobId)
+          keyOwningRow(
+            updateSubagentTool(toolName, evt.detail || "", { error: true }, saName, saJobId),
+            evt,
+          )
         }
       }
 
@@ -1246,33 +1313,39 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       // live, instead of a mystery "B started processing" with no
       // explanation.
       cur = null
-      result.push({
-        id: stableId("h_"),
-        role: "wire_inbound",
-        from: evt.from || evt.detail || "",
-        to: evt.to || "",
-        preview: evt.content_preview || "",
-        withContent: evt.with_content !== false,
-        turnIndex: evt.source_turn_index || 0,
-        // Cross-site delivery flag — backend sets metadata.cross_node
-        // on remote forwards via terrarium.broadcast.  The frontend
-        // chips the entry with a "cross-site" badge.
-        crossNode: !!(evt.cross_node || evt.metadata?.cross_node),
-        timestamp: "",
-      })
+      pushKeyed(
+        {
+          id: stableId("h_"),
+          role: "wire_inbound",
+          from: evt.from || evt.detail || "",
+          to: evt.to || "",
+          preview: evt.content_preview || "",
+          withContent: evt.with_content !== false,
+          turnIndex: evt.source_turn_index || 0,
+          // Cross-site delivery flag — backend sets metadata.cross_node
+          // on remote forwards via terrarium.broadcast.  The frontend
+          // chips the entry with a "cross-site" badge.
+          crossNode: !!(evt.cross_node || evt.metadata?.cross_node),
+          timestamp: "",
+        },
+        evt,
+      )
     } else if (t === "trigger_fired") {
       cur = null
       const ch = evt.channel || ""
       const sender = evt.sender || ""
-      result.push({
-        id: stableId("h_"),
-        role: "trigger",
-        content: ch ? `channel: ${ch}${sender ? ` from ${sender}` : ""}` : "",
-        triggerContent: evt.content || "",
-        channel: ch,
-        sender,
-        timestamp: "",
-      })
+      pushKeyed(
+        {
+          id: stableId("h_"),
+          role: "trigger",
+          content: ch ? `channel: ${ch}${sender ? ` from ${sender}` : ""}` : "",
+          triggerContent: evt.content || "",
+          channel: ch,
+          sender,
+          timestamp: "",
+        },
+        evt,
+      )
     } else if (t === "tool_call") {
       addTool(evt.name, "tool", evt.args || {}, evt.call_id || evt.job_id, _evtStartedTs(evt))
       if (cur) addHistoryKey(cur, evt)
@@ -1320,32 +1393,38 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         addTool(evt.name, "subagent", {}, evt.job_id, _evtStartedTs(evt))
       tool.llm_name = evt.llm_name || tool.llm_name || ""
       tool.model = evt.model || tool.model || ""
-      updateTool(
-        evt.name,
-        evt.output || evt.error || "",
-        {
-          error: evt.error ? true : false,
-          interrupted: !!evt.interrupted,
-          finalState: evt.final_state,
-          tools_used: evt.tools_used,
-          turns: evt.turns,
-          duration: evt.duration,
-          total_tokens: evt.total_tokens,
-          prompt_tokens: evt.prompt_tokens,
-          completion_tokens: evt.completion_tokens,
-        },
-        evt.job_id,
+      keyOwningRow(
+        updateTool(
+          evt.name,
+          evt.output || evt.error || "",
+          {
+            error: evt.error ? true : false,
+            interrupted: !!evt.interrupted,
+            finalState: evt.final_state,
+            tools_used: evt.tools_used,
+            turns: evt.turns,
+            duration: evt.duration,
+            total_tokens: evt.total_tokens,
+            prompt_tokens: evt.prompt_tokens,
+            completion_tokens: evt.completion_tokens,
+          },
+          evt.job_id,
+        ) || tool,
+        evt,
       )
     } else if (t === "subagent_tool") {
       const toolName = evt.tool_name || ""
       const saName = evt.subagent || ""
       const saJobId = evt.job_id || ""
       if (evt.activity === "tool_start") {
-        addSubagentTool(toolName, { info: evt.detail || "" }, saName, saJobId)
+        keyOwningRow(addSubagentTool(toolName, { info: evt.detail || "" }, saName, saJobId), evt)
       } else if (evt.activity === "tool_done") {
-        updateSubagentTool(toolName, evt.detail || "", null, saName, saJobId)
+        keyOwningRow(updateSubagentTool(toolName, evt.detail || "", null, saName, saJobId), evt)
       } else if (evt.activity === "tool_error") {
-        updateSubagentTool(toolName, evt.detail || "", { error: true }, saName, saJobId)
+        keyOwningRow(
+          updateSubagentTool(toolName, evt.detail || "", { error: true }, saName, saJobId),
+          evt,
+        )
       }
     } else if (t === "channel_message") {
       const normalized = normalizeMessageContent(evt.content)
@@ -1361,11 +1440,14 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       result.push(channelMessage)
     } else if (t === "compact_summary" || t === "compact_complete") {
       cur = null
-      upsertCompactMessage(
-        evt.compact_round || evt.round || 0,
-        evt.summary || "",
-        "done",
-        evt.messages_compacted || 0,
+      addHistoryKey(
+        upsertCompactMessage(
+          evt.compact_round || evt.round || 0,
+          evt.summary || "",
+          "done",
+          evt.messages_compacted || 0,
+        ),
+        evt,
       )
     } else if (t === "compact_replace") {
       // Wave C state-bearing event. Used by replay_conversation and
@@ -1373,27 +1455,37 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       // history was replaced with a summary. Render as a compact
       // bubble — NOT as a plain assistant message.
       cur = null
-      upsertCompactMessage(
-        evt.round || 0,
-        evt.summary_text || evt.summary || "",
-        "done",
-        evt.messages_compacted || 0,
+      addHistoryKey(
+        upsertCompactMessage(
+          evt.round || 0,
+          evt.summary_text || evt.summary || "",
+          "done",
+          evt.messages_compacted || 0,
+        ),
+        evt,
       )
     } else if (t === "compact_start") {
       cur = null
-      upsertCompactMessage(evt.compact_round || evt.round || 0, "", "running", 0)
+      addHistoryKey(
+        upsertCompactMessage(evt.compact_round || evt.round || 0, "", "running", 0),
+        evt,
+      )
     } else if (t === "background_result") {
       cur = null
       // A combined delivery banner carries `labels` (one per folded
       // completion); older single-event frames carry only `label`.
-      result.push({
-        id: stableId("bgres_"),
-        role: "bg_result",
-        label: (Array.isArray(evt.labels) ? evt.labels.join(", ") : evt.label) || evt.job_id || "",
-        kind: evt.kind || "tool",
-        jobId: evt.job_id || "",
-        timestamp: "",
-      })
+      pushKeyed(
+        {
+          id: stableId("bgres_"),
+          role: "bg_result",
+          label:
+            (Array.isArray(evt.labels) ? evt.labels.join(", ") : evt.label) || evt.job_id || "",
+          kind: evt.kind || "tool",
+          jobId: evt.job_id || "",
+          timestamp: "",
+        },
+        evt,
+      )
     } else if (t === "compact_skipped") {
       // Terminal for a started round that didn't complete — without it
       // the bubble from compact_start spins forever on replay.
@@ -1405,21 +1497,27 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       }
     } else if (t === "processing_error") {
       cur = null
-      result.push({
-        id: stableId("err_"),
-        role: "error",
-        errorType: evt.error_type || "Error",
-        content: evt.error || "",
-        timestamp: "",
-      })
+      pushKeyed(
+        {
+          id: stableId("err_"),
+          role: "error",
+          errorType: evt.error_type || "Error",
+          content: evt.error || "",
+          timestamp: "",
+        },
+        evt,
+      )
     } else if (t === "context_cleared") {
       cur = null
-      result.push({
-        id: stableId("clear_"),
-        role: "clear",
-        messagesCleared: evt.messages_cleared || 0,
-        timestamp: "",
-      })
+      pushKeyed(
+        {
+          id: stableId("clear_"),
+          role: "clear",
+          messagesCleared: evt.messages_cleared || 0,
+          timestamp: "",
+        },
+        evt,
+      )
     } else if (t === "assistant_image") {
       // Replay the image into the current assistant message so resumed
       // sessions (and plain history reloads) show it in place. Mirrors
@@ -1442,6 +1540,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
           revised_prompt: evt.revised_prompt,
         },
       })
+      addHistoryKey(c, evt)
     } else if (t === "assistant_reasoning") {
       const c = ensureCur()
       _insertReasoningSegments(
@@ -1450,6 +1549,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         typeof evt.event_id === "number" ? `h_${evt.event_id}_r` : "h_reasoning_",
       )
       c._pendingReasoningCursor = undefined
+      addHistoryKey(c, evt)
     } else if (t === "token_usage") {
       if (cur) cur._pendingReasoningCursor = cur.parts.length
     } else if (t === "processing_complete") {
@@ -6048,7 +6148,7 @@ const _chatStoreOptions = {
 
     /** Dispose every paged controller for this store. */
     _disposeHistoryPageControllers() {
-      const map = _historyPageControllers.get(this)
+      const map = _historyPageControllers.get(_storeKey(this))
       if (!map) return
       for (const controller of map.values()) controller.dispose()
       map.clear()

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -4679,6 +4679,7 @@ const _chatStoreOptions = {
             )
           }
           if (data?.is_processing) this.processingByTab[tab] = true
+          if (this.tokenUsage[tab]) this.tokenUsage[tab].partial = false
           return true
         }
         if (options.initialLoad && data.events.length === 0 && !data.messages?.length) {
@@ -4700,6 +4701,7 @@ const _chatStoreOptions = {
             ),
           )
           if (data?.is_processing) this.processingByTab[tab] = true
+          if (this.tokenUsage[tab]) this.tokenUsage[tab].partial = false
           return true
         }
 
@@ -6050,7 +6052,7 @@ const _chatStoreOptions = {
       tab,
       controller,
       records,
-      { payload = {}, fetchedAt, legacy, merged } = {},
+      { payload = {}, fetchedAt, legacy, head } = {},
     ) {
       const stream = controller.getState().stream
       if (legacy) {
@@ -6078,11 +6080,11 @@ const _chatStoreOptions = {
       this.historyPageByTab[tab] = {
         ...controller.getState(),
       }
-      // An older-page merge must not clear a flag a live WS event raised:
-      // its payload is the last head read, not a fresh processing state.
+      // Only a head read carries a fresh processing state; an older-page
+      // merge or a detail read reuses the last head payload.
       this.processingByTab[tab] =
         controller.kind !== "saved" &&
-        (merged === true ? this.processingByTab[tab] === true : payload.is_processing === true)
+        (head === true ? payload.is_processing === true : this.processingByTab[tab] === true)
       if (stream === "snapshot") {
         const branchSelection = new Map()
         adoptLocalCommandResultSelections(

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -2485,6 +2485,7 @@ const _chatStoreOptions = {
     closeTab(tab) {
       const idx = this.tabs.indexOf(tab)
       if (idx === -1) return
+      this._dropHistoryController(tab)
       this.tabs = this.tabs.filter((_, i) => i !== idx)
       if (this.activeTab === tab) {
         this.setActiveTab(this.tabs[Math.min(idx, this.tabs.length - 1)] || null)
@@ -4643,10 +4644,11 @@ const _chatStoreOptions = {
         const controller = _historyPageMap(this).get(tab)
         const branchPending = !!this._branchResyncPendingByTab[tab]?.active
         if (!branchPending && !options.full && (options.initialLoad || controller)) {
-          const result =
-            options.initialLoad || !controller?.getState().historyId
-              ? await this.initHistoryPage(tab)
-              : await this.refreshHistoryHead(tab)
+          // Reconnect keeps an established paged range: only a tab with no
+          // range yet needs the reset that a fresh initialize performs.
+          const result = !controller?.getState().historyId
+            ? await this.initHistoryPage(tab)
+            : await this.refreshHistoryHead(tab)
           if (result.resetRequired) return (await this.initHistoryPage(tab)).applied
           return result.applied
         }
@@ -5933,6 +5935,7 @@ const _chatStoreOptions = {
      *  emptied as a result collapse. */
     pruneTab(tab) {
       if (!tab) return
+      this._dropHistoryController(tab)
       // Legacy tabs
       const legacyIdx = this.tabs.indexOf(tab)
       if (legacyIdx !== -1) {
@@ -6075,6 +6078,8 @@ const _chatStoreOptions = {
         )
         if (controller.kind !== "saved")
           this._reconcileRunningJobs(tab, replay.pendingJobs, fetchedAt)
+        if (controller.kind !== "saved" && payload.is_processing === true)
+          this.processingByTab[tab] = true
         return
       }
       this.historyPageByTab[tab] = {
@@ -6108,7 +6113,11 @@ const _chatStoreOptions = {
       this._setEvents(tab, prepared.events)
       if (!this.tokenUsage[tab] || this.tokenUsage[tab].partial) {
         this._restoreTokenUsage(tab, prepared.events, true)
-        this.tokenUsage[tab].partial = true
+      }
+      if (this.tokenUsage[tab]) {
+        this.tokenUsage[tab].partial = !!(
+          this.historyPageByTab[tab]?.hasOlder || this.historyPageByTab[tab]?.hasNewer
+        )
       }
       this._rebuildMessages(tab, fetchedAt, prepared, payload.live_job_ids)
       if (controller.kind !== "saved") {
@@ -6156,6 +6165,16 @@ const _chatStoreOptions = {
     resetHistoryPage(tab) {
       const controller = _historyPageMap(this).get(tab)
       if (controller) controller.reset()
+    },
+
+    /** Dispose the paged controller for ``tab`` (cached pages, in-flight fences). */
+    _dropHistoryController(tab) {
+      const map = _historyPageControllers.get(_storeKey(this))
+      const controller = map?.get(tab)
+      if (!controller) return
+      controller.dispose()
+      map.delete(tab)
+      delete this.historyPageByTab[tab]
     },
 
     /** Dispose every paged controller for this store. */

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -1,5 +1,6 @@
 import { ElMessage } from "element-plus"
 import { getCurrentInstance, markRaw } from "vue"
+import { extractReasoning } from "@/utils/chatReasoning"
 
 import { injectScope, registerScopeDisposer, scopeOfStoreId } from "@/composables/useScope"
 import { createVisibilityInterval } from "@/composables/useVisibilityInterval"
@@ -27,7 +28,8 @@ import { useLocaleStore } from "@/stores/locale"
 import { useMessagesStore } from "@/stores/messages"
 import { useNotificationsStore } from "@/stores/notifications"
 import { useStatusStore } from "@/stores/status"
-import { agentAPI, terrariumAPI } from "@/utils/api"
+import { agentAPI, sessionAPI, terrariumAPI } from "@/utils/api"
+import { createHistoryPageController } from "@/stores/historyPageController"
 import { translate } from "@/utils/i18n"
 import { readLocalJsonPref, writeLocalJsonPref } from "@/utils/uiPrefs"
 import { wsUrl } from "@/utils/wsUrl"
@@ -206,6 +208,23 @@ function contentSignature(content) {
 // rebuilt on every wholesale replacement (``_setMessages``), so they
 // stay out of Pinia state — reactive, devtools-visible copies would
 // cost more than the scans they replace.
+// Per-store paged-history controllers. One controller per (store, tab);
+// a WeakMap keyed by the store instance keeps this out of reactive state
+// and lets the per-scope disposer free it on tab/store teardown. The
+// source it wraps already fences every async step by source-key /
+// instance-generation / mutation-generation, so a response that returns
+// after the user switched tab, session, or mutated history is discarded.
+const _historyPageControllers = new WeakMap()
+
+function _historyPageMap(store) {
+  let map = _historyPageControllers.get(store)
+  if (!map) {
+    map = new Map()
+    _historyPageControllers.set(store, map)
+  }
+  return map
+}
+
 const _indexesByStore = new WeakMap()
 
 function _tabIndexes(store, tab) {
@@ -314,9 +333,18 @@ function toolResultPayload(result, data = {}) {
 /**
  * Convert OpenAI-format conversation history to frontend messages.
  */
-export function _convertHistory(messages) {
+export function _convertHistory(messages, options = {}) {
   const result = []
   const toolResults = {}
+  // A paged snapshot keys each rendered row by its stable physical
+  // identity so prepending another page does not shift every id. Legacy
+  // full-read conversion keeps the positional ``h_<index>`` ids.
+  const paged = !!options.paged
+  const stableId = (msg) => {
+    const key = msg?._history_key ?? msg?.message_id ?? msg?.id
+    return key != null ? String(key) : null
+  }
+  const rowId = (msg) => (paged ? (stableId(msg) ?? `abs_${result.length}`) : `h_${result.length}`)
   for (const msg of messages) {
     if (msg.role === "tool") toolResults[msg.tool_call_id] = msg.content
   }
@@ -324,12 +352,14 @@ export function _convertHistory(messages) {
     if (msg.role === "system" || msg.role === "tool") continue
     if (msg.role === "user") {
       const normalized = normalizeMessageContent(msg.content)
+      const id = rowId(msg)
       result.push({
-        id: "h_" + result.length,
+        id,
         role: "user",
         content: normalized.content,
         contentParts: normalized.contentParts,
         timestamp: "",
+        ...(paged ? { _historyKey: [id], _historyKeys: [id] } : {}),
       })
     } else if (msg.role === "assistant") {
       const tcs = (msg.tool_calls || []).map((tc) => ({
@@ -341,13 +371,16 @@ export function _convertHistory(messages) {
         result: toolResults[tc.id] || "",
       }))
       const normalized = normalizeMessageContent(msg.content)
+      const id = rowId(msg)
       const message = {
-        id: "h_" + result.length,
+        id,
         role: "assistant",
+        _fallbackReasoning: !Array.isArray(msg._kt_assistant_segments) ? extractReasoning(msg) : [],
         content: normalized.content,
         contentParts: normalized.contentParts,
         timestamp: "",
         tool_calls: tcs.length ? tcs : undefined,
+        ...(paged ? { _historyKey: [id], _historyKeys: [id] } : {}),
       }
       if (Array.isArray(msg._kt_assistant_segments) && msg._kt_assistant_segments.length) {
         const tcById = new Map(tcs.map((tc) => [tc.id, tc]))
@@ -677,6 +710,18 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
     return prefix + (curEventKey ?? String(result.length))
   }
 
+  // Record the physical ``_history_key`` of an event that contributed to a
+  // rendered row so a surviving row can be found by key after page-bounded
+  // materialization merges or re-keys it (page-boundary text merge, cross-
+  // page duplicate collapse). The fallback is the row's stable ``id``; the
+  // viewport anchor resolves by key containment first.
+  function addHistoryKey(target, evt) {
+    const k = evt?._history_key != null ? String(evt._history_key) : null
+    if (k == null) return
+    if (!target._historyKeys) target._historyKeys = []
+    if (!target._historyKeys.includes(k)) target._historyKeys.push(k)
+  }
+
   function ensureCur() {
     if (!cur) {
       cur = {
@@ -684,6 +729,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         role: "assistant",
         parts: [],
         timestamp: "",
+        _historyKeys: [],
       }
       result.push(cur)
     }
@@ -924,7 +970,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
 
   for (const evt of events) {
     const t = evt.type
-    curEventKey = typeof evt.event_id === "number" ? `e${evt.event_id}` : null
+    curEventKey = evt._history_key ?? (typeof evt.event_id === "number" ? `e${evt.event_id}` : null)
 
     // Skip events on a non-selected branch of their turn (siblings of
     // regen / edit+rerun stay on disk for the <1/N> navigator but
@@ -955,6 +1001,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       const key = typeof ti === "number" && typeof bi === "number" ? `${ti}/${bi}` : null
       if (key && _seenUserRender.has(key)) {
         const prior = _seenUserRender.get(key)
+        addHistoryKey(prior, evt)
         if (prior && typeof evt.pending_id === "string") {
           prior.eventId = evt.pending_id
         }
@@ -977,6 +1024,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
             ? { eventId: evt.event_id, turnIndex: ti, branchId: bi }
             : null,
       }
+      addHistoryKey(userMessage, evt)
       result.push(userMessage)
       if (key) _seenUserRender.set(key, userMessage)
     } else if (t === "user_input_injected") {
@@ -998,7 +1046,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       }
       cur = null
       const normalized = normalizeMessageContent(evt.content)
-      result.push({
+      const injected = {
         id: stableId("h_"),
         role: "user",
         content: normalized.content,
@@ -1007,7 +1055,9 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         turnIndex: typeof evt?.turn_index === "number" ? evt.turn_index : null,
         injectedMidTurn: true,
         timestamp: "",
-      })
+      }
+      addHistoryKey(injected, evt)
+      result.push(injected)
     } else if (["ask_text", "confirm", "selection", "card"].includes(t)) {
       const uiEventId = evt.ui_event_id ?? evt.payload?.event_id
       if (!uiEventId) continue
@@ -1046,12 +1096,14 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         role: "assistant",
         parts: [],
         timestamp: "",
+        _historyKeys: [],
       }
       result.push(cur)
     } else if (t === "text" || t === "text_chunk") {
       // text_chunk is the Wave C per-chunk streaming format; replay
       // collapses consecutive chunks into one assistant text part.
       appendText(evt.content || "")
+      if (cur) addHistoryKey(cur, evt)
     } else if (t === "processing_end" || t === "idle") {
       // Do NOT clear cur if sub-agents might still be adding tools to this message
       // But mark text as done
@@ -1223,7 +1275,12 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       })
     } else if (t === "tool_call") {
       addTool(evt.name, "tool", evt.args || {}, evt.call_id || evt.job_id, _evtStartedTs(evt))
+      if (cur) addHistoryKey(cur, evt)
     } else if (t === "tool_result") {
+      const jobId = evt.call_id || evt.job_id
+      if (evt._history_key && jobId && !findToolByJobId(jobId)) {
+        addTool(evt.name, "tool", {}, jobId)
+      }
       updateTool(
         evt.name,
         evt.output || evt.error || "",
@@ -1243,6 +1300,9 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
         },
         evt.call_id || evt.job_id,
       )
+      const tool = jobId ? findToolByJobId(jobId) : null
+      const owner = tool ? result.find((message) => message.parts?.includes(tool)) : cur
+      if (owner) addHistoryKey(owner, evt)
     } else if (t === "subagent_call") {
       const tool = addTool(
         evt.name,
@@ -1253,6 +1313,7 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       )
       tool.llm_name = evt.llm_name || ""
       tool.model = evt.model || ""
+      if (cur) addHistoryKey(cur, evt)
     } else if (t === "subagent_result") {
       const tool =
         findSubagent(evt.name, evt.job_id) ||
@@ -1288,14 +1349,16 @@ function _replayPreparedEvents(messages, prepared, tab = "") {
       }
     } else if (t === "channel_message") {
       const normalized = normalizeMessageContent(evt.content)
-      result.push({
+      const channelMessage = {
         id: stableId("ch_"),
         role: "channel",
         sender: evt.sender || "",
         content: normalized.content,
         contentParts: normalized.contentParts,
         timestamp: "",
-      })
+      }
+      addHistoryKey(channelMessage, evt)
+      result.push(channelMessage)
     } else if (t === "compact_summary" || t === "compact_complete") {
       cur = null
       upsertCompactMessage(
@@ -1873,6 +1936,7 @@ const _chatStoreOptions = {
     _historyRequestSeqByTab: {},
     /** @type {Record<string, number>} Per-tab live/optimistic mutation generation invalidating in-flight snapshots */
     _historyMutationSeqByTab: {},
+    historyPageByTab: {},
     /**
      * Per-tab raw text seen on the current turn's WS stream. Deliberately
      * branch-agnostic — notification summaries describe the turn that just
@@ -3262,6 +3326,7 @@ const _chatStoreOptions = {
           lastPrompt: 0,
         }
         this.tokenUsage[source] = {
+          ...(prev.partial ? { partial: true } : {}),
           prompt: prev.prompt + (data.prompt_tokens || 0),
           completion: prev.completion + (data.completion_tokens || 0),
           total: prev.total + (data.total_tokens || 0),
@@ -4475,6 +4540,17 @@ const _chatStoreOptions = {
         // this request is in flight is newer than the history it
         // returns, so job-reconciliation must not prune it.
         const fetchedAt = Date.now()
+        const controller = _historyPageMap(this).get(tab)
+        const branchPending = !!this._branchResyncPendingByTab[tab]?.active
+        if (!branchPending && !options.full && (options.initialLoad || controller)) {
+          const result =
+            options.initialLoad || !controller?.getState().historyId
+              ? await this.initHistoryPage(tab)
+              : await this.refreshHistoryHead(tab)
+          if (result.resetRequired) return (await this.initHistoryPage(tab)).applied
+          return result.applied
+        }
+        if (controller) controller.reset()
         const data = await terrariumAPI.getHistory(this._instanceGraphId, tab)
         if (
           requestId !== this._historyRequestSeqByTab[tab] ||
@@ -4643,7 +4719,7 @@ const _chatStoreOptions = {
      * Rebuild ``messagesByTab[tab]`` from the cached event log,
      * applying the current ``branchViewByTab[tab]`` override.
      */
-    _rebuildMessages(tab, fetchedAt = null, prepared = null) {
+    _rebuildMessages(tab, fetchedAt = null, prepared = null, liveJobIds = null) {
       const events = this.eventsByTab[tab]
       if (!events) return
       const branchView = this.branchViewByTab[tab] || null
@@ -4654,6 +4730,40 @@ const _chatStoreOptions = {
         ? _replayPreparedEvents([], prepared, tab)
         : _replayEvents([], events, branchView, tab)
       const { messages, pendingJobs } = replay
+      if (liveJobIds == null && _historyPageMap(this).has(tab)) {
+        for (const message of messages) {
+          for (const part of message.parts || []) {
+            if (
+              part.type === "tool" &&
+              part.status === "running" &&
+              part.jobId &&
+              this._findToolPart(tab, this.messagesByTab[tab] || [], part.name, part.jobId)
+                ?.status === "interrupted"
+            ) {
+              part.status = "interrupted"
+              delete pendingJobs[part.jobId]
+            }
+          }
+        }
+      }
+      if (_historyPageMap(this).get(tab)?.kind === "saved") liveJobIds = []
+      if (Array.isArray(liveJobIds)) {
+        const live = new Set(liveJobIds)
+        for (const message of messages) {
+          for (const part of message.parts || []) {
+            if (part.type === "tool" && part.status === "running" && !live.has(part.jobId)) {
+              part.status = "interrupted"
+              delete pendingJobs[part.jobId]
+              if (
+                fetchedAt != null &&
+                this.runningJobs[part.jobId]?.tab === tab &&
+                this.runningJobs[part.jobId].startedAt <= fetchedAt
+              )
+                delete this.runningJobs[part.jobId]
+            }
+          }
+        }
+      }
       const branchSelection = replay.branchMetadata.branchSelection
       adoptLocalCommandResultSelections(
         this._pendingCommandResultContextsByTab[tab],
@@ -5344,6 +5454,7 @@ const _chatStoreOptions = {
       this._historyRequestSeqByTab = {}
       this._pendingCommandResultContextsByTab = {}
       this._appliedMaxEventIdByTab = {}
+      this._disposeHistoryPageControllers()
       this._clearBranchResyncTimers()
       if (this._reconnectTimer) {
         clearTimeout(this._reconnectTimer)
@@ -5741,6 +5852,207 @@ const _chatStoreOptions = {
       }
       this._syncLegacyFromGroups()
       this._persistGroupState()
+    },
+
+    // ─── Paged-history vertical slice (frontend store integration) ─────
+    //
+    // These actions bind a per-tab ``createHistoryPageController`` (which
+    // wraps a ``createHistoryPageSource``) to this store and drive the
+    // materialize/replay/render flow. Live (``terrariumAPI``) and saved
+    // (``sessionAPI``) viewers use the SAME actions with a different
+    // ``kind``, so one viewport coordinator serves both.
+
+    /** Get (or create) the paged controller for ``tab``. ``kind`` is
+     *  ``"live"`` (terrarium / active session) or ``"saved"`` (v1 saved
+     *  session reader). A switch of kind for the same tab tears the old
+     *  controller down so no cached range leaks across viewers. */
+    _controllerForTab(tab, opts = {}) {
+      if (!tab) return null
+      const map = _historyPageMap(this)
+      let controller = map.get(tab)
+      const kind = opts.kind || controller?.kind || "live"
+      if (
+        controller &&
+        (controller.kind !== kind ||
+          (opts.sessionName && controller.sessionName !== opts.sessionName))
+      ) {
+        controller.dispose()
+        map.delete(tab)
+        controller = null
+      }
+      if (controller) return controller
+      const graphId = this._instanceGraphId
+      controller = createHistoryPageController({
+        kind,
+        fetchPage:
+          kind === "saved"
+            ? (params) => sessionAPI.getHistoryPage(opts.sessionName, tab, params)
+            : (params) => terrariumAPI.getHistoryPage(graphId, tab, params),
+        getSourceKey: () =>
+          kind === "saved"
+            ? `saved:${opts.sessionName}:${tab}:${this._instanceId}`
+            : `live:${this._instanceGraphId}:${tab}:${this._instanceId}`,
+        getInstanceGeneration: () => this._instanceGeneration,
+        getMutationGeneration: () => this._historyMutationSeqByTab[tab] || 0,
+        pageSize: opts.pageSize || 400,
+        fetchDetail:
+          kind === "saved"
+            ? (params) => sessionAPI.getHistoryDetail(opts.sessionName, tab, params)
+            : (params) => terrariumAPI.getHistoryDetail(graphId, tab, params),
+        onChange: (state) => {
+          this.historyPageByTab[tab] = { ...this.historyPageByTab[tab], ...state }
+        },
+        applyReplay: (records, run) => this._applyHistoryPageRecords(tab, controller, records, run),
+        onResetRequired: () => this.resetHistoryPage(tab),
+      })
+      controller.sessionName = opts.sessionName
+      map.set(tab, controller)
+      return controller
+    },
+
+    /** Map raw backend records for a paged stream into replay events.
+     *  The events stream is already event rows; the channel stream is
+     *  delivered in ``payload.messages`` and becomes ``channel_message``
+     *  events preserving sender/content/ts/message_id/_history_key. */
+    _projectHistoryPageRecords(records, stream) {
+      if (stream !== "channel") return records
+      return (records || []).map((record) =>
+        record?.type === "channel_message"
+          ? record
+          : {
+              ...record,
+              type: "channel_message",
+              sender: record?.sender || "",
+              content: record?.content ?? "",
+              channel: record?.channel || "",
+              message_id: record?.message_id,
+              _history_key: record?._history_key,
+            },
+      )
+    },
+
+    /** Render a freshly-materialized raw page range into the store. The
+     *  snapshot stream is a pre-rendered message list (``_convertHistory``
+     *  with paged keys); every other stream is replayed as events. */
+    _setHistoryDetails(tab, records) {
+      const previews = new Set(
+        (records || [])
+          .filter((record) => record._history_truncated && record._history_detail)
+          .map((record) => record._history_key),
+      )
+      for (const message of this.messagesByTab[tab] || []) {
+        message._historyDetails = (message._historyKeys || []).filter((key) => previews.has(key))
+      }
+    },
+
+    _applyHistoryPageRecords(tab, controller, records, { payload = {}, fetchedAt, legacy } = {}) {
+      const stream = controller.getState().stream
+      if (legacy) {
+        const replay = _replayEvents(
+          payload.messages || [],
+          payload.events || [],
+          this.branchViewByTab[tab],
+          tab,
+        )
+        this._setEvents(tab, payload.events || [])
+        const selection = replay.branchMetadata?.branchSelection || new Map()
+        adoptLocalCommandResultSelections(
+          this._pendingCommandResultContextsByTab[tab],
+          this._localCommandResultsByTab[tab],
+          selection,
+        )
+        this._setMessages(
+          tab,
+          mergeLocalCommandResults(replay.messages, this._localCommandResultsByTab[tab], selection),
+        )
+        if (controller.kind !== "saved")
+          this._reconcileRunningJobs(tab, replay.pendingJobs, fetchedAt)
+        return
+      }
+      this.historyPageByTab[tab] = {
+        ...controller.getState(),
+      }
+      this.processingByTab[tab] = controller.kind !== "saved" && payload.is_processing === true
+      if (stream === "snapshot") {
+        const branchSelection = new Map()
+        adoptLocalCommandResultSelections(
+          this._pendingCommandResultContextsByTab[tab],
+          this._localCommandResultsByTab[tab],
+          branchSelection,
+        )
+        this._setMessages(
+          tab,
+          mergeLocalCommandResults(
+            _convertHistory(records || [], { paged: true }),
+            this._localCommandResultsByTab[tab],
+            branchSelection,
+          ),
+        )
+        this._setHistoryDetails(tab, records)
+        return
+      }
+      const events = this._projectHistoryPageRecords(records || [], stream)
+      const prepared = _prepareReplayEvents(events, this.branchViewByTab[tab] || null)
+      this._setEvents(tab, prepared.events)
+      if (!this.tokenUsage[tab] || this.tokenUsage[tab].partial) {
+        this._restoreTokenUsage(tab, prepared.events, true)
+        this.tokenUsage[tab].partial = true
+      }
+      this._rebuildMessages(tab, fetchedAt, prepared, payload.live_job_ids)
+      if (controller.kind !== "saved") {
+        this.attentionByTab[tab] = restoreAttentionFromHistory(
+          events,
+          this.attentionByTab[tab] || createAttentionState(),
+        )
+        publishAttention(scopeOfStoreId(this.$id) || "default", tab, this.attentionByTab[tab])
+      }
+      const maxEventId = this._maxEventId(events)
+      if (maxEventId != null) this._appliedMaxEventIdByTab[tab] = maxEventId
+      this._setHistoryDetails(tab, records)
+    },
+
+    /** Establish the bounded newest page for ``tab``. Idempotent: the
+     *  source rejects a stale continuation, and re-running just refetches
+     *  the current head. */
+    async initHistoryPage(tab, opts = {}) {
+      if (!tab) return { applied: false }
+      const controller = this._controllerForTab(tab, opts)
+      return controller.initialize()
+    },
+
+    async prefetchOlderHistory(tab) {
+      return _historyPageMap(this).get(tab)?.prefetchOlder() ?? { discarded: false, cached: false }
+    },
+
+    materializeOlderHistory(tab, beforeApply) {
+      return _historyPageMap(this).get(tab)?.materializeOlder(beforeApply) ?? { applied: false }
+    },
+
+    async loadHistoryRecord(tab, key) {
+      return _historyPageMap(this).get(tab)?.loadRecord(key) ?? { applied: false }
+    },
+
+    /** Refresh the newest side of the paged range (no older-range change). */
+    async refreshHistoryHead(tab, opts = {}) {
+      if (!tab) return { applied: false }
+      const controller = this._controllerForTab(tab, opts)
+      return controller.refreshHead()
+    },
+
+    /** Drop the paged controller for ``tab`` (clears its cached raw range
+     *  and invalidates in-flight requests). */
+    resetHistoryPage(tab) {
+      const controller = _historyPageMap(this).get(tab)
+      if (controller) controller.reset()
+    },
+
+    /** Dispose every paged controller for this store. */
+    _disposeHistoryPageControllers() {
+      const map = _historyPageControllers.get(this)
+      if (!map) return
+      for (const controller of map.values()) controller.dispose()
+      map.clear()
+      this.historyPageByTab = {}
     },
   },
 }

--- a/src/kohakuterrarium-frontend/src/stores/chat.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.js
@@ -4793,6 +4793,7 @@ const _chatStoreOptions = {
         const prepared = _prepareReplayEvents(data.events, this.branchViewByTab[tab])
         this._setEvents(tab, prepared.events)
         this._restoreTokenUsage(tab, prepared.events, true)
+        if (this.tokenUsage[tab]) this.tokenUsage[tab].partial = false
         this._rebuildMessages(tab, fetchedAt, prepared)
         const scope = scopeOfStoreId(this.$id) || "default"
         this.attentionByTab[tab] = restoreAttentionFromHistory(
@@ -6045,7 +6046,12 @@ const _chatStoreOptions = {
       }
     },
 
-    _applyHistoryPageRecords(tab, controller, records, { payload = {}, fetchedAt, legacy } = {}) {
+    _applyHistoryPageRecords(
+      tab,
+      controller,
+      records,
+      { payload = {}, fetchedAt, legacy, merged } = {},
+    ) {
       const stream = controller.getState().stream
       if (legacy) {
         const replay = _replayEvents(
@@ -6072,7 +6078,11 @@ const _chatStoreOptions = {
       this.historyPageByTab[tab] = {
         ...controller.getState(),
       }
-      this.processingByTab[tab] = controller.kind !== "saved" && payload.is_processing === true
+      // An older-page merge must not clear a flag a live WS event raised:
+      // its payload is the last head read, not a fresh processing state.
+      this.processingByTab[tab] =
+        controller.kind !== "saved" &&
+        (merged === true ? this.processingByTab[tab] === true : payload.is_processing === true)
       if (stream === "snapshot") {
         const branchSelection = new Map()
         adoptLocalCommandResultSelections(

--- a/src/kohakuterrarium-frontend/src/stores/chat.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/chat.test.js
@@ -1,12 +1,20 @@
-import { createPinia, setActivePinia } from "pinia"
+import { createPinia, getActivePinia, setActivePinia } from "pinia"
 import { computed, isReactive, toRaw } from "vue"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import { terrariumAPI } from "@/utils/api"
 import { subscribeAttentionEdges } from "./attention"
 import { _parseSlashCommand, _replayEvents, useChatStore } from "./chat.js"
 
 beforeEach(() => {
   setActivePinia(createPinia())
+  vi.spyOn(terrariumAPI, "getHistoryPage").mockImplementation((id, tab) =>
+    terrariumAPI.getHistory(id, tab),
+  )
+})
+afterEach(() => {
+  for (const store of getActivePinia()._s.values()) store._cleanup?.()
+  vi.restoreAllMocks()
 })
 
 describe("chat store — slash commands", () => {

--- a/src/kohakuterrarium-frontend/src/stores/historyDetail.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/historyDetail.test.js
@@ -1,0 +1,105 @@
+import { createPinia, setActivePinia } from "pinia"
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
+import api, { sessionAPI, terrariumAPI } from "@/utils/api"
+import { useChatStore } from "./chat"
+let chat
+const record = {
+  _history_key: "key",
+  _history_truncated: true,
+  _history_detail: "opaque",
+  content: "preview",
+  sender: "worker",
+}
+const metadata = {
+  version: 1,
+  stream: "channel",
+  history_id: "h",
+  before: "b",
+  after: "a",
+  has_older: true,
+  has_newer: false,
+  reset_required: false,
+}
+beforeEach(() => {
+  setActivePinia(createPinia())
+  chat = useChatStore()
+  chat._instanceId = "g"
+  chat._instanceGraphId = "g"
+})
+afterEach(() => {
+  chat._cleanup()
+  vi.restoreAllMocks()
+})
+it.each(["live", "saved"])(
+  "retrieves %s full records with opaque identity parameters and no paging limit",
+  async (kind) => {
+    const get = vi
+      .spyOn(api, "get")
+      .mockResolvedValue({ data: { record: {}, history_page: metadata } })
+    const adapter = kind === "live" ? terrariumAPI : sessionAPI
+    await adapter.getHistoryDetail("id", "ch:work", {
+      stream: "channel",
+      ref: "opaque",
+      history_id: "h",
+    })
+    expect(get).toHaveBeenCalledWith(
+      kind === "live"
+        ? "/sessions/id/creatures/ch%3Awork/history/detail"
+        : "/sessions/id/history/ch%3Awork/detail",
+      { params: { stream: "channel", ref: "opaque", history_id: "h" } },
+    )
+  },
+)
+it("keeps saved channel detail linked across older materialization and drops stale detail responses", async () => {
+  vi.spyOn(sessionAPI, "getHistoryPage")
+    .mockResolvedValueOnce({ messages: [record], events: [], history_page: metadata })
+    .mockResolvedValueOnce({
+      messages: [{ ...record, _history_key: "older", content: "old", _history_truncated: false }],
+      events: [],
+      history_page: { ...metadata, before: "older", has_older: false },
+    })
+  let release
+  const detail = vi.spyOn(sessionAPI, "getHistoryDetail").mockImplementationOnce(
+    () =>
+      new Promise((r) => {
+        release = r
+      }),
+  )
+  await chat.initHistoryPage("ch:work", { kind: "saved", sessionName: "saved" })
+  expect(chat.messagesByTab["ch:work"][0]._historyDetails).toEqual(["key"])
+  const pending = chat.loadHistoryRecord("ch:work", "key")
+  await chat.prefetchOlderHistory("ch:work")
+  chat.materializeOlderHistory("ch:work")
+  release({
+    record: { ...record, content: "full value", _history_truncated: false },
+    history_page: metadata,
+  })
+  expect((await pending).applied).toBe(true)
+  expect(chat.messagesByTab["ch:work"].map((m) => m.content)).toEqual(["old", "full value"])
+  expect(chat.messagesByTab["ch:work"][1]._historyDetails).toEqual([])
+  expect(detail).toHaveBeenCalledWith("saved", "ch:work", {
+    stream: "channel",
+    ref: "opaque",
+    history_id: "h",
+  })
+  vi.mocked(sessionAPI.getHistoryPage).mockResolvedValueOnce({
+    messages: [record],
+    events: [],
+    history_page: metadata,
+  })
+  await chat.initHistoryPage("ch:work", { kind: "saved", sessionName: "saved" })
+  detail.mockImplementationOnce(
+    () =>
+      new Promise((r) => {
+        release = r
+      }),
+  )
+  const stale = chat.loadHistoryRecord("ch:work", "key")
+  chat.resetHistoryPage("ch:work")
+  release({
+    record: { ...record, content: "stale full", _history_truncated: false },
+    history_page: metadata,
+  })
+  expect((await stale).applied).toBe(false)
+  expect(chat.messagesByTab["ch:work"][0].content).toBe("preview")
+})

--- a/src/kohakuterrarium-frontend/src/stores/historyHead.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/historyHead.test.js
@@ -43,6 +43,7 @@ it("drains bounded head pages atomically and shares a prefetch refresh with the 
     getMutationGeneration: () => mutation,
   })
   await controller.initialize()
+  expect(applyReplay.mock.calls[0][1].head).toBe(true)
   mutation++
   const prefetch = controller.prefetchOlder()
   const resync = controller.refreshHead()
@@ -60,6 +61,7 @@ it("drains bounded head pages atomically and shares a prefetch refresh with the 
     "a900",
   ])
   expect(controller.materializeOlder().applied).toBe(true)
+  expect(applyReplay.mock.calls[2][1].head).toBe(false)
   expect(applyReplay.mock.calls[2][0]).toHaveLength(1001)
   let next = 1001
   fetchPage.mockImplementation(async () => page(next++, 1, true))
@@ -70,4 +72,42 @@ it("drains bounded head pages atomically and shares a prefetch refresh with the 
   fetchPage.mockResolvedValueOnce(page(1033, 1))
   expect((await controller.refreshHead()).applied).toBe(true)
   expect(applyReplay.mock.calls[3][0]).toHaveLength(1034)
+  expect(applyReplay.mock.calls[3][1].head).toBe(true)
+})
+
+it("marks only head reads as authoritative processing state", async () => {
+  const fetchPage = vi.fn().mockResolvedValue({
+    events: [{ _history_key: "e:1", _history_truncated: true, _history_detail: "opaque" }],
+    history_page: {
+      version: 1,
+      stream: "events",
+      history_id: "h",
+      before: "b",
+      after: "a",
+      has_older: true,
+      has_newer: false,
+      reset_required: false,
+    },
+    live_job_ids: [],
+    is_processing: false,
+  })
+  const fetchDetail = vi.fn().mockResolvedValue({
+    record: { _history_key: "e:1", _history_truncated: false },
+    history_page: { version: 1, stream: "events", history_id: "h" },
+  })
+  const applyReplay = vi.fn()
+  const controller = createHistoryPageController({
+    fetchPage,
+    fetchDetail,
+    applyReplay,
+    getSourceKey: () => "source",
+    getInstanceGeneration: () => 0,
+    getMutationGeneration: () => 0,
+  })
+  await controller.initialize()
+  expect(applyReplay.mock.calls[0][1].head).toBe(true)
+  expect((await controller.loadRecord("e:1")).applied).toBe(true)
+  expect(applyReplay.mock.calls[1][1].head).toBe(false)
+  expect((await controller.refreshHead()).applied).toBe(true)
+  expect(applyReplay.mock.calls[2][1].head).toBe(true)
 })

--- a/src/kohakuterrarium-frontend/src/stores/historyHead.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/historyHead.test.js
@@ -1,0 +1,73 @@
+import { expect, it, vi } from "vitest"
+import { createHistoryPageController } from "./historyPageController"
+
+const page = (start, count, hasNewer = false) => ({
+  events: Array.from({ length: count }, (_, i) => ({
+    _history_key: `e:${start + i}`,
+    event_id: start + i,
+  })),
+  history_page: {
+    version: 1,
+    stream: "events",
+    history_id: "h",
+    before: `b${start}`,
+    after: `a${start + count - 1}`,
+    has_older: true,
+    has_newer: hasNewer,
+    reset_required: false,
+  },
+  live_job_ids: [],
+  is_processing: false,
+})
+it("drains bounded head pages atomically and shares a prefetch refresh with the authoritative resync", async () => {
+  let mutation = 0,
+    release
+  const fetchPage = vi
+    .fn()
+    .mockResolvedValueOnce(page(100, 1))
+    .mockResolvedValueOnce(page(101, 400, true))
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = resolve
+        }),
+    )
+    .mockResolvedValueOnce(page(901, 100))
+    .mockResolvedValueOnce(page(0, 100))
+  const applyReplay = vi.fn()
+  const controller = createHistoryPageController({
+    fetchPage,
+    applyReplay,
+    getSourceKey: () => "source",
+    getInstanceGeneration: () => 0,
+    getMutationGeneration: () => mutation,
+  })
+  await controller.initialize()
+  mutation++
+  const prefetch = controller.prefetchOlder()
+  const resync = controller.refreshHead()
+  await vi.waitFor(() => expect(release).toBeTypeOf("function"))
+  expect(applyReplay).toHaveBeenCalledTimes(1)
+  release(page(501, 400, true))
+  expect((await resync).applied).toBe(true)
+  await prefetch
+  expect(applyReplay).toHaveBeenCalledTimes(2)
+  expect(applyReplay.mock.calls[1][0]).toHaveLength(901)
+  expect(applyReplay.mock.calls[1][0].at(-1)._history_key).toBe("e:1000")
+  expect(fetchPage.mock.calls.map(([params]) => params.after).filter(Boolean)).toEqual([
+    "a100",
+    "a500",
+    "a900",
+  ])
+  expect(controller.materializeOlder().applied).toBe(true)
+  expect(applyReplay.mock.calls[2][0]).toHaveLength(1001)
+  let next = 1001
+  fetchPage.mockImplementation(async () => page(next++, 1, true))
+  await controller.refreshHead()
+  expect(fetchPage).toHaveBeenCalledTimes(37)
+  expect(controller.getState().hasNewer).toBe(true)
+  expect(applyReplay).toHaveBeenCalledTimes(3)
+  fetchPage.mockResolvedValueOnce(page(1033, 1))
+  expect((await controller.refreshHead()).applied).toBe(true)
+  expect(applyReplay.mock.calls[3][0]).toHaveLength(1034)
+})

--- a/src/kohakuterrarium-frontend/src/stores/historyPageController.js
+++ b/src/kohakuterrarium-frontend/src/stores/historyPageController.js
@@ -1,0 +1,62 @@
+import { createHistoryPageSource } from "./historyPageSource"
+
+export function createHistoryPageController({ kind = "live", applyReplay, onChange, ...options }) {
+  const source = createHistoryPageSource(options)
+  function getState() {
+    const window = source.getWindow()
+    return {
+      ...source.getState(),
+      historyId: window?.historyId ?? null,
+      stream: window?.stream ?? null,
+    }
+  }
+  function publish() {
+    onChange?.(getState())
+  }
+  function apply(result) {
+    if (result.discarded) return { applied: false, resetRequired: result.resetRequired }
+    if (!result.applied && !result.legacy) return { applied: false }
+    if (source.getWindow()?.hasNewer) return { applied: false, catchingUp: true }
+    applyReplay(result.records, result)
+    return { applied: true, legacy: !!result.legacy, payload: result.payload }
+  }
+  async function run(method, argument) {
+    const promise = source[method](argument)
+    publish()
+    try {
+      return apply(await promise)
+    } finally {
+      publish()
+    }
+  }
+  return {
+    kind,
+    getState,
+    isCurrent: source.isCurrent,
+    initialize: () => run("initialize"),
+    refreshHead: () => run("refreshHead"),
+    loadRecord: (key) => run("loadRecord", key),
+    async prefetchOlder() {
+      const promise = source.prefetchOlder()
+      publish()
+      try {
+        return await promise
+      } finally {
+        publish()
+      }
+    },
+    materializeOlder(beforeApply) {
+      const result = source.materializeCachedOlder(beforeApply)
+      const out = result.merged ? apply(result) : { applied: false }
+      publish()
+      return out
+    },
+    reset() {
+      source.reset()
+      publish()
+    },
+    dispose() {
+      source.reset()
+    },
+  }
+}

--- a/src/kohakuterrarium-frontend/src/stores/historyPageSource.js
+++ b/src/kohakuterrarium-frontend/src/stores/historyPageSource.js
@@ -86,8 +86,8 @@ export function createHistoryPageSource({
       resetRequired: false,
     }
   }
-  function applied() {
-    return { discarded: false, applied: true, records: [...suffix], ...metadata }
+  function applied(head = false) {
+    return { discarded: false, applied: true, records: [...suffix], head, ...metadata }
   }
   const source = {
     getWindow: () => (window ? { ...window } : null),
@@ -124,7 +124,7 @@ export function createHistoryPageSource({
       suffixFence = result.fence
       metadata = { payload: result.payload, fetchedAt: result.fetchedAt }
       setWindow(result.page)
-      return applied()
+      return applied(true)
     },
     async prefetchOlder() {
       if (window && isCurrent(suffixFence, false) && !isCurrent(suffixFence)) {
@@ -209,7 +209,7 @@ export function createHistoryPageSource({
         window.after = after
         window.hasNewer = !!result.page.has_newer
         metadata = { payload: result.payload, fetchedAt: result.fetchedAt }
-        return applied()
+        return applied(true)
       })()
       pendingHead = promise
       try {

--- a/src/kohakuterrarium-frontend/src/stores/historyPageSource.js
+++ b/src/kohakuterrarium-frontend/src/stores/historyPageSource.js
@@ -1,0 +1,245 @@
+import { mergeRawRecords } from "./historyProjection"
+
+export function createHistoryPageSource({
+  fetchPage,
+  fetchDetail,
+  getSourceKey,
+  getInstanceGeneration,
+  getMutationGeneration,
+  pageSize = 400,
+  onResetRequired,
+}) {
+  let generation = 0
+  let headSequence = 0
+  let pendingHead = null
+  let inFlight = 0
+  let window = null
+  let suffix = []
+  let metadata = null
+  let suffixFence = null
+  let resetRequired = false
+  const cache = new Map()
+  const pendingOlder = new Map()
+
+  function capture() {
+    return [generation, getSourceKey(), getInstanceGeneration(), getMutationGeneration()]
+  }
+  function isCurrent(fence, includeMutation = true) {
+    return (
+      !!fence &&
+      capture().every((value, index) => (!includeMutation && index === 3) || value === fence[index])
+    )
+  }
+  function reset() {
+    generation += 1
+    headSequence += 1
+    pendingHead = null
+    window = null
+    resetRequired = false
+    suffix = []
+    metadata = null
+    suffixFence = null
+    cache.clear()
+    pendingOlder.clear()
+    return { discarded: false }
+  }
+  function invalidate() {
+    reset()
+    onResetRequired?.()
+    resetRequired = true
+    return { discarded: true, resetRequired: true }
+  }
+  async function request(options) {
+    const fence = capture()
+    const fetchedAt = Date.now()
+    inFlight += 1
+    try {
+      const payload = await fetchPage({ limit: pageSize, ...options })
+      if (!isCurrent(fence)) return { discarded: true, resetRequired: false }
+      const page = payload?.history_page
+      if (!page) return { discarded: false, legacy: true, payload, fetchedAt, fence }
+      if (page.reset_required) return invalidate()
+      if (window && (page.history_id !== window.historyId || page.stream !== window.stream)) {
+        return invalidate()
+      }
+      const records = page.stream === "events" ? payload.events : payload.messages
+      return {
+        discarded: false,
+        records: Array.isArray(records) ? records : [],
+        page,
+        payload,
+        fetchedAt,
+        fence,
+      }
+    } finally {
+      inFlight -= 1
+    }
+  }
+  function setWindow(page) {
+    window = {
+      before: page.before ?? null,
+      after: page.after ?? null,
+      hasOlder: !!page.has_older,
+      hasNewer: !!page.has_newer,
+      historyId: page.history_id ?? null,
+      stream: page.stream,
+      resetRequired: false,
+    }
+  }
+  function applied() {
+    return { discarded: false, applied: true, records: [...suffix], ...metadata }
+  }
+  const source = {
+    getWindow: () => (window ? { ...window } : null),
+    getRecords: () => [...suffix],
+    isCurrent: () => isCurrent(suffixFence),
+    getState: () => ({
+      pending: inFlight > 0,
+      resetRequired,
+      sourceKey: getSourceKey(),
+      hasOlder: !!window?.hasOlder,
+      hasNewer: !!window?.hasNewer,
+      hasCachedOlder: cache.has(window?.before),
+    }),
+    async initialize(options = {}) {
+      reset()
+      const sequence = headSequence
+      let result = await request(options)
+      if (result.discarded || sequence !== headSequence)
+        return { discarded: true, resetRequired: result.resetRequired }
+      if (result.legacy) return result
+      if (
+        result.page.stream === "events" &&
+        !result.records.length &&
+        !result.page.has_older &&
+        result.page.before == null &&
+        options.stream == null
+      ) {
+        result = await request({ stream: "snapshot" })
+        if (result.discarded || sequence !== headSequence)
+          return { discarded: true, resetRequired: result.resetRequired }
+        if (result.legacy) return result
+      }
+      suffix = result.records
+      suffixFence = result.fence
+      metadata = { payload: result.payload, fetchedAt: result.fetchedAt }
+      setWindow(result.page)
+      return applied()
+    },
+    async prefetchOlder() {
+      if (window && isCurrent(suffixFence, false) && !isCurrent(suffixFence)) {
+        const refreshed = await source.refreshHead()
+        if (refreshed.discarded) return refreshed
+      }
+      const before = window?.before
+      if (before == null || !window.hasOlder || !isCurrent(suffixFence))
+        return { discarded: false, cached: false }
+      if (cache.has(before)) return { discarded: false, cached: true, boundary: before }
+      if (pendingOlder.has(before)) return pendingOlder.get(before)
+      const promise = (async () => {
+        const result = await request({
+          before,
+          history_id: window.historyId,
+          stream: window.stream,
+        })
+        if (result.discarded) return result
+        if (result.legacy) return invalidate()
+        cache.set(before, result)
+        return { discarded: false, cached: true, boundary: before }
+      })()
+      pendingOlder.set(before, promise)
+      try {
+        return await promise
+      } finally {
+        if (pendingOlder.get(before) === promise) pendingOlder.delete(before)
+      }
+    },
+    materializeCachedOlder(beforeApply) {
+      const cached = cache.get(window?.before)
+      if (!cached || window?.hasNewer || !isCurrent(cached.fence, false) || !isCurrent(suffixFence))
+        return { discarded: true, merged: false }
+      beforeApply?.()
+      cache.delete(window.before)
+      suffix = mergeRawRecords(cached.records, suffix)
+      window.before = cached.page.before
+      window.hasOlder = !!cached.page.has_older
+      return { ...applied(), merged: true, before: window.before, hasOlder: window.hasOlder }
+    },
+    async ensureOlder() {
+      if (cache.has(window?.before)) {
+        const result = source.materializeCachedOlder()
+        return { ...result, action: "materialized", resetRequired: false }
+      }
+      const result = await source.prefetchOlder()
+      return {
+        ...result,
+        action: result.cached ? "prefetched" : "none",
+        resetRequired: !!result.resetRequired,
+      }
+    },
+    async refreshHead() {
+      if (pendingHead) return pendingHead
+      if (!window || !isCurrent(suffixFence, false)) return { discarded: true, applied: false }
+      const sequence = ++headSequence
+      const fence = capture()
+      const promise = (async () => {
+        let after = window.after
+        let records = []
+        let result
+        for (let pageCount = 0; pageCount < 32; pageCount++) {
+          result = await request({
+            ...(after != null ? { after } : {}),
+            history_id: window.historyId,
+            stream: window.stream,
+          })
+          if (result.discarded || sequence !== headSequence || !isCurrent(fence))
+            return { discarded: true, resetRequired: result.resetRequired }
+          if (result.legacy) return invalidate()
+          records = mergeRawRecords(records, result.records)
+          const next = result.page.after ?? after
+          if (!result.page.has_newer) {
+            after = next
+            break
+          }
+          if (next === after) return invalidate()
+          after = next
+        }
+        suffix = mergeRawRecords(suffix, records)
+        suffixFence = result.fence
+        window.after = after
+        window.hasNewer = !!result.page.has_newer
+        metadata = { payload: result.payload, fetchedAt: result.fetchedAt }
+        return applied()
+      })()
+      pendingHead = promise
+      try {
+        return await promise
+      } finally {
+        if (pendingHead === promise) pendingHead = null
+      }
+    },
+    async loadRecord(key) {
+      const record = suffix.find((item) => item._history_key === key)
+      if (!record?._history_truncated || !record._history_detail || !isCurrent(suffixFence))
+        return { discarded: true }
+      const fence = capture()
+      const { stream, historyId } = window
+      const detail = await fetchDetail({
+        stream,
+        history_id: historyId,
+        ref: record._history_detail,
+      })
+      if (!isCurrent(fence) || !isCurrent(suffixFence)) return { discarded: true }
+      if (
+        detail.history_page?.history_id !== historyId ||
+        detail.history_page?.stream !== stream ||
+        detail.record?._history_key !== key
+      )
+        return { discarded: true }
+      suffix = suffix.map((item) => (item._history_key === key ? detail.record : item))
+      return applied()
+    },
+    reset,
+  }
+  return source
+}

--- a/src/kohakuterrarium-frontend/src/stores/historyPaging.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/historyPaging.test.js
@@ -1,0 +1,362 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { mergeRawRecords, physicalKey } from "./historyProjection"
+import { createHistoryPageSource } from "./historyPageSource"
+
+// Raw backend record shape: stable physical ``_history_key``, never a
+// frontend ``_messageId`` (the backend does not invent one).
+function record(key, extra = {}) {
+  return { _history_key: `events:root:${key}`, content: key, ...extra }
+}
+
+function makePage({
+  before = null,
+  after = null,
+  hasOlder = false,
+  hasNewer = false,
+  reset = false,
+  records = [],
+  historyId = "h1",
+  stream = "events",
+} = {}) {
+  return {
+    events: records,
+    messages: [],
+    history_page: {
+      version: 1,
+      stream,
+      history_id: historyId,
+      before,
+      after,
+      has_older: hasOlder,
+      has_newer: hasNewer,
+      reset_required: reset,
+    },
+    is_processing: false,
+    live_job_ids: [],
+  }
+}
+
+function makeHarness(overrides = {}) {
+  const pages = []
+  const calls = []
+  const fetchPage =
+    overrides.fetchPage ||
+    (async (options) => {
+      calls.push(options)
+      const next = pages.shift()
+      return typeof next === "function" ? next(options) : next
+    })
+  const source = createHistoryPageSource({
+    fetchPage,
+    getSourceKey: overrides.getSourceKey || (() => "g:root"),
+    getInstanceGeneration: overrides.getInstanceGeneration || (() => 1),
+    getMutationGeneration: overrides.getMutationGeneration || (() => 0),
+    pageSize: overrides.pageSize || 400,
+    onResetRequired: overrides.onResetRequired,
+  })
+  return { pages, calls, source }
+}
+
+describe("projection: physical record identity", () => {
+  it("prefers _history_key, then message_id, then id", () => {
+    expect(physicalKey({ _history_key: "events:root:5", id: "x" })).toBe("events:root:5")
+    expect(physicalKey({ message_id: "m1", id: "x" })).toBe("m1")
+    expect(physicalKey({ id: "h_5" })).toBe("h_5")
+  })
+
+  it("returns null when no stable key is present", () => {
+    expect(physicalKey({ content: "hi" })).toBeNull()
+  })
+})
+
+describe("projection: mergeRawRecords", () => {
+  it("concatenates contiguous ranges in order", () => {
+    const merged = mergeRawRecords([record("c0"), record("c1")], [record("c2")])
+    expect(merged.map((r) => r.content)).toEqual(["c0", "c1", "c2"])
+  })
+
+  it("drops a boundary repeat that shares a physical key", () => {
+    const merged = mergeRawRecords([record("c0"), record("c1")], [record("c1"), record("c2")])
+    expect(merged.map((r) => r.content)).toEqual(["c0", "c1", "c2"])
+  })
+
+  it("keeps distinct keys even when content is identical", () => {
+    const merged = mergeRawRecords(
+      [record("c0"), { ...record("c1"), _history_key: "events:root:other" }],
+      [record("c2")],
+    )
+    expect(merged.map((r) => r._history_key)).toEqual([
+      "events:root:c0",
+      "events:root:other",
+      "events:root:c2",
+    ])
+  })
+})
+
+describe("history page source", () => {
+  it("returns null window and empty records before initialize", () => {
+    const { source } = makeHarness()
+    expect(source.getWindow()).toBeNull()
+    expect(source.getRecords()).toEqual([])
+  })
+
+  it("initialize returns raw records and the exclusive window", async () => {
+    const { pages, source } = makeHarness()
+    pages.push(() =>
+      makePage({
+        before: "c10",
+        after: "c20",
+        hasOlder: true,
+        records: [record("c10"), record("c11")],
+      }),
+    )
+    const out = await source.initialize()
+    expect(out.discarded).toBe(false)
+    expect(out.applied).toBe(true)
+    expect(out.records.map((r) => r.content)).toEqual(["c10", "c11"])
+    expect(source.getRecords().map((r) => r.content)).toEqual(["c10", "c11"])
+    expect(source.getWindow()).toMatchObject({ before: "c10", after: "c20", hasOlder: true })
+  })
+
+  it("prefetch caches raw records by the requested boundary, never the returned after", async () => {
+    const { pages, calls, source } = makeHarness()
+    pages.push(() =>
+      makePage({
+        before: "c10",
+        after: "c20",
+        hasOlder: true,
+        records: [record("c10"), record("c11")],
+      }),
+    )
+    await source.initialize()
+    // Older page: the backend's returned newest cursor (c9) is STRICTLY below
+    // the requested before (c10), so c9 can never be the join token.
+    pages.push(() => makePage({ before: "c0", after: "c9", records: [record("c0"), record("c9")] }))
+    const out = await source.prefetchOlder()
+    expect(out.cached).toBe(true)
+    expect(out.boundary).toBe("c10")
+    // The fetch is a bare pagination read: no projector options, no conversion.
+    expect(calls[1]).toEqual({ limit: 400, before: "c10", history_id: "h1", stream: "events" })
+    // Cache holds raw records; the materialized range is untouched (no replay).
+    expect(source.getRecords().map((r) => r.content)).toEqual(["c10", "c11"])
+    expect(source.getState().hasCachedOlder).toBe(true)
+  })
+
+  it("materialize prepends raw records and advances the oldest window", async () => {
+    const { pages, source } = makeHarness()
+    pages.push(() =>
+      makePage({
+        before: "c10",
+        after: "c20",
+        hasOlder: true,
+        records: [record("c10"), record("c11")],
+      }),
+    )
+    await source.initialize()
+    pages.push(() => makePage({ before: "c0", after: "c9", records: [record("c0"), record("c9")] }))
+    await source.prefetchOlder()
+    const out = source.materializeCachedOlder()
+    expect(out.merged).toBe(true)
+    expect(out.records.map((r) => r.content)).toEqual(["c0", "c9", "c10", "c11"])
+    expect(source.getRecords().map((r) => r.content)).toEqual(["c0", "c9", "c10", "c11"])
+    expect(source.getWindow()).toMatchObject({ before: "c0", hasOlder: false })
+    expect(source.getState().hasCachedOlder).toBe(false)
+  })
+
+  it("refresh keeps the oldest range and preserves a cached older page", async () => {
+    const { pages, calls, source } = makeHarness()
+    pages.push(() =>
+      makePage({
+        before: "c10",
+        after: "c20",
+        hasOlder: true,
+        hasNewer: true,
+        records: [record("c10"), record("c11")],
+      }),
+    )
+    await source.initialize()
+    pages.push(() => makePage({ before: "c0", after: "c9", records: [record("c0"), record("c9")] }))
+    await source.prefetchOlder()
+    pages.push(() =>
+      makePage({
+        before: "c21",
+        after: "c30",
+        hasNewer: false,
+        records: [record("c21"), record("c22")],
+      }),
+    )
+    const out = await source.refreshHead()
+    expect(out.applied).toBe(true)
+    expect(calls[2]).toEqual({ limit: 400, after: "c20", history_id: "h1", stream: "events" })
+    expect(out.records.map((r) => r.content)).toEqual(["c10", "c11", "c21", "c22"])
+    // Oldest range and the raw cached older page are preserved.
+    expect(source.getWindow()).toMatchObject({ before: "c10", hasOlder: true, after: "c30" })
+    expect(source.getState().hasCachedOlder).toBe(true)
+    const mat = source.materializeCachedOlder()
+    expect(mat.records.map((r) => r.content)).toEqual(["c0", "c9", "c10", "c11", "c21", "c22"])
+  })
+
+  it("an empty after page preserves the prior head cursor", async () => {
+    const { pages, source } = makeHarness()
+    pages.push(() =>
+      makePage({ before: "c10", after: "c20", hasNewer: true, records: [record("c10")] }),
+    )
+    await source.initialize()
+    pages.push(() => makePage({ hasNewer: false, records: [] }))
+    const out = await source.refreshHead()
+    expect(out.applied).toBe(true)
+    expect(source.getWindow()).toMatchObject({ after: "c20", hasNewer: false })
+    expect(source.getRecords().map((r) => r.content)).toEqual(["c10"])
+  })
+
+  it("prefetchOlder is a no-op when there is no older range", async () => {
+    const { pages, source } = makeHarness()
+    pages.push(() => makePage({ before: "c10", after: "c20", records: [record("c10")] }))
+    await source.initialize()
+    const out = await source.prefetchOlder()
+    expect(out.cached).toBe(false)
+    expect(source.getState().hasCachedOlder).toBe(false)
+  })
+
+  it("repeated prefetch for the same boundary dedupes without a new request", async () => {
+    const { pages, calls, source } = makeHarness()
+    pages.push(() =>
+      makePage({ before: "c10", after: "c20", hasOlder: true, records: [record("c10")] }),
+    )
+    await source.initialize()
+    pages.push(() => makePage({ before: "c0", after: "c9", records: [record("c0")] }))
+    expect((await source.prefetchOlder()).cached).toBe(true)
+    const second = await source.prefetchOlder()
+    expect(second.cached).toBe(true)
+    expect(second.boundary).toBe("c10")
+    expect(calls).toHaveLength(2) // initialize + one prefetch, no duplicate fetch
+  })
+
+  it("ensureOlder materializes a cached older page before fetching", async () => {
+    const { pages, calls, source } = makeHarness()
+    pages.push(() =>
+      makePage({
+        before: "c10",
+        after: "c20",
+        hasOlder: true,
+        records: [record("c10"), record("c11")],
+      }),
+    )
+    await source.initialize()
+    pages.push(() => makePage({ before: "c0", after: "c9", records: [record("c0")] }))
+    await source.prefetchOlder()
+    const before = calls.length
+    const out = await source.ensureOlder()
+    expect(out.action).toBe("materialized")
+    expect(out.records.map((r) => r.content)).toEqual(["c0", "c10", "c11"])
+    expect(calls).toHaveLength(before)
+    expect(source.getWindow()).toMatchObject({ before: "c0" })
+  })
+
+  it("prefetch and refresh complete out of order without corrupting the range", async () => {
+    const resolvers = []
+    const { source } = makeHarness({
+      fetchPage: () => new Promise((resolve) => resolvers.push((payload) => resolve(payload))),
+    })
+    const initPromise = source.initialize()
+    resolvers[0](
+      makePage({
+        before: "c10",
+        after: "c20",
+        hasOlder: true,
+        hasNewer: true,
+        records: [record("c10"), record("c11")],
+      }),
+    )
+    await initPromise
+    const prefetchPromise = source.prefetchOlder()
+    const refreshPromise = source.refreshHead()
+    // Newest side resolves first (refresh), then the older prefetch arrives.
+    resolvers[2](
+      makePage({ before: "c21", after: "c30", hasNewer: false, records: [record("c21")] }),
+    )
+    await refreshPromise
+    resolvers[1](
+      makePage({
+        before: "c0",
+        after: "c9",
+        hasOlder: false,
+        records: [record("c0"), record("c9")],
+      }),
+    )
+    await prefetchPromise
+    expect(source.getRecords().map((r) => r.content)).toEqual(["c10", "c11", "c21"])
+    expect(source.getState().hasCachedOlder).toBe(true)
+    const mat = source.materializeCachedOlder()
+    expect(mat.records.map((r) => r.content)).toEqual(["c0", "c9", "c10", "c11", "c21"])
+  })
+
+  it("a stale in-flight request cannot clear a newer request's pending state", async () => {
+    const resolvers = []
+    const { source } = makeHarness({
+      fetchPage: () => new Promise((resolve) => resolvers.push((payload) => resolve(payload))),
+    })
+    const first = source.initialize()
+    const second = source.initialize()
+    // Resolve the superseded first request; it must not apply nor clear pending.
+    resolvers[0](makePage({ before: "c10", after: "c20", records: [record("c10")] }))
+    await first
+    expect(source.getState().pending).toBe(true)
+    expect(source.getRecords()).toEqual([])
+    resolvers[1](makePage({ before: "c10", after: "c20", records: [record("c10")] }))
+    await second
+    expect(source.getState().pending).toBe(false)
+    expect(source.getRecords().map((r) => r.content)).toEqual(["c10"])
+  })
+
+  it("reset invalidates an outstanding request and clears cached state", async () => {
+    const resolvers = []
+    const { source } = makeHarness({
+      fetchPage: () => new Promise((resolve) => resolvers.push((payload) => resolve(payload))),
+    })
+    const initPromise = source.initialize()
+    resolvers[0](
+      makePage({ before: "c10", after: "c20", hasOlder: true, records: [record("c10")] }),
+    )
+    await initPromise
+    const prefetchPromise = source.prefetchOlder()
+    source.reset()
+    expect(source.getWindow()).toBeNull()
+    expect(source.getRecords()).toEqual([])
+    resolvers[1](makePage({ before: "c0", after: "c9", records: [record("c0")] }))
+    const out = await prefetchPromise
+    expect(out.discarded).toBe(true)
+    expect(source.getRecords()).toEqual([])
+  })
+
+  it("surfaces a reset_required response without merging it", async () => {
+    const { pages, source, onResetRequired } = makeHarness({ onResetRequired: vi.fn() })
+    pages.push(() =>
+      makePage({ before: "c10", after: "c20", hasOlder: true, records: [record("c10")] }),
+    )
+    await source.initialize()
+    pages.push(() => makePage({ reset: true }))
+    const out = await source.prefetchOlder()
+    expect(out.discarded).toBe(true)
+    expect(out.resetRequired).toBe(true)
+    expect(source.getRecords()).toEqual([])
+    expect(source.getWindow()).toBeNull()
+  })
+
+  it("rejects a continuation whose history identity or stream changes", async () => {
+    const { pages, source } = makeHarness()
+    pages.push(() =>
+      makePage({ before: "c10", after: "c20", hasOlder: true, records: [record("c10")] }),
+    )
+    await source.initialize()
+    // Same route but a different history identity: do not merge into the cache.
+    pages.push(() =>
+      makePage({ before: "c21", after: "c30", historyId: "different", records: [record("c21")] }),
+    )
+    const out = await source.refreshHead()
+    expect(out.discarded).toBe(true)
+    expect(out.resetRequired).toBe(true)
+    expect(source.getRecords()).toEqual([])
+  })
+})

--- a/src/kohakuterrarium-frontend/src/stores/historyProjection.js
+++ b/src/kohakuterrarium-frontend/src/stores/historyProjection.js
@@ -1,0 +1,41 @@
+// Raw-record merge helpers for the paged-history source/cache.
+//
+// The source caches RAW backend records (never page-projected rows) and
+// hands the caller one contiguous raw materialized range to replay once.
+// These helpers only reason about physical record identity; semantic dedupe
+// (e.g. consecutive text events collapsing into one assistant message)
+// belongs to the real replay/projection, not the cache.
+
+/**
+ * Stable physical identity of a raw history record.
+ *
+ * Backend records carry ``_history_key``. ``message_id`` and ``id`` are
+ * last-resort fallbacks. Returns ``null`` when no stable key exists, which
+ * means that record is never deduplicated at the cache layer.
+ */
+export function physicalKey(record) {
+  const raw = record?._history_key ?? record?.message_id ?? record?.id
+  return raw != null ? String(raw) : null
+}
+
+/**
+ * Combine two contiguous raw record arrays, preserving order.
+ *
+ * ``olderRecords`` is prepended, ``newerRecords`` appended. A record already
+ * present by physical key (the page-boundary repeat) is dropped rather than
+ * duplicated; records carrying distinct keys are never collapsed even when
+ * their content matches (true duplicates).
+ */
+export function mergeRawRecords(olderRecords, newerRecords) {
+  const seen = new Set()
+  const out = []
+  for (const record of [...olderRecords, ...newerRecords]) {
+    const key = physicalKey(record)
+    if (key != null) {
+      if (seen.has(key)) continue
+      seen.add(key)
+    }
+    out.push(record)
+  }
+  return out
+}

--- a/src/kohakuterrarium-frontend/src/utils/api.historyPage.test.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.historyPage.test.js
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import api from "@/utils/api"
+import { terrariumAPI, sessionAPI } from "@/utils/api"
+
+function pagePayload(overrides = {}) {
+  return {
+    events: [],
+    messages: [],
+    history_page: {
+      version: 1,
+      stream: "events",
+      history_id: "hist-1",
+      before: null,
+      after: newerCursor,
+      has_older: false,
+      has_newer: false,
+      reset_required: false,
+      ...(overrides.history_page || {}),
+    },
+    is_processing: false,
+    live_job_ids: [],
+    ...overrides,
+  }
+}
+
+let newerCursor = "cursor-newest"
+let apiGet
+
+beforeEach(() => {
+  newerCursor = "cursor-newest"
+  apiGet = vi.spyOn(api, "get").mockResolvedValue({ data: pagePayload() })
+})
+
+afterEach(() => {
+  apiGet.mockRestore()
+})
+
+describe("terrariumAPI.getHistoryPage", () => {
+  it("preserves legacy getHistory by leaving it on its own URL and params", async () => {
+    apiGet.mockResolvedValue({ data: { messages: [], events: [] } })
+    await terrariumAPI.getHistory("graph-1", "root")
+    expect(apiGet).toHaveBeenCalledWith("/sessions/graph-1/creatures/root/history", {})
+  })
+
+  it("opts in with paged=true and a default clamped limit", async () => {
+    await terrariumAPI.getHistoryPage("graph-1", "root")
+    const [, config] = apiGet.mock.calls[0]
+    expect(apiGet.mock.calls[0][0]).toBe("/sessions/graph-1/creatures/root/history")
+    expect(config.params).toMatchObject({ paged: true, limit: 400 })
+  })
+
+  it("clamps a limit above 400 and refuses a non-positive limit", async () => {
+    await terrariumAPI.getHistoryPage("g", "root", { limit: 1200 })
+    expect(apiGet.mock.calls[0][1].params.limit).toBe(400)
+
+    apiGet.mockClear()
+    await expect(terrariumAPI.getHistoryPage("g", "root", { limit: 0 })).rejects.toThrow()
+    expect(apiGet).not.toHaveBeenCalled()
+  })
+
+  it("sends exactly one opaque cursor and never both before and after", async () => {
+    await terrariumAPI.getHistoryPage("g", "root", { before: "old" })
+    let params = apiGet.mock.calls[0][1].params
+    expect(params.before).toBe("old")
+    expect(Object.hasOwn(params, "after")).toBe(false)
+
+    apiGet.mockClear()
+    await terrariumAPI.getHistoryPage("g", "root", { after: "new" })
+    params = apiGet.mock.calls[0][1].params
+    expect(params.after).toBe("new")
+    expect(Object.hasOwn(params, "before")).toBe(false)
+
+    apiGet.mockClear()
+    apiGet.mockResolvedValue({ data: pagePayload() })
+    await expect(
+      terrariumAPI.getHistoryPage("g", "root", { before: "old", after: "new" }),
+    ).rejects.toThrow()
+    expect(apiGet).not.toHaveBeenCalled()
+  })
+
+  it("carries an optional history_id and returns the raw paged payload", async () => {
+    const payload = pagePayload({ history_id: "hist-9", is_processing: true, live_job_ids: ["j1"] })
+    apiGet.mockResolvedValue({ data: payload })
+    const out = await terrariumAPI.getHistoryPage("g", "root", { history_id: "hist-9" })
+    expect(apiGet.mock.calls[0][1].params.history_id).toBe("hist-9")
+    expect(out).toEqual(payload)
+    expect(out.history_page.has_older).toBe(false)
+  })
+
+  it("keeps existing calls without paged=true on the full legacy URL", async () => {
+    apiGet.mockResolvedValue({ data: { messages: [], events: [] } })
+    await terrariumAPI.getHistory("g", "root", 42)
+    const [, config] = apiGet.mock.calls[0]
+    expect(config.params).toEqual({ since_event_id: 42 })
+    expect(config.params.paged).toBeUndefined()
+  })
+})
+
+describe("sessionAPI.getHistoryPage", () => {
+  it("adds a paged adapter alongside the legacy session getHistory", async () => {
+    apiGet.mockResolvedValue({ data: pagePayload() })
+    const out = await sessionAPI.getHistoryPage("session-a", "root", { limit: 120 })
+    expect(apiGet.mock.calls[0][0]).toBe("/sessions/session-a/history/root")
+    expect(apiGet.mock.calls[0][1].params).toMatchObject({ paged: true, limit: 120 })
+    expect(out.history_page.stream).toBe("events")
+  })
+
+  it("preserves explicit snapshot stream on continuations", async () => {
+    await sessionAPI.getHistoryPage("saved", "root", {
+      stream: "snapshot",
+      before: "s1",
+      history_id: "h1",
+    })
+    expect(apiGet.mock.calls[0][1].params).toMatchObject({
+      stream: "snapshot",
+      before: "s1",
+      history_id: "h1",
+    })
+  })
+
+  it("does not alter the raw session getHistory contract", async () => {
+    apiGet.mockResolvedValue({ data: { meta: {}, targets: [] } })
+    await sessionAPI.getHistory("session-a", "root")
+    expect(apiGet.mock.calls[0][0]).toBe("/sessions/session-a/history/root")
+    expect(apiGet.mock.calls[0][1]).toBeUndefined()
+  })
+})

--- a/src/kohakuterrarium-frontend/src/utils/api.js
+++ b/src/kohakuterrarium-frontend/src/utils/api.js
@@ -52,6 +52,31 @@ function encodeTarget(target) {
   return encodeURIComponent(target)
 }
 
+const HISTORY_PAGE_LIMIT_DEFAULT = 400
+const HISTORY_PAGE_LIMIT_MAX = 400
+
+// Build query params for an opt-in paged history read. ``before`` and
+// ``after`` are opaque string cursors and are mutually exclusive. The
+// limit must be a positive number; it is clamped to the backend page
+// bound when too large. Without ``paged`` the legacy full history call
+// is unchanged.
+function buildHistoryPageParams({ limit, before, after, history_id, stream } = {}) {
+  const raw = limit ?? HISTORY_PAGE_LIMIT_DEFAULT
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 1) {
+    throw new Error("history page limit must be a positive number")
+  }
+  const clamped = Math.min(Math.floor(raw), HISTORY_PAGE_LIMIT_MAX)
+  const params = { paged: true, limit: clamped }
+  if (history_id != null) params.history_id = history_id
+  if (stream != null) params.stream = stream
+  if (before != null && after != null) {
+    throw new Error("history page before/after cursors are mutually exclusive")
+  }
+  if (before != null) params.before = before
+  if (after != null) params.after = after
+  return params
+}
+
 // ``baseURL`` stays empty so the interceptor controls every URL.
 const api = axios.create({
   baseURL: "",
@@ -346,6 +371,23 @@ export const terrariumAPI = {
       `/sessions/${id}/creatures/${encodeTarget(target)}/history`,
       params,
     )
+    return data
+  },
+
+  async getHistoryDetail(id, target, { stream, ref, history_id }) {
+    const { data } = await api.get(
+      `/sessions/${id}/creatures/${encodeTarget(target)}/history/detail`,
+      { params: { stream, ref, history_id } },
+    )
+    return data
+  },
+
+  /** Read one bounded live history page. */
+  async getHistoryPage(id, target, options = {}) {
+    const params = buildHistoryPageParams(options)
+    const { data } = await api.get(`/sessions/${id}/creatures/${encodeTarget(target)}/history`, {
+      params,
+    })
     return data
   },
 
@@ -898,6 +940,23 @@ export const sessionAPI = {
 
   async getHistory(sessionName, target) {
     const { data } = await api.get(`/sessions/${sessionName}/history/${encodeTarget(target)}`)
+    return data
+  },
+
+  async getHistoryDetail(sessionName, target, { stream, ref, history_id }) {
+    const { data } = await api.get(
+      `/sessions/${sessionName}/history/${encodeTarget(target)}/detail`,
+      { params: { stream, ref, history_id } },
+    )
+    return data
+  },
+
+  /** Read one bounded saved history page. */
+  async getHistoryPage(sessionName, target, options = {}) {
+    const params = buildHistoryPageParams(options)
+    const { data } = await api.get(`/sessions/${sessionName}/history/${encodeTarget(target)}`, {
+      params,
+    })
     return data
   },
 

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/en.js
@@ -516,6 +516,7 @@ export default {
   "chat.dropToAttach": "Drop files to attach",
   "chat.queueShowMore": ({ count }) => `+${count} more queued`,
   "chat.showEarlier": ({ count }) => `Show ${count} earlier messages`,
+  "chat.loadEarlierGenerating": "Generating — earlier messages load when this turn finishes",
   "chat.queueCollapse": "Show fewer",
   "chat.queueEdit": "Edit queued message",
   "chat.queueCancel": "Cancel queued message",

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-CN.js
@@ -441,6 +441,7 @@ export default {
   "chat.slash.empty": "没有匹配的命令或技能",
   "chat.slash.commands": "命令",
   "chat.slash.skills": "技能",
+  "chat.loadEarlierGenerating": "生成中——本轮结束后可加载更早的消息",
   "chat.slash.noDescription": "暂无说明",
   "chat.command.completed": "命令已完成。",
   "chat.getStarted": "发送消息开始使用",

--- a/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-TW.js
+++ b/src/kohakuterrarium-frontend/src/utils/i18n/locales/zh-TW.js
@@ -409,6 +409,7 @@ export default {
   "chat.slash.empty": "沒有符合的命令或技能",
   "chat.slash.commands": "命令",
   "chat.slash.skills": "技能",
+  "chat.loadEarlierGenerating": "生成中——本回合結束後可載入更早的訊息",
   "chat.slash.noDescription": "暫無說明",
   "chat.command.completed": "命令已完成。",
   "chat.getStarted": "傳送訊息開始使用",

--- a/src/kohakuterrarium/api/routes/persistence/history.py
+++ b/src/kohakuterrarium/api/routes/persistence/history.py
@@ -17,7 +17,6 @@ from urllib.parse import unquote
 from fastapi import APIRouter, Depends, HTTPException
 
 from kohakuterrarium.api.deps import get_service
-from kohakuterrarium.session.history_paging import HistoryPagingError
 from kohakuterrarium.api.routes.persistence.live_paths import live_store_entry
 from kohakuterrarium.errors import (
     ConflictError,
@@ -25,6 +24,7 @@ from kohakuterrarium.errors import (
     SessionError,
     SessionNotFoundError,
 )
+from kohakuterrarium.session.history_paging import HistoryPagingError
 from kohakuterrarium.session.history_records import history_detail
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio._runtime import host_engine_or_none
@@ -135,7 +135,7 @@ def _saved_history_page(
         store = SessionStore(path)
         return history_page_from_store(
             store,
-            session_id=path.stem,
+            session_id=store.session_id,
             session_name=path.stem,
             target=target,
             stream=stream,
@@ -160,7 +160,7 @@ def _saved_history_detail(path: Path, target: str, **kwargs) -> dict:
         raise SessionNotFoundError(str(path))
     store = SessionStore(path)
     try:
-        return history_detail(store, target, session_id=path.stem, **kwargs)
+        return history_detail(store, target, session_id=store.session_id, **kwargs)
     finally:
         store.close(update_status=False)
 

--- a/src/kohakuterrarium/api/routes/persistence/history.py
+++ b/src/kohakuterrarium/api/routes/persistence/history.py
@@ -17,13 +17,22 @@ from urllib.parse import unquote
 from fastapi import APIRouter, Depends, HTTPException
 
 from kohakuterrarium.api.deps import get_service
+from kohakuterrarium.session.history_paging import HistoryPagingError
 from kohakuterrarium.api.routes.persistence.live_paths import live_store_entry
+from kohakuterrarium.errors import (
+    ConflictError,
+    NotFoundError,
+    SessionError,
+    SessionNotFoundError,
+)
+from kohakuterrarium.session.history_records import history_detail
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio._runtime import host_engine_or_none
 from kohakuterrarium.studio.persistence.history import (
     history_from_store,
     history_index_from_store,
     history_index_payload,
+    history_page_from_store,
     history_payload,
 )
 from kohakuterrarium.studio.persistence.store import resolve_session_path_default
@@ -74,6 +83,128 @@ def _live_session_name(store: SessionStore, session_name: str) -> str:
     return Path(path).stem if path else session_name
 
 
+def _live_is_processing(service: TerrariumService, graph_id: str, target: str) -> bool:
+    """Whether the live target's agent (or any agent in the graph) is
+    processing. Saved sessions have no live agent and report ``False``."""
+    engine = host_engine_or_none(service)
+    if engine is None:
+        return False
+    try:
+        graph = engine.get_graph(graph_id)
+    except KeyError:
+        return False
+    if not target.startswith("ch:"):
+        for creature_id in graph.creature_ids:
+            try:
+                creature = engine.get_creature(creature_id)
+            except KeyError:
+                continue
+            if getattr(creature, "name", None) == target:
+                agent = getattr(creature, "agent", None)
+                return bool(
+                    agent is not None and getattr(agent, "is_processing", False)
+                )
+    for creature_id in graph.creature_ids:
+        try:
+            agent = engine.get_creature(creature_id).agent
+        except KeyError:
+            continue
+        if agent is not None and getattr(agent, "is_processing", False):
+            return True
+    return False
+
+
+def _saved_history_page(
+    path: Path,
+    target: str,
+    *,
+    stream: str,
+    limit: int,
+    before: str | None,
+    after: str | None,
+    history_id: str | None,
+) -> dict[str, Any]:
+    """Build a paged history slice for a saved (on-disk) session in a worker
+    thread. The store is opened and closed within this call so a failed lookup
+    never leaves a Windows file handle behind."""
+    path = Path(path)
+    if not path.exists():
+        raise SessionNotFoundError(f"Session not found: {path}")
+    store: SessionStore | None = None
+    try:
+        store = SessionStore(path)
+        return history_page_from_store(
+            store,
+            session_id=path.stem,
+            session_name=path.stem,
+            target=target,
+            stream=stream,
+            limit=limit,
+            before=before,
+            after=after,
+            history_id=history_id,
+            is_processing=False,
+        )
+    except (NotFoundError, SessionError, HistoryPagingError):
+        raise
+    except Exception as e:
+        raise SessionError(f"History page load failed: {e}") from e
+    finally:
+        if store is not None:
+            store.close(update_status=False)
+
+
+def _saved_history_detail(path: Path, target: str, **kwargs) -> dict:
+    """Read one full record from a saved session with deterministic closure."""
+    if not path.exists():
+        raise SessionNotFoundError(str(path))
+    store = SessionStore(path)
+    try:
+        return history_detail(store, target, session_id=path.stem, **kwargs)
+    finally:
+        store.close(update_status=False)
+
+
+@router.get("/{session_name}/history/{target}/detail")
+async def get_session_history_detail(
+    session_name: str,
+    target: str,
+    stream: str,
+    ref: str,
+    history_id: str,
+    service: TerrariumService = Depends(get_service),
+) -> dict:
+    """Retrieve the full value for a saved or live-store history preview."""
+    target = unquote(target)
+    try:
+        entry = live_store_entry(service, session_name)
+        if entry is not None:
+            graph_id, store = entry
+            return history_detail(
+                store,
+                target,
+                session_id=graph_id,
+                stream=stream,
+                ref=ref,
+                history_id=history_id,
+            )
+        path = await _resolve_saved_path(session_name)
+        return await asyncio.to_thread(
+            _saved_history_detail,
+            path,
+            target,
+            stream=stream,
+            ref=ref,
+            history_id=history_id,
+        )
+    except ConflictError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    except (NotFoundError, KeyError) as exc:
+        raise HTTPException(404, str(exc)) from exc
+    except HistoryPagingError as exc:
+        raise HTTPException(400, str(exc)) from exc
+
+
 @router.get("/{session_name}/history")
 async def get_session_history_index(
     session_name: str,
@@ -92,21 +223,60 @@ async def get_session_history_index(
 async def get_session_history(
     session_name: str,
     target: str,
+    paged: bool = False,
+    stream: str = "events",
+    limit: int = 400,
+    before: str | None = None,
+    after: str | None = None,
+    history_id: str | None = None,
     service: TerrariumService = Depends(get_service),
 ) -> dict[str, Any]:
     """Return history for an agent, root, or channel target.
 
-    Live job IDs prevent active background work from appearing interrupted.
-    Saved sessions have no live-job set, so persisted unfinished work receives
-    the normal terminal representation.
+    Legacy (``paged`` omitted) returns the full history for live or saved
+    sessions. With ``paged=true`` it returns one bounded cursor-driven page via
+    ``history_page``, reusing the same session pager as the live creature
+    route. Channels are addressed by the ``ch:`` prefix and always page the
+    ``channel`` stream.
     """
     target = unquote(target)
     entry = live_store_entry(service, session_name)
     if entry is not None:
         graph_id, store = entry
+        live_session_name = _live_session_name(store, session_name)
+        if paged:
+            live_job_ids = _live_job_ids_for_graph(service, graph_id) or set()
+            try:
+                return history_page_from_store(
+                    store,
+                    session_id=graph_id,
+                    session_name=live_session_name,
+                    target=target,
+                    stream=stream,
+                    limit=limit,
+                    before=before,
+                    after=after,
+                    history_id=history_id,
+                    live_job_ids=live_job_ids,
+                    is_processing=_live_is_processing(service, graph_id, target),
+                )
+            except HistoryPagingError as exc:
+                raise HTTPException(400, str(exc)) from exc
         live_job_ids = _live_job_ids_for_graph(service, graph_id)
-        return history_from_store(
-            store, _live_session_name(store, session_name), target, live_job_ids
-        )
+        return history_from_store(store, live_session_name, target, live_job_ids)
     path = await _resolve_saved_path(session_name)
+    if paged:
+        try:
+            return await asyncio.to_thread(
+                _saved_history_page,
+                path,
+                target,
+                stream=stream,
+                limit=limit,
+                before=before,
+                after=after,
+                history_id=history_id,
+            )
+        except HistoryPagingError as exc:
+            raise HTTPException(400, str(exc)) from exc
     return await asyncio.to_thread(history_payload, path, target, None)

--- a/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
+++ b/src/kohakuterrarium/api/routes/sessions_v2/creatures_chat.py
@@ -3,6 +3,8 @@
 Service routing sends remote creature operations to their home workers.
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, Header, HTTPException
 
 from kohakuterrarium.api.deps import get_service
@@ -144,16 +146,37 @@ async def creature_history(
     session_id: str,
     creature_id: str,
     since_event_id: int | None = None,
+    paged: bool = False,
+    stream: str = "events",
+    limit: int = 400,
+    before: str | None = None,
+    after: str | None = None,
+    history_id: str | None = None,
     service: TerrariumService = Depends(get_service),
 ):
     """History payload with an optional event cursor.
 
-    ``since_event_id`` trims ``events`` to those after the cursor so the
-    client can append incrementally instead of re-fetching the whole log
-    after every turn. The full payload remains available (cursor omitted)
-    for the rewind/branch/compact resync path. ``max_event_id`` reports the
-    newest event in the full log so the client can advance its cursor.
+    Legacy behaviour (``paged`` omitted / ``False``) is unchanged:
+    ``since_event_id`` trims ``events`` and ``max_event_id`` reports the
+    newest event. With ``paged=true`` the endpoint returns a bounded,
+    cursor-driven page via ``history_page``; the numeric cursor filter is
+    rejected in paged mode; use the opaque before/after cursors instead.
     """
+    if paged:
+        if since_event_id is not None:
+            raise HTTPException(400, "paged history uses after, not since_event_id")
+        if limit <= 0:
+            raise HTTPException(400, "limit must be a positive integer")
+        return await _paged_history(
+            service,
+            session_id,
+            creature_id,
+            stream=stream,
+            limit=limit,
+            before=before,
+            after=after,
+            history_id=history_id,
+        )
     # Channel tabs share this endpoint through the ``ch:`` prefix.
     if creature_id.startswith("ch:"):
         channel_name = creature_id[3:]
@@ -201,6 +224,89 @@ async def creature_history(
         payload.pop("messages", None)
     payload["max_event_id"] = max_eid
     return payload
+
+
+async def _paged_history(
+    service: TerrariumService,
+    session_id: str,
+    creature_id: str,
+    *,
+    stream: str,
+    limit: int,
+    before: str | None,
+    after: str | None,
+    history_id: str | None,
+) -> dict[str, Any]:
+    """Build a bounded paged history slice for the ``paged=true`` mode.
+
+    Channel tabs route through the ``ch:`` prefix and are paged from the
+    channel message log; channels are never given a numeric ``since_event_id``
+    cursor. Event/snapshot streams forward to the service so remote and
+    multi-node adapters page at the record's home node.
+    """
+    if creature_id.startswith("ch:"):
+        if stream not in ("events", "channel"):
+            raise HTTPException(400, "channel target requires channel stream")
+        try:
+            return await service.channel_history_page(
+                session_id,
+                creature_id[3:],
+                limit=limit,
+                before=before,
+                after=after,
+                history_id=history_id,
+            )
+        except KeyError as exc:
+            raise HTTPException(404, str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+    if stream not in ("events", "snapshot"):
+        raise HTTPException(400, f"unsupported paged stream {stream!r}")
+    cid = await resolve_creature_id(service, creature_id, session_id)
+    try:
+        return await service.chat_history_page(
+            cid,
+            stream=stream,
+            limit=limit,
+            before=before,
+            after=after,
+            history_id=history_id,
+        )
+    except KeyError:
+        raise HTTPException(404, f"creature {creature_id!r} not found")
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+
+
+@router.get("/{session_id}/creatures/{creature_id}/history/detail")
+async def creature_history_detail(
+    session_id: str,
+    creature_id: str,
+    stream: str,
+    ref: str,
+    history_id: str,
+    service: TerrariumService = Depends(get_service),
+):
+    """Retrieve a full history record identified by an opaque detail token."""
+    try:
+        if creature_id.startswith("ch:"):
+            return await service.channel_history_detail(
+                session_id,
+                creature_id[3:],
+                stream=stream,
+                ref=ref,
+                history_id=history_id,
+            )
+        cid = await resolve_creature_id(service, creature_id, session_id)
+        return await service.chat_history_detail(
+            cid, stream=stream, ref=ref, history_id=history_id
+        )
+    except ConflictError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    except (NotFoundError, KeyError) as exc:
+        raise HTTPException(404, str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
 
 
 @router.get("/{session_id}/creatures/{creature_id}/events/{event_id}")

--- a/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
+++ b/src/kohakuterrarium/laboratory/adapters/terrarium_runtime.py
@@ -529,6 +529,24 @@ class TerrariumRuntimeAdapter:
                 self._require_hosted(cid)
                 return {"history": chat_history_for(self._engine, cid)}
 
+            case (
+                "chat_history_detail"
+                | "chat_history_page"
+                | "channel_history_page"
+                | "channel_history_detail"
+            ):
+                body = dict(msg.body)
+                service = LocalTerrariumService(self._engine)
+                if msg.type in ("chat_history_page", "chat_history_detail"):
+                    cid = body.pop("creature_id")
+                    self._require_hosted(cid)
+                    result = await getattr(service, msg.type)(cid, **body)
+                else:
+                    graph_id, name = body.pop("graph_id"), body.pop("name")
+                    operation = getattr(service, msg.type)
+                    result = await operation(graph_id, name, **body)
+                return {"history": result}
+
             case "chat_branches":
                 cid = msg.body["creature_id"]
                 self._require_hosted(cid)

--- a/src/kohakuterrarium/session/history_paging.py
+++ b/src/kohakuterrarium/session/history_paging.py
@@ -1,0 +1,322 @@
+"""Bounded physical history pages for event, channel, and snapshot streams."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from kohakuterrarium.session.store import iter_kv_keys
+
+DEFAULT_LIMIT = 400
+MAX_LIMIT = 400
+MAX_PAGE_BYTES = 4 * 1024 * 1024
+
+
+class HistoryPagingError(ValueError):
+    """Invalid history page or detail request."""
+
+
+@dataclass(frozen=True, slots=True)
+class PageCursor:
+    """Opaque exclusive cursor bound to one physical record."""
+
+    stream: str
+    target: str
+    ref: str
+    fingerprint: str
+    history_id: str = ""
+
+
+def _canonical_json(record: Any) -> bytes:
+    return json.dumps(
+        record, sort_keys=True, separators=(",", ":"), default=str
+    ).encode()
+
+
+def _record_fingerprint(record: Any) -> str:
+    return hashlib.sha256(_canonical_json(record)).hexdigest()[:16]
+
+
+def _unavailable_fingerprint(ref: str) -> str:
+    return "u:" + hashlib.sha256(ref.encode()).hexdigest()[:16]
+
+
+def encode_cursor(cursor: PageCursor) -> str:
+    """Encode an opaque, URL-safe exclusive record cursor."""
+    payload = dict(
+        v=1,
+        s=cursor.stream,
+        t=cursor.target,
+        r=cursor.ref,
+        f=cursor.fingerprint,
+        h=cursor.history_id,
+    )
+    return base64.urlsafe_b64encode(_canonical_json(payload)).decode("ascii")
+
+
+def decode_cursor(raw: str) -> PageCursor:
+    """Decode a structurally valid cursor."""
+    try:
+        if not isinstance(raw, str) or len(raw) > 16384:
+            raise ValueError("invalid size")
+        payload = json.loads(
+            base64.b64decode(raw.encode("ascii"), altchars=b"-_", validate=True)
+        )
+        if not isinstance(payload, dict) or payload.get("v") != 1:
+            raise ValueError("invalid version")
+        if not all(
+            isinstance(payload.get(k), str) and payload[k] for k in ("s", "t", "r", "f")
+        ):
+            raise ValueError("invalid fields")
+        if not isinstance(payload.get("h", ""), str):
+            raise ValueError("invalid identity")
+        return PageCursor(
+            payload["s"], payload["t"], payload["r"], payload["f"], payload.get("h", "")
+        )
+    except (ValueError, TypeError, UnicodeError) as exc:
+        raise HistoryPagingError("malformed history cursor") from exc
+
+
+def _stream_identity(session_id: str, stream: str, target: str) -> str:
+    return hashlib.sha256(_canonical_json([session_id, stream, target])).hexdigest()[
+        :16
+    ]
+
+
+def physical_refs(vault: Any, target: str, kind: str) -> list[str]:
+    """Enumerate exact target records in numeric storage order, without values."""
+    vault.flush_cache()
+    prefix = f"{target}:{kind}"
+    refs = []
+    for key in iter_kv_keys(vault, prefix=prefix):
+        ref = key.decode("utf-8") if isinstance(key, bytes) else key
+        suffix = ref[len(prefix) :]
+        if suffix and suffix.isascii() and suffix.isdigit():
+            refs.append(ref)
+    return sorted(refs, key=lambda ref: int(ref[len(prefix) :]))
+
+
+def _ordered_event_refs(store: Any, agent: str) -> list[str]:
+    return physical_refs(store.events, agent, "e")
+
+
+def _history_key(stream: str, target: str, ref: str) -> str:
+    return f"{stream}:{target}:{ref}"
+
+
+def _try_get(get_record: Callable, ref: str) -> tuple[Any, str]:
+    try:
+        record = get_record(ref)
+        if isinstance(record, dict):
+            return record, _record_fingerprint(record)
+    except Exception:
+        pass
+    return None, _unavailable_fingerprint(ref)
+
+
+def _preview_value(value: Any, depth: int = 0) -> Any:
+    if depth >= 4:
+        return "…"
+    if isinstance(value, str):
+        return value if len(value) <= 2000 else value[:2000] + "…"
+    if isinstance(value, list):
+        return [_preview_value(item, depth + 1) for item in value[:8]]
+    if isinstance(value, dict):
+        return {
+            str(k)[:100]: _preview_value(v, depth + 1)
+            for k, v in list(value.items())[:20]
+        }
+    return value
+
+
+def _bounded_preview(record: dict, detail: str, max_bytes: int) -> dict:
+    """Produce a preview retaining physical identity within the byte budget."""
+    markers = {
+        "_history_key": record["_history_key"],
+        "_history_detail": detail,
+        "_history_truncated": True,
+    }
+    preview = {**_preview_value(record), **markers}
+    if isinstance(preview.get("output"), str):
+        preview["output_preview"] = preview["output"][:50]
+    while len(_canonical_json(preview)) > min(4096, max_bytes):
+        candidates = [k for k in preview if k not in markers]
+        if not candidates:
+            break
+        key = max(candidates, key=lambda k: len(_canonical_json({k: preview[k]})))
+        value = preview[key]
+        if isinstance(value, str) and len(value) > 16:
+            preview[key] = value[: len(value) // 2] + "…"
+        else:
+            del preview[key]
+    return preview
+
+
+def _clamp_limit(limit: int) -> int:
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+        raise HistoryPagingError("limit must be a positive integer")
+    return min(limit, MAX_LIMIT)
+
+
+def _page(
+    refs: list[str],
+    get_record: Callable,
+    *,
+    stream: str,
+    target: str,
+    session_id: str,
+    limit: int = DEFAULT_LIMIT,
+    before: str | None = None,
+    after: str | None = None,
+    history_id: str | None = None,
+    is_processing: bool = False,
+    live_job_ids: tuple[str, ...] = (),
+    envelope: dict | None = None,
+    revision: str | None = None,
+) -> dict:
+    limit = _clamp_limit(limit)
+    if before is not None and after is not None:
+        raise HistoryPagingError("before and after cursors are mutually exclusive")
+    identity = _stream_identity(session_id, stream, target)
+    if revision is not None:
+        identity = _record_fingerprint([identity, revision])
+    reset = history_id is not None and history_id != identity
+    index = None
+    if before is not None or after is not None:
+        cursor = decode_cursor(before if before is not None else after)
+        if cursor.stream != stream or cursor.target != target:
+            raise HistoryPagingError("cursor stream or target does not match")
+        if cursor.history_id and cursor.history_id != identity:
+            reset = True
+        if cursor.ref not in refs:
+            reset = True
+        else:
+            index = refs.index(cursor.ref)
+            _, fingerprint = _try_get(get_record, cursor.ref)
+            reset |= fingerprint != cursor.fingerprint
+    meta = dict(
+        version=1,
+        stream=stream,
+        history_id=identity,
+        before=None,
+        after=None,
+        has_older=False,
+        has_newer=False,
+        reset_required=reset,
+    )
+    result = dict(
+        items=[],
+        history_page=meta,
+        is_processing=is_processing,
+        live_job_ids=list(live_job_ids),
+    )
+    reserve = dict(result)
+    longest = max(refs, key=lambda ref: len(_canonical_json(ref)), default="0")
+    placeholder = encode_cursor(
+        PageCursor(stream, target, longest, "u:" + "f" * 16, identity)
+    )
+    reserve["history_page"] = {**meta, "before": placeholder, "after": placeholder}
+    if envelope is not None:
+        reserve = {**reserve, **envelope, "events": [], "messages": []}
+    budget = MAX_PAGE_BYTES - len(_canonical_json(reserve)) - limit
+    if budget <= 0:
+        raise HistoryPagingError("history metadata exceeds page byte budget")
+    if reset:
+        return result
+    indexes = (
+        range(index + 1, len(refs))
+        if after is not None and index is not None
+        else range((index if index is not None else len(refs)) - 1, -1, -1)
+    )
+    consumed = []
+    total = 0
+    for idx in indexes:
+        if len(consumed) == limit:
+            break
+        ref = refs[idx]
+        record, fingerprint = _try_get(get_record, ref)
+        token = encode_cursor(PageCursor(stream, target, ref, fingerprint, identity))
+        key = _history_key(stream, target, ref)
+        if record is None:
+            item = dict(
+                _history_key=key, _history_unavailable=True, _history_detail=token
+            )
+        else:
+            item = {**record, "_history_key": key}
+            if len(_canonical_json(item)) > budget:
+                item = _bounded_preview(item, token, budget)
+        size = len(_canonical_json(item))
+        if total + size > budget:
+            if not consumed:
+                raise HistoryPagingError("record identity exceeds page byte budget")
+            break
+        consumed.append((idx, token, item))
+        total += size
+    if after is None:
+        consumed.reverse()
+    if consumed:
+        meta.update(
+            before=consumed[0][1],
+            after=consumed[-1][1],
+            has_older=consumed[0][0] > 0,
+            has_newer=consumed[-1][0] < len(refs) - 1,
+        )
+    result["items"] = [entry[2] for entry in consumed]
+    return result
+
+
+def page_events(store: Any, agent: str, *, session_id: str, **kwargs) -> dict:
+    """Page an agent's exact physical event records."""
+    return _page(
+        _ordered_event_refs(store, agent),
+        lambda ref: store.events[ref],
+        stream="events",
+        target=agent,
+        session_id=session_id,
+        **kwargs,
+    )
+
+
+def page_channel_store(store: Any, channel: str, *, session_id: str, **kwargs) -> dict:
+    """Page channel records without loading the full message log."""
+    return _page(
+        physical_refs(store.channels, channel, "m"),
+        lambda ref: store.channels[ref],
+        stream="channel",
+        target=channel,
+        session_id=session_id,
+        **kwargs,
+    )
+
+
+def page_channels(
+    messages: list[dict], *, session_id: str, channel: str, **kwargs
+) -> dict:
+    """Page an already merged channel list in its existing order."""
+    return _page(
+        [str(i) for i in range(len(messages))],
+        lambda ref: messages[int(ref)],
+        stream="channel",
+        target=channel,
+        session_id=session_id,
+        **kwargs,
+    )
+
+
+def page_snapshot(
+    messages: list[dict], *, session_id: str, target: str, **kwargs
+) -> dict:
+    """Page a legacy snapshot with absolute-position record identities."""
+    return _page(
+        [str(i) for i in range(len(messages))],
+        lambda ref: messages[int(ref)],
+        stream="snapshot",
+        target=target,
+        session_id=session_id,
+        revision=_record_fingerprint(messages),
+        **kwargs,
+    )

--- a/src/kohakuterrarium/session/history_records.py
+++ b/src/kohakuterrarium/session/history_records.py
@@ -1,0 +1,136 @@
+"""Shared stream selection, response envelopes, and full history record reads."""
+
+import re
+from typing import Any
+
+from kohakuterrarium.errors import ConflictError, NotFoundError
+from kohakuterrarium.session.history_paging import (
+    HistoryPagingError,
+    _history_key,
+    _record_fingerprint,
+    _stream_identity,
+    _unavailable_fingerprint,
+    decode_cursor,
+    page_channel_store,
+    page_events,
+    page_snapshot,
+    physical_refs,
+)
+
+
+def history_page(
+    store: Any,
+    target: str,
+    *,
+    session_id: str,
+    stream: str = "events",
+    snapshot: list | None = None,
+    envelope: dict | None = None,
+    **kwargs,
+) -> dict:
+    """Select a stored stream and return its complete response envelope."""
+    envelope = envelope or {}
+    if target.startswith("ch:"):
+        if stream not in ("events", "channel"):
+            raise HistoryPagingError("channel target requires channel stream")
+        page = page_channel_store(
+            store, target[3:], session_id=session_id, envelope=envelope, **kwargs
+        )
+    else:
+        if stream not in ("events", "snapshot"):
+            raise HistoryPagingError("unsupported paged stream")
+        initial = all(
+            kwargs.get(key) is None for key in ("before", "after", "history_id")
+        )
+        if (
+            stream == "events"
+            and initial
+            and not physical_refs(store.events, target, "e")
+        ):
+            stream = "snapshot"
+        if stream == "snapshot":
+            messages = (
+                snapshot
+                if snapshot is not None
+                else store.load_conversation(target) or []
+            )
+            page = page_snapshot(
+                messages,
+                target=target,
+                session_id=session_id,
+                envelope=envelope,
+                **kwargs,
+            )
+        else:
+            page = page_events(
+                store, target, session_id=session_id, envelope=envelope, **kwargs
+            )
+    items = page.pop("items")
+    return {
+        **envelope,
+        **page,
+        "events": items if page["history_page"]["stream"] == "events" else [],
+        "messages": items if page["history_page"]["stream"] != "events" else [],
+    }
+
+
+def history_detail(
+    store: Any,
+    target: str,
+    *,
+    session_id: str,
+    stream: str,
+    ref: str,
+    history_id: str,
+    snapshot: list | None = None,
+    channel_messages: list | None = None,
+) -> dict:
+    """Read a complete record after validating stream, target, and physical identity."""
+    is_channel = target.startswith("ch:")
+    if (is_channel and stream != "channel") or (
+        not is_channel and stream not in ("events", "snapshot")
+    ):
+        raise HistoryPagingError("detail stream does not match target")
+    name = target[3:] if is_channel else target
+    cursor = decode_cursor(ref)
+    if cursor.stream != stream or cursor.target != name:
+        raise HistoryPagingError("detail reference does not match target or stream")
+    identity = _stream_identity(session_id, stream, name)
+    if stream == "snapshot":
+        snapshot = (
+            snapshot if snapshot is not None else store.load_conversation(name) or []
+        )
+        identity = _record_fingerprint([identity, _record_fingerprint(snapshot)])
+    if history_id != identity or cursor.history_id != identity:
+        raise ConflictError("history identity changed; reload history")
+    indexed = stream == "snapshot" or channel_messages is not None
+    pattern = (
+        r"(?:0|[1-9][0-9]*)"
+        if indexed
+        else re.escape(name) + (r":e[0-9]+" if stream == "events" else r":m[0-9]+")
+    )
+    if re.fullmatch(pattern, cursor.ref) is None:
+        raise HistoryPagingError("invalid physical detail reference")
+    try:
+        if indexed:
+            messages = channel_messages if channel_messages is not None else snapshot
+            if messages is None:
+                messages = store.load_conversation(name) or []
+            record = messages[int(cursor.ref)]
+        else:
+            vault = store.events if stream == "events" else store.channels
+            vault.flush_cache()
+            record = vault[cursor.ref]
+    except (KeyError, IndexError, ValueError, OSError) as exc:
+        raise NotFoundError("history record unavailable") from exc
+    if not isinstance(record, dict):
+        raise NotFoundError("history record unavailable")
+    if (
+        cursor.fingerprint != _unavailable_fingerprint(cursor.ref)
+        and _record_fingerprint(record) != cursor.fingerprint
+    ):
+        raise ConflictError("history record changed; reload history")
+    return {
+        "record": {**record, "_history_key": _history_key(stream, name, cursor.ref)},
+        "history_page": {"version": 1, "stream": stream, "history_id": identity},
+    }

--- a/src/kohakuterrarium/studio/persistence/history.py
+++ b/src/kohakuterrarium/studio/persistence/history.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from kohakuterrarium.errors import NotFoundError, SessionError, SessionNotFoundError
+from kohakuterrarium.session.history_paging import physical_refs
 from kohakuterrarium.session.history_records import history_page
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio.persistence.store import (
@@ -124,6 +125,12 @@ def history_page_from_store(
     Callers that only want the legacy full read keep using ``history_from_store``
     / ``history_payload`` unchanged.
     """
+    meta = store.load_meta()
+    known = target in set(session_targets(store, meta))
+    if not known and target.startswith("ch:"):
+        known = bool(physical_refs(store.channels, target[3:], "m"))
+    if not known:
+        raise NotFoundError(f"Target not found in session: {target}")
     return history_page(
         store,
         target,

--- a/src/kohakuterrarium/studio/persistence/history.py
+++ b/src/kohakuterrarium/studio/persistence/history.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from kohakuterrarium.errors import NotFoundError, SessionError, SessionNotFoundError
+from kohakuterrarium.session.history_records import history_page
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio.persistence.store import (
     session_history_payload,
@@ -98,3 +99,41 @@ def history_payload(
         # file handles that block deletion.
         if store is not None:
             store.close(update_status=False)
+
+
+def history_page_from_store(
+    store: SessionStore,
+    session_id: str,
+    session_name: str,
+    target: str,
+    *,
+    stream: str = "events",
+    limit: int = 400,
+    before: str | None = None,
+    after: str | None = None,
+    history_id: str | None = None,
+    live_job_ids: set[str] | None = None,
+    is_processing: bool = False,
+) -> dict[str, Any]:
+    """Build a bounded paged history slice from an open session store.
+
+    Channels are addressed by the ``ch:`` prefix on ``target`` and are always
+    paged as the ``channel`` stream; agent/root targets page the ``events``
+    (default) or ``snapshot`` stream. Reuses the shared session pager, so
+    cursors, history identity, and byte bounds are identical to the live route.
+    Callers that only want the legacy full read keep using ``history_from_store``
+    / ``history_payload`` unchanged.
+    """
+    return history_page(
+        store,
+        target,
+        session_id=session_id,
+        stream=stream,
+        limit=limit,
+        before=before,
+        after=after,
+        history_id=history_id,
+        live_job_ids=tuple(sorted(live_job_ids or ())),
+        is_processing=is_processing,
+        envelope={"target": target, "session_name": session_name},
+    )

--- a/src/kohakuterrarium/terrarium/history_remote.py
+++ b/src/kohakuterrarium/terrarium/history_remote.py
@@ -1,0 +1,43 @@
+"""Remote and multi-node history paging delegation."""
+
+from kohakuterrarium.session.history_records import history_detail
+from kohakuterrarium.terrarium.history_service import channel_list_page
+
+
+class RemoteHistoryServiceMixin:
+    async def chat_history_page(self, creature_id: str, **kwargs) -> dict:
+        return await self._history_request(
+            "chat_history_page", {"creature_id": creature_id, **kwargs}
+        )
+
+    async def chat_history_detail(self, creature_id: str, **kwargs) -> dict:
+        return await self._history_request(
+            "chat_history_detail", {"creature_id": creature_id, **kwargs}
+        )
+
+    async def channel_history_page(self, graph_id: str, name: str, **kwargs) -> dict:
+        return await self._history_request(
+            "channel_history_page", {"graph_id": graph_id, "name": name, **kwargs}
+        )
+
+    async def channel_history_detail(self, graph_id: str, name: str, **kwargs) -> dict:
+        return await self._history_request(
+            "channel_history_detail", {"graph_id": graph_id, "name": name, **kwargs}
+        )
+
+
+class MultiNodeHistoryServiceMixin:
+    async def chat_history_detail(self, creature_id: str, **kwargs) -> dict:
+        return await self._route_per_creature(
+            creature_id, lambda svc: svc.chat_history_detail(creature_id, **kwargs)
+        )
+
+    async def channel_history_page(self, graph_id: str, name: str, **kwargs) -> dict:
+        messages = await self.channel_history(graph_id, name)
+        return channel_list_page(messages, graph_id, name, **kwargs)
+
+    async def channel_history_detail(self, graph_id: str, name: str, **kwargs) -> dict:
+        messages = await self.channel_history(graph_id, name)
+        return history_detail(
+            None, f"ch:{name}", session_id=graph_id, channel_messages=messages, **kwargs
+        )

--- a/src/kohakuterrarium/terrarium/history_service.py
+++ b/src/kohakuterrarium/terrarium/history_service.py
@@ -2,7 +2,7 @@
 
 from typing import Protocol
 
-from kohakuterrarium.session.history_paging import page_channels, physical_refs
+from kohakuterrarium.session.history_paging import page_channels
 from kohakuterrarium.session.history_records import history_detail, history_page
 from kohakuterrarium.terrarium.creature_ops import agent_live_job_ids
 
@@ -58,11 +58,6 @@ class LocalHistoryServiceMixin:
         envelope = {"session_id": graph_id, "creature_id": f"ch:{name}"}
         store = self._engine._session_stores.get(graph_id)
         if store is not None:
-            envs = getattr(self._engine, "_environments", None) or {}
-            env = envs.get(graph_id)
-            live = env is not None and env.shared_channels.get(name) is not None
-            if not live and not physical_refs(store.channels, name, "m"):
-                raise KeyError(f"channel {name!r} not in graph {graph_id!r}")
             return history_page(
                 store, f"ch:{name}", session_id=graph_id, envelope=envelope, **kwargs
             )

--- a/src/kohakuterrarium/terrarium/history_service.py
+++ b/src/kohakuterrarium/terrarium/history_service.py
@@ -1,0 +1,87 @@
+"""History paging service protocol and local channel reads."""
+
+from typing import Protocol
+
+from kohakuterrarium.session.history_paging import page_channels
+from kohakuterrarium.session.history_records import history_detail, history_page
+from kohakuterrarium.terrarium.creature_ops import agent_live_job_ids
+
+
+class HistoryServiceProtocol(Protocol):
+    async def chat_history_page(self, creature_id: str, **kwargs) -> dict: ...
+
+    async def chat_history_detail(self, creature_id: str, **kwargs) -> dict: ...
+
+    async def channel_history_page(
+        self, graph_id: str, name: str, **kwargs
+    ) -> dict: ...
+
+    async def channel_history_detail(
+        self, graph_id: str, name: str, **kwargs
+    ) -> dict: ...
+
+
+class LocalHistoryServiceMixin:
+    async def chat_history_page(self, creature_id: str, **kwargs) -> dict:
+        creature, store = self._history_source(creature_id)
+        return history_page(
+            store,
+            creature.name,
+            session_id=creature.graph_id,
+            snapshot=getattr(creature.agent, "conversation_history", None),
+            is_processing=bool(creature.agent.is_processing),
+            live_job_ids=tuple(sorted(agent_live_job_ids(creature.agent))),
+            envelope={"creature_id": creature_id, "session_id": creature.graph_id},
+            **kwargs,
+        )
+
+    async def chat_history_detail(self, creature_id: str, **kwargs) -> dict:
+        creature, store = self._history_source(creature_id)
+        return history_detail(
+            store,
+            creature.name,
+            session_id=creature.graph_id,
+            snapshot=getattr(creature.agent, "conversation_history", None),
+            **kwargs,
+        )
+
+    def _history_source(self, creature_id: str):
+        creature = self._engine.get_creature(creature_id)
+        store = getattr(
+            creature.agent, "session_store", None
+        ) or self._engine._session_stores.get(creature.graph_id)
+        if store is None:
+            raise KeyError(creature_id)
+        return creature, store
+
+    async def channel_history_page(self, graph_id: str, name: str, **kwargs) -> dict:
+        envelope = {"session_id": graph_id, "creature_id": f"ch:{name}"}
+        store = self._engine._session_stores.get(graph_id)
+        if store is not None:
+            return history_page(
+                store, f"ch:{name}", session_id=graph_id, envelope=envelope, **kwargs
+            )
+        messages = await self.channel_history(graph_id, name)
+        return channel_list_page(messages, graph_id, name, **kwargs)
+
+    async def channel_history_detail(self, graph_id: str, name: str, **kwargs) -> dict:
+        store = self._engine._session_stores.get(graph_id)
+        messages = (
+            None if store is not None else await self.channel_history(graph_id, name)
+        )
+        return history_detail(
+            store,
+            f"ch:{name}",
+            session_id=graph_id,
+            channel_messages=messages,
+            **kwargs,
+        )
+
+
+def channel_list_page(messages: list, graph_id: str, name: str, **kwargs) -> dict:
+    """Build a bounded response from an already materialized channel list."""
+    envelope = {"session_id": graph_id, "creature_id": f"ch:{name}"}
+    page = page_channels(
+        messages, session_id=graph_id, channel=name, envelope=envelope, **kwargs
+    )
+    return {**envelope, "events": [], "messages": page.pop("items"), **page}

--- a/src/kohakuterrarium/terrarium/history_service.py
+++ b/src/kohakuterrarium/terrarium/history_service.py
@@ -2,7 +2,7 @@
 
 from typing import Protocol
 
-from kohakuterrarium.session.history_paging import page_channels
+from kohakuterrarium.session.history_paging import page_channels, physical_refs
 from kohakuterrarium.session.history_records import history_detail, history_page
 from kohakuterrarium.terrarium.creature_ops import agent_live_job_ids
 
@@ -58,6 +58,11 @@ class LocalHistoryServiceMixin:
         envelope = {"session_id": graph_id, "creature_id": f"ch:{name}"}
         store = self._engine._session_stores.get(graph_id)
         if store is not None:
+            envs = getattr(self._engine, "_environments", None) or {}
+            env = envs.get(graph_id)
+            live = env is not None and env.shared_channels.get(name) is not None
+            if not live and not physical_refs(store.channels, name, "m"):
+                raise KeyError(f"channel {name!r} not in graph {graph_id!r}")
             return history_page(
                 store, f"ch:{name}", session_id=graph_id, envelope=envelope, **kwargs
             )

--- a/src/kohakuterrarium/terrarium/multi_node_service.py
+++ b/src/kohakuterrarium/terrarium/multi_node_service.py
@@ -38,6 +38,7 @@ from kohakuterrarium.terrarium.drive.multi_node_ops import MultiNodeDriveService
 from kohakuterrarium.terrarium.drive.service_protocol import (
     DriveServiceUnsupportedMixin,
 )
+from kohakuterrarium.terrarium.history_remote import MultiNodeHistoryServiceMixin
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium.events import (
     ConnectionResult,
@@ -97,6 +98,7 @@ class CrossNodeNotSupportedError(RuntimeError):
 
 
 class MultiNodeTerrariumService(
+    MultiNodeHistoryServiceMixin,
     MultiNodeDriveServiceMixin,
     MultiNodeRuntimeOptionsMixin,
     DriveServiceUnsupportedMixin,
@@ -575,6 +577,28 @@ class MultiNodeTerrariumService(
     async def chat_history(self, creature_id: str) -> dict[str, Any]:
         return await self._route_per_creature(
             creature_id, lambda svc: svc.chat_history(creature_id)
+        )
+
+    async def chat_history_page(
+        self,
+        creature_id: str,
+        *,
+        stream: str = "events",
+        limit: int = 400,
+        before: str | None = None,
+        after: str | None = None,
+        history_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._route_per_creature(
+            creature_id,
+            lambda svc: svc.chat_history_page(
+                creature_id,
+                stream=stream,
+                limit=limit,
+                before=before,
+                after=after,
+                history_id=history_id,
+            ),
         )
 
     async def chat_branches(self, creature_id: str) -> list[dict[str, Any]]:

--- a/src/kohakuterrarium/terrarium/remote_service.py
+++ b/src/kohakuterrarium/terrarium/remote_service.py
@@ -49,6 +49,7 @@ from kohakuterrarium.terrarium.events import (
     EngineEvent,
     EventFilter,
 )
+from kohakuterrarium.terrarium.history_remote import RemoteHistoryServiceMixin
 from kohakuterrarium.terrarium.remote_recipe import RemoteRecipeServiceMixin
 from kohakuterrarium.terrarium.service import CreatureInfo
 from kohakuterrarium.terrarium.service_dto import BranchMutationResult
@@ -159,6 +160,7 @@ def _branch_mutation_result(body: dict[str, Any]) -> BranchMutationResult:
 
 
 class RemoteTerrariumService(
+    RemoteHistoryServiceMixin,
     RemoteRecipeServiceMixin,
     RemoteDriveServiceMixin,
     DriveServiceUnsupportedMixin,
@@ -351,6 +353,9 @@ class RemoteTerrariumService(
             await self._req("chat_history", {"creature_id": creature_id})
         )
         return body.get("history", {})
+
+    async def _history_request(self, verb: str, payload: dict) -> dict:
+        return _maybe_raise(await self._req(verb, payload))["history"]
 
     async def chat_branches(self, creature_id: str) -> list[dict[str, Any]]:
         body = _maybe_raise(

--- a/src/kohakuterrarium/terrarium/service.py
+++ b/src/kohakuterrarium/terrarium/service.py
@@ -69,6 +69,10 @@ from kohakuterrarium.terrarium.creature_ops import (
     session_attach_policies_for as _session_attach_policies_for,
     wire_creature_on_engine as _wire_creature_on_engine,
 )
+from kohakuterrarium.terrarium.history_service import (
+    HistoryServiceProtocol,
+    LocalHistoryServiceMixin,
+)
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.terrarium.events import (
     ConnectionResult,
@@ -100,7 +104,7 @@ def _completed_branch_result(
 
 
 @runtime_checkable
-class TerrariumService(DriveServiceProtocol, Protocol):
+class TerrariumService(HistoryServiceProtocol, DriveServiceProtocol, Protocol):
     """Operations Studio needs from a terrarium runtime.
 
     Method semantics match the underlying
@@ -470,7 +474,9 @@ class TerrariumService(DriveServiceProtocol, Protocol):
     ) -> AsyncIterator[EngineEvent]: ...
 
 
-class LocalTerrariumService(LocalCommandServiceMixin, DriveServiceMixin):
+class LocalTerrariumService(
+    LocalHistoryServiceMixin, LocalCommandServiceMixin, DriveServiceMixin
+):
     """Direct in-process implementation backed by a :class:`Terrarium`.
 
     Every method delegates to the underlying engine with at most a

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1392,6 +1392,194 @@ class TestApiIntegration:
         assert resp.status_code == 200
         assert "persist this turn" in str(resp.json())
 
+        # ── History paging (bounded, cursor-driven pages) ─────────────
+        # The dashboard opts into ``paged=true``; legacy full reads above
+        # are unchanged. Live event pages carry raw event records with a
+        # physical ``_history_key`` and NEVER embed the conversation
+        # snapshot (no snapshot giant on an event page). Cursors are
+        # opaque exclusive record tokens; ``history_id`` is the
+        # session-and-target scoped history identity.
+        resp = client.get(
+            f"/api/sessions/{session_id}/creatures/{creature_id}/history",
+            params={"paged": "true", "limit": 3, "stream": "events"},
+        )
+        assert resp.status_code == 200
+        live_page = resp.json()
+        live_hp = live_page["history_page"]
+        assert live_hp["version"] == 1
+        assert live_hp["stream"] == "events"
+        assert live_hp["history_id"] and len(live_hp["history_id"]) == 16
+        assert isinstance(live_hp["has_older"], bool)
+        assert isinstance(live_hp["has_newer"], bool)
+        assert live_hp["reset_required"] is False
+        assert live_hp["before"] and live_hp["after"]
+        assert live_page["messages"] == []
+        assert live_page["events"] and isinstance(live_page["events"], list)
+        assert live_page["is_processing"] is False
+        assert live_page["live_job_ids"] == []
+        live_keys = [e["_history_key"] for e in live_page["events"]]
+        assert all(k.startswith("events:") for k in live_keys)
+
+        # ``before`` walks to the next OLDER page; ``after`` walks back to
+        # the next NEWER page. Together they prove bounded pages stitch into
+        # a contiguous history without holes or duplicates.
+        older = client.get(
+            f"/api/sessions/{session_id}/creatures/{creature_id}/history",
+            params={
+                "paged": "true",
+                "limit": 3,
+                "stream": "events",
+                "before": live_hp["before"],
+                "history_id": live_hp["history_id"],
+            },
+        ).json()
+        assert older["history_page"]["history_id"] == live_hp["history_id"]
+        assert older["history_page"]["has_newer"] is True
+        older_keys = [e["_history_key"] for e in older["events"]]
+        assert older_keys and older_keys != live_keys
+        assert set(older_keys).isdisjoint(set(live_keys))
+
+        back = client.get(
+            f"/api/sessions/{session_id}/creatures/{creature_id}/history",
+            params={
+                "paged": "true",
+                "limit": 3,
+                "stream": "events",
+                "after": older["history_page"]["after"],
+                "history_id": older["history_page"]["history_id"],
+            },
+        ).json()
+        assert [e["_history_key"] for e in back["events"]] == live_keys
+        assert back["history_page"]["history_id"] == live_hp["history_id"]
+
+        # A stale / cross-session ``history_id`` forces a reset signal rather
+        # than a wrong payload — the client must discard the cached page.
+        stale = client.get(
+            f"/api/sessions/{session_id}/creatures/{creature_id}/history",
+            params={
+                "paged": "true",
+                "limit": 3,
+                "stream": "events",
+                "before": live_hp["before"],
+                "history_id": "0000000000000000",
+            },
+        ).json()
+        assert stale["history_page"]["reset_required"] is True
+        assert stale["events"] == []
+
+        # Malformed / wrong-target cursors are rejected as 400, never merged.
+        assert (
+            client.get(
+                f"/api/sessions/{session_id}/creatures/{creature_id}/history",
+                params={
+                    "paged": "true",
+                    "limit": 3,
+                    "stream": "events",
+                    "after": "not-a-cursor",
+                },
+            ).status_code
+            == 400
+        )
+
+        # Saved (on-disk) paging reuses the same bounded pager over the
+        # persisted store, with the same envelope + cursor semantics. The
+        # saved event page also omits the conversation snapshot.
+        resp = client.get(
+            f"/api/sessions/{saved_name}/history/alice",
+            params={"paged": "true", "limit": 3, "stream": "events"},
+        )
+        assert resp.status_code == 200
+        saved_page = resp.json()
+        assert saved_page["target"] == "alice"
+        saved_hp = saved_page["history_page"]
+        assert saved_hp["version"] == 1
+        assert saved_hp["stream"] == "events"
+        assert saved_hp["history_id"] and len(saved_hp["history_id"]) == 16
+        assert saved_page["messages"] == []
+        assert saved_page["events"]
+        saved_keys = [e["_history_key"] for e in saved_page["events"]]
+        assert all(k.startswith("events:") for k in saved_keys)
+        saved_older = client.get(
+            f"/api/sessions/{saved_name}/history/alice",
+            params={
+                "paged": "true",
+                "limit": 3,
+                "stream": "events",
+                "before": saved_hp["before"],
+                "history_id": saved_hp["history_id"],
+            },
+        ).json()
+        assert saved_older["history_page"]["history_id"] == saved_hp["history_id"]
+        assert saved_older["events"] and saved_older["events"] != saved_page["events"]
+
+        # ── History detail (full raw record behind a page) ────────────
+        # The opaque ref token addresses one physical record; the detail
+        # endpoint returns the complete raw record with the identical
+        # ``_history_key`` carried on the paged item. ``history_page.after``
+        # is an opaque record cursor for the page's newest event.
+        live_detail = client.get(
+            f"/api/sessions/{session_id}/creatures/{creature_id}/history/detail",
+            params={
+                "stream": "events",
+                "ref": live_hp["after"],
+                "history_id": live_hp["history_id"],
+            },
+        )
+        assert live_detail.status_code == 200
+        live_body = live_detail.json()
+        assert live_body["record"]["_history_key"] == live_keys[-1]
+        assert live_body["history_page"]["version"] == 1
+        assert live_body["history_page"]["stream"] == "events"
+        assert live_body["history_page"]["history_id"] == live_hp["history_id"]
+
+        saved_detail = client.get(
+            f"/api/sessions/{saved_name}/history/alice/detail",
+            params={
+                "stream": "events",
+                "ref": saved_hp["after"],
+                "history_id": saved_hp["history_id"],
+            },
+        )
+        assert saved_detail.status_code == 200
+        assert saved_detail.json()["record"]["_history_key"] == saved_keys[-1]
+        assert saved_detail.json()["history_page"]["stream"] == "events"
+
+        # Detail validation: malformed refs are 400 and a changed/foreign
+        # history identity is 409 (stale) — never a silently wrong record.
+        assert (
+            client.get(
+                f"/api/sessions/{session_id}/creatures/{creature_id}/history/detail",
+                params={
+                    "stream": "events",
+                    "ref": "not-a-cursor",
+                    "history_id": live_hp["history_id"],
+                },
+            ).status_code
+            == 400
+        )
+        assert (
+            client.get(
+                f"/api/sessions/{session_id}/creatures/{creature_id}/history/detail",
+                params={
+                    "stream": "events",
+                    "ref": live_hp["after"],
+                    "history_id": "0000000000000000",
+                },
+            ).status_code
+            == 409
+        )
+        assert (
+            client.get(
+                f"/api/sessions/{saved_name}/history/alice/detail",
+                params={
+                    "stream": "events",
+                    "ref": "not-a-cursor",
+                    "history_id": saved_hp["history_id"],
+                },
+            ).status_code
+            == 400
+        )
+
         # Artifacts route — the session has no artifacts directory, so
         # any file path 404s (the path-resolution guard rejects it
         # before a FileResponse is built).

--- a/tests/integration/test_laboratory.py
+++ b/tests/integration/test_laboratory.py
@@ -294,6 +294,42 @@ class TestLaboratoryMultiNodeService:
             alpha_info = await service.add_creature(a_cfg, on_node="w1", start=True)
             assert alpha_info.creature_id
             assert alpha_info.is_running is True
+            alpha = w1_engine.get_creature(alpha_info.creature_id)
+            paging_store = w1_engine._session_stores[alpha.graph_id]
+            for index in range(4):
+                paging_store.append_event(
+                    alpha.name, "text", {"content": f"page-{index}"}
+                )
+            tail = await service.chat_history_page(alpha_info.creature_id, limit=2)
+            assert [row["content"] for row in tail["events"]] == ["page-2", "page-3"]
+            assert tail["messages"] == []
+            older = await service.chat_history_page(
+                alpha_info.creature_id,
+                limit=2,
+                before=tail["history_page"]["before"],
+                history_id=tail["history_page"]["history_id"],
+                stream="events",
+            )
+            assert [row["content"] for row in older["events"]] == ["page-0", "page-1"]
+            newer = await service.chat_history_page(
+                alpha_info.creature_id,
+                limit=2,
+                after=older["history_page"]["after"],
+                history_id=older["history_page"]["history_id"],
+                stream="events",
+            )
+            assert newer["events"] == tail["events"]
+            detail = await service.chat_history_detail(
+                alpha_info.creature_id,
+                stream="events",
+                ref=tail["history_page"]["after"],
+                history_id=tail["history_page"]["history_id"],
+            )
+            assert detail["record"] == tail["events"][-1]
+            with pytest.raises(ValueError):
+                await service.chat_history_page(
+                    alpha_info.creature_id, before="malformed"
+                )
 
             b_cfg = load_agent_config(cfg_bravo)
             bravo_info = await service.add_creature(b_cfg, on_node="w2", start=True)

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -37,6 +37,11 @@ from kohakuterrarium.session.errors import (
     NotAttachedError,
 )
 from kohakuterrarium.session.session import Session
+from kohakuterrarium.session.history_records import (
+    history_detail,
+    history_page,
+)
+
 from kohakuterrarium.session.history import (
     collect_branch_metadata,
     collect_user_groups,
@@ -423,6 +428,131 @@ class TestSessionIntegration:
         assert store.load_triggers("nobody") == []
         assert await agent.remove_trigger(hb_id) is True
         assert [t["trigger_id"] for t in store.load_triggers("scribe")] == [t2_id]
+
+        # ── History paging + detail over the shared session pager ─────
+        # The runtime writes raw physical event + channel records; the
+        # shared ``session.history_records`` pager returns bounded,
+        # cursor-driven pages over those exact records (the same backend
+        # the live/saved HTTP routes expose).
+        sid = session_path.stem
+        page = history_page(store, "scribe", session_id=sid, stream="events", limit=5)
+        page_hp = page["history_page"]
+        assert page_hp["version"] == 1
+        assert page_hp["stream"] == "events"
+        assert page_hp["history_id"] and len(page_hp["history_id"]) == 16
+        assert page["messages"] == []
+        assert page["events"]
+        page_keys = [e["_history_key"] for e in page["events"]]
+        assert all(k.startswith("events:") for k in page_keys)
+
+        # ``before`` walks older; ``after`` walks newer — the two pages
+        # stitch into one contiguous span without holes or duplicates.
+        older_page = history_page(
+            store,
+            "scribe",
+            session_id=sid,
+            stream="events",
+            limit=5,
+            before=page_hp["before"],
+            history_id=page_hp["history_id"],
+        )
+        assert older_page["history_page"]["history_id"] == page_hp["history_id"]
+        older_keys = [e["_history_key"] for e in older_page["events"]]
+        assert older_keys and older_keys != page_keys
+        assert set(older_keys).isdisjoint(set(page_keys))
+        back_page = history_page(
+            store,
+            "scribe",
+            session_id=sid,
+            stream="events",
+            limit=5,
+            after=older_page["history_page"]["after"],
+            history_id=older_page["history_page"]["history_id"],
+        )
+        assert [e["_history_key"] for e in back_page["events"]] == page_keys
+
+        # A stale history identity signals a reset, never a wrong payload.
+        stale_page = history_page(
+            store,
+            "scribe",
+            session_id=sid,
+            stream="events",
+            limit=5,
+            before=page_hp["before"],
+            history_id="0000000000000000",
+        )
+        assert stale_page["history_page"]["reset_required"] is True
+        assert stale_page["events"] == []
+
+        # Channel records page the ``channel`` stream with their own
+        # physical identity (no invented event id) and stable cursors.
+        chan = history_page(
+            store, "ch:broadcast", session_id=sid, stream="channel", limit=1
+        )
+        chan_hp = chan["history_page"]
+        assert chan_hp["stream"] == "channel"
+        assert chan_hp["has_older"] is True
+        assert len(chan["messages"]) == 1
+        chan_older = history_page(
+            store,
+            "ch:broadcast",
+            session_id=sid,
+            stream="channel",
+            limit=1,
+            before=chan_hp["before"],
+            history_id=chan_hp["history_id"],
+        )
+        assert len(chan_older["messages"]) == 1
+        assert chan_older["messages"] != chan["messages"]
+
+        # Detail resolves the full raw record behind an opaque ref cursor,
+        # returning the identical ``_history_key`` for both streams.
+        detail = history_detail(
+            store,
+            "scribe",
+            session_id=sid,
+            stream="events",
+            ref=page_hp["after"],
+            history_id=page_hp["history_id"],
+        )
+        assert detail["record"]["_history_key"] == page_keys[-1]
+        assert detail["history_page"]["version"] == 1
+        assert detail["history_page"]["stream"] == "events"
+        assert detail["history_page"]["history_id"] == page_hp["history_id"]
+        chan_detail = history_detail(
+            store,
+            "ch:broadcast",
+            session_id=sid,
+            stream="channel",
+            ref=chan_hp["after"],
+            history_id=chan_hp["history_id"],
+        )
+        assert (
+            chan_detail["record"]["_history_key"]
+            == chan["messages"][-1]["_history_key"]
+        )
+
+        # A store that never streamed physical events keeps its history
+        # ONLY in the conversation snapshot; the default ``events`` page
+        # falls back to the ``snapshot`` stream rather than returning an
+        # empty window or fabricating event ids for legacy sessions.
+        snap_dir = tmp_path / "snapper"
+        snap_dir.mkdir()
+        snap_path = snap_dir / "snapper.kohakutr.v2"
+        snap_store = _new_store(snap_path, config_path=config_path, agents=["snapper"])
+        snap_store.save_conversation(
+            "snapper",
+            [
+                {"role": "user", "content": "snapshot question"},
+                {"role": "assistant", "content": "snapshot answer"},
+            ],
+        )
+        snap_page = history_page(
+            snap_store, "snapper", session_id=snap_path.stem, stream="events"
+        )
+        assert snap_page["history_page"]["stream"] == "snapshot"
+        assert snap_page["messages"] and not snap_page["events"]
+        snap_store.close()
         store.close()
 
         # ---- version probe + session-type detection on the closed file ----
@@ -1253,6 +1383,25 @@ class TestSessionIntegration:
             ],
         )
         snap_v1.flush()
+        # This snapshot-only store has NO physical event records, so the
+        # shared history pager's initial ``events`` request falls back to
+        # the ``snapshot`` stream (contract: ``paged=true`` default events
+        # falls back to snapshot when there are no physical events and no
+        # cursor/history_id). The snapshot page carries the conversation as
+        # ``messages`` with physical ``_history_key`` identity, never as
+        # synthetic ``events``.
+        fallback = history_page(
+            snap_v1,
+            "legacy",
+            session_id="snaponly",
+            stream="events",
+            limit=10,
+            envelope={"target": "legacy", "session_name": "snaponly"},
+        )
+        assert fallback["history_page"]["stream"] == "snapshot"
+        assert fallback["events"] == []
+        assert len(fallback["messages"]) >= 2
+        assert all("_history_key" in m for m in fallback["messages"])
         snap_v1.close()
 
         snap_migrated_path = ensure_latest_version(snap_v1_path)

--- a/tests/unit/api/test_creature_chat_route.py
+++ b/tests/unit/api/test_creature_chat_route.py
@@ -5,7 +5,8 @@ from fastapi.testclient import TestClient
 
 from kohakuterrarium.api.deps import get_service
 from kohakuterrarium.api.routes.sessions_v2 import creatures_chat as chat_mod
-from kohakuterrarium.terrarium.service import CreatureInfo
+from kohakuterrarium.terrarium.engine import Terrarium
+from kohakuterrarium.terrarium.service import CreatureInfo, LocalTerrariumService
 
 
 def _info(cid="cid", name="alice"):
@@ -117,6 +118,26 @@ def _client(service):
     app.dependency_overrides[get_service] = lambda: service
     app.include_router(chat_mod.router, prefix="/sessions")
     return TestClient(app)
+
+
+class TestPagedChannelValidation:
+    def test_invalid_limit_returns_client_error(self):
+        client = _client(LocalTerrariumService(Terrarium()))
+        response = client.get(
+            "/sessions/g/creatures/ch:general/history",
+            params={"paged": "true", "limit": 0},
+        )
+        assert response.status_code == 400
+        assert "limit" in response.json()["detail"]
+
+    def test_numeric_incremental_cursor_is_rejected(self):
+        client = _client(LocalTerrariumService(Terrarium()))
+        response = client.get(
+            "/sessions/g/creatures/ch:general/history",
+            params={"paged": "true", "since_event_id": 0},
+        )
+        assert response.status_code == 400
+        assert "since_event_id" in response.json()["detail"]
 
 
 # ── chat ───────────────────────────────────────────────────────

--- a/tests/unit/api/test_persistence_fork_history_routes.py
+++ b/tests/unit/api/test_persistence_fork_history_routes.py
@@ -127,6 +127,20 @@ class TestForkRoute:
 
 
 class TestHistoryRoutes:
+    def test_saved_paging_invalid_limit_returns_400(self, monkeypatch, tmp_path):
+        path = tmp_path / "paged-validation.kohakutr"
+        store = SessionStore(path)
+        store.append_event("alice", "user_input", {"content": "hello"})
+        store.close(update_status=False)
+        monkeypatch.setattr(history_mod, "resolve_session_path_default", lambda _: path)
+        client = TestClient(_app(history_mod.router))
+        response = client.get(
+            "/api/paged-validation/history/alice",
+            params={"paged": "true", "limit": 0},
+        )
+        assert response.status_code == 400
+        assert "limit" in response.json()["detail"]
+
     def test_index_missing(self, monkeypatch):
         monkeypatch.setattr(history_mod, "resolve_session_path_default", lambda n: None)
         client = TestClient(_app(history_mod.router))

--- a/tests/unit/session/test_history_page_records.py
+++ b/tests/unit/session/test_history_page_records.py
@@ -1,0 +1,194 @@
+"""Physical history reads and detail validation."""
+
+import json
+
+import pytest
+
+from dataclasses import replace
+
+from kohakuterrarium.errors import ConflictError, NotFoundError
+from kohakuterrarium.session.history_records import history_detail
+from kohakuterrarium.session import history_paging as hp
+from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.studio.persistence.history import history_page_from_store
+
+
+@pytest.fixture()
+def store(tmp_path):
+    store = SessionStore(tmp_path / "detail.kohakutr")
+    yield store
+    store.close()
+
+
+def test_channel_values_are_read_only_for_page(store, monkeypatch):
+    for index in range(10):
+        store.save_channel_message("room", {"content": str(index), "message_id": "dup"})
+    monkeypatch.setattr(
+        store, "get_channel_messages", lambda *_: pytest.fail("full read")
+    )
+    page = history_page_from_store(store, "s", "s", "ch:room", limit=2)
+    assert [item["content"] for item in page["messages"]] == ["8", "9"]
+    assert len({item["_history_key"] for item in page["messages"]}) == 2
+    assert hp.decode_cursor(page["history_page"]["before"]).ref == "room:m000008"
+
+
+def test_snapshot_fallback_only_for_initial_request(store):
+    store.save_conversation("ag", [{"role": "user", "content": "snapshot"}])
+    page = history_page_from_store(store, "s", "s", "ag", limit=1)
+    assert page["history_page"]["stream"] == "snapshot"
+    assert page["messages"][0]["content"] == "snapshot"
+    continuation = history_page_from_store(
+        store,
+        "s",
+        "s",
+        "ag",
+        stream="snapshot",
+        limit=1,
+        before=page["history_page"]["before"],
+        history_id=page["history_page"]["history_id"],
+    )
+    assert continuation["messages"] == []
+    stale = history_page_from_store(store, "s", "s", "ag", history_id="stale")
+    assert stale["history_page"]["stream"] == "events"
+    assert stale["history_page"]["reset_required"]
+    assert stale["messages"] == []
+
+
+def test_complete_envelope_byte_bound_and_huge_routing_field(store, monkeypatch):
+    monkeypatch.setattr(hp, "MAX_PAGE_BYTES", 2400)
+    store.append_event("ag", "tool_result", {"output": "x" * 5000, "name": "n" * 5000})
+    page = history_page_from_store(store, "s", "s" * 100, "ag", limit=2)
+    assert page["events"], "oversized routing data must not silently drop the record"
+    assert page["events"][0]["_history_truncated"]
+    assert len(json.dumps(page, separators=(",", ":")).encode()) <= 2400
+
+
+def test_event_prefix_does_not_include_another_agent(store):
+    store.append_event("ag", "text", {"content": "mine"})
+    store.append_event("ag:evil", "text", {"content": "secret"})
+    page = hp.page_events(store, "ag", session_id="s")
+    assert [item["content"] for item in page["items"]] == ["mine"]
+
+
+@pytest.mark.parametrize(
+    "stream,target", [("events", "ag"), ("snapshot", "ag"), ("channel", "ch:room")]
+)
+def test_full_detail_roundtrip_and_stale_record(store, monkeypatch, stream, target):
+    monkeypatch.setattr(hp, "MAX_PAGE_BYTES", 2400)
+    content = "漢字" * 10000
+    if stream == "events":
+        store.append_event(target, "text", {"content": content})
+    elif stream == "channel":
+        store.save_channel_message("room", {"content": content})
+    else:
+        store.save_conversation(target, [{"role": "user", "content": content}])
+    page = history_page_from_store(store, "s", "s", target, stream=stream)
+    item = (page["events"] or page["messages"])[0]
+    kwargs = dict(
+        session_id="s",
+        stream=stream,
+        ref=item["_history_detail"],
+        history_id=page["history_page"]["history_id"],
+    )
+    assert history_detail(store, target, **kwargs)["record"]["content"] == content
+    assert (
+        history_detail(store, target, **kwargs)["record"]["_history_key"]
+        == item["_history_key"]
+    )
+    with pytest.raises(ConflictError):
+        history_detail(store, target, **{**kwargs, "history_id": "foreign"})
+    with pytest.raises(hp.HistoryPagingError):
+        history_detail(store, "ch:other" if stream == "channel" else "other", **kwargs)
+    cursor = hp.decode_cursor(kwargs["ref"])
+    for bad_ref in ("../secret", "other:e000000", "-1"):
+        with pytest.raises(hp.HistoryPagingError):
+            history_detail(
+                store,
+                target,
+                **{**kwargs, "ref": hp.encode_cursor(replace(cursor, ref=bad_ref))},
+            )
+    if stream == "snapshot":
+        store.save_conversation(target, [{"role": "user", "content": "changed"}])
+    else:
+        vault = store.events if stream == "events" else store.channels
+        vault[cursor.ref] = {"content": "changed"}
+    with pytest.raises(ConflictError):
+        history_detail(store, target, **kwargs)
+    if stream == "snapshot":
+        store.save_conversation(target, [])
+    else:
+        del vault[cursor.ref]
+    with pytest.raises(ConflictError if stream == "snapshot" else NotFoundError):
+        history_detail(store, target, **kwargs)
+
+
+def test_channel_append_and_deleted_cursor_are_stable(store):
+    for i in range(4):
+        store.save_channel_message("room", {"content": str(i), "message_id": "dup"})
+    page = history_page_from_store(store, "s", "s", "ch:room", limit=2)
+    hp_meta = page["history_page"]
+    store.save_channel_message("room", {"content": "4"})
+    newer = history_page_from_store(
+        store,
+        "s",
+        "s",
+        "ch:room",
+        after=hp_meta["after"],
+        history_id=hp_meta["history_id"],
+    )
+    assert [item["content"] for item in newer["messages"]] == ["4"]
+    del store.channels[hp.decode_cursor(hp_meta["after"]).ref]
+    stale = history_page_from_store(store, "s", "s", "ch:room", after=hp_meta["after"])
+    assert stale["history_page"]["reset_required"]
+    assert stale["messages"] == []
+
+
+def test_snapshot_middle_replacement_resets_with_unchanged_anchor(store):
+    store.save_conversation("ag", [{"content": text} for text in "ABCD"])
+    page = history_page_from_store(store, "s", "s", "ag", limit=1)
+    store.save_conversation("ag", [{"content": text} for text in "AXYD"])
+    older = history_page_from_store(
+        store,
+        "s",
+        "s",
+        "ag",
+        stream="snapshot",
+        limit=2,
+        before=page["history_page"]["before"],
+        history_id=page["history_page"]["history_id"],
+    )
+    assert older["history_page"]["reset_required"]
+    assert older["messages"] == []
+    with pytest.raises(ConflictError):
+        history_detail(
+            store,
+            "ag",
+            session_id="s",
+            stream="snapshot",
+            ref=page["history_page"]["after"],
+            history_id=page["history_page"]["history_id"],
+        )
+
+
+def test_forged_unavailable_fingerprint_does_not_bypass_replacement(store):
+    store.append_event("ag", "text", {"content": "old"})
+    page = hp.page_events(store, "ag", session_id="s")
+    cursor = hp.decode_cursor(page["history_page"]["after"])
+    store.events[cursor.ref] = {"content": "replacement"}
+    with pytest.raises(ConflictError):
+        history_detail(
+            store,
+            "ag",
+            session_id="s",
+            stream="events",
+            ref=hp.encode_cursor(replace(cursor, fingerprint="u:fake")),
+            history_id=page["history_page"]["history_id"],
+        )
+
+
+def test_malformed_and_wrong_target_cursor_are_bad_requests(store):
+    with pytest.raises(hp.HistoryPagingError):
+        hp.page_events(store, "ag", session_id="s", before="bad")
+    cursor = hp.encode_cursor(hp.PageCursor("events", "other", "other:e000000", "f"))
+    with pytest.raises(hp.HistoryPagingError):
+        hp.page_events(store, "ag", session_id="s", before=cursor)

--- a/tests/unit/session/test_history_paging.py
+++ b/tests/unit/session/test_history_paging.py
@@ -1,0 +1,470 @@
+"""Unit tests for :mod:`kohakuterrarium.session.history_paging`."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kohakuterrarium.session import history_paging as hp
+from kohakuterrarium.session.history_paging import (
+    HistoryPagingError,
+    decode_cursor,
+    encode_cursor,
+    page_channels,
+    page_events,
+    page_snapshot,
+)
+from kohakuterrarium.session.store import SessionStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = SessionStore(str(tmp_path / "s.kohakutr"))
+    yield s
+    s.close()
+
+
+def _events(store, content):
+    for text in content:
+        store.append_event("ag", "text", {"content": text})
+
+
+def _cursor(history_page, which):
+    value = history_page[which]
+    assert value is not None
+    return value
+
+
+def _walk_oldest(store, limit=2):
+    """Walk back to the oldest page; returns (ordered keys, oldest page)."""
+    page = page_events(store, "ag", session_id="g", limit=limit)
+    ordered = [item["_history_key"] for item in page["items"]]
+    before = _cursor(page["history_page"], "before")
+    last = page
+    while True:
+        page = page_events(store, "ag", session_id="g", limit=limit, before=before)
+        if not page["items"]:
+            break
+        ordered = [item["_history_key"] for item in page["items"]] + ordered
+        before = _cursor(page["history_page"], "before")
+        last = page
+    return ordered, last
+
+
+def test_tail_page_returns_newest_bounded_slice(store):
+    _events(store, ["c0", "c1", "c2", "c3", "c4"])
+    page = page_events(store, "ag", session_id="g", limit=2)
+    assert [item["content"] for item in page["items"]] == ["c3", "c4"]
+    hp_meta = page["history_page"]
+    assert hp_meta["version"] == 1
+    assert hp_meta["stream"] == "events"
+    assert hp_meta["has_older"] is True
+    assert hp_meta["has_newer"] is False
+    assert hp_meta["reset_required"] is False
+    # Cursors are exclusive and point at the oldest/newest raw items.
+    assert decode_cursor(hp_meta["before"]).ref == "ag:e000003"
+    assert decode_cursor(hp_meta["after"]).ref == "ag:e000004"
+
+
+def test_event_page_never_includes_conversation_snapshot(store):
+    store.save_conversation("ag", [{"role": "user", "content": "snap"}])
+    _events(store, ["c0"])
+    page = page_events(store, "ag", session_id="g", limit=5)
+    # Paged events are physical records, not the snapshot messages.
+    assert [item["content"] for item in page["items"]] == ["c0"]
+    assert "role" not in page["items"][0]
+
+
+def test_complete_before_traversal_has_no_holes_or_repeats(store):
+    _events(store, ["c0", "c1", "c2", "c3", "c4"])
+    page = page_events(store, "ag", session_id="g", limit=2)
+    seen = [item["_history_key"] for item in page["items"]]
+    before = _cursor(page["history_page"], "before")
+    while True:
+        page = page_events(store, "ag", session_id="g", limit=2, before=before)
+        if not page["items"]:
+            break
+        seen = [item["_history_key"] for item in page["items"]] + seen
+        before = _cursor(page["history_page"], "before")
+    assert seen == [f"events:ag:ag:e00000{i}" for i in range(5)]
+    assert len(set(seen)) == len(seen)
+
+
+def test_complete_after_traversal_from_head(store):
+    _events(store, ["c0", "c1", "c2", "c3", "c4"])
+    _ordered, oldest = _walk_oldest(store, limit=2)
+    after = _cursor(oldest["history_page"], "after")
+    seen = [item["_history_key"] for item in oldest["items"]]
+    while True:
+        page = page_events(store, "ag", session_id="g", limit=2, after=after)
+        if not page["items"]:
+            break
+        seen += [item["_history_key"] for item in page["items"]]
+        after = _cursor(page["history_page"], "after")
+    assert seen == [f"events:ag:ag:e00000{i}" for i in range(5)]
+    assert len(set(seen)) == len(seen)
+
+
+def test_physical_key_order_not_event_id_order(store):
+    # Mirrored/imported ids are not monotonic with the physical key order.
+    store.append_event("ag", "text", {"content": "first", "event_id": 100})
+    store.append_event("ag", "text", {"content": "second", "event_id": 1})
+    store.append_event("ag", "text", {"content": "third", "event_id": 50})
+    page = page_events(store, "ag", session_id="g", limit=3)
+    # Ordered by the physical numeric suffix, not by event_id.
+    assert [item["content"] for item in page["items"]] == [
+        "first",
+        "second",
+        "third",
+    ]
+    assert [item["event_id"] for item in page["items"]] == [100, 1, 50]
+
+
+def test_events_carry_stable_history_key(store):
+    _events(store, ["c0"])
+    page = page_events(store, "ag", session_id="g", limit=5)
+    assert page["items"][0]["_history_key"] == "events:ag:ag:e000000"
+
+
+def test_history_id_survives_append(store):
+    page1 = page_events(store, "ag", session_id="g", limit=5)
+    hid = page1["history_page"]["history_id"]
+    _events(store, ["new"])
+    page2 = page_events(store, "ag", session_id="g", limit=5, history_id=hid)
+    assert page2["history_page"]["reset_required"] is False
+    assert page2["history_page"]["history_id"] == hid
+
+
+def test_wrong_history_id_triggers_reset(store):
+    _events(store, ["c0"])
+    page = page_events(store, "ag", session_id="g", limit=5, history_id="stale")
+    assert page["history_page"]["reset_required"] is True
+    assert page["items"] == []
+
+
+def test_malformed_cursor_triggers_reset(store):
+    _events(store, ["c0", "c1"])
+    with pytest.raises(HistoryPagingError):
+        page_events(store, "ag", session_id="g", limit=5, before="not-a-valid-cursor!!")
+
+
+def test_wrong_target_cursor_triggers_reset(store):
+    _events(store, ["c0", "c1"])
+    bad = encode_cursor(
+        hp.PageCursor("events", "other-agent", "ag:e000001", "deadbeef")
+    )
+    with pytest.raises(HistoryPagingError):
+        page_events(store, "ag", session_id="g", limit=5, before=bad)
+
+
+def test_changed_head_cursor_triggers_reset(store):
+    # A fingerprint mismatch (row content changed) forces reset_required.
+    _events(store, ["c0", "c1", "c2"])
+    page = page_events(store, "ag", session_id="g", limit=2)
+    original_cursor = page["history_page"]["before"]
+    ref = decode_cursor(original_cursor).ref
+    store.events[ref] = {"content": "mutated", "type": "text"}
+    store.events.flush_cache()
+    reset = page_events(store, "ag", session_id="g", limit=2, before=original_cursor)
+    assert reset["history_page"]["reset_required"] is True
+    assert reset["items"] == []
+
+
+def test_missing_cursor_key_triggers_reset(store):
+    _events(store, ["c0", "c1", "c2"])
+    page = page_events(store, "ag", session_id="g", limit=2)
+    cursor = page["history_page"]["before"]
+    ref = decode_cursor(cursor).ref
+    del store.events[ref]
+    store.events.flush_cache()
+    reset = page_events(store, "ag", session_id="g", limit=2, before=cursor)
+    assert reset["history_page"]["reset_required"] is True
+
+
+def test_before_and_after_mutually_exclusive(store):
+    _events(store, ["c0", "c1"])
+    page = page_events(store, "ag", session_id="g", limit=2)
+    with pytest.raises(HistoryPagingError):
+        page_events(
+            store,
+            "ag",
+            session_id="g",
+            limit=2,
+            before=page["history_page"]["before"],
+            after=page["history_page"]["after"],
+        )
+
+
+def test_limit_clamped_to_max(store):
+    _events(store, ["c0", "c1"])
+    page = page_events(store, "ag", session_id="g", limit=10_000)
+    # Clamped to MAX_LIMIT; still returns everything available.
+    assert len(page["items"]) == 2
+    assert page["history_page"]["after"] is not None
+
+
+def test_nonpositive_limit_rejected(store):
+    _events(store, ["c0"])
+    with pytest.raises(HistoryPagingError):
+        page_events(store, "ag", session_id="g", limit=0)
+    with pytest.raises(HistoryPagingError):
+        page_events(store, "ag", session_id="g", limit=-1)
+
+
+def test_oversize_records_are_truncated_previews(store):
+    huge = "x" * 3000
+    for _ in range(3):
+        store.append_event("ag", "tool_result", {"output": huge, "name": "tool_a"})
+    old = hp.MAX_PAGE_BYTES
+    hp.MAX_PAGE_BYTES = 3100
+    try:
+        page = page_events(store, "ag", session_id="g", limit=3)
+    finally:
+        hp.MAX_PAGE_BYTES = old
+    assert page["items"]
+    for item in page["items"]:
+        assert item["_history_truncated"] is True
+        # Routing metadata preserved; content is a bounded preview.
+        assert item["name"] == "tool_a"
+        assert item["type"] == "tool_result"
+        assert item["_history_key"] != ""
+        assert len(item["output"]) <= 2001
+        assert "output_preview" in item
+    assert _page_bytes(page) <= hp.MAX_PAGE_BYTES
+
+
+def test_oversize_page_never_exceeds_hard_byte_bound(store):
+    huge = "y" * 200_000
+    for _ in range(50):
+        store.append_event("ag", "text", {"content": huge})
+    old = hp.MAX_PAGE_BYTES
+    hp.MAX_PAGE_BYTES = 2048
+    try:
+        page = page_events(store, "ag", session_id="g", limit=400)
+        budget = hp.MAX_PAGE_BYTES
+    finally:
+        hp.MAX_PAGE_BYTES = old
+    assert len(page["items"]) > 0
+    assert all("_history_truncated" in item for item in page["items"])
+    assert _page_bytes(page) <= budget
+
+
+def test_channel_page_preserves_message_id_and_never_fabricates_event_id():
+    messages = [
+        {"message_id": "m-1", "sender": "a", "content": "one", "timestamp": "10:00"},
+        {"message_id": "m-2", "sender": "b", "content": "two", "timestamp": "10:01"},
+        {"message_id": "m-3", "sender": "c", "content": "three", "timestamp": "10:02"},
+    ]
+    page = page_channels(messages, session_id="g", channel="room", limit=2)
+    assert [item["message_id"] for item in page["items"]] == ["m-2", "m-3"]
+    for item in page["items"]:
+        assert "event_id" not in item
+        assert "timestamp" in item
+        assert item["_history_key"].startswith("channel:room:")
+
+
+def test_channel_page_stable_key_and_no_repeat_across_pages():
+    messages = [
+        {
+            "message_id": f"m-{i}",
+            "sender": "a",
+            "content": f"c{i}",
+            "timestamp": "10:00",
+        }
+        for i in range(5)
+    ]
+    page = page_channels(messages, session_id="g", channel="room", limit=2)
+    seen = [item["_history_key"] for item in page["items"]]
+    before = _cursor(page["history_page"], "before")
+    while True:
+        page = page_channels(
+            messages, session_id="g", channel="room", limit=2, before=before
+        )
+        if not page["items"]:
+            break
+        seen = [item["_history_key"] for item in page["items"]] + seen
+        before = _cursor(page["history_page"], "before")
+    assert len(set(seen)) == len(seen)
+    assert page["history_page"]["stream"] == "channel"
+
+
+def test_snapshot_page_bounded_items_with_absolute_index_identity():
+    messages = [{"role": "user", "content": f"u{i}"} for i in range(5)]
+    page = page_snapshot(messages, session_id="g", target="ag", limit=2)
+    assert [item["content"] for item in page["items"]] == ["u3", "u4"]
+    before = _cursor(page["history_page"], "before")
+    page2 = page_snapshot(messages, session_id="g", target="ag", limit=2, before=before)
+    assert [item["content"] for item in page2["items"]] == ["u1", "u2"]
+    assert page["history_page"]["stream"] == "snapshot"
+
+
+def test_live_metadata_passed_through(store):
+    _events(store, ["c0"])
+    page = page_events(
+        store,
+        "ag",
+        session_id="g",
+        limit=5,
+        is_processing=True,
+        live_job_ids=("job-1",),
+    )
+    assert page["is_processing"] is True
+    assert page["live_job_ids"] == ["job-1"]
+
+
+def test_cursor_round_trip():
+    cursor = hp.PageCursor("events", "ag", "ag:e000042", "deadbeef1234")
+    decoded = decode_cursor(encode_cursor(cursor))
+    assert decoded == cursor
+
+
+def test_decode_malformed_cursor_raises():
+    with pytest.raises(HistoryPagingError):
+        decode_cursor("!!not-base64!!")
+    with pytest.raises(HistoryPagingError):
+        decode_cursor("")
+
+
+# ---------------------------------------------------------------------------
+# Red tests for the previously-uncaught correctness bugs.
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvents:
+    """KVault-shaped stub that can mark individual refs as unreadable."""
+
+    def __init__(self, records):
+        self._records = records
+
+    def flush_cache(self):
+        pass
+
+    def keys(self, prefix=None, limit=None):
+        prefix = prefix or ""
+        return [
+            k.encode("utf-8") for k in sorted(self._records) if k.startswith(prefix)
+        ]
+
+    def __getitem__(self, ref):
+        value = self._records[ref]
+        if value is _UNREADABLE:
+            raise KeyError(ref)
+        return value
+
+
+class _FakeStore:
+    def __init__(self, records):
+        self.events = _FakeEvents(records)
+
+
+class _Unreadable:
+    def __repr__(self):
+        return "<unreadable>"
+
+
+_UNREADABLE = _Unreadable()
+
+
+def _page_bytes(page):
+    return len(json.dumps(page, separators=(",", ":"), default=str).encode("utf-8"))
+
+
+def test_byte_bound_page_payload_with_many_records(store):
+    # Many records whose cumulative body would blow past the budget must be
+    # terminated by actual bytes, not record count.
+    for i in range(40):
+        store.append_event("ag", "text", {"content": "z" * 4000})
+    old = hp.MAX_PAGE_BYTES
+    hp.MAX_PAGE_BYTES = 20_000
+    try:
+        page = page_events(store, "ag", session_id="g", limit=400)
+    finally:
+        hp.MAX_PAGE_BYTES = old
+    assert page["items"]
+    assert _page_bytes(page) <= hp.MAX_PAGE_BYTES
+
+
+def test_byte_bound_nested_args_and_multimodal_content(store):
+    # A single record with deeply nested dict args / multimodal (list-of-dict)
+    # content must be un-bounded and the whole page stay under budget.
+    huge_payload = {
+        "type": "tool",
+        "name": "search",
+        "args": {
+            "filters": [{"k": "v" * 60_000}],
+            "nested": {"deep": {"deeper": ["x" * 60_000, {"y": "z" * 60_000}]}},
+        },
+        "content": [
+            {"type": "image", "data": "b64" * 20_000},
+            {"type": "text", "text": "w" * 40_000},
+        ],
+    }
+    store.append_event("ag", "tool_result", huge_payload)
+    old = hp.MAX_PAGE_BYTES
+    hp.MAX_PAGE_BYTES = 30_000
+    try:
+        page = page_events(store, "ag", session_id="g", limit=100)
+    finally:
+        hp.MAX_PAGE_BYTES = old
+    assert page["items"]
+    item = page["items"][0]
+    assert item["_history_truncated"] is True
+    assert item["_history_detail"] != ""
+    # Routing identity retains the tool name/type.
+    assert item["name"] == "search"
+    assert item["type"] == "tool_result"
+    assert _page_bytes(page) <= hp.MAX_PAGE_BYTES
+
+
+def test_unreadable_boundary_cursor_is_consumed_and_traversable():
+    # The unreadable record is represented explicitly (not silently skipped),
+    # the before cursor references a consumed record, and paging back does not
+    # reset because of a ref/fingerprint mismatch.
+    records = {
+        "ag:e000000": {"content": "c0", "type": "text"},
+        "ag:e000001": _UNREADABLE,
+        "ag:e000002": {"content": "c2", "type": "text"},
+    }
+    store = _FakeStore(records)
+    page = page_events(store, "ag", session_id="g", limit=2)
+    assert len(page["items"]) == 2
+    # The unreadable record is surfaced as an explicit unavailable item.
+    keys = [item["_history_key"] for item in page["items"]]
+    assert "events:ag:ag:e000001" in keys
+    unavail = [i for i in page["items"] if i.get("_history_unavailable")]
+    assert len(unavail) == 1
+    assert decode_cursor(unavail[0]["_history_detail"]).ref == "ag:e000001"
+
+    before = page["history_page"]["before"]
+    cursor = decode_cursor(before)
+    # Cursor references an actual consumed (physically present) record.
+    assert cursor.ref in records
+    # Re-requesting the previous page resolves cleanly, not as a reset.
+    older = page_events(store, "ag", session_id="g", limit=2, before=before)
+    assert older["history_page"]["reset_required"] is False
+
+
+def test_channel_duplicate_and_missing_message_ids_are_distinct():
+    messages = [
+        {"message_id": "dup", "sender": "a", "content": "c0"},
+        {"message_id": "dup", "sender": "b", "content": "c1"},
+        {"sender": "c", "content": "c2"},
+    ]
+    page = page_channels(messages, session_id="g", channel="room", limit=3)
+    keys = [item["_history_key"] for item in page["items"]]
+    assert len(set(keys)) == 3
+    assert len(page["items"]) == 3
+    # message_id is preserved where present and never fabricated otherwise.
+    got_ids = [item.get("message_id") for item in page["items"]]
+    assert "dup" in got_ids and got_ids.count("dup") == 2
+    assert got_ids.count(None) == 1
+    for item in page["items"]:
+        assert "event_id" not in item
+
+
+def test_encode_cursor_docstring_does_not_claim_tamper_evidence():
+    # base64 is not tamper-evident; the doc must not claim it is.
+    doc = hp.encode_cursor.__doc__ or ""
+    assert "tamper" not in doc.lower()
+    assert "opaque" in doc.lower() or "exclusive" in doc.lower()

--- a/tests/unit/studio/persistence/test_saved_history_paging.py
+++ b/tests/unit/studio/persistence/test_saved_history_paging.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 
+from kohakuterrarium.errors import NotFoundError
 from kohakuterrarium.session.history_paging import HistoryPagingError
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.studio.persistence.history import history_page_from_store
@@ -94,6 +95,7 @@ def test_saved_channel_target_uses_channel_stream(store):
 
 
 def test_saved_channel_stream_without_ch_target_rejected(store):
+    _events(store, ["c0"])
     with pytest.raises(HistoryPagingError):
         history_page_from_store(
             store,
@@ -106,6 +108,7 @@ def test_saved_channel_stream_without_ch_target_rejected(store):
 
 
 def test_saved_unsupported_stream_is_explicit(store):
+    _events(store, ["c0"])
     with pytest.raises(HistoryPagingError):
         history_page_from_store(
             store,
@@ -118,6 +121,7 @@ def test_saved_unsupported_stream_is_explicit(store):
 
 
 def test_saved_nonpositive_limit_rejected(store):
+    _events(store, ["c0"])
     with pytest.raises(HistoryPagingError):
         history_page_from_store(
             store,
@@ -126,4 +130,16 @@ def test_saved_nonpositive_limit_rejected(store):
             target="ag",
             stream="events",
             limit=0,
+        )
+
+
+def test_saved_unknown_target_is_not_an_empty_page(store):
+    _events(store, ["c0"])
+    with pytest.raises(NotFoundError):
+        history_page_from_store(
+            store, session_id="s", session_name="s", target="missing", limit=5
+        )
+    with pytest.raises(NotFoundError):
+        history_page_from_store(
+            store, session_id="s", session_name="s", target="ch:missing", limit=5
         )

--- a/tests/unit/studio/persistence/test_saved_history_paging.py
+++ b/tests/unit/studio/persistence/test_saved_history_paging.py
@@ -1,0 +1,129 @@
+"""Saved-session paged history helper tests.
+
+``history_page_from_store`` is the read path shared by the saved-history HTTP
+route and the engine-owned live-store path: given an open ``SessionStore`` and a
+target it returns a bounded, cursor-driven page reusing the session pager. This
+is the piece that was NOT wired before: the saved ``/history/{target}`` route
+only ever returned the full snapshot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kohakuterrarium.session.history_paging import HistoryPagingError
+from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.studio.persistence.history import history_page_from_store
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = SessionStore(str(tmp_path / "s.kohakutr"))
+    yield s
+    s.close()
+
+
+def _events(store, content, agent="ag"):
+    for text in content:
+        store.append_event(agent, "text", {"content": text})
+
+
+def _cursor(history_page, which):
+    value = history_page[which]
+    assert value is not None
+    return value
+
+
+def test_saved_event_page_envelope(store):
+    _events(store, ["c0", "c1", "c2", "c3"])
+    page = history_page_from_store(
+        store, session_id="s", session_name="s", target="ag", limit=2
+    )
+    assert [item["content"] for item in page["events"]] == ["c2", "c3"]
+    assert page["messages"] == []
+    hp = page["history_page"]
+    assert hp["version"] == 1
+    assert hp["stream"] == "events"
+    assert hp["has_older"] is True
+    assert hp["has_newer"] is False
+    assert hp["reset_required"] is False
+    assert hp["history_id"]
+    assert page["is_processing"] is False
+    assert page["live_job_ids"] == []
+
+
+def test_saved_event_traversal_no_holes_or_repeats(store):
+    _events(store, ["c0", "c1", "c2", "c3", "c4"])
+    seen: list[str] = []
+    before = None
+    while True:
+        page = history_page_from_store(
+            store,
+            session_id="s",
+            session_name="s",
+            target="ag",
+            limit=2,
+            before=before,
+        )
+        if not page["events"]:
+            break
+        seen = [item["_history_key"] for item in page["events"]] + seen
+        before = _cursor(page["history_page"], "before")
+    assert len(seen) == 5
+    assert len(set(seen)) == len(seen)
+
+
+def test_saved_snapshot_page(store):
+    store.save_conversation("ag", [{"role": "user", "content": "u0"}])
+    page = history_page_from_store(
+        store, session_id="s", session_name="s", target="ag", stream="snapshot", limit=1
+    )
+    assert [item["content"] for item in page["messages"]] == ["u0"]
+    assert page["events"] == []
+    assert page["history_page"]["stream"] == "snapshot"
+
+
+def test_saved_channel_target_uses_channel_stream(store):
+    store.save_channel_message("room", {"sender": "a", "content": "hello"})
+    page = history_page_from_store(
+        store, session_id="s", session_name="s", target="ch:room", limit=5
+    )
+    assert page["history_page"]["stream"] == "channel"
+    assert [item["content"] for item in page["messages"]] == ["hello"]
+    assert page["events"] == []
+
+
+def test_saved_channel_stream_without_ch_target_rejected(store):
+    with pytest.raises(HistoryPagingError):
+        history_page_from_store(
+            store,
+            session_id="s",
+            session_name="s",
+            target="ag",
+            stream="channel",
+            limit=5,
+        )
+
+
+def test_saved_unsupported_stream_is_explicit(store):
+    with pytest.raises(HistoryPagingError):
+        history_page_from_store(
+            store,
+            session_id="s",
+            session_name="s",
+            target="ag",
+            stream="bogus",
+            limit=5,
+        )
+
+
+def test_saved_nonpositive_limit_rejected(store):
+    with pytest.raises(HistoryPagingError):
+        history_page_from_store(
+            store,
+            session_id="s",
+            session_name="s",
+            target="ag",
+            stream="events",
+            limit=0,
+        )

--- a/tests/unit/terrarium/test_chat_history_page_service.py
+++ b/tests/unit/terrarium/test_chat_history_page_service.py
@@ -30,7 +30,7 @@ def _events(store, content):
         store.append_event("ag", "text", {"content": text})
 
 
-def _fake_engine(store, env=None):
+def _fake_engine(store):
     agent = SimpleNamespace(
         session_store=store,
         conversation_history=[{"role": "user", "content": "snap"}],
@@ -43,7 +43,6 @@ def _fake_engine(store, env=None):
     return SimpleNamespace(
         get_creature=lambda cid: creature,
         _session_stores={"g": store},
-        _environments={"g": env} if env is not None else {},
     )
 
 
@@ -91,9 +90,8 @@ async def test_service_channel_page_reads_stored_records(store):
     assert page["history_page"]["stream"] == "channel"
 
 
-async def test_service_live_empty_channel_pages_without_error(store):
-    env = SimpleNamespace(shared_channels={"room": object()})
-    service = LocalTerrariumService(_fake_engine(store, env=env))
-    page = await service.channel_history_page("g", "room", limit=5)
+async def test_service_unknown_channel_page_is_an_empty_page(store):
+    service = LocalTerrariumService(_fake_engine(store))
+    page = await service.channel_history_page("g", "missing", limit=5)
     assert page["messages"] == []
     assert page["history_page"]["has_older"] is False

--- a/tests/unit/terrarium/test_chat_history_page_service.py
+++ b/tests/unit/terrarium/test_chat_history_page_service.py
@@ -30,7 +30,7 @@ def _events(store, content):
         store.append_event("ag", "text", {"content": text})
 
 
-def _fake_engine(store):
+def _fake_engine(store, env=None):
     agent = SimpleNamespace(
         session_store=store,
         conversation_history=[{"role": "user", "content": "snap"}],
@@ -43,6 +43,7 @@ def _fake_engine(store):
     return SimpleNamespace(
         get_creature=lambda cid: creature,
         _session_stores={"g": store},
+        _environments={"g": env} if env is not None else {},
     )
 
 
@@ -80,3 +81,25 @@ async def test_service_nonpositive_limit_rejected(store):
     service = LocalTerrariumService(_fake_engine(store))
     with pytest.raises(HistoryPagingError):
         await service.chat_history_page("ag", stream="events", limit=0)
+
+
+async def test_service_unknown_channel_page_is_not_an_empty_page(store):
+    service = LocalTerrariumService(_fake_engine(store))
+    with pytest.raises(KeyError):
+        await service.channel_history_page("g", "missing", limit=5)
+
+
+async def test_service_channel_page_reads_stored_records(store):
+    store.save_channel_message("room", {"sender": "a", "content": "hello"})
+    service = LocalTerrariumService(_fake_engine(store))
+    page = await service.channel_history_page("g", "room", limit=5)
+    assert [item["content"] for item in page["messages"]] == ["hello"]
+    assert page["history_page"]["stream"] == "channel"
+
+
+async def test_service_live_empty_channel_pages_without_error(store):
+    env = SimpleNamespace(shared_channels={"room": object()})
+    service = LocalTerrariumService(_fake_engine(store, env=env))
+    page = await service.channel_history_page("g", "room", limit=5)
+    assert page["messages"] == []
+    assert page["history_page"]["has_older"] is False

--- a/tests/unit/terrarium/test_chat_history_page_service.py
+++ b/tests/unit/terrarium/test_chat_history_page_service.py
@@ -1,0 +1,82 @@
+"""Service-level tests for :meth:`TerrariumService.chat_history_page`.
+
+These exercise the same delegation a real HTTP paged request hits: the
+``LocalTerrariumService`` reads a bounded physical event / snapshot slice and
+wraps it in the contract envelope. The engine is a minimal stand-in backed by
+a real :class:`SessionStore` so physical key ordering and history identity are
+genuine.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from kohakuterrarium.session.history_paging import HistoryPagingError
+from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.terrarium.service import LocalTerrariumService
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = SessionStore(str(tmp_path / "s.kohakutr"))
+    yield s
+    s.close()
+
+
+def _events(store, content):
+    for text in content:
+        store.append_event("ag", "text", {"content": text})
+
+
+def _fake_engine(store):
+    agent = SimpleNamespace(
+        session_store=store,
+        conversation_history=[{"role": "user", "content": "snap"}],
+        is_processing=True,
+        _direct_job_meta={"job-x": 1},
+        subagent_manager=SimpleNamespace(get_running_jobs=lambda: []),
+        executor=SimpleNamespace(get_running_jobs=lambda: []),
+    )
+    creature = SimpleNamespace(agent=agent, graph_id="g", name="ag")
+    return SimpleNamespace(
+        get_creature=lambda cid: creature,
+        _session_stores={"g": store},
+    )
+
+
+async def test_service_event_page_matches_contract(store):
+    _events(store, ["c0", "c1", "c2", "c3", "c4"])
+    service = LocalTerrariumService(_fake_engine(store))
+    page = await service.chat_history_page("ag", stream="events", limit=2)
+    assert [item["content"] for item in page["events"]] == ["c3", "c4"]
+    assert page["messages"] == []
+    hp = page["history_page"]
+    assert hp["version"] == 1
+    assert hp["stream"] == "events"
+    assert hp["has_older"] is True
+    assert hp["has_newer"] is False
+    assert hp["reset_required"] is False
+    assert page["is_processing"] is True
+    assert page["live_job_ids"] == ["job-x"]
+
+
+async def test_service_snapshot_page_matches_contract(store):
+    service = LocalTerrariumService(_fake_engine(store))
+    page = await service.chat_history_page("ag", stream="snapshot", limit=1)
+    assert [item["content"] for item in page["messages"]] == ["snap"]
+    assert page["events"] == []
+    assert page["history_page"]["stream"] == "snapshot"
+
+
+async def test_service_unsupported_stream_is_explicit(store):
+    service = LocalTerrariumService(_fake_engine(store))
+    with pytest.raises(HistoryPagingError):
+        await service.chat_history_page("ag", stream="bogus", limit=2)
+
+
+async def test_service_nonpositive_limit_rejected(store):
+    service = LocalTerrariumService(_fake_engine(store))
+    with pytest.raises(HistoryPagingError):
+        await service.chat_history_page("ag", stream="events", limit=0)

--- a/tests/unit/terrarium/test_chat_history_page_service.py
+++ b/tests/unit/terrarium/test_chat_history_page_service.py
@@ -83,12 +83,6 @@ async def test_service_nonpositive_limit_rejected(store):
         await service.chat_history_page("ag", stream="events", limit=0)
 
 
-async def test_service_unknown_channel_page_is_not_an_empty_page(store):
-    service = LocalTerrariumService(_fake_engine(store))
-    with pytest.raises(KeyError):
-        await service.channel_history_page("g", "missing", limit=5)
-
-
 async def test_service_channel_page_reads_stored_records(store):
     store.save_channel_message("room", {"sender": "a", "content": "hello"})
     service = LocalTerrariumService(_fake_engine(store))


### PR DESCRIPTION
> **Draft — replaces #299.** The direction is tracked in #295. #299 implemented it first; reviewing it found the direction sound and the client integration wrong (details in the issue), so this PR keeps the backend paging goal, replaces the cursor contract, and reworks the dashboard onto separated cache / projection / render layers. Opened as a draft; the CI matrix is running on this PR.

## Summary

Bounds every session-history response with an opt-in paged contract (`paged=true` + `limit` + opaque `before` / `after` cursors carrying a history identity) on the saved, live, and multi-node routes, and moves the dashboard onto a three-layer split — raw page cache, message projection range, DOM render window — so a long session loads a bounded first page without losing viewport behavior.

## PR Type

- [ ] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

#295: `GET /{session}/history/{target}` returns every event of a target — on the 331 MB / 75,474-event reference session that is a 123.7 MB JSON body built in ~7 s, past the dashboard's 30 s client timeout; the live-creature route has the same shape and additionally blocks the API event loop for its full build.

#299 was the first implementation. Reviewing it found the direction right and the integration wrong: it treated "fetch one page" as "mount one page", anchored the viewport on positions / DOM nodes, and let a page-boundary merge fight the reader. This PR replaces it — same goal, a cursor contract with an explicit history identity, and a client whose cache, projection range, and render window are separate layers.

## Changes

Backend:

- `session/history_paging.py`: cursor tokens carry stream + history identity + fingerprint; `reset_required` when that identity changed; exclusive `before` / `after`; byte-budget cap. `SessionStore` public API unchanged.
- Saved route: `paged=true` with `limit` (default 400) / `before` / `after` / `history_id`. An unknown paged target is now a 404 instead of an empty page; the saved `history_id` is `store.session_id`, stable across reopen (not the filename stem).
- Live route: pages at the store read (no second SQLite connection to a live store, per the documented POSIX constraint); `ch:` channel targets page from stored channel records; multi-node / remote service signatures updated, including the laboratory adapter's history delegation.
- `terrarium/history_service.py`: one service entry shared by the local and remote services.

Frontend:

- Three layers: raw page cache (prefetch), message projection range (replay + merge), DOM render window (tail budget + upward batches). Viewport anchors are physical `_history_key` provenance recorded per contributing row, so a page-boundary merge still resolves the anchor.
- An upward gesture at the top requests the next batch instead of requiring a decreasing `scrollTop`; a live turn refuses the older-page fetch and says why, resuming when the turn ends; a reconnect keeps the materialized range; a closed or pruned tab disposes its paged controller; the saved viewer surfaces a refresh it could not apply.

## Validation

```bash
ruff check src/ tests/                                                   # clean
black --check src/ tests/                                                # clean
pytest tests/unit/session tests/unit/studio tests/unit/api tests/unit/terrarium -q   # 6151 passed, 5 skipped
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py              # 12939 passed, 17 skipped, 11 failed (pre-existing)
pytest tests/unit/test_file_sizes.py -q                                   # 1766 passed
pytest tests/integration -q                                               # 174 passed, 1 failed (pre-existing)
cd src/kohakuterrarium-frontend && npm run format:check && npx eslint src/ && npm run build && npx vitest run
```

- Frontend: `format:check`, `eslint`, `build` clean; full vitest **1409 tests, 1389 passed, 20 failed** — all 20 in `layoutPanels`, `studio/ui`, `studio/workspace`, `StudioHomePage`, unrelated to this PR and failing identically on `main` on this machine.
- Browser acceptance: dev-server walkthrough of the paged live tab, the saved viewer, and back-scrolling a long session. Each fix below is pinned by a test that fails when the fix is reverted.
- Review: three independent review rounds on the six commits; every confirmed defect was fixed with a negative-control test (details in the review notes on the fork).

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [x] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it — #295 exists and was opened before the work; the maintainer (@SLAPaper, this author) directed this replacement PR on 2026-09-09 in place of #299
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow — the paged contract is documented on the route (`api/routes/persistence/history.py`, `creatures_chat.py`). `docs/en/reference/http.md` documents these two endpoints at endpoint level only and has never listed their query params (`stream`, `since_event_id`, `max_event_id` are equally absent), and its response line stays accurate because the default response is unchanged.
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [ ] CI on my fork is green, or I explained the exception below — running at time of writing

## Related Issues / Discussions

- Closes #295
- Supersedes #299

## Notes for Reviewers

- The behavior change is opt-in: without `paged=true` both history routes keep the previous full payload, and the studio facade default is unchanged.
- Known limits (unchanged or by design, all documented): every paged apply replays the whole loaded suffix, so a head refresh costs O(events in range) and the suffix is not evicted; multi-node channel merges still read fully before slicing; `physical_refs` and snapshot stream reads remain per-page O(N); token totals stay partial while history is incomplete.
- An older-page materialize is deliberately rejected while a live turn is mutating history; the panel refuses the fetch for that window and resumes automatically when the turn ends.

## Exceptions / Not Run

- `pytest tests/integration -q`: `test_prompt_budget.py::TestPromptBudget::test_framework_payload_stays_within_budget` fails at 16108 chars vs the 16000 budget. Reproduced on a clean `origin/main` (`d70788e4`) checkout with the identical character count; unrelated to this PR.
- `pytest tests/unit/`: 11 failures, all reproduced identically on clean `origin/main` — 4 in `laboratory/test_transport_ws.py` (local socket), 1 in `llm/test_grok_auth.py` (grok CLI), 6 in `packages/test_git_backend_dulwich_integration.py` (network clones).
- The e2e tier is not run in CI by policy; it was not part of this change's verification.
