### PR TITLE
feat(canvas): canvas_image tool and a bounded Studio strip

### DIFF
--- a/src/kohakuterrarium-frontend/src/components/panels/CanvasPanel.vue
+++ b/src/kohakuterrarium-frontend/src/components/panels/CanvasPanel.vue
@@ -6,6 +6,7 @@
       <button v-for="a in canvas.artifacts" :key="a.id" class="flex items-center gap-1 px-2 py-0.5 rounded transition-colors shrink-0" :class="canvas.activeId === a.id ? 'bg-iolite/15 text-iolite' : 'text-warm-500 hover:text-warm-700 dark:hover:text-warm-300 hover:bg-warm-100 dark:hover:bg-warm-800'" :title="`${a.name} · ${a.type}`" @click="canvas.setActive(a.id)">
         <span :class="typeIcon(a.type)" class="text-[11px]" />
         <span class="truncate max-w-32">{{ a.name }}</span>
+        <span class="i-carbon-close text-[10px] opacity-50 hover:opacity-100" title="Remove from canvas" @click.stop="canvas.dismissArtifact(a.id)" />
       </button>
 
       <div class="flex-1" />
@@ -19,6 +20,9 @@
           <div class="i-carbon-download text-[12px]" />
         </button>
       </template>
+      <button v-if="canvas.artifacts.length" class="w-6 h-6 flex items-center justify-center rounded text-warm-400 hover:text-warm-600 dark:hover:text-warm-300 transition-colors shrink-0" title="Clear canvas" @click="canvas.clearArtifacts()">
+        <div class="i-carbon-close-outline text-[12px]" />
+      </button>
     </div>
 
     <!-- Viewer -->

--- a/src/kohakuterrarium-frontend/src/composables/useArtifactDetector.js
+++ b/src/kohakuterrarium-frontend/src/composables/useArtifactDetector.js
@@ -34,9 +34,7 @@ export function useArtifactDetector(scope, options = {}) {
     const tab = chat.activeTab
     if (!tab) return
     const msgs = chat.messagesByTab?.[tab] || []
-    for (const m of msgs) {
-      canvas.scanMessage(m)
-    }
+    canvas.scanMessages(msgs)
   }
 
   // While processing, scan every 2s to catch completed code blocks

--- a/src/kohakuterrarium-frontend/src/composables/useArtifactDetector.test.js
+++ b/src/kohakuterrarium-frontend/src/composables/useArtifactDetector.test.js
@@ -18,6 +18,52 @@ afterEach(() => {
 })
 
 describe("useArtifactDetector", () => {
+  it("keeps dismissal through older history but reopens for a new reverting edit", async () => {
+    const scope = "paged-dismissal"
+    const chat = useChatStore(scope)
+    const canvas = useCanvasStore(scope)
+    const preview = (id, content) => ({
+      id,
+      role: "assistant",
+      parts: [
+        {
+          type: "tool",
+          jobId: id,
+          resultMeta: {
+            canvas_preview: { kind: "edit", file_path: "/work/a.py", lang: "py", content },
+          },
+        },
+      ],
+    })
+    chat.activeTab = "agent"
+    chat.messagesByTab.agent = [preview("m2", "v2")]
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          useArtifactDetector(scope)
+          return () => null
+        },
+      }),
+    )
+    try {
+      await nextTick()
+      canvas.dismissArtifact(canvas.activeId)
+      chat.messagesByTab.agent.unshift(preview("m1", "v1"))
+      await nextTick()
+      expect(canvas.artifacts).toHaveLength(0)
+      chat.messagesByTab.agent.push(preview("m3", "v1"))
+      await nextTick()
+      expect(canvas.artifacts).toHaveLength(1)
+      expect(canvas.activeArtifact.content).toBe("v1")
+      canvas.dismissArtifact(canvas.activeId)
+      chat.messagesByTab.agent.push(preview("m4", "v2"))
+      await nextTick()
+      expect(canvas.activeArtifact.content).toBe("v2")
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
   it("rescans scoped chat content when the owning macro tab is activated", async () => {
     const active = ref(false)
     const scope = "instance-activation"

--- a/src/kohakuterrarium-frontend/src/stores/canvas.js
+++ b/src/kohakuterrarium-frontend/src/stores/canvas.js
@@ -107,16 +107,17 @@ function _setupCanvasStore() {
     /** Upsert an artifact. Same sourceId refreshes in place without
      *  changing selection. A new sourceId appends and becomes active.
      *  A closed path stays hidden through rescan of known versions, then
-     *  reopens when content is something the strip has not seen. */
-    function upsertArtifact({ sourceId, content, lang, type, seedName }) {
+     *  reopens for a new publication or updated content. */
+    function upsertArtifact({ sourceId, content, lang, type, seedName, revisionId = null }) {
+      const revision = JSON.stringify([revisionId, content])
       if (hiddenSourceIds.value.has(sourceId)) {
         const seen = seenContentBySource.value.get(sourceId)
-        if (seen && seen.has(content)) return null
+        if (seen && seen.has(revision)) return null
         const next = new Set(hiddenSourceIds.value)
         next.delete(sourceId)
         hiddenSourceIds.value = next
       }
-      _noteSeen(sourceId, content)
+      _noteSeen(sourceId, revision)
       const existing = artifacts.value.find((a) => a.sourceId === sourceId)
       if (existing) {
         if (existing.content === content) return existing
@@ -145,7 +146,7 @@ function _setupCanvasStore() {
      *  edit tool previews, ``##canvas##`` markers, or long fenced code
      *  blocks, upserting one artifact per match. Idempotent — running
      *  twice on the same message produces the same set of artifacts. */
-    function scanMessage(msg) {
+    function scanMessage(msg, upsert = upsertArtifact) {
       if (!msg || msg.role !== "assistant") return
 
       // Image parts (provider-native ``image_gen`` outputs etc.) become
@@ -159,7 +160,7 @@ function _setupCanvasStore() {
           if (!url) continue
           const meta = p.meta || {}
           const lang = (meta.output_format || _extOfDataUrl(url) || "png").toLowerCase()
-          upsertArtifact({
+          upsert({
             sourceId: `${msg.id}:image:${imgIdx}`,
             content: url,
             lang,
@@ -178,15 +179,16 @@ function _setupCanvasStore() {
       // ``content === null`` means the file exceeded the preview cap;
       // skip those so the canvas doesn't show an empty bubble.
       if (msg.parts && Array.isArray(msg.parts)) {
-        for (const p of msg.parts) {
+        for (const [partIndex, p] of msg.parts.entries()) {
           if (p.type !== "tool") continue
           const preview = p.resultMeta?.canvas_preview
           if (!preview || preview.content == null) continue
           if (!preview.file_path) continue
           const isImage = preview.kind === "image"
           const raw = preview.content
-          upsertArtifact({
+          upsert({
             sourceId: `file:${preview.file_path}`,
+            revisionId: p.jobId || p.id || `${msg.id}:tool:${partIndex}`,
             content: isImage ? mediaSourceUrl(raw) || raw : raw,
             lang: preview.lang || (isImage ? "png" : "text"),
             type: isImage ? "image" : _guessTypeFromLang(preview.lang),
@@ -215,7 +217,7 @@ function _setupCanvasStore() {
         const body = m[2] || ""
         const lang = /lang=([\w-]+)/.exec(meta)?.[1] || "text"
         const name = /name=([^\s]+)/.exec(meta)?.[1] || null
-        upsertArtifact({
+        upsert({
           sourceId: `${msg.id}:marker:${m.index}`,
           content: body,
           lang,
@@ -232,12 +234,24 @@ function _setupCanvasStore() {
         const body = f[2] || ""
         const lines = body.split("\n").length
         if (lines < MIN_LINES_FOR_HEURISTIC) continue
-        upsertArtifact({
+        upsert({
           sourceId: `${msg.id}:fence:${f.index}`,
           content: body,
           lang,
           type: _guessTypeFromLang(lang),
         })
+      }
+    }
+
+    function scanMessages(messages) {
+      const latest = new Map()
+      for (const msg of messages) {
+        scanMessage(msg, (artifact) => {
+          latest.set(artifact.sourceId, artifact)
+        })
+      }
+      for (const artifact of latest.values()) {
+        upsertArtifact(artifact)
       }
     }
 
@@ -282,6 +296,7 @@ function _setupCanvasStore() {
       dismissed,
       upsertArtifact,
       scanMessage,
+      scanMessages,
       setActive,
       dismiss,
       dismissArtifact,

--- a/src/kohakuterrarium-frontend/src/stores/canvas.js
+++ b/src/kohakuterrarium-frontend/src/stores/canvas.js
@@ -186,10 +186,15 @@ function _setupCanvasStore() {
           if (!preview.file_path) continue
           const isImage = preview.kind === "image"
           const raw = preview.content
+          const revisionId = p.jobId || p.id || `${msg.id}:tool:${partIndex}`
+          let content = isImage ? mediaSourceUrl(raw) || raw : raw
+          if (isImage && raw.startsWith("file://") && content.startsWith("/api/files/raw?")) {
+            content += `&canvas_revision=${encodeURIComponent(revisionId)}`
+          }
           upsert({
             sourceId: `file:${preview.file_path}`,
-            revisionId: p.jobId || p.id || `${msg.id}:tool:${partIndex}`,
-            content: isImage ? mediaSourceUrl(raw) || raw : raw,
+            revisionId,
+            content,
             lang: preview.lang || (isImage ? "png" : "text"),
             type: isImage ? "image" : _guessTypeFromLang(preview.lang),
             seedName: preview.file_path,

--- a/src/kohakuterrarium-frontend/src/stores/canvas.js
+++ b/src/kohakuterrarium-frontend/src/stores/canvas.js
@@ -65,6 +65,7 @@ function _setupCanvasStore() {
     const activeId = ref(null)
     const dismissed = ref(false)
     const hiddenSourceIds = ref(new Set())
+    const seenContentBySource = ref(new Map())
 
     const activeArtifact = computed(
       () => artifacts.value.find((a) => a.id === activeId.value) || null,
@@ -76,6 +77,17 @@ function _setupCanvasStore() {
       const next = new Set(hiddenSourceIds.value)
       next.add(sourceId)
       hiddenSourceIds.value = next
+    }
+
+    function _noteSeen(sourceId, content) {
+      let set = seenContentBySource.value.get(sourceId)
+      if (!set) {
+        set = new Set()
+        const map = new Map(seenContentBySource.value)
+        map.set(sourceId, set)
+        seenContentBySource.value = map
+      }
+      set.add(content)
     }
 
     function _selectNewest() {
@@ -94,9 +106,17 @@ function _setupCanvasStore() {
 
     /** Upsert an artifact. Same sourceId refreshes in place without
      *  changing selection. A new sourceId appends and becomes active.
-     *  Hidden sourceIds (closed or evicted) stay off the strip. */
+     *  A closed path stays hidden through rescan of known versions, then
+     *  reopens when content is something the strip has not seen. */
     function upsertArtifact({ sourceId, content, lang, type, seedName }) {
-      if (hiddenSourceIds.value.has(sourceId)) return null
+      if (hiddenSourceIds.value.has(sourceId)) {
+        const seen = seenContentBySource.value.get(sourceId)
+        if (seen && seen.has(content)) return null
+        const next = new Set(hiddenSourceIds.value)
+        next.delete(sourceId)
+        hiddenSourceIds.value = next
+      }
+      _noteSeen(sourceId, content)
       const existing = artifacts.value.find((a) => a.sourceId === sourceId)
       if (existing) {
         if (existing.content === content) return existing
@@ -251,6 +271,7 @@ function _setupCanvasStore() {
       activeId.value = null
       dismissed.value = false
       hiddenSourceIds.value = new Set()
+      seenContentBySource.value = new Map()
     }
 
     return {

--- a/src/kohakuterrarium-frontend/src/stores/canvas.js
+++ b/src/kohakuterrarium-frontend/src/stores/canvas.js
@@ -20,8 +20,12 @@ import { defineStore } from "pinia"
 import { computed, getCurrentInstance, ref } from "vue"
 
 import { injectScope, registerScopeDisposer } from "@/composables/useScope"
+import { mediaSourceUrl } from "@/utils/artifacts"
 
 const MIN_LINES_FOR_HEURISTIC = 15
+/** Soft cap on the strip. Oldest tiles are hidden (and stay hidden on
+ *  rescan) so a long attach does not grow an unbounded tab list. */
+export const MAX_CANVAS_ARTIFACTS = 12
 // Match fenced code blocks: opening ```lang\n ... closing ```
 // Uses \n``` on its own line (not $ anchor which is fragile with \r\n).
 const CODE_FENCE = /```(\w*)\n([\s\S]*?)\n```/g
@@ -60,6 +64,7 @@ function _setupCanvasStore() {
     const artifacts = ref([])
     const activeId = ref(null)
     const dismissed = ref(false)
+    const hiddenSourceIds = ref(new Set())
 
     const activeArtifact = computed(
       () => artifacts.value.find((a) => a.id === activeId.value) || null,
@@ -67,9 +72,31 @@ function _setupCanvasStore() {
     // Back-compat alias kept for any caller that imported ``activeVersion``.
     const activeVersion = activeArtifact
 
-    /** Upsert an artifact. If a sourceId already exists, refresh it in
-     *  place; otherwise append. */
+    function _hideSource(sourceId) {
+      const next = new Set(hiddenSourceIds.value)
+      next.add(sourceId)
+      hiddenSourceIds.value = next
+    }
+
+    function _selectNewest() {
+      const last = artifacts.value[artifacts.value.length - 1]
+      activeId.value = last ? last.id : null
+    }
+
+    function _evictOverflow() {
+      while (artifacts.value.length > MAX_CANVAS_ARTIFACTS) {
+        const oldest = artifacts.value[0]
+        _hideSource(oldest.sourceId)
+        artifacts.value = artifacts.value.slice(1)
+        if (activeId.value === oldest.id) _selectNewest()
+      }
+    }
+
+    /** Upsert an artifact. Same sourceId refreshes in place without
+     *  changing selection. A new sourceId appends and becomes active.
+     *  Hidden sourceIds (closed or evicted) stay off the strip. */
     function upsertArtifact({ sourceId, content, lang, type, seedName }) {
+      if (hiddenSourceIds.value.has(sourceId)) return null
       const existing = artifacts.value.find((a) => a.sourceId === sourceId)
       if (existing) {
         if (existing.content === content) return existing
@@ -77,7 +104,6 @@ function _setupCanvasStore() {
         existing.lang = lang || existing.lang
         existing.type = type || existing.type
         existing.name = _artifactName(seedName || content)
-        activeId.value = existing.id
         return existing
       }
       const id = `artifact_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`
@@ -91,6 +117,7 @@ function _setupCanvasStore() {
       }
       artifacts.value = [...artifacts.value, a]
       activeId.value = id
+      _evictOverflow()
       return a
     }
 
@@ -124,11 +151,10 @@ function _setupCanvasStore() {
         }
       }
 
-      // Feat 1 — tool parts carrying a ``canvas_preview`` payload (from
-      // write / edit / multi_edit) become code artifacts keyed by
-      // file path. Re-editing the same file refreshes the existing
-      // artifact in place; the canvas latches onto the latest one
-      // because ``upsertArtifact`` updates ``activeId`` on touch.
+      // Tool parts carrying ``canvas_preview`` become artifacts keyed by
+      // file path. write / edit / multi_edit emit text previews; canvas_image
+      // emits ``kind: "image"`` whose ``content`` is a displayable URL.
+      // Re-touching the same path refreshes the existing artifact in place.
       // ``content === null`` means the file exceeded the preview cap;
       // skip those so the canvas doesn't show an empty bubble.
       if (msg.parts && Array.isArray(msg.parts)) {
@@ -137,14 +163,13 @@ function _setupCanvasStore() {
           const preview = p.resultMeta?.canvas_preview
           if (!preview || preview.content == null) continue
           if (!preview.file_path) continue
+          const isImage = preview.kind === "image"
+          const raw = preview.content
           upsertArtifact({
-            // Key by file path — the artifact tracks the file, not the
-            // tool call. Two write calls to the same path produce ONE
-            // artifact with the latest content.
             sourceId: `file:${preview.file_path}`,
-            content: preview.content,
-            lang: preview.lang || "text",
-            type: _guessTypeFromLang(preview.lang),
+            content: isImage ? mediaSourceUrl(raw) || raw : raw,
+            lang: preview.lang || (isImage ? "png" : "text"),
+            type: isImage ? "image" : _guessTypeFromLang(preview.lang),
             seedName: preview.file_path,
           })
         }
@@ -206,10 +231,26 @@ function _setupCanvasStore() {
       dismissed.value = true
     }
 
+    function dismissArtifact(id) {
+      const art = artifacts.value.find((a) => a.id === id)
+      if (!art) return
+      _hideSource(art.sourceId)
+      const wasActive = activeId.value === id
+      artifacts.value = artifacts.value.filter((a) => a.id !== id)
+      if (wasActive) _selectNewest()
+    }
+
+    function clearArtifacts() {
+      for (const a of artifacts.value) _hideSource(a.sourceId)
+      artifacts.value = []
+      activeId.value = null
+    }
+
     function reset() {
       artifacts.value = []
       activeId.value = null
       dismissed.value = false
+      hiddenSourceIds.value = new Set()
     }
 
     return {
@@ -222,6 +263,8 @@ function _setupCanvasStore() {
       scanMessage,
       setActive,
       dismiss,
+      dismissArtifact,
+      clearArtifacts,
       reset,
     }
   }

--- a/src/kohakuterrarium-frontend/src/stores/canvas.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/canvas.test.js
@@ -402,8 +402,30 @@ describe("canvas store — dismiss and cap", () => {
     store.dismissArtifact(gone.id)
     expect(store.artifacts.map((a) => a.sourceId)).toEqual(["keep"])
     expect(store.activeId).toBe(first.id)
-    store.upsertArtifact({ sourceId: "drop", content: "b2", lang: "js" })
+    store.upsertArtifact({ sourceId: "drop", content: "b", lang: "js" })
     expect(store.artifacts.map((a) => a.sourceId)).toEqual(["keep"])
+  })
+
+  it("an edit of a dismissed path puts the tile back and selects it", () => {
+    const store = useCanvasStore()
+    const gone = store.upsertArtifact({ sourceId: "file:/work/a.py", content: "v1", lang: "py" })
+    store.dismissArtifact(gone.id)
+    store.upsertArtifact({ sourceId: "file:/work/a.py", content: "v1", lang: "py" })
+    expect(store.artifacts).toHaveLength(0)
+    const back = store.upsertArtifact({ sourceId: "file:/work/a.py", content: "v2", lang: "py" })
+    expect(store.artifacts).toHaveLength(1)
+    expect(store.artifacts[0].content).toBe("v2")
+    expect(store.activeId).toBe(back.id)
+  })
+
+  it("rescan of an older version does not reopen a dismissed path", () => {
+    const store = useCanvasStore()
+    store.upsertArtifact({ sourceId: "file:/work/a.py", content: "v1", lang: "py" })
+    const latest = store.upsertArtifact({ sourceId: "file:/work/a.py", content: "v2", lang: "py" })
+    store.dismissArtifact(latest.id)
+    store.upsertArtifact({ sourceId: "file:/work/a.py", content: "v1", lang: "py" })
+    store.upsertArtifact({ sourceId: "file:/work/a.py", content: "v2", lang: "py" })
+    expect(store.artifacts).toHaveLength(0)
   })
 
   it("scanMessage does not restore a dismissed file preview", () => {
@@ -444,6 +466,9 @@ describe("canvas store — dismiss and cap", () => {
     expect(store.activeId).toBeNull()
     store.upsertArtifact({ sourceId: "a", content: "1", lang: "js" })
     expect(store.artifacts).toHaveLength(0)
+    const back = store.upsertArtifact({ sourceId: "a", content: "1-edited", lang: "js" })
+    expect(store.artifacts.map((a) => a.sourceId)).toEqual(["a"])
+    expect(store.activeId).toBe(back.id)
   })
 
   it("evicts the oldest tile once the cap is exceeded", () => {
@@ -454,7 +479,42 @@ describe("canvas store — dismiss and cap", () => {
     expect(store.artifacts).toHaveLength(MAX_CANVAS_ARTIFACTS)
     expect(store.artifacts[0].sourceId).toBe("n1")
     expect(store.artifacts.at(-1).sourceId).toBe(`n${MAX_CANVAS_ARTIFACTS}`)
-    store.upsertArtifact({ sourceId: "n0", content: "again", lang: "js" })
+    store.upsertArtifact({ sourceId: "n0", content: "0", lang: "js" })
     expect(store.artifacts.some((a) => a.sourceId === "n0")).toBe(false)
+    store.upsertArtifact({ sourceId: "n0", content: "again", lang: "js" })
+    expect(store.artifacts.at(-1).sourceId).toBe("n0")
+    expect(store.artifacts).toHaveLength(MAX_CANVAS_ARTIFACTS)
+    expect(store.artifacts.some((a) => a.sourceId === "n1")).toBe(false)
+  })
+
+  it("scanMessage reopens a dismissed file after a later edit preview", () => {
+    const store = useCanvasStore()
+    const preview = (id, content) => ({
+      id,
+      role: "assistant",
+      parts: [
+        {
+          type: "tool",
+          name: "edit",
+          resultMeta: {
+            canvas_preview: {
+              kind: "edit",
+              file_path: "/work/a.py",
+              lang: "py",
+              content,
+              bytes: content.length,
+              truncated: false,
+            },
+          },
+        },
+      ],
+    })
+    store.scanMessage(preview("m1", "v1"))
+    store.dismissArtifact(store.artifacts[0].id)
+    store.scanMessage(preview("m1", "v1"))
+    expect(store.artifacts).toHaveLength(0)
+    store.scanMessage(preview("m2", "v2"))
+    expect(store.artifacts).toHaveLength(1)
+    expect(store.artifacts[0].content).toBe("v2")
   })
 })

--- a/src/kohakuterrarium-frontend/src/stores/canvas.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/canvas.test.js
@@ -395,6 +395,25 @@ describe("canvas store — canvas_image preview", () => {
 })
 
 describe("canvas store — dismiss and cap", () => {
+  it("a new publication can restore previously seen content", () => {
+    const store = useCanvasStore()
+    const publish = (revisionId, content) =>
+      store.upsertArtifact({
+        sourceId: "file:/work/out.png",
+        revisionId,
+        content,
+        type: "image",
+      })
+    publish("call1", "a.png")
+    const latest = publish("call2", "b.png")
+    store.dismissArtifact(latest.id)
+    publish("call1", "a.png")
+    publish("call2", "b.png")
+    expect(store.artifacts).toHaveLength(0)
+    publish("call3", "a.png")
+    expect(store.activeArtifact.content).toBe("a.png")
+  })
+
   it("dismissArtifact removes a tile and a later upsert of that source stays gone", () => {
     const store = useCanvasStore()
     const first = store.upsertArtifact({ sourceId: "keep", content: "a", lang: "js" })

--- a/src/kohakuterrarium-frontend/src/stores/canvas.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/canvas.test.js
@@ -304,6 +304,40 @@ describe("canvas store — write / edit canvas_preview (Feat 1)", () => {
 })
 
 describe("canvas store — canvas_image preview", () => {
+  it("refreshes the live file fallback when the same image path is published again", () => {
+    const store = useCanvasStore()
+    const publish = (jobId) =>
+      store.scanMessage({
+        id: "same-message",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool",
+            jobId,
+            resultMeta: {
+              canvas_preview: {
+                kind: "image",
+                file_path: "/work/out.png",
+                lang: "png",
+                content: "file:///work/out.png",
+              },
+            },
+          },
+        ],
+      })
+    publish("first")
+    const firstId = store.activeId
+    const firstUrl = store.activeArtifact.content
+    publish("second")
+    expect(store.activeId).toBe(firstId)
+    expect(store.artifacts).toHaveLength(1)
+    expect(store.activeArtifact.content).not.toBe(firstUrl)
+    expect(store.activeArtifact.content).toContain("path=%2Fwork%2Fout.png")
+    const secondUrl = store.activeArtifact.content
+    publish("second")
+    expect(store.activeArtifact.content).toBe(secondUrl)
+  })
+
   it("picks up kind image as an image artifact, not code", () => {
     const store = useCanvasStore()
     const msg = {
@@ -333,7 +367,9 @@ describe("canvas store — canvas_image preview", () => {
     expect(a.type).toBe("image")
     expect(a.lang).toBe("png")
     expect(a.sourceId).toBe("file:/Users/me/out.png")
-    expect(a.content).toBe(`/api/files/raw?path=${encodeURIComponent("/Users/me/out.png")}`)
+    expect(a.content).toBe(
+      `/api/files/raw?path=${encodeURIComponent("/Users/me/out.png")}&canvas_revision=m_img%3Atool%3A0`,
+    )
   })
 
   it("keeps a session artifact URL as the image content", () => {

--- a/src/kohakuterrarium-frontend/src/stores/canvas.test.js
+++ b/src/kohakuterrarium-frontend/src/stores/canvas.test.js
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { createPinia, setActivePinia } from "pinia"
 
-import { useCanvasStore } from "./canvas.js"
+import { MAX_CANVAS_ARTIFACTS, useCanvasStore } from "./canvas.js"
 
 beforeEach(() => {
   setActivePinia(createPinia())
@@ -62,6 +62,26 @@ describe("canvas store — artifact detection", () => {
     expect(store.artifacts[0].content).toBe("v2 body")
     expect(store.artifacts[0].name).toBe("v2 body")
     expect(store.activeId).toBe(art.id)
+  })
+
+  it("does not steal selection when an older artifact's content refreshes", () => {
+    const store = useCanvasStore()
+    const first = store.upsertArtifact({ sourceId: "old", content: "file://a.png", type: "image" })
+    const second = store.upsertArtifact({ sourceId: "new", content: "file://b.png", type: "image" })
+    expect(store.activeId).toBe(second.id)
+    store.upsertArtifact({ sourceId: "old", content: "/api/files/raw?path=a.png", type: "image" })
+    expect(store.activeId).toBe(second.id)
+    expect(first.content).toBe("/api/files/raw?path=a.png")
+  })
+
+  it("a new publish becomes active even after the user clicked an older tab", () => {
+    const store = useCanvasStore()
+    const first = store.upsertArtifact({ sourceId: "a", content: "one", lang: "js" })
+    store.upsertArtifact({ sourceId: "b", content: "two", lang: "js" })
+    store.setActive(first.id)
+    const third = store.upsertArtifact({ sourceId: "c", content: "three", lang: "js" })
+    expect(store.activeId).toBe(third.id)
+    expect(store.artifacts).toHaveLength(3)
   })
 
   it("auto-activates newly detected artifacts after an activation catch-up scan", () => {
@@ -271,8 +291,7 @@ describe("canvas store — write / edit canvas_preview (Feat 1)", () => {
   it("tool parts without canvas_preview are ignored", () => {
     // Regression: non-file tools (bash, glob, etc.) must NOT spawn
     // canvas artifacts. The detector only fires when the tool result
-    // carries a ``canvas_preview`` dict — which only write / edit /
-    // multi_edit produce today.
+    // carries a ``canvas_preview`` dict.
     const store = useCanvasStore()
     const msg = {
       id: "m_bash",
@@ -281,5 +300,161 @@ describe("canvas store — write / edit canvas_preview (Feat 1)", () => {
     }
     store.scanMessage(msg)
     expect(store.artifacts).toHaveLength(0)
+  })
+})
+
+describe("canvas store — canvas_image preview", () => {
+  it("picks up kind image as an image artifact, not code", () => {
+    const store = useCanvasStore()
+    const msg = {
+      id: "m_img",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool",
+          name: "canvas_image",
+          status: "done",
+          resultMeta: {
+            canvas_preview: {
+              kind: "image",
+              file_path: "/Users/me/out.png",
+              lang: "png",
+              content: "file:///Users/me/out.png",
+              bytes: 1200,
+              truncated: false,
+            },
+          },
+        },
+      ],
+    }
+    store.scanMessage(msg)
+    expect(store.artifacts).toHaveLength(1)
+    const a = store.artifacts[0]
+    expect(a.type).toBe("image")
+    expect(a.lang).toBe("png")
+    expect(a.sourceId).toBe("file:/Users/me/out.png")
+    expect(a.content).toBe(`/api/files/raw?path=${encodeURIComponent("/Users/me/out.png")}`)
+  })
+
+  it("keeps a session artifact URL as the image content", () => {
+    const store = useCanvasStore()
+    const url = "/api/sessions/abc/artifacts/canvas_images/shot.png"
+    const msg = {
+      id: "m_art",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool",
+          name: "canvas_image",
+          resultMeta: {
+            canvas_preview: {
+              kind: "image",
+              file_path: "/work/shot.png",
+              lang: "png",
+              content: url,
+              bytes: 80,
+              truncated: false,
+            },
+          },
+        },
+      ],
+    }
+    store.scanMessage(msg)
+    expect(store.artifacts[0].type).toBe("image")
+    expect(store.artifacts[0].content).toBe(url)
+  })
+
+  it("re-promoting the same path updates the existing image", () => {
+    const store = useCanvasStore()
+    const make = (id, content) => ({
+      id,
+      role: "assistant",
+      parts: [
+        {
+          type: "tool",
+          name: "canvas_image",
+          resultMeta: {
+            canvas_preview: {
+              kind: "image",
+              file_path: "/work/out.png",
+              lang: "png",
+              content,
+              bytes: 10,
+              truncated: false,
+            },
+          },
+        },
+      ],
+    })
+    store.scanMessage(make("m1", "/api/sessions/s/artifacts/canvas_images/a.png"))
+    store.scanMessage(make("m2", "/api/sessions/s/artifacts/canvas_images/b.png"))
+    expect(store.artifacts).toHaveLength(1)
+    expect(store.artifacts[0].content).toBe("/api/sessions/s/artifacts/canvas_images/b.png")
+    expect(store.activeArtifact?.content).toBe("/api/sessions/s/artifacts/canvas_images/b.png")
+  })
+})
+
+describe("canvas store — dismiss and cap", () => {
+  it("dismissArtifact removes a tile and a later upsert of that source stays gone", () => {
+    const store = useCanvasStore()
+    const first = store.upsertArtifact({ sourceId: "keep", content: "a", lang: "js" })
+    const gone = store.upsertArtifact({ sourceId: "drop", content: "b", lang: "js" })
+    store.dismissArtifact(gone.id)
+    expect(store.artifacts.map((a) => a.sourceId)).toEqual(["keep"])
+    expect(store.activeId).toBe(first.id)
+    store.upsertArtifact({ sourceId: "drop", content: "b2", lang: "js" })
+    expect(store.artifacts.map((a) => a.sourceId)).toEqual(["keep"])
+  })
+
+  it("scanMessage does not restore a dismissed file preview", () => {
+    const store = useCanvasStore()
+    const msg = {
+      id: "m_drop",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool",
+          name: "canvas_image",
+          resultMeta: {
+            canvas_preview: {
+              kind: "image",
+              file_path: "/work/gone.png",
+              lang: "png",
+              content: "/api/files/raw?path=gone.png",
+              bytes: 10,
+              truncated: false,
+            },
+          },
+        },
+      ],
+    }
+    store.scanMessage(msg)
+    expect(store.artifacts).toHaveLength(1)
+    store.dismissArtifact(store.artifacts[0].id)
+    store.scanMessage(msg)
+    expect(store.artifacts).toHaveLength(0)
+  })
+
+  it("clearArtifacts hides every current tile from later scans", () => {
+    const store = useCanvasStore()
+    store.upsertArtifact({ sourceId: "a", content: "1", lang: "js" })
+    store.upsertArtifact({ sourceId: "b", content: "2", lang: "js" })
+    store.clearArtifacts()
+    expect(store.artifacts).toHaveLength(0)
+    expect(store.activeId).toBeNull()
+    store.upsertArtifact({ sourceId: "a", content: "1", lang: "js" })
+    expect(store.artifacts).toHaveLength(0)
+  })
+
+  it("evicts the oldest tile once the cap is exceeded", () => {
+    const store = useCanvasStore()
+    for (let i = 0; i < MAX_CANVAS_ARTIFACTS + 1; i++) {
+      store.upsertArtifact({ sourceId: `n${i}`, content: String(i), lang: "js" })
+    }
+    expect(store.artifacts).toHaveLength(MAX_CANVAS_ARTIFACTS)
+    expect(store.artifacts[0].sourceId).toBe("n1")
+    expect(store.artifacts.at(-1).sourceId).toBe(`n${MAX_CANVAS_ARTIFACTS}`)
+    store.upsertArtifact({ sourceId: "n0", content: "again", lang: "js" })
+    expect(store.artifacts.some((a) => a.sourceId === "n0")).toBe(false)
   })
 })

--- a/src/kohakuterrarium/builtin_skills/tools/canvas_image.md
+++ b/src/kohakuterrarium/builtin_skills/tools/canvas_image.md
@@ -1,0 +1,30 @@
+---
+name: canvas_image
+description: Put a local image file on the Studio canvas. Not for inspecting a file - use read.
+category: builtin
+tags: [media, canvas]
+---
+
+# canvas_image
+
+Copies a PNG, JPEG, GIF, or WEBP onto the Studio canvas as a product.
+
+## Arguments
+
+| Arg | Type | Req | Description |
+| --- | --- | --- | --- |
+| path | string | yes | Local image file to promote |
+
+## Behavior
+
+- Resolves `path` against the working directory and verifies the bytes decode
+  as PNG, JPEG, GIF, or WEBP.
+- When a session store is attached, writes a copy under `canvas_images/` and
+  the canvas loads the served artifact URL. Otherwise the canvas uses `file://`.
+- Does not generate an image. Produce the file first (CLI, `write`,
+  `image_gen`), then call this with that path.
+
+## Limits
+
+- One path per call. Use `read` to inspect a file. Not a substitute for
+  `image_gen`.

--- a/src/kohakuterrarium/builtins/tools/__init__.py
+++ b/src/kohakuterrarium/builtins/tools/__init__.py
@@ -14,6 +14,7 @@ from kohakuterrarium.builtins.tool_catalog import (
 # Import side effects populate the built-in registry.
 from kohakuterrarium.builtins.tools.ask_user import AskUserTool
 from kohakuterrarium.builtins.tools.bash import BashTool
+from kohakuterrarium.builtins.tools.canvas_image import CanvasImageTool
 from kohakuterrarium.builtins.tools.delete_trigger import DeleteTriggerTool
 from kohakuterrarium.builtins.tools.python import PythonTool
 from kohakuterrarium.builtins.tools.edit import EditTool
@@ -51,6 +52,7 @@ __all__ = [
     # Tools
     "AskUserTool",
     "BashTool",
+    "CanvasImageTool",
     "DeleteTriggerTool",
     "PythonTool",
     "ReadTool",

--- a/src/kohakuterrarium/builtins/tools/canvas_image.py
+++ b/src/kohakuterrarium/builtins/tools/canvas_image.py
@@ -1,0 +1,174 @@
+"""Promote a local image file onto the Studio canvas."""
+
+import io
+from pathlib import Path
+from typing import Any
+
+from PIL import Image, UnidentifiedImageError
+
+from kohakuterrarium.core.tool_output import artifact_served_url
+from kohakuterrarium.llm.message import ImagePart, TextPart
+from kohakuterrarium.utils.logging import get_logger
+from kohakuterrarium.builtins.tools.canvas_preview import build_image_canvas_preview
+from kohakuterrarium.builtins.tools.registry import register_builtin
+from kohakuterrarium.modules.tool.base import (
+    BaseTool,
+    ExecutionMode,
+    ToolContext,
+    ToolResult,
+    resolve_tool_path,
+)
+
+logger = get_logger(__name__)
+
+MAX_IMAGE_BYTES = 20 * 1024 * 1024
+
+_IMAGE_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
+_PIL_FORMAT_TO_EXT = {
+    "PNG": "png",
+    "JPEG": "jpg",
+    "GIF": "gif",
+    "WEBP": "webp",
+}
+
+
+@register_builtin("canvas_image")
+class CanvasImageTool(BaseTool):
+    """Put a local image file onto the Studio canvas as a product."""
+
+    needs_context = True
+
+    @property
+    def tool_name(self) -> str:
+        return "canvas_image"
+
+    @property
+    def description(self) -> str:
+        return "Put a local image file on the Studio canvas. Not for inspecting a file - use read."
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        return ExecutionMode.DIRECT
+
+    async def _execute(
+        self, args: dict[str, Any], context: ToolContext | None = None
+    ) -> ToolResult:
+        path = str(args.get("path") or "").strip()
+        if not path:
+            return ToolResult(error="No path provided")
+
+        file_path = resolve_tool_path(path, context)
+
+        if context and context.path_guard:
+            msg = context.path_guard.check(str(file_path))
+            if msg:
+                return ToolResult(error=msg)
+
+        if not file_path.exists():
+            return ToolResult(error=f"File not found: {path}")
+        if not file_path.is_file():
+            return ToolResult(error=f"Not a file: {path}")
+
+        suffix = file_path.suffix.lower()
+        if suffix not in _IMAGE_MIME:
+            return ToolResult(
+                error=(
+                    f"Unsupported image format {suffix!r}. "
+                    f"Supported: {', '.join(sorted(_IMAGE_MIME))}."
+                )
+            )
+
+        file_size = file_path.stat().st_size
+        if file_size > MAX_IMAGE_BYTES:
+            return ToolResult(
+                error=(
+                    f"Image too large ({file_size // 1024}KB). "
+                    f"Max: {MAX_IMAGE_BYTES // (1024 * 1024)}MB."
+                )
+            )
+
+        try:
+            data = file_path.read_bytes()
+        except OSError as e:
+            return ToolResult(error=f"Failed to read image: {e}")
+
+        verified = _verify_image(data)
+        if verified is None:
+            return ToolResult(
+                error=(
+                    f"File {path} is not a valid image, or its format "
+                    "is unsupported (need PNG / JPEG / WEBP / GIF)."
+                )
+            )
+
+        lang = _PIL_FORMAT_TO_EXT.get(verified, suffix.lstrip(".") or "png")
+        url = _display_url(file_path, data, context)
+        resolved = str(file_path.resolve())
+
+        logger.info(
+            "Image promoted to canvas",
+            file_path=resolved,
+            size_kb=len(data) // 1024,
+            lang=lang,
+        )
+
+        return ToolResult(
+            output=[
+                TextPart(text=f"Canvas: {path} ({len(data) // 1024}KB, {lang})"),
+                ImagePart(
+                    url=url,
+                    detail="auto",
+                    source_type="file",
+                    source_name=file_path.name,
+                ),
+            ],
+            exit_code=0,
+            metadata={
+                "canvas_preview": build_image_canvas_preview(
+                    resolved,
+                    url,
+                    lang=lang,
+                    nbytes=len(data),
+                ),
+            },
+        )
+
+
+def _display_url(file_path: Path, data: bytes, context: ToolContext | None) -> str:
+    store = getattr(getattr(context, "agent", None), "session_store", None)
+    if store is not None and hasattr(store, "write_artifact"):
+        rel = f"canvas_images/{_safe_filename(file_path.name)}"
+        try:
+            disk_path = store.write_artifact(rel, data)
+            return artifact_served_url(store, rel, disk_path)
+        except Exception as e:
+            logger.warning(
+                "Failed to copy image into session artifacts",
+                error=str(e),
+            )
+    return file_path.resolve().as_uri()
+
+
+def _safe_filename(name: str) -> str:
+    cleaned = "".join(c if c.isalnum() or c in "._-" else "_" for c in name.strip())
+    return cleaned or "image.png"
+
+
+def _verify_image(data: bytes) -> str | None:
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            img.verify()
+        with Image.open(io.BytesIO(data)) as img:
+            fmt = img.format
+            img.load()
+        return fmt
+    except (UnidentifiedImageError, OSError, ValueError, SyntaxError) as e:
+        logger.debug("Image verification failed", error=str(e))
+        return None

--- a/src/kohakuterrarium/builtins/tools/canvas_image.py
+++ b/src/kohakuterrarium/builtins/tools/canvas_image.py
@@ -1,5 +1,6 @@
 """Promote a local image file onto the Studio canvas."""
 
+import hashlib
 import io
 from pathlib import Path
 from typing import Any
@@ -100,7 +101,7 @@ class CanvasImageTool(BaseTool):
             return ToolResult(error=f"Failed to read image: {e}")
 
         verified = _verify_image(data)
-        if verified is None:
+        if verified not in _PIL_FORMAT_TO_EXT:
             return ToolResult(
                 error=(
                     f"File {path} is not a valid image, or its format "
@@ -108,7 +109,7 @@ class CanvasImageTool(BaseTool):
                 )
             )
 
-        lang = _PIL_FORMAT_TO_EXT.get(verified, suffix.lstrip(".") or "png")
+        lang = _PIL_FORMAT_TO_EXT[verified]
         url = _display_url(file_path, data, context)
         resolved = str(file_path.resolve())
 
@@ -144,7 +145,8 @@ class CanvasImageTool(BaseTool):
 def _display_url(file_path: Path, data: bytes, context: ToolContext | None) -> str:
     store = getattr(getattr(context, "agent", None), "session_store", None)
     if store is not None and hasattr(store, "write_artifact"):
-        rel = f"canvas_images/{_safe_filename(file_path.name)}"
+        digest = hashlib.sha256(data).hexdigest()
+        rel = f"canvas_images/{digest}/{_safe_filename(file_path.name)}"
         try:
             disk_path = store.write_artifact(rel, data)
             return artifact_served_url(store, rel, disk_path)

--- a/src/kohakuterrarium/builtins/tools/canvas_preview.py
+++ b/src/kohakuterrarium/builtins/tools/canvas_preview.py
@@ -99,3 +99,25 @@ def build_canvas_preview(
         "bytes": len(encoded),
         "truncated": False,
     }
+
+
+def build_image_canvas_preview(
+    file_path: str | Path,
+    url: str,
+    *,
+    lang: str | None = None,
+    nbytes: int = 0,
+) -> dict[str, Any]:
+    """Build image preview metadata whose ``content`` is a displayable URL."""
+    path_str = str(file_path)
+    ext = (lang or Path(path_str).suffix.lower().lstrip(".") or "png").lower()
+    if ext == "jpeg":
+        ext = "jpg"
+    return {
+        "kind": "image",
+        "file_path": path_str,
+        "lang": ext,
+        "content": url,
+        "bytes": nbytes,
+        "truncated": False,
+    }

--- a/src/kohakuterrarium/llm/tool_schemas.py
+++ b/src/kohakuterrarium/llm/tool_schemas.py
@@ -449,6 +449,16 @@ _BUILTIN_SCHEMAS: dict[str, dict] = {
         },
         "required": ["job_id"],
     },
+    "canvas_image": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Local image path to put on the Studio canvas",
+            },
+        },
+        "required": ["path"],
+    },
     "image_gen": {
         "type": "object",
         "properties": {

--- a/tests/integration/test_modules.py
+++ b/tests/integration/test_modules.py
@@ -29,11 +29,13 @@ import asyncio
 from typing import Any
 
 import pytest
+from PIL import Image
 
 from kohakuterrarium.bootstrap import agent_init as _agent_init
 from kohakuterrarium.bootstrap import llm as _bootstrap_llm
 from kohakuterrarium.builtins.subagents.research import RESEARCH_CONFIG
 from kohakuterrarium.builtins.tools import web_search
+from kohakuterrarium.builtins.tools.canvas_image import CanvasImageTool
 from kohakuterrarium.builtins.tools.web_search import WebSearchTool
 from kohakuterrarium.core.agent import Agent
 from kohakuterrarium.core.config_types import (
@@ -1494,7 +1496,9 @@ class TestModulesIntegration:
         finally:
             await agent.stop()
 
-    async def test_tool_executes_direct_mode_feeds_controller(self, make_agent):
+    async def test_tool_executes_direct_mode_feeds_controller(
+        self, make_agent, tmp_path
+    ):
         """tool protocol — a real DIRECT-mode tool is dispatched by the
         controller from a ``[/...]`` block, the executor runs it, and the
         result is fed back into the controller's conversation so the next
@@ -1523,11 +1527,28 @@ class TestModulesIntegration:
                     "[/recorder]@@msg=explode\n[recorder/]", match="trigger a failure"
                 ),
                 ScriptEntry("handled the failure", match="deliberate explosion"),
+                ScriptEntry(
+                    f"[/canvas_image]@@path={tmp_path / 'out.png'}\n[canvas_image/]",
+                    match="publish first image",
+                ),
+                ScriptEntry("first image published", match="Canvas:"),
+                ScriptEntry(
+                    f"[/canvas_image]@@path={tmp_path / 'out.png'}\n[canvas_image/]",
+                    match="publish updated image",
+                ),
+                ScriptEntry("updated image published", match="Canvas:"),
             ]
         )
         tool = RecordingTool()
         agent.registry.register_tool(tool)
         agent.executor.register_tool(tool)
+        canvas_tool = CanvasImageTool()
+        agent.registry.register_tool(canvas_tool)
+        agent.executor.register_tool(canvas_tool)
+        store = SessionStore(str(tmp_path / "canvas.kohakutr"))
+        store.init_meta("canvas", "agent", "", str(tmp_path), [agent.config.name])
+        agent.attach_session_store(store)
+        agent.workspace.set(tmp_path)
 
         await agent.start()
         try:
@@ -1578,8 +1599,31 @@ class TestModulesIntegration:
             assert "recorder failed: deliberate explosion" in convo_text
             last = agent.controller.conversation.get_last_assistant_message()
             assert "handled the failure" in last.get_text_content()
+            image_path = tmp_path / "out.png"
+            Image.new("RGB", (2, 2), "red").save(image_path)
+            original = image_path.read_bytes()
+            await agent._process_event(create_user_input_event("publish first image"))
+            artifacts = list((store.artifacts_dir / "canvas_images").rglob("*.png"))
+            assert len(artifacts) == 1, [
+                m.get_text_content()
+                for m in agent.controller.conversation.get_messages()[-3:]
+            ]
+            first_artifact = artifacts[0]
+            assert first_artifact.read_bytes() == original
+            Image.new("RGB", (2, 2), "blue").save(image_path)
+            await agent._process_event(create_user_input_event("publish updated image"))
+            artifacts = list((store.artifacts_dir / "canvas_images").rglob("*.png"))
+            assert len(artifacts) == 2
+            assert first_artifact.read_bytes() == original
+            assert {p.read_bytes() for p in artifacts} == {
+                original,
+                image_path.read_bytes(),
+            }
+            last = agent.controller.conversation.get_last_assistant_message()
+            assert last.get_text_content() == "updated image published"
         finally:
             await agent.stop()
+            store.close()
 
     async def test_web_search_backend_switch_executes_and_resumes(
         self, make_agent, monkeypatch, tmp_path

--- a/tests/unit/builtins/tools/test_canvas_image.py
+++ b/tests/unit/builtins/tools/test_canvas_image.py
@@ -7,11 +7,14 @@ Studio canvas actually keys on.
 """
 
 from pathlib import Path
+from urllib.parse import unquote
 
+import pytest
 from PIL import Image
 
-from kohakuterrarium.builtins.tools.canvas_image import CanvasImageTool
 from kohakuterrarium.llm.message import ImagePart
+from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.builtins.tools.canvas_image import CanvasImageTool
 from kohakuterrarium.modules.tool.base import ToolContext
 
 
@@ -68,6 +71,48 @@ def _image_part(result) -> ImagePart:
 
 
 class TestCanvasImagePromotes:
+    @pytest.mark.parametrize("names", [("out.png", "out.png"), ("a b.png", "a_b.png")])
+    async def test_publications_preserve_prior_bytes(self, tmp_path, names):
+        store = SessionStore(str(tmp_path / "run.kohakutr"))
+        try:
+            paths = []
+            for folder, name, color in zip(("left", "right"), names, ("red", "blue")):
+                directory = tmp_path / folder
+                directory.mkdir()
+                path = directory / name
+                Image.new("RGB", (2, 2), color).save(path)
+                paths.append(path)
+            ctx = _ctx(tmp_path, agent=_Agent(store))
+            first = await CanvasImageTool()._execute({"path": str(paths[0])}, ctx)
+            second = await CanvasImageTool()._execute({"path": str(paths[1])}, ctx)
+            first_url = _image_part(first).url
+            second_url = _image_part(second).url
+            assert first_url != second_url
+            for url, source in ((first_url, paths[0]), (second_url, paths[1])):
+                relative = unquote(url.split("/artifacts/", 1)[1])
+                assert (
+                    store.artifacts_dir / relative
+                ).read_bytes() == source.read_bytes()
+
+            original = paths[0].read_bytes()
+            Image.new("RGB", (2, 2), "green").save(paths[0])
+            updated = await CanvasImageTool()._execute({"path": str(paths[0])}, ctx)
+            repeated = await CanvasImageTool()._execute({"path": str(paths[0])}, ctx)
+            assert _image_part(updated).url != first_url
+            assert _image_part(repeated).url == _image_part(updated).url
+            relative = unquote(first_url.split("/artifacts/", 1)[1])
+            assert (store.artifacts_dir / relative).read_bytes() == original
+        finally:
+            store.close()
+
+    async def test_rejects_unsupported_decoded_format(self, tmp_path):
+        path = tmp_path / "disguised.png"
+        Image.new("RGB", (2, 2), "red").save(path, "TIFF")
+        result = await CanvasImageTool()._execute({"path": str(path)}, _ctx(tmp_path))
+        assert result.error
+        assert "unsupported" in result.error
+        assert result.metadata.get("canvas_preview") is None
+
     async def test_missing_path_errors(self, tmp_path):
         result = await CanvasImageTool()._execute({}, _ctx(tmp_path))
         assert result.error

--- a/tests/unit/builtins/tools/test_canvas_image.py
+++ b/tests/unit/builtins/tools/test_canvas_image.py
@@ -1,0 +1,177 @@
+"""Unit tests for :class:`CanvasImageTool`.
+
+The tool is the promote door: a local image path becomes a pinned
+``ImagePart`` plus ``canvas_preview.kind == "image"``. ``read`` of the
+same file must stay a look-up, so this test pins the metadata the
+Studio canvas actually keys on.
+"""
+
+from pathlib import Path
+
+from PIL import Image
+
+from kohakuterrarium.builtins.tools.canvas_image import CanvasImageTool
+from kohakuterrarium.llm.message import ImagePart
+from kohakuterrarium.modules.tool.base import ToolContext
+
+
+class _Store:
+    def __init__(self, tmp: Path) -> None:
+        self.path = tmp / "run.kohakutr"
+        self.session_id = "run"
+        self.dir = tmp / "run.artifacts"
+        self.dir.mkdir()
+        self.written: list[tuple[str, bytes]] = []
+
+    def write_artifact(self, filename: str, data: bytes) -> Path:
+        self.written.append((filename, data))
+        dest = self.dir / filename
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+        return dest
+
+
+class _Agent:
+    def __init__(self, store: _Store | None = None) -> None:
+        self.session_store = store
+
+
+class _Guard:
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def check(self, path: str) -> str:
+        return self.message
+
+
+def _ctx(tmp_path: Path, *, agent=None, path_guard=None) -> ToolContext:
+    return ToolContext(
+        agent_name="test",
+        session=None,
+        working_dir=tmp_path,
+        agent=agent,
+        path_guard=path_guard,
+    )
+
+
+def _png(path: Path) -> Path:
+    Image.new("RGB", (2, 2), (220, 40, 40)).save(path, "PNG")
+    return path
+
+
+def _image_part(result) -> ImagePart:
+    parts = result.output
+    assert isinstance(parts, list)
+    images = [p for p in parts if isinstance(p, ImagePart)]
+    assert images, f"expected an ImagePart, got {parts!r}"
+    return images[0]
+
+
+class TestCanvasImagePromotes:
+    async def test_missing_path_errors(self, tmp_path):
+        result = await CanvasImageTool()._execute({}, _ctx(tmp_path))
+        assert result.error
+        assert result.metadata.get("canvas_preview") is None
+
+    async def test_missing_file_errors(self, tmp_path):
+        result = await CanvasImageTool()._execute(
+            {"path": str(tmp_path / "gone.png")}, _ctx(tmp_path)
+        )
+        assert result.error
+        assert "not found" in result.error.lower()
+        assert result.metadata.get("canvas_preview") is None
+
+    async def test_directory_errors(self, tmp_path):
+        result = await CanvasImageTool()._execute(
+            {"path": str(tmp_path)}, _ctx(tmp_path)
+        )
+        assert result.error
+        assert result.metadata.get("canvas_preview") is None
+
+    async def test_non_image_errors(self, tmp_path):
+        txt = tmp_path / "notes.txt"
+        txt.write_text("hello")
+        result = await CanvasImageTool()._execute({"path": str(txt)}, _ctx(tmp_path))
+        assert result.error
+        assert result.metadata.get("canvas_preview") is None
+
+    async def test_corrupt_png_errors(self, tmp_path):
+        bad = tmp_path / "bad.png"
+        bad.write_bytes(b"not an image")
+        result = await CanvasImageTool()._execute({"path": str(bad)}, _ctx(tmp_path))
+        assert result.error
+        assert result.metadata.get("canvas_preview") is None
+
+    async def test_path_guard_blocks(self, tmp_path):
+        png = _png(tmp_path / "secret.png")
+        result = await CanvasImageTool()._execute(
+            {"path": str(png)},
+            _ctx(tmp_path, path_guard=_Guard("blocked by policy")),
+        )
+        assert result.error == "blocked by policy"
+        assert result.metadata.get("canvas_preview") is None
+
+    async def test_promotes_without_session_store(self, tmp_path):
+        png = _png(tmp_path / "out.png")
+        result = await CanvasImageTool()._execute({"path": str(png)}, _ctx(tmp_path))
+        assert result.success
+        preview = result.metadata["canvas_preview"]
+        resolved = png.resolve()
+        assert preview["kind"] == "image"
+        assert preview["file_path"] == str(resolved)
+        assert preview["lang"] in {"png", "jpg"}
+        assert preview["content"] == resolved.as_uri()
+        assert preview["truncated"] is False
+        image = _image_part(result)
+        assert image.url == resolved.as_uri()
+        assert image.source_type == "file"
+        assert image.source_name == "out.png"
+
+    async def test_copies_into_session_artifacts(self, tmp_path):
+        png = _png(tmp_path / "shot.png")
+        store = _Store(tmp_path)
+        result = await CanvasImageTool()._execute(
+            {"path": str(png)},
+            _ctx(tmp_path, agent=_Agent(store)),
+        )
+        assert result.success
+        assert store.written
+        rel, data = store.written[0]
+        assert rel.startswith("canvas_images/")
+        assert data == png.read_bytes()
+        preview = result.metadata["canvas_preview"]
+        assert preview["kind"] == "image"
+        assert preview["file_path"] == str(png.resolve())
+        assert preview["content"].startswith("/api/sessions/")
+        assert "artifacts/" in preview["content"]
+        image = _image_part(result)
+        assert image.url == preview["content"]
+
+    async def test_artifact_write_failure_falls_back_to_file_uri(self, tmp_path):
+        class _BadStore:
+            def write_artifact(self, filename: str, data: bytes) -> Path:
+                raise RuntimeError("disk full")
+
+        png = _png(tmp_path / "x.png")
+        result = await CanvasImageTool()._execute(
+            {"path": str(png)},
+            _ctx(tmp_path, agent=_Agent(_BadStore())),
+        )
+        assert result.success
+        assert result.metadata["canvas_preview"]["content"] == png.resolve().as_uri()
+
+    async def test_too_large_errors(self, tmp_path, monkeypatch):
+        from kohakuterrarium.builtins.tools import canvas_image as mod
+
+        png = _png(tmp_path / "big.png")
+        monkeypatch.setattr(mod, "MAX_IMAGE_BYTES", 1)
+        result = await CanvasImageTool()._execute({"path": str(png)}, _ctx(tmp_path))
+        assert result.error
+        assert "large" in result.error.lower()
+        assert result.metadata.get("canvas_preview") is None
+
+
+def test_registered_as_builtin():
+    from kohakuterrarium.builtins.tool_catalog import get_builtin_tool
+
+    assert get_builtin_tool("canvas_image") is not None

--- a/tests/unit/builtins/tools/test_canvas_preview.py
+++ b/tests/unit/builtins/tools/test_canvas_preview.py
@@ -8,6 +8,7 @@ import pytest
 from kohakuterrarium.builtins.tools.canvas_preview import (
     PREVIEW_MAX_BYTES,
     build_canvas_preview,
+    build_image_canvas_preview,
     lang_for_path,
 )
 from kohakuterrarium.builtins.tools.edit import EditTool
@@ -63,6 +64,21 @@ class TestBuildCanvasPreview:
         assert out["content"] is None
         assert out["truncated"] is True
         assert out["bytes"] == PREVIEW_MAX_BYTES + 1
+
+    def test_image_preview_keeps_url_and_normalizes_jpeg(self):
+        out = build_image_canvas_preview(
+            "/repo/shot.jpeg",
+            "/api/sessions/s/artifacts/canvas_images/shot.jpeg",
+            nbytes=12,
+        )
+        assert out == {
+            "kind": "image",
+            "file_path": "/repo/shot.jpeg",
+            "lang": "jpg",
+            "content": "/api/sessions/s/artifacts/canvas_images/shot.jpeg",
+            "bytes": 12,
+            "truncated": False,
+        }
 
     def test_none_content_propagates(self):
         # Edge case for tools that mutate the file but don't know the

--- a/tests/unit/studio/persistence/session_index/test_hooks.py
+++ b/tests/unit/studio/persistence/session_index/test_hooks.py
@@ -1,10 +1,12 @@
 """Unit tests for ``session_index.hooks`` — every code path."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.studio.persistence.session_index import hooks as hooks_mod
 from kohakuterrarium.studio.persistence.session_index.hooks import (
     SessionIndexHook,
     push_index_update,
@@ -115,20 +117,18 @@ class TestSessionIndexHook:
         assert row2["preview"] == "one"
 
     def test_event_flush_debounced_by_time(self, idx, tmp_path, monkeypatch):
-        # Use n=999 so count never fires; advance monotonic clock
-        # manually to trigger the time gate.
+        now = 100.0
+        monkeypatch.setattr(hooks_mod, "time", SimpleNamespace(monotonic=lambda: now))
         s = _make_store(tmp_path, "alice")
         try:
             hook = SessionIndexHook(
-                s, idx, flush_every_n_events=999, flush_every_seconds=0.001
+                s, idx, flush_every_n_events=999, flush_every_seconds=5
             )
-            # Default ``time.monotonic`` runs in real time; with our
-            # tiny ``flush_every_seconds``, the next ``append_event``
-            # almost certainly trips the gate.
-            import time as _time
-
-            _time.sleep(0.01)
+            now = 104.0
             s.append_event("alice", "user_input", {"content": "after gate"})
+            assert idx.get("alice.kohakutr")["preview"] == ""
+            now = 105.0
+            s.append_event("alice", "text", {"content": "gate reached"})
             hook.detach()
         finally:
             s.close()

--- a/tests/unit/test_tool_doc_shape.py
+++ b/tests/unit/test_tool_doc_shape.py
@@ -48,6 +48,7 @@ CONFUSABLE = {
     "web_fetch",
     "web_search",
     "info",
+    "canvas_image",
     "skill",
     "explore",
     "plan",


### PR DESCRIPTION
## Summary

Add `canvas_image` to publish local PNG/JPEG/GIF/WEBP files onto Studio's canvas. The strip supports closing individual tiles, clearing all tiles, and a 12-tile cap; new file publications reopen dismissed tiles while historical rescans keep them dismissed.

## PR Type

- [x] Bug fix
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [x] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

Reading a locally generated image is an inspection operation and does not publish it to the canvas. An explicit publish tool makes those images available in Studio without growing the strip indefinitely.

## Changes

- Register `canvas_image` and its tool schema/documentation; emit an image part and explicit image canvas metadata.
- Store image artifacts under content-digest directories, preserving earlier publications when source files share a basename or change in place.
- Validate the decoded image format as well as the filename extension, including rejection of TIFF data disguised as PNG.
- Retain the newest preview for each source during history scans and identify tool publications by their call identity. Loading older history keeps dismissed tiles hidden; a new edit restoring earlier content reopens them.
- Keep existing-tile refreshes from stealing selection. New tiles become active; exceeding 12 tiles removes the oldest tile.
- Refresh live-file fallback previews on republish through a versioned browser request URL.
- Replace the unrelated Windows CI test's 10 ms sleep with a controlled monotonic clock, checking both sides of the debounce boundary.

## Validation

**All 13 CI checks passed on `4812663730ca7e4c2233671a01d50fe1b9aecada`, including Linux/macOS/Windows tests, lint, frontend, structural guards, and packaging.**

Commands used with the isolated Python 3.12 environment:

```bash
python -m black --check src/ tests/
python -m ruff check src/ tests/
python -m pytest tests/unit/builtins/tools/test_canvas_image.py tests/unit/builtins/tools/test_canvas_preview.py tests/unit/test_tool_doc_shape.py tests/unit/studio/persistence/session_index/test_hooks.py tests/integration/test_modules.py -q
python -m pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py tests/e2e/test_api_studio.py tests/e2e/test_prog_studio.py -q
python -m pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py --ignore=tests/unit/test_dep_graph_lint.py
ulimit -n 4096
python -m pytest tests/integration/ tests/e2e/ -q
cd src/kohakuterrarium-frontend
npm ci
npx vitest run src/stores/canvas.test.js src/composables/useArtifactDetector.test.js
npm test
npm run format:check
npm run build
```

- Tool, hook, schema, and module workflows: **404 passed**, including a real controller publishing two image revisions through a real session store.
- Guards and Studio e2e journeys: **1,778 passed**.
- Focused frontend: **30 passed**; formatting and production build passed.
- Full unit tier: **13,051 passed, 1 skipped**, with the three local exceptions below.
- Full integration + e2e: **248 passed**, with seven pre-existing e2e failures. All integration workflows passed with the descriptor limit raised.
- Full frontend: **1,424 tests passed**; one existing MacroShell suite cannot resolve its Monaco Editor import.
- Regression cases were observed failing before their corresponding fixes.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [ ] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [ ] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

The feature-approval discussion is not linked in this PR; the approval checklist remains unverified. #310 contains the separate file-URL/session-path fixes.

## Notes for Reviewers

Official creatures with explicit tool lists, including `@kt-biome/creatures/general`, need a separate [kt-biome](https://github.com/Kohaku-Lab/kt-biome) update after merge:

```yaml
- name: canvas_image
  type: builtin
```

Existing sessions require Stop → Resume to rebuild their tool list. The 12-tile limit is the frontend `MAX_CANVAS_ARTIFACTS` constant. Closing tiles affects this page session; a hard refresh rebuilds the strip from history.

Preserving historical image bytes requires a session artifact store. If artifact storage is unavailable or fails, the tool falls back to the live local file; republishing refreshes that file preview, but this fallback does not archive older bytes.

## Screenshots / Logs (if applicable)

Automated tests cover same-name image collisions, in-place image updates, disguised TIFF data, dismissal across older-page loading, reverting edits, and live-file refresh.

## Breaking Changes (if applicable)

None.

## Exceptions / Not Run

- Two existing local logging tests fail to capture the expected warnings: `test_dir_barrier_einval_reports_file_only_and_warns` and `test_dir_fsync_einval_is_tolerated_but_signalled`. They reproduce on both branches; a handler attached directly to the framework logger captures the exact expected warnings (`caplog` misses them because propagation is disabled).
- The config-pollution guard observed changed `ui_prefs.json` content during the full unit run. The guard cannot identify whether the live local application or a test wrote it.
- Seven e2e failures reproduce on the baseline: three cross-node forwarding probes, the deep channel-trigger probe, the multi-node journey, worker subagent dispatch, and the stale `## Live Group` prompt assertion.
- The default macOS descriptor limit of 256 caused database-open errors in the separate integration run; raising it to 4096 eliminated those errors.
- `MacroShell.test.js` fails while resolving the existing `monaco-editor` import from `MonacoEditor.vue`; all collected frontend tests and the production build pass.
- No local Windows host or live-browser smoke run was used. Fresh PR CI covers the OS matrix; the existing PR was updated directly because the fork has no push-triggered feature-branch workflow.
