### PR TITLE
fix(fs): parse file:// URLs before Path/mkdir

### DIFF
--- a/src/kohakuterrarium/api/deps.py
+++ b/src/kohakuterrarium/api/deps.py
@@ -23,6 +23,7 @@ from kohakuterrarium.api.auth.engine_pool import EnginePool, _user_session_dir
 from kohakuterrarium.api.auth.models import User
 from kohakuterrarium.studio.hooks import register_group_hooks
 from kohakuterrarium.utils.config_dir import config_dir
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -44,7 +45,7 @@ def _session_dir() -> str:
     """
     explicit = os.environ.get("KT_SESSION_DIR")
     if explicit:
-        return explicit
+        return str(coerce_fs_path(explicit))
     return str(config_dir() / "sessions")
 
 

--- a/src/kohakuterrarium/api/deps.py
+++ b/src/kohakuterrarium/api/deps.py
@@ -23,7 +23,7 @@ from kohakuterrarium.api.auth.engine_pool import EnginePool, _user_session_dir
 from kohakuterrarium.api.auth.models import User
 from kohakuterrarium.studio.hooks import register_group_hooks
 from kohakuterrarium.utils.config_dir import config_dir
-from kohakuterrarium.utils.fs_path import coerce_fs_path
+from kohakuterrarium.utils.fs_path import env_fs_path_text
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -45,7 +45,7 @@ def _session_dir() -> str:
     """
     explicit = os.environ.get("KT_SESSION_DIR")
     if explicit:
-        return str(coerce_fs_path(explicit))
+        return env_fs_path_text(explicit)
     return str(config_dir() / "sessions")
 
 

--- a/src/kohakuterrarium/cli/run.py
+++ b/src/kohakuterrarium/cli/run.py
@@ -22,6 +22,7 @@ from kohakuterrarium.packages.resolve import resolve_any_path
 from kohakuterrarium.studio.hooks import register_group_hooks
 from kohakuterrarium.utils.config_dir import config_dir
 from kohakuterrarium.utils.fd_limit import raise_fd_limit
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import (
     configure_utf8_stdio,
     enable_stderr_logging,
@@ -43,7 +44,7 @@ def _session_dir() -> Path:
     """Resolve the CLI session root using the shared configuration rules."""
     explicit = os.environ.get("KT_SESSION_DIR")
     if explicit:
-        return Path(explicit).expanduser()
+        return coerce_fs_path(explicit)
     docs_default = Path.home() / ".kohakuterrarium" / "sessions"
     if _SESSION_DIR != docs_default:
         return _SESSION_DIR

--- a/src/kohakuterrarium/llm/artifact_resolve.py
+++ b/src/kohakuterrarium/llm/artifact_resolve.py
@@ -9,14 +9,13 @@ import base64
 import re
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
-from urllib.request import url2pathname
 
 from kohakuterrarium.studio.persistence.artifacts import (
     resolve_artifact_file,
     resolve_artifacts_dir,
 )
 from kohakuterrarium.studio.persistence.store import _session_dir
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -44,10 +43,10 @@ def file_reference_path(url: str) -> Path | None:
     """Return the local path a ``file://`` reference names, or ``None``."""
     if not isinstance(url, str) or not url.startswith(_FILE_SCHEME):
         return None
-    parsed = urlparse(url)
-    if parsed.scheme != "file" or parsed.netloc not in ("", "localhost"):
+    try:
+        return coerce_fs_path(url)
+    except ValueError:
         return None
-    return Path(url2pathname(parsed.path))
 
 
 def _local_media_path(url: str) -> Path | None:

--- a/src/kohakuterrarium/llm/artifact_resolve.py
+++ b/src/kohakuterrarium/llm/artifact_resolve.py
@@ -9,6 +9,7 @@ import base64
 import re
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from kohakuterrarium.studio.persistence.artifacts import (
     resolve_artifact_file,
@@ -44,6 +45,8 @@ def file_reference_path(url: str) -> Path | None:
     if not isinstance(url, str) or not url.startswith(_FILE_SCHEME):
         return None
     try:
+        if urlparse(url).netloc.lower() not in ("", "localhost"):
+            return None
         return coerce_fs_path(url)
     except ValueError:
         return None

--- a/src/kohakuterrarium/modules/tool/base.py
+++ b/src/kohakuterrarium/modules/tool/base.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from kohakuterrarium.builtin_skills import get_builtin_tool_doc
 from kohakuterrarium.modules.tool.media_policy import MediaPolicy
 from kohakuterrarium.modules.tool.runtime_options import validate_tool_options
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -63,7 +64,7 @@ class ToolContext:
 
     def resolve_path(self, path_str: str) -> Path:
         """Resolve relative paths against the agent directory, not process cwd."""
-        p = Path(path_str).expanduser()
+        p = coerce_fs_path(path_str)
         if not p.is_absolute():
             return (self.working_dir / p).resolve()
         return p.resolve()
@@ -78,7 +79,7 @@ def resolve_tool_path(path_str: str, context: ToolContext | None = None) -> Path
     """Resolve a path against agent context when one is available."""
     if context:
         return context.resolve_path(path_str)
-    return Path(path_str).expanduser().resolve()
+    return coerce_fs_path(path_str).resolve()
 
 
 def has_interactive_responder(router: Any) -> bool:

--- a/src/kohakuterrarium/session/readonly.py
+++ b/src/kohakuterrarium/session/readonly.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from kohakuvault import KVault
 
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -33,11 +34,7 @@ def _load_meta(path: str | Path) -> dict[str, Any]:
 
 def read_session_meta(path: str | Path) -> dict[str, Any]:
     """Return metadata without creating WAL, SHM, schema, or status writes."""
-    source = Path(path).expanduser().resolve(strict=True)
-    wal = Path(f"{source}-wal")
-    if not wal.exists():
-        return _load_meta(f"file:{source.as_posix()}?mode=ro&immutable=1")
-
+    source = coerce_fs_path(path).expanduser().resolve(strict=True)
     tmp = Path(tempfile.mkdtemp(prefix="kt-session-read-"))
     try:
         target = tmp / source.name

--- a/src/kohakuterrarium/session/store.py
+++ b/src/kohakuterrarium/session/store.py
@@ -40,6 +40,7 @@ from kohakuterrarium.session.token_views import (
     token_usage_all_loops as _token_usage_all_loops_impl,
 )
 from kohakuterrarium.session.version import FORMAT_VERSION
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -84,7 +85,7 @@ class SessionStore:
         flush_every_n_seconds: float | None = None,
         writer_lock: bool = False,
     ) -> None:
-        self._path = str(Path(path).expanduser())
+        self._path = str(coerce_fs_path(path))
         Path(self._path).parent.mkdir(parents=True, exist_ok=True)
         # Read-only consumers must not alter status or recency on close.
         self._readonly = False

--- a/src/kohakuterrarium/session/version.py
+++ b/src/kohakuterrarium/session/version.py
@@ -7,6 +7,7 @@ versioned suffixes so original sources remain intact.
 from pathlib import Path
 
 from kohakuterrarium.session.readonly import read_session_meta
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -21,7 +22,7 @@ def detect_format_version(path: str | Path) -> int:
     Only metadata is opened. Missing or invalid version values resolve to version
     1, whose files predate the explicit field.
     """
-    p = Path(path)
+    p = coerce_fs_path(path)
     if not p.exists():
         raise FileNotFoundError(p)
     try:

--- a/src/kohakuterrarium/studio/attach/workspace_files.py
+++ b/src/kohakuterrarium/studio/attach/workspace_files.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from fastapi import HTTPException
 
+from kohakuterrarium.utils.fs_path import coerce_fs_path
+
 # Editor language IDs are derived from lowercase filename extensions.
 _EXT_LANG: dict[str, str] = {
     ".py": "python",
@@ -73,7 +75,7 @@ _SKIP_NAMES: set[str] = {
 def _validate_path(path_str: str) -> Path:
     """Resolve a filesystem path or raise an HTTP-friendly validation error."""
     try:
-        return Path(path_str).resolve()
+        return coerce_fs_path(path_str).resolve()
     except (ValueError, OSError) as e:
         raise HTTPException(400, f"Invalid path: {e}")
 

--- a/src/kohakuterrarium/studio/persistence/session_index/__init__.py
+++ b/src/kohakuterrarium/studio/persistence/session_index/__init__.py
@@ -19,6 +19,7 @@ from kohakuterrarium.studio.persistence.session_index.entry import (
     SessionIndexEntry,
 )
 from kohakuterrarium.utils.config_dir import config_dir
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.studio.persistence.session_index.hooks import (
     SessionIndexHook,
     push_index_update,
@@ -84,7 +85,7 @@ def _default_session_dir() -> Path:
     """
     env = os.environ.get("KT_SESSION_DIR")
     if env:
-        return Path(env)
+        return coerce_fs_path(env)
     return config_dir() / "sessions"
 
 
@@ -99,7 +100,7 @@ def get_session_index_default(session_dir: Path | None = None) -> SessionIndex:
     """
     if session_dir is None:
         session_dir = _default_session_dir()
-    normalized_dir = Path(session_dir).expanduser().resolve(strict=False)
+    normalized_dir = coerce_fs_path(session_dir).expanduser().resolve(strict=False)
     cache_key = os.path.normcase(str(normalized_dir))
     with _singleton_lock:
         cached = _singletons.get(cache_key)

--- a/src/kohakuterrarium/studio/persistence/store.py
+++ b/src/kohakuterrarium/studio/persistence/store.py
@@ -31,6 +31,7 @@ from kohakuterrarium.studio.persistence.viewer.paths import (
 )
 from kohakuterrarium.utils import drive_migration_lock
 from kohakuterrarium.utils.config_dir import config_dir
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -50,7 +51,7 @@ def _session_dir() -> Path:
     """
     env = os.environ.get("KT_SESSION_DIR")
     if env:
-        return Path(env)
+        return coerce_fs_path(env)
     # A replaced module default takes precedence; otherwise deriving from
     # ``config_dir`` keeps configuration-directory overrides isolated.
     _docs_default = Path.home() / ".kohakuterrarium" / "sessions"

--- a/src/kohakuterrarium/studio/sessions/store_attach.py
+++ b/src/kohakuterrarium/studio/sessions/store_attach.py
@@ -18,7 +18,7 @@ from kohakuterrarium.studio.sessions.registry import stores_for
 from kohakuterrarium.terrarium import TerrariumService
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.utils.config_dir import config_dir
-from kohakuterrarium.utils.fs_path import coerce_fs_path
+from kohakuterrarium.utils.fs_path import env_fs_path_text
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -28,7 +28,7 @@ def session_dir() -> str:
     """Return ``KT_SESSION_DIR`` or the config-local session directory."""
     # Deriving the fallback from config_dir keeps isolated config roots self-contained.
     raw = os.environ.get("KT_SESSION_DIR") or str(config_dir() / "sessions")
-    return str(coerce_fs_path(raw))
+    return env_fs_path_text(raw)
 
 
 def attach_session_store_for_creature(

--- a/src/kohakuterrarium/studio/sessions/store_attach.py
+++ b/src/kohakuterrarium/studio/sessions/store_attach.py
@@ -18,6 +18,7 @@ from kohakuterrarium.studio.sessions.registry import stores_for
 from kohakuterrarium.terrarium import TerrariumService
 from kohakuterrarium.terrarium.engine import Terrarium
 from kohakuterrarium.utils.config_dir import config_dir
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -26,7 +27,8 @@ logger = get_logger(__name__)
 def session_dir() -> str:
     """Return ``KT_SESSION_DIR`` or the config-local session directory."""
     # Deriving the fallback from config_dir keeps isolated config roots self-contained.
-    return os.environ.get("KT_SESSION_DIR") or str(config_dir() / "sessions")
+    raw = os.environ.get("KT_SESSION_DIR") or str(config_dir() / "sessions")
+    return str(coerce_fs_path(raw))
 
 
 def attach_session_store_for_creature(

--- a/src/kohakuterrarium/terrarium/autosession.py
+++ b/src/kohakuterrarium/terrarium/autosession.py
@@ -23,6 +23,7 @@ from kohakuterrarium.core.config import AgentConfig
 from kohakuterrarium.core.config_serde import pack_agent_config
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.utils.config_dir import config_dir
+from kohakuterrarium.utils.fs_path import coerce_fs_path
 from kohakuterrarium.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -43,10 +44,10 @@ def default_session_dir(engine: "Terrarium") -> Path:
     """
     base = getattr(engine, "_session_dir", None)
     if base:
-        return Path(base).expanduser()
+        return coerce_fs_path(base)
     env = os.environ.get("KT_SESSION_DIR")
     if env:
-        return Path(env).expanduser()
+        return coerce_fs_path(env)
     return config_dir() / "sessions"
 
 
@@ -78,7 +79,7 @@ def mint_store(
         directory.mkdir(parents=True, exist_ok=True)
         path = directory / f"{graph_id}.kohakutr"
     else:
-        path = Path(path).expanduser()
+        path = coerce_fs_path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
 
     store = SessionStore(path, writer_lock=True)
@@ -293,7 +294,9 @@ def recipe_session_reuses_store(
     if not isinstance(session, (str, Path)):
         return False
     try:
-        return Path(existing.path).resolve() == Path(session).expanduser().resolve()
+        return (
+            coerce_fs_path(existing.path).resolve() == coerce_fs_path(session).resolve()
+        )
     except (OSError, RuntimeError, ValueError):
         return False
 

--- a/src/kohakuterrarium/utils/config_dir.py
+++ b/src/kohakuterrarium/utils/config_dir.py
@@ -17,6 +17,8 @@ paths under it.
 import os
 from pathlib import Path
 
+from kohakuterrarium.utils.fs_path import coerce_fs_path
+
 _DEFAULT = "~/.kohakuterrarium"
 
 
@@ -28,7 +30,7 @@ def config_dir() -> Path:
     the directory is created if it doesn't exist.
     """
     raw = os.environ.get("KT_CONFIG_DIR") or _DEFAULT
-    path = Path(raw).expanduser()
+    path = coerce_fs_path(raw)
     path.mkdir(parents=True, exist_ok=True)
     return path
 

--- a/src/kohakuterrarium/utils/fs_path.py
+++ b/src/kohakuterrarium/utils/fs_path.py
@@ -1,0 +1,30 @@
+"""Turn user-supplied path strings (including ``file://`` URLs) into Paths."""
+
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+
+def coerce_fs_path(value: str | Path) -> Path:
+    """Return a filesystem Path for a plain path or a local ``file://`` URL.
+
+    Remote ``file://host/...`` strings raise ``ValueError`` so callers cannot
+    ``mkdir`` a folder named ``file:``.
+    """
+    text = value if isinstance(value, str) else str(value)
+    if not text:
+        raise ValueError("path must be non-empty")
+    if text.startswith("file:"):
+        return _path_from_file_uri(text)
+    return Path(text).expanduser()
+
+
+def _path_from_file_uri(text: str) -> Path:
+    uri = text if text.startswith("file://") else "file://" + text[len("file:") :]
+    parsed = urlparse(uri)
+    if parsed.scheme != "file" or parsed.netloc not in ("", "localhost"):
+        raise ValueError(f"unsupported file URI: {text!r}")
+    path = url2pathname(parsed.path)
+    if not path:
+        raise ValueError(f"unsupported file URI: {text!r}")
+    return Path(path)

--- a/src/kohakuterrarium/utils/fs_path.py
+++ b/src/kohakuterrarium/utils/fs_path.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 from urllib.request import url2pathname
 
 
@@ -43,9 +43,9 @@ def _path_from_file_uri(text: str) -> Path:
     if parsed.netloc and parsed.netloc.lower() != "localhost":
         if os.name != "nt":
             raise ValueError(f"unsupported file URI: {text!r}")
-        share = url2pathname(unquote(parsed.path))
+        share = url2pathname(parsed.path)
         return Path(f"\\\\{parsed.netloc}{share}")
-    path = url2pathname(unquote(parsed.path))
+    path = url2pathname(parsed.path)
     if not path:
         raise ValueError(f"unsupported file URI: {text!r}")
     if len(path) >= 3 and path[0] in "/\\" and path[1].isalpha() and path[2] == ":":
@@ -55,6 +55,7 @@ def _path_from_file_uri(text: str) -> Path:
 
 def _from_windows_pathlib_form(rest: str) -> Path:
     """Recover ``file:\\C:\\Users\\...`` from ``str(Path(as_uri()))`` on Windows."""
+    normalized = rest.replace("\\", "/")
     if len(rest) >= 3 and rest[1].isalpha() and rest[2] == ":":
-        rest = rest[1:]
-    return Path(rest.replace("\\", "/"))
+        return _path_from_file_uri("file://" + normalized)
+    return _path_from_file_uri("file://" + normalized.lstrip("/"))

--- a/src/kohakuterrarium/utils/fs_path.py
+++ b/src/kohakuterrarium/utils/fs_path.py
@@ -1,15 +1,17 @@
 """Turn user-supplied path strings (including ``file://`` URLs) into Paths."""
 
+import os
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
 
 def coerce_fs_path(value: str | Path) -> Path:
     """Return a filesystem Path for a plain path or a local ``file://`` URL.
 
-    Remote ``file://host/...`` strings raise ``ValueError`` so callers cannot
-    ``mkdir`` a folder named ``file:``.
+    Remote ``file://host/...`` strings raise ``ValueError`` on POSIX so
+    callers cannot ``mkdir`` a folder named ``file:``. On Windows those
+    URLs are UNC paths (``\\\\host\\share\\...``).
     """
     text = value if isinstance(value, str) else str(value)
     if not text:
@@ -19,12 +21,40 @@ def coerce_fs_path(value: str | Path) -> Path:
     return Path(text).expanduser()
 
 
+def env_fs_path_text(raw: str) -> str:
+    """Keep a plain env path verbatim; parse only ``file:`` URIs.
+
+    ``Path('/custom')`` on Windows becomes ``\\custom``, which breaks
+    callers and tests that store POSIX env overrides as strings.
+    """
+    if raw.startswith("file:"):
+        return str(coerce_fs_path(raw))
+    return raw
+
+
 def _path_from_file_uri(text: str) -> Path:
-    uri = text if text.startswith("file://") else "file://" + text[len("file:") :]
+    rest = text[5:]
+    if rest.startswith("\\"):
+        return _from_windows_pathlib_form(rest)
+    uri = text if text.startswith("file://") else "file://" + rest
     parsed = urlparse(uri)
-    if parsed.scheme != "file" or parsed.netloc not in ("", "localhost"):
+    if parsed.scheme != "file":
         raise ValueError(f"unsupported file URI: {text!r}")
-    path = url2pathname(parsed.path)
+    if parsed.netloc and parsed.netloc.lower() != "localhost":
+        if os.name != "nt":
+            raise ValueError(f"unsupported file URI: {text!r}")
+        share = url2pathname(unquote(parsed.path))
+        return Path(f"\\\\{parsed.netloc}{share}")
+    path = url2pathname(unquote(parsed.path))
     if not path:
         raise ValueError(f"unsupported file URI: {text!r}")
+    if len(path) >= 3 and path[0] in "/\\" and path[1].isalpha() and path[2] == ":":
+        path = path[1:]
     return Path(path)
+
+
+def _from_windows_pathlib_form(rest: str) -> Path:
+    """Recover ``file:\\C:\\Users\\...`` from ``str(Path(as_uri()))`` on Windows."""
+    if len(rest) >= 3 and rest[1].isalpha() and rest[2] == ":":
+        rest = rest[1:]
+    return Path(rest.replace("\\", "/"))

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -56,6 +56,7 @@ from kohakuterrarium.session.migrations import (
     migration_marker,
     path_for_version,
 )
+from kohakuterrarium.session.readonly import read_session_meta
 from kohakuterrarium.session.resume import detect_session_type, resume_agent
 from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.session.version import FORMAT_VERSION, detect_format_version
@@ -558,6 +559,12 @@ class TestSessionIntegration:
         # ---- version probe + session-type detection on the closed file ----
         # detect_format_version reads the stamped version off disk.
         assert detect_format_version(session_path) == FORMAT_VERSION
+        source_bytes = session_path.read_bytes()
+        source_mtime = session_path.stat().st_mtime_ns
+        assert detect_format_version(session_path.as_uri()) == FORMAT_VERSION
+        assert read_session_meta(session_path.as_uri())["agents"] == ["scribe"]
+        assert session_path.read_bytes() == source_bytes
+        assert session_path.stat().st_mtime_ns == source_mtime
         # A missing path is a hard FileNotFoundError, not a silent 1.
         with pytest.raises(FileNotFoundError):
             detect_format_version(tmp_path / "nope.kohakutr.v2")

--- a/tests/unit/api/test_deps.py
+++ b/tests/unit/api/test_deps.py
@@ -36,6 +36,11 @@ class TestSessionDir:
         monkeypatch.setenv("KT_SESSION_DIR", "/custom/path")
         assert _session_dir() == "/custom/path"
 
+    def test_file_uri_env_override(self, tmp_path, monkeypatch):
+        target = (tmp_path / "sessions").resolve()
+        monkeypatch.setenv("KT_SESSION_DIR", target.as_uri())
+        assert _session_dir() == str(target)
+
     def test_kt_config_dir_overrides_default_subdir(self, tmp_path, monkeypatch):
         # When KT_SESSION_DIR is unset, KT_CONFIG_DIR drives the fallback
         # — pollution-safe by construction.

--- a/tests/unit/builtins/tui/test_session.py
+++ b/tests/unit/builtins/tui/test_session.py
@@ -212,19 +212,31 @@ async def test_background_tab_culling_keeps_target_history_count() -> None:
         assert session._culled_count == {"bob": 2}
 
 
-async def test_long_markdown_fence_keeps_content_and_has_visible_scrollbar() -> None:
+async def test_long_markdown_fence_keeps_content_and_has_visible_scrollbar(
+    monkeypatch,
+) -> None:
+    async def immediate_idle(_min_sleep=0):
+        return None
+
+    monkeypatch.setattr("textual.pilot.wait_for_idle", immediate_idle)
     long_path = "/" + "very-long-path-segment/" * 10 + "artifact.png"
     session = TUISession()
     await session.start()
     assert session._app is not None
 
-    async with session._app.run_test(size=(60, 20)) as pilot:
+    async with session._app.run_test(size=(60, 20)):
         session.begin_streaming()
         session.append_stream(f"```text\n{long_path}\n```")
         session.end_streaming()
-        await pilot.pause()
 
-        fence = session._app.query_one(MarkdownFence)
+        async def wait_for_fence_layout():
+            while True:
+                fence = next(iter(session._app.query(MarkdownFence)), None)
+                if fence is not None and fence.region and fence.virtual_size.width:
+                    return fence
+                await session._app.wait_for_refresh()
+
+        fence = await asyncio.wait_for(wait_for_fence_layout(), 2)
         assert fence.code == long_path
         assert long_path in fence.query_one("#code-content", Label).render().plain
         assert fence.max_scroll_x > 0
@@ -232,7 +244,7 @@ async def test_long_markdown_fence_keeps_content_and_has_visible_scrollbar() -> 
         assert fence.horizontal_scrollbar.region.height == 1
 
         fence.scroll_to(x=fence.max_scroll_x, animate=False)
-        await pilot.pause()
+        await fence.wait_for_refresh()
         assert fence.scroll_x == fence.max_scroll_x
 
 

--- a/tests/unit/llm/test_artifact_resolve.py
+++ b/tests/unit/llm/test_artifact_resolve.py
@@ -102,6 +102,10 @@ class TestFileReferences:
         assert file_reference_path("https://example.com/x.png") is None
         assert file_reference_path(None) is None
 
+    @pytest.mark.parametrize("authority", ["host", "127.0.0.1", "user@localhost"])
+    def test_remote_authority_is_not_a_local_media_reference(self, authority):
+        assert file_reference_path(f"file://{authority}/share/x.png") is None
+
 
 class TestResolveMessageImageUrls:
     def test_identity_when_no_local_artifacts(self):

--- a/tests/unit/modules/tool/test_tool_base.py
+++ b/tests/unit/modules/tool/test_tool_base.py
@@ -190,6 +190,12 @@ class TestToolContextPathResolution:
         absolute = (tmp_path / "abs.txt").resolve()
         assert ctx.resolve_path(str(absolute)) == absolute
 
+    def test_file_uri_resolves_to_the_named_path(self, tmp_path):
+        ctx = ToolContext(agent_name="a", session=None, working_dir=tmp_path)
+        absolute = (tmp_path / "abs.txt").resolve()
+        assert ctx.resolve_path(absolute.as_uri()) == absolute
+        assert not (tmp_path / "file:").exists()
+
     def test_channels_and_scratchpad_proxy_session(self):
         class _Sess:
             channels = ["ch"]

--- a/tests/unit/session/test_readonly.py
+++ b/tests/unit/session/test_readonly.py
@@ -1,0 +1,77 @@
+"""Unit tests for :mod:`kohakuterrarium.session.readonly`."""
+
+from pathlib import Path
+
+import pytest
+
+from kohakuterrarium.session.readonly import read_session_meta
+from kohakuterrarium.session.store import SessionStore
+
+
+def _closed_session(path: Path) -> Path:
+    store = SessionStore(str(path), writer_lock=True)
+    try:
+        store.init_meta("sess", "agent", "/p", "/w", ["alice"])
+    finally:
+        store.close()
+    for suffix in ("-wal", "-shm"):
+        sidecar = Path(f"{path}{suffix}")
+        if sidecar.exists():
+            sidecar.unlink()
+    return path
+
+
+class TestReadSessionMeta:
+    @pytest.mark.parametrize("as_uri", [False, True])
+    def test_read_preserves_source_and_sidecars(self, tmp_path, monkeypatch, as_uri):
+        monkeypatch.chdir(tmp_path)
+        session = _closed_session(tmp_path / "s %20 #.kohakutr")
+        before = {
+            p.name: (p.read_bytes(), p.stat().st_mtime_ns) for p in tmp_path.iterdir()
+        }
+
+        meta = read_session_meta(session.as_uri() if as_uri else session)
+
+        assert meta["session_id"] == "sess"
+        assert {
+            p.name: (p.read_bytes(), p.stat().st_mtime_ns) for p in tmp_path.iterdir()
+        } == before
+
+    def test_wal_free_read_does_not_mkdir_cwd_file_scheme(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        session = tmp_path / "real" / "s.kohakutr"
+        _closed_session(session)
+        monkeypatch.chdir(cwd)
+
+        meta = read_session_meta(session)
+
+        assert meta["session_id"] == "sess"
+        assert not (cwd / "file:").exists()
+
+    def test_file_uri_reads_the_named_session(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        session = tmp_path / "real" / "s.kohakutr"
+        session.parent.mkdir()
+        _closed_session(session)
+        monkeypatch.chdir(cwd)
+
+        meta = read_session_meta(session.resolve().as_uri())
+
+        assert meta["session_id"] == "sess"
+        assert not (cwd / "file:").exists()
+
+    def test_copies_wal_sidecar_when_present(self, tmp_path):
+        session = tmp_path / "s.kohakutr"
+        store = SessionStore(str(session), writer_lock=True)
+        try:
+            store.init_meta("sess", "agent", "/p", "/w", ["alice"])
+            store.append_event("alice", "text", {"content": "hello"})
+            store.flush()
+            assert Path(f"{session}-wal").stat().st_size > 0
+            meta = read_session_meta(session)
+            assert meta["session_id"] == "sess"
+            assert store.load_meta()["session_id"] == "sess"
+        finally:
+            store.close()

--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -176,6 +176,19 @@ class TestSessionStoreConstruction:
         finally:
             s.close()
 
+    def test_file_uri_opens_the_named_store(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        real = (tmp_path / "real" / "s.kohakutr").resolve()
+        s = SessionStore(real.as_uri())
+        try:
+            assert Path(s.path).resolve() == real
+            assert real.is_file()
+            assert not (cwd / "file:").exists()
+        finally:
+            s.close()
+
 
 # ── append_event / read paths ────────────────────────────────────
 

--- a/tests/unit/session/test_version.py
+++ b/tests/unit/session/test_version.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from kohakuterrarium.session.store import SessionStore
 from kohakuterrarium.session.version import FORMAT_VERSION, detect_format_version
 
 
@@ -14,6 +15,17 @@ class TestFormatVersionConstant:
 
 
 class TestDetectFormatVersion:
+    def test_file_uri_preserves_exact_filename(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / "session %20 #.kohakutr"
+        store = SessionStore(str(path))
+        try:
+            store.init_meta("uri-session", "agent", "", "", ["alice"])
+        finally:
+            store.close()
+        assert detect_format_version(path.as_uri()) == FORMAT_VERSION
+        assert not (tmp_path / "file:").exists()
+
     def test_missing_file_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             detect_format_version(tmp_path / "nope.kohakutr")

--- a/tests/unit/studio/persistence/session_index/test_hooks.py
+++ b/tests/unit/studio/persistence/session_index/test_hooks.py
@@ -1,10 +1,12 @@
 """Unit tests for ``session_index.hooks`` — every code path."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.studio.persistence.session_index import hooks as hooks_mod
 from kohakuterrarium.studio.persistence.session_index.hooks import (
     SessionIndexHook,
     push_index_update,
@@ -115,20 +117,18 @@ class TestSessionIndexHook:
         assert row2["preview"] == "one"
 
     def test_event_flush_debounced_by_time(self, idx, tmp_path, monkeypatch):
-        # Use n=999 so count never fires; advance monotonic clock
-        # manually to trigger the time gate.
+        now = 100.0
+        monkeypatch.setattr(hooks_mod, "time", SimpleNamespace(monotonic=lambda: now))
         s = _make_store(tmp_path, "alice")
         try:
             hook = SessionIndexHook(
-                s, idx, flush_every_n_events=999, flush_every_seconds=0.001
+                s, idx, flush_every_n_events=999, flush_every_seconds=5
             )
-            # Default ``time.monotonic`` runs in real time; with our
-            # tiny ``flush_every_seconds``, the next ``append_event``
-            # almost certainly trips the gate.
-            import time as _time
-
-            _time.sleep(0.01)
+            now = 104.0
             s.append_event("alice", "user_input", {"content": "after gate"})
+            assert idx.get("alice.kohakutr")["preview"] == ""
+            now = 105.0
+            s.append_event("alice", "text", {"content": "gate reached"})
             hook.detach()
         finally:
             s.close()

--- a/tests/unit/studio/persistence/session_index/test_singleton.py
+++ b/tests/unit/studio/persistence/session_index/test_singleton.py
@@ -51,6 +51,16 @@ class TestSidecarPath:
 
 
 class TestSingleton:
+    def test_file_uri_and_path_share_index(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        sdir = tmp_path / "sessions %20"
+        sdir.mkdir()
+        _make_session(sdir, "alice", preview="indexed via URI")
+        uri_index = get_session_index_default(sdir.as_uri())
+        assert uri_index is get_session_index_default(sdir)
+        assert uri_index.get("alice.kohakutr")["preview"] == "indexed via URI"
+        assert not (tmp_path / "file:").exists()
+
     def test_first_open_bootstraps_from_disk(self, tmp_path, monkeypatch):
         sdir = tmp_path / "sessions"
         sdir.mkdir()
@@ -401,6 +411,19 @@ class TestDefaultSessionDirResolver:
     def test_env_var_wins(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KT_SESSION_DIR", str(tmp_path / "envdir"))
         assert pkg._default_session_dir() == tmp_path / "envdir"
+
+    def test_file_uri_env_does_not_mkdir_cwd_file_scheme(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        named = tmp_path / "sessions"
+        named.mkdir()
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv("KT_SESSION_DIR", named.resolve().as_uri())
+        assert pkg._default_session_dir() == named
+        idx = get_session_index_default(session_dir=None)
+        assert idx.path == str(sidecar_path_for(named))
+        assert not (cwd / "file:").exists()
+        close_session_index()
 
     def test_falls_back_to_config_dir(self, tmp_path, monkeypatch):
         monkeypatch.delenv("KT_SESSION_DIR", raising=False)

--- a/tests/unit/studio/test_persistence_store.py
+++ b/tests/unit/studio/test_persistence_store.py
@@ -28,6 +28,16 @@ class TestSessionDir:
         # Sessions live under the '<config home>/sessions' directory.
         assert out.name == "sessions"
 
+    def test_file_uri_env_is_the_named_directory(self, monkeypatch, tmp_path):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        named = tmp_path / "sessions"
+        monkeypatch.setenv("KT_SESSION_DIR", named.resolve().as_uri())
+        out = store_mod._session_dir()
+        assert out == named.resolve()
+        assert not (cwd / "file:").exists()
+
 
 # ── shared helper ────────────────────────────────────────────
 

--- a/tests/unit/studio/test_workspace_files.py
+++ b/tests/unit/studio/test_workspace_files.py
@@ -16,6 +16,14 @@ class TestValidatePath:
         out = wf._validate_path(str(tmp_path))
         assert out == tmp_path.resolve()
 
+    def test_file_uri_is_the_named_path(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        out = wf._validate_path(tmp_path.resolve().as_uri())
+        assert out == tmp_path.resolve()
+        assert not (cwd / "file:").exists()
+
 
 class TestParentDirectory:
     def test_normal(self, tmp_path):
@@ -203,6 +211,16 @@ class TestWriteFile:
         assert out["success"] is True
         assert target.read_text() == "hello"
 
+    async def test_file_uri_writes_to_the_named_path(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        target = tmp_path / "real" / "x.txt"
+        out = await wf.write_file(target.resolve().as_uri(), "hello")
+        assert out["success"] is True
+        assert target.read_text() == "hello"
+        assert not (cwd / "file:").exists()
+
 
 class TestRenameFile:
     async def test_source_missing(self, tmp_path):
@@ -259,6 +277,16 @@ class TestMakeDirectory:
         out = await wf.make_directory(str(new_dir))
         assert out["success"]
         assert new_dir.is_dir()
+
+    async def test_file_uri_creates_the_named_directory(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        new_dir = tmp_path / "real" / "sessions"
+        out = await wf.make_directory(new_dir.resolve().as_uri())
+        assert out["success"]
+        assert new_dir.is_dir()
+        assert not (cwd / "file:").exists()
 
 
 # ── _list_browse_roots ─────────────────────────────────────

--- a/tests/unit/terrarium/test_autosession.py
+++ b/tests/unit/terrarium/test_autosession.py
@@ -76,6 +76,21 @@ class TestAutosessionViaSessionDir:
         finally:
             reopened.close(update_status=False)
 
+    async def test_file_uri_session_dir_mints_into_the_named_directory(
+        self, tmp_path, monkeypatch
+    ):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        sess_dir = tmp_path / "runs"
+        t = Terrarium(session_dir=sess_dir.resolve().as_uri())
+        try:
+            c = await t.add_creature(_prebuilt("alice"), start=False)
+            assert (sess_dir / f"{c.creature_id}.kohakutr").exists()
+            assert not (cwd / "file:").exists()
+        finally:
+            await t.shutdown()
+
     async def test_shutdown_closes_owned_store_when_stop_cancelled(self, tmp_path):
         # The stop loop can be cancelled mid-await; store closure runs in
         # a ``finally`` so a leaked writer lock (which blocks any later
@@ -140,6 +155,21 @@ class TestSessionArg:
             assert reopened.load_meta()["status"] == "paused"
         finally:
             reopened.close(update_status=False)
+
+    async def test_explicit_file_uri_mints_the_named_store(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        target = tmp_path / "sub" / "student-42.kohakutr"
+        t = Terrarium()
+        try:
+            await t.add_creature(
+                _prebuilt("grader"), start=False, session=target.resolve().as_uri()
+            )
+            assert target.exists()
+            assert not (cwd / "file:").exists()
+        finally:
+            await t.shutdown()
 
     async def test_true_uses_default_dir(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KT_SESSION_DIR", str(tmp_path / "envdir"))

--- a/tests/unit/utils/test_config_dir.py
+++ b/tests/unit/utils/test_config_dir.py
@@ -36,6 +36,17 @@ class TestConfigDir:
         assert out == override
         assert out.is_dir()
 
+    def test_file_uri_env_creates_the_named_directory(self, monkeypatch, tmp_path):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        named = tmp_path / "elsewhere"
+        monkeypatch.setenv("KT_CONFIG_DIR", named.resolve().as_uri())
+        out = config_dir()
+        assert out == named.resolve()
+        assert named.is_dir()
+        assert not (cwd / "file:").exists()
+
     def test_env_override_with_user_expansion(self, monkeypatch, tmp_path):
         # ``~/foo`` should expand to ``<home>/foo``.
         monkeypatch.setenv("KT_CONFIG_DIR", os.path.join("~", "kt-test-cd"))

--- a/tests/unit/utils/test_fs_path.py
+++ b/tests/unit/utils/test_fs_path.py
@@ -1,5 +1,6 @@
 """Unit tests for :mod:`kohakuterrarium.utils.fs_path`."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -22,9 +23,25 @@ class TestCoerceFsPath:
         assert not mangled.startswith("file:///")
         assert coerce_fs_path(mangled) == target
 
-    def test_remote_file_uri_rejected(self):
-        with pytest.raises(ValueError, match="unsupported file URI"):
-            coerce_fs_path("file://host/share/x.png")
+    def test_windows_drive_triple_slash_uri(self):
+        got = coerce_fs_path("file:///C:/Users/me/x.png")
+        assert got.name == "x.png"
+        assert "Users" in got.parts
+        assert got.as_posix().endswith("C:/Users/me/x.png")
+
+    def test_windows_pathlib_mangled_backslash_form(self):
+        got = coerce_fs_path(r"file:\C:\Users\me\x.png")
+        assert got.name == "x.png"
+        assert "Users" in got.parts
+        assert got.as_posix().endswith("C:/Users/me/x.png")
+
+    def test_remote_file_uri(self):
+        raw = "file://host/share/x.png"
+        if os.name == "nt":
+            assert coerce_fs_path(raw) == Path(r"\\host\share\x.png")
+        else:
+            with pytest.raises(ValueError, match="unsupported file URI"):
+                coerce_fs_path(raw)
 
     def test_empty_rejected(self):
         with pytest.raises(ValueError, match="non-empty"):

--- a/tests/unit/utils/test_fs_path.py
+++ b/tests/unit/utils/test_fs_path.py
@@ -1,0 +1,40 @@
+"""Unit tests for :mod:`kohakuterrarium.utils.fs_path`."""
+
+from pathlib import Path
+
+import pytest
+
+from kohakuterrarium.utils.fs_path import coerce_fs_path
+
+
+class TestCoerceFsPath:
+    def test_plain_relative_path(self):
+        assert coerce_fs_path("sub/file.txt") == Path("sub/file.txt")
+
+    def test_local_file_uri(self, tmp_path):
+        target = (tmp_path / "a b.txt").resolve()
+        assert coerce_fs_path(target.as_uri()) == target
+
+    def test_recovers_pathlib_single_slash_form(self, tmp_path):
+        target = (tmp_path / "x").resolve()
+        mangled = str(Path(target.as_uri()))
+        assert mangled.startswith("file:")
+        assert not mangled.startswith("file:///")
+        assert coerce_fs_path(mangled) == target
+
+    def test_remote_file_uri_rejected(self):
+        with pytest.raises(ValueError, match="unsupported file URI"):
+            coerce_fs_path("file://host/share/x.png")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            coerce_fs_path("")
+
+    def test_mkdir_uses_named_path_not_cwd_file_scheme(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        named = tmp_path / "real" / "sessions"
+        coerce_fs_path(named.resolve().as_uri()).mkdir(parents=True, exist_ok=True)
+        assert named.is_dir()
+        assert not (cwd / "file:").exists()

--- a/tests/unit/utils/test_fs_path.py
+++ b/tests/unit/utils/test_fs_path.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`kohakuterrarium.utils.fs_path`."""
 
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -14,6 +14,21 @@ class TestCoerceFsPath:
 
     def test_local_file_uri(self, tmp_path):
         target = (tmp_path / "a b.txt").resolve()
+        assert coerce_fs_path(target.as_uri()) == target
+
+    @pytest.mark.parametrize(
+        "name", ["image%20name.png", "image%25name.png", "image%2Fname.png"]
+    )
+    def test_file_uri_preserves_literal_percent_escapes(self, tmp_path, name):
+        target = (tmp_path / name).resolve()
+        assert coerce_fs_path(target.as_uri()) == target
+
+    @pytest.mark.skipif(os.name != "nt", reason="UNC paths require Windows")
+    @pytest.mark.parametrize(
+        "name", ["image%20name.png", "image%25name.png", "image%2Fname.png"]
+    )
+    def test_remote_file_uri_preserves_literal_percent_escapes(self, name):
+        target = Path(r"\\host\share") / name
         assert coerce_fs_path(target.as_uri()) == target
 
     def test_recovers_pathlib_single_slash_form(self, tmp_path):
@@ -34,6 +49,17 @@ class TestCoerceFsPath:
         assert got.name == "x.png"
         assert "Users" in got.parts
         assert got.as_posix().endswith("C:/Users/me/x.png")
+
+    @pytest.mark.parametrize("name", ["a b.png", "日本語.png", "image%20name.png"])
+    def test_windows_pathlib_form_decodes_once(self, name):
+        target = PureWindowsPath("C:/Users/me") / name
+        mangled = str(PureWindowsPath(target.as_uri()))
+        assert coerce_fs_path(mangled).as_posix() == target.as_posix()
+
+    @pytest.mark.skipif(os.name != "nt", reason="UNC paths require Windows")
+    def test_windows_pathlib_form_preserves_unc_anchor(self):
+        target = Path(r"\\server\share\a b%20.png")
+        assert coerce_fs_path(Path(target.as_uri())) == target
 
     def test_remote_file_uri(self):
         raw = "file://host/share/x.png"


### PR DESCRIPTION
## Summary

Parse file URLs before filesystem operations so local session/tool paths do not create a relative `file:` directory. Decode percent escapes exactly once, preserve Windows drive/UNC paths, and read session metadata through a temporary copy without changing the source database.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

`Path("file:///...")` treats a URL as a relative filesystem path. The first fix also decoded escapes twice, turning a literal `image%20name.png` into `image name.png`, including reading the wrong neighboring image. Passing SQLite URI strings to KohakuVault during metadata probes independently recreated the unwanted `file:` directory.

## Changes

- Normalize file URLs at tool, workspace, config, and session filesystem boundaries.
- Decode local and UNC URL paths once; recover Windows pathlib forms with their drive/network anchor and escaped filenames intact.
- Copy session databases and existing WAL/SHM sidecars into a temporary directory before reading metadata.
- Normalize file URLs in format-version detection and default session-index lookup.
- Preserve the media resolver's local-only contract: general filesystem operations accept Windows UNC paths, but provider media resolution rejects remote file-URL authorities.
- Use a controlled clock for the Windows debounce regression test and wait for actual Markdown fence layout in the terminal scrollbar test.
- Cover literal percent escapes, Unicode/space filenames, UNC paths, metadata immutability, and shared URI/path index identity.

## Validation

**All 13 CI checks passed on `cc42cc7615f824870d07ba402fceacd3665f81cd`, including both Windows jobs.**

Commands used with the isolated Python 3.12 environment:

```bash
python -m black --check src/ tests/
python -m ruff check src/ tests/
python -m pytest tests/unit/utils/test_fs_path.py tests/unit/llm/test_artifact_resolve.py tests/unit/llm/test_grok_image_gen.py -q
python -m pytest tests/unit/utils/test_fs_path.py tests/unit/session/ tests/unit/studio/persistence/session_index/ tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py tests/integration/test_session.py tests/integration/test_studio.py tests/e2e/test_prog_studio.py tests/e2e/test_api_studio.py -q
python -m pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py --ignore=tests/unit/test_dep_graph_lint.py
ulimit -n 4096
python -m pytest tests/integration/ tests/e2e/ -q
```

- Focused decoding regressions: **42 passed, 4 Windows-only skips**.
- Session, index, guard, and Studio workflows: **2,775 passed, 4 skips**.
- Full unit tier: **13,058 passed, 5 skipped**, with two existing logging-capture failures described below.
- Full integration + e2e: **248 passed**, with seven pre-existing e2e failures; all integration workflows passed with the descriptor limit raised.
- New regression tests were observed failing before the corresponding fixes.

Windows follow-up verification: `python -m pytest tests/unit/builtins/tui/ tests/unit/llm/ tests/unit/studio/persistence/session_index/ tests/integration/test_llm.py -q` — **1,071 passed**. The terminal timing failure was reproduced deterministically before the layout-wait fix; all original scrollbar assertions remain.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [ ] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

- Windows compatibility review: https://github.com/Kohaku-Lab/KohakuTerrarium/pull/310#issuecomment-5647581865
- Separate canvas work remains in #311.

## Notes for Reviewers

The first follow-up CI passed all Linux/macOS jobs; Windows exposed the media resolver's remote-authority regression, plus existing debounce and terminal-layout timing failures. These are tracked separately from the original percent-decoding failures.

The metadata probe copies the database even when no WAL exists. This avoids KohakuVault treating a SQLite URI as a mkdir path, at the cost of copying the database for that probe.

## Screenshots / Logs (if applicable)

The regression tests assert that the working directory gains no `file:` child and the original session bytes/mtime stay unchanged.

## Breaking Changes (if applicable)

None. Plain filesystem paths retain their existing behavior.

## Exceptions / Not Run

- Two existing local unit tests (`test_dir_barrier_einval_reports_file_only_and_warns`, `test_dir_fsync_einval_is_tolerated_but_signalled`) fail to capture warnings. Both reproduce on the other branch; a handler attached directly to the framework logger receives the expected warnings, while `caplog` at the root receives none (`propagate=False`).
- Seven e2e failures reproduce on the baseline: three cross-node forwarding probes, the deep channel-trigger probe, the multi-node journey, worker subagent dispatch, and the stale `## Live Group` prompt assertion.
- The initial combined run also observed a change to the local application's `ui_prefs.json`; that guard cannot identify the writer. The separate full unit rerun did not reproduce it.
- The default macOS descriptor limit of 256 caused database-open errors in a separate integration run. Raising the limit to 4096 eliminated those errors.
- No frontend files changed. No local Windows host, live UI restart, or deletion of existing unwanted directories was used; fresh PR CI covers the OS matrix. The existing PR was updated directly to run that matrix; there is no push-triggered feature-branch workflow on the fork.
