### PR TITLE
test(session): un-shadow the duplicate `TestDiscoverAttachedAgents` class (3 tests were never collected)

### DIFF
--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -994,7 +994,7 @@ class TestInitMetaTerrariumFields:
 # -- discover_attached_agents key filtering -----------------------
 
 
-class TestDiscoverAttachedAgents:
+class TestDiscoverAttachedAgentsNamespaceShapes:
     def test_well_formed_attached_namespace_discovered(self, tmp_path):
         s = _store(tmp_path)
         try:


### PR DESCRIPTION
### What

`tests/unit/session/test_store.py` declares `class TestDiscoverAttachedAgents`
twice — once at line 679 and again at line 997:

```
$ grep -n '^class TestDiscoverAttachedAgents' tests/unit/session/test_store.py
679:class TestDiscoverAttachedAgents:
997:class TestDiscoverAttachedAgents:
```

The two classes hold **different** tests. The second binding replaces the first
in the module namespace, so pytest never collects the first one:

| line 679 (shadowed, never runs) | line 997 (runs) |
|---|---|
| `test_empty` | `test_well_formed_attached_namespace_discovered` |
| `test_parses_namespace` | `test_malformed_attached_namespaces_skipped` |
| `test_invalid_seq_skipped` | `test_duplicate_attached_namespace_deduped` |

`pyflakes` sees it too:

```
tests/unit/session/test_store.py:997:1: redefinition of unused 'TestDiscoverAttachedAgents' from line 679
```

The three lost tests cover cases the surviving class does not: the empty-store
case, the parsed `host` / `role` / `attach_seq` fields, and a non-integer
`attach_seq` being skipped.

### Fix

Rename the second class to `TestDiscoverAttachedAgentsNamespaceShapes`, which is
what its three tests actually check. Nothing is deleted and no test body changes.

### Verification

Collection count before and after, and the restored tests actually run green:

```
# before
$ pytest tests/unit/session/test_store.py --collect-only -q
95 tests collected

# after
$ pytest tests/unit/session/test_store.py --collect-only -q
98 tests collected

$ pytest tests/unit/session/test_store.py -k DiscoverAttachedAgents -v
TestDiscoverAttachedAgents::test_empty                                    PASSED
TestDiscoverAttachedAgents::test_parses_namespace                         PASSED
TestDiscoverAttachedAgents::test_invalid_seq_skipped                      PASSED
TestDiscoverAttachedAgentsNamespaceShapes::test_well_formed_attached_...  PASSED
TestDiscoverAttachedAgentsNamespaceShapes::test_malformed_attached_...    PASSED
TestDiscoverAttachedAgentsNamespaceShapes::test_duplicate_attached_...    PASSED
6 passed

# whole file
$ pytest tests/unit/session/test_store.py -q
97 passed, 1 skipped
```

(The skip is `test_failed_open_leaves_no_descriptors_behind` — `RLIMIT_NOFILE` is
POSIX-only and I ran this on Windows.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
