### PR TITLE
fix(llm): omit unresolved local media and avoid duplicate retries

### DIFF
--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -797,6 +797,31 @@ jobs only. Conversation and Inspector Trace rows record the model actually bound
 to each new job, preferring its canonical profile selector and falling back to
 the raw model id.
 
+### OpenAI-compatible retries
+
+`OpenAIProvider` uses the framework's `retry_policy` to retry rate limits,
+server errors, and transient failures, including HTTP 408/409 and responses
+with `x-should-retry: true`. The OpenAI SDK's automatic
+retries are disabled, so a retry budget of `N` allows at most `N + 1` HTTP
+attempts for a retryable failure. With the default retry classes, a local-media
+configuration error such as
+`Cannot load local files without --allowed-local-media-path` fails after one
+request. This applies to streaming and non-streaming chat and remains in
+effect after credential reloads and model switches.
+
+Retries honor `retry-after-ms` and `Retry-After` (seconds or an HTTP date)
+when the requested delay is positive and at most 60 seconds, matching the
+SDK's limit. Otherwise they use the policy's exponential backoff and jitter.
+
+When constructing `OpenAIProvider` directly, `max_retries` supplies the budget
+if `retry_policy` is omitted; an explicit policy takes precedence. Defaults
+allow three retries. `max_retries=0`, or `retry_policy={"max_retries": 0}`,
+disables retries. Overflow recovery remains separate: it may compact or drop
+a tool round before sending a smaller request.
+
+These controls describe `OpenAIProvider`; LiteLLM and native Anthropic clients
+have their own retry behavior.
+
 ### Adding a custom LLM backend provider
 
 For most providers you only need a backend entry plus a preset:

--- a/src/kohakuterrarium/llm/artifact_resolve.py
+++ b/src/kohakuterrarium/llm/artifact_resolve.py
@@ -87,10 +87,16 @@ def resolve_artifact_url(url: str) -> str:
     return f"data:{mime};base64,{b64}"
 
 
+def _is_unresolved_local_media(url: str) -> bool:
+    if url.startswith("data:"):
+        return False
+    return url.startswith(_FILE_SCHEME) or url.startswith("/api/sessions/")
+
+
 def resolve_message_image_urls(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Inline local image parts while preserving object identity when unchanged."""
+    """Inline local image parts; omit refs that did not become a data URL."""
     any_changed = False
     out: list[dict[str, Any]] = []
     for msg in messages:
@@ -109,6 +115,13 @@ def resolve_message_image_urls(
                 iu = part["image_url"]
                 url = iu.get("url")
                 resolved = resolve_artifact_url(url) if isinstance(url, str) else url
+                if isinstance(resolved, str) and _is_unresolved_local_media(resolved):
+                    logger.warning(
+                        "Media reference unresolved — omitting image part",
+                        url=url,
+                    )
+                    msg_changed = True
+                    continue
                 if resolved is not url and resolved != url:
                     new_content.append({**part, "image_url": {**iu, "url": resolved}})
                     msg_changed = True

--- a/src/kohakuterrarium/llm/openai.py
+++ b/src/kohakuterrarium/llm/openai.py
@@ -42,8 +42,8 @@ from kohakuterrarium.llm.openai_ws import stream_ws_turn
 from kohakuterrarium.llm.recovery import (
     ErrorClass,
     RetryPolicy,
-    backoff_delay,
     classify_openai_error,
+    retry_delay,
 )
 from kohakuterrarium.llm.responses_ws import ResponsesWSError, ResponsesWSSession
 from kohakuterrarium.utils.logging import get_logger
@@ -77,7 +77,7 @@ class OpenAIProvider(BaseLLMProvider):
         retry_policy: RetryPolicy | dict[str, Any] | None = None,
         websocket_mode: bool = False,
     ):
-        """Configure an OpenAI-compatible client and optional stateful reasoning echo."""
+        """Configure the client, using max_retries when retry_policy is omitted."""
         super().__init__(
             LLMConfig(
                 model=model,
@@ -93,12 +93,14 @@ class OpenAIProvider(BaseLLMProvider):
         )
         self._ws_session: ResponsesWSSession | None = None
         self.echo_reasoning = bool(echo_reasoning)
-        self._retry_policy = RetryPolicy.from_value(retry_policy)
+        self._retry_policy = RetryPolicy.from_value(
+            {"max_retries": max_retries} if retry_policy is None else retry_policy
+        )
         self._api_key = api_key
         self._base_url_input = base_url
         self._timeout = timeout
         self._extra_headers = extra_headers or {}
-        self._max_retries = max_retries
+        self._max_retries = 0
         self._last_usage: dict[str, int] = {}
         self._last_assistant_extra_fields: dict[str, Any] = {}
         self.prompt_cache_key: str | None = None
@@ -115,7 +117,7 @@ class OpenAIProvider(BaseLLMProvider):
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
-            max_retries=max_retries,
+            max_retries=self._max_retries,
             default_headers=extra_headers or {},
         )
 
@@ -289,7 +291,7 @@ class OpenAIProvider(BaseLLMProvider):
                     and attempt < self._retry_policy.max_retries
                 ):
                     attempt += 1
-                    delay = backoff_delay(attempt, self._retry_policy)
+                    delay = retry_delay(exc, attempt, self._retry_policy)
                     logger.warning(
                         "provider_retry",
                         attempt=attempt,
@@ -507,7 +509,7 @@ class OpenAIProvider(BaseLLMProvider):
                     and attempt < self._retry_policy.max_retries
                 ):
                     attempt += 1
-                    delay = backoff_delay(attempt, self._retry_policy)
+                    delay = retry_delay(exc, attempt, self._retry_policy)
                     logger.warning(
                         "provider_retry",
                         attempt=attempt,

--- a/src/kohakuterrarium/llm/recovery.py
+++ b/src/kohakuterrarium/llm/recovery.py
@@ -5,7 +5,9 @@ Share retry policy, error classification, backoff, and overflow reduction.
 
 import asyncio
 import random
+import time
 from dataclasses import dataclass, field
+from email.utils import mktime_tz, parsedate_tz
 from enum import Enum
 from typing import Any
 
@@ -27,7 +29,7 @@ class ErrorClass(Enum):
 
 @dataclass(frozen=True)
 class RetryPolicy:
-    """Framework retry policy layered on provider SDK retries."""
+    """Framework retry policy for provider-boundary recovery."""
 
     max_retries: int = 3
     base_delay: float = 1.0
@@ -146,6 +148,10 @@ def classify_openai_error(exc: BaseException) -> ErrorClass:
         return ErrorClass.USER_ERROR
     if isinstance(status, int) and 500 <= status <= 599:
         return ErrorClass.SERVER
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", {})
+    if status in {408, 409} or headers.get("x-should-retry") == "true":
+        return ErrorClass.TRANSIENT
     if isinstance(status, int) and status in {400, 401, 403, 404}:
         return ErrorClass.USER_ERROR
     if _contains_any(message, _TRANSIENT_MARKERS):
@@ -194,6 +200,30 @@ def backoff_delay(attempt: int, policy: RetryPolicy) -> float:
         return base
     spread = base * policy.jitter
     return max(0.0, base + random.uniform(-spread, spread))
+
+
+def retry_delay(exc: BaseException, attempt: int, policy: RetryPolicy) -> float:
+    """Honor OpenAI-compatible retry headers up to 60 seconds, else use backoff."""
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", {})
+    delay = None
+    try:
+        delay = float(headers.get("retry-after-ms")) / 1000
+    except (TypeError, ValueError):
+        value = headers.get("retry-after")
+        try:
+            delay = float(value)
+        except (TypeError, ValueError):
+            if value:
+                try:
+                    date = parsedate_tz(value)
+                    if date is not None:
+                        delay = mktime_tz(date) - time.time()
+                except (TypeError, ValueError, OverflowError):
+                    pass
+    if delay is not None and 0 < delay <= 60:
+        return delay
+    return backoff_delay(attempt, policy)
 
 
 def _message_text_bytes(message: dict[str, Any]) -> int:

--- a/src/kohakuterrarium/llm/recovery.py
+++ b/src/kohakuterrarium/llm/recovery.py
@@ -91,6 +91,10 @@ _RATE_LIMIT_MARKERS = (
     "too many requests",
     "quota_exceeded",
 )
+_LOCAL_MEDIA_MARKERS = (
+    "allowed-local-media-path",
+    "cannot load local files",
+)
 _TRANSIENT_MARKERS = (
     "connection reset",
     "connection error",
@@ -136,6 +140,10 @@ def classify_openai_error(exc: BaseException) -> ErrorClass:
         or _contains_any(message, _RATE_LIMIT_MARKERS)
     ):
         return ErrorClass.RATE_LIMIT
+    if _contains_any(code, _LOCAL_MEDIA_MARKERS) or _contains_any(
+        message, _LOCAL_MEDIA_MARKERS
+    ):
+        return ErrorClass.USER_ERROR
     if isinstance(status, int) and 500 <= status <= 599:
         return ErrorClass.SERVER
     if isinstance(status, int) and status in {400, 401, 403, 404}:

--- a/tests/integration/test_llm.py
+++ b/tests/integration/test_llm.py
@@ -5,10 +5,9 @@ does NOT need a live network service: the profile / preset / backend
 config system, ``api_keys`` storage, the native tool-schema builder, and
 the multimodal ``Message`` / ``ContentPart`` types.
 
-The live provider clients (``openai.py``, ``anthropic_provider.py``,
-``codex_*.py``, ``litellm_provider.py``) are CARVED OUT — they require
-real endpoints. What is exercised here is the abstraction surface that
-``bootstrap/llm.py`` drives before it ever constructs a provider:
+Live endpoint checks are excluded. The multimodal workflow also exercises
+the real OpenAI SDK with an in-memory HTTP transport; the remaining workflows
+exercise the abstraction surface that ``bootstrap/llm.py`` drives:
 
     resolve_controller_llm()  -> LLMProfile
     get_api_key()             -> str
@@ -36,6 +35,7 @@ from typing import Any
 
 import httpx
 import pytest
+from openai import APIStatusError
 from PIL import Image
 
 from kohakuterrarium.builtins.tools.grok_image_gen import GrokImageGenTool
@@ -76,6 +76,7 @@ from kohakuterrarium.llm.message import (
     make_multimodal_content,
     messages_to_dicts,
 )
+from kohakuterrarium.llm.openai import OpenAIProvider
 from kohakuterrarium.llm.presets import iter_all_presets, resolve_alias
 from kohakuterrarium.llm.profile_types import LLMBackend, LLMPreset, LLMProfile
 from kohakuterrarium.llm.profiles import (
@@ -92,6 +93,7 @@ from kohakuterrarium.llm.profiles import (
     save_profile,
     set_default_model,
 )
+from kohakuterrarium.llm.recovery import RetryPolicy
 from kohakuterrarium.llm.tools import build_provider_native_tools, build_tool_schemas
 from kohakuterrarium.llm.variations import (
     apply_patch_map,
@@ -1298,6 +1300,80 @@ class TestLlmIntegration:
                     "url": f"data:image/png;base64,{encoded}",
                     "type": "image_url",
                 }
+
+            missing_reference = (tmp_path / "missing.png").as_uri()
+            chat_messages = [
+                UserMessage(
+                    [
+                        TextPart("Compare these images"),
+                        ImagePart(url=file_reference),
+                        ImagePart(url=artifact_reference),
+                        ImagePart(url=missing_reference),
+                    ]
+                )
+            ]
+            original_wire = messages_to_dicts(chat_messages)
+            chat_requests = []
+
+            def chat_response(request):
+                chat_requests.append(json.loads(request.content))
+                if len(chat_requests) <= 2:
+                    message = (
+                        "Cannot load local files without --allowed-local-media-path"
+                        if len(chat_requests) == 1
+                        else "temporary outage"
+                    )
+                    return httpx.Response(
+                        500 if len(chat_requests) == 1 else 503,
+                        json={"error": {"message": message}},
+                        headers={"retry-after-ms": "1"},
+                    )
+                return httpx.Response(
+                    200,
+                    json={
+                        "id": "comparison",
+                        "model": "test",
+                        "created": 0,
+                        "object": "chat.completion",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "same red square",
+                                },
+                                "finish_reason": "stop",
+                            }
+                        ],
+                    },
+                )
+
+            async with OpenAIProvider(
+                api_key="test-key",
+                model="test",
+                retry_policy=RetryPolicy(max_retries=1, base_delay=0, jitter=0),
+            ) as chat_provider:
+                initial_client = chat_provider._client
+                chat_provider._client = initial_client.with_options(
+                    http_client=httpx.AsyncClient(
+                        transport=httpx.MockTransport(chat_response)
+                    )
+                )
+                await initial_client.close()
+                with pytest.raises(APIStatusError, match="allowed-local-media-path"):
+                    await chat_provider.chat_complete(chat_messages)
+                assert len(chat_requests) == 1
+                response = await chat_provider.chat_complete(chat_messages)
+                assert response.content == "same red square"
+                assert len(chat_requests) == 3
+                assert chat_requests[0] == chat_requests[1] == chat_requests[2]
+                sent_parts = chat_requests[0]["messages"][0]["content"]
+                assert len(sent_parts) == 3
+                assert [part["image_url"]["url"] for part in sent_parts[1:]] == [
+                    f"data:image/png;base64,{encoded}",
+                    f"data:image/png;base64,{encoded}",
+                ]
+                assert messages_to_dicts(chat_messages) == original_wire
         finally:
             store.close()
         assert len(requests) == 3

--- a/tests/unit/llm/test_artifact_resolve.py
+++ b/tests/unit/llm/test_artifact_resolve.py
@@ -159,3 +159,49 @@ class TestResolveMessageImageUrls:
         ]
         # A text part that merely *contains* the path is not rewritten.
         assert resolve_message_image_urls(msgs) is msgs
+
+    def test_missing_file_reference_is_not_sent(self, tmp_path):
+        url = (tmp_path / "gone.png").resolve().as_uri()
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": {"url": url}},
+                ],
+            }
+        ]
+        out = resolve_message_image_urls(msgs)
+        assert out is not msgs
+        assert [p.get("type") for p in out[0]["content"]] == ["text"]
+        assert url not in str(out)
+        assert msgs[0]["content"][1]["image_url"]["url"] == url
+
+    def test_missing_artifact_url_is_not_sent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(artifact_resolve, "_session_dir", lambda: tmp_path)
+        url = "/api/sessions/sid/artifacts/nope.png"
+        msgs = [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": url}}],
+            }
+        ]
+        out = resolve_message_image_urls(msgs)
+        assert out[0]["content"] == []
+        assert url not in str(out)
+
+    def test_existing_file_reference_still_inlined(self, tmp_path):
+        pic = tmp_path / "kept.png"
+        pic.write_bytes(b"PNGDATA")
+        url = pic.resolve().as_uri()
+        msgs = [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": url}}],
+            }
+        ]
+        out = resolve_message_image_urls(msgs)
+        assert out[0]["content"][0]["image_url"]["url"].startswith(
+            "data:image/png;base64,"
+        )
+        assert msgs[0]["content"][0]["image_url"]["url"] == url

--- a/tests/unit/llm/test_openai.py
+++ b/tests/unit/llm/test_openai.py
@@ -1,0 +1,250 @@
+"""OpenAI provider recovery through the real SDK and an in-memory HTTP transport."""
+
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import APIStatusError
+
+from kohakuterrarium.llm import openai as provider_module
+from kohakuterrarium.llm.openai import OpenAIProvider
+from kohakuterrarium.llm.recovery import RetryPolicy
+
+MESSAGES = [{"role": "user", "content": "inspect the image"}]
+LOCAL_MEDIA_ERROR = "Cannot load local files without --allowed-local-media-path"
+
+
+async def _attach_transport(provider, respond):
+    previous = provider._client
+    provider._client = previous.with_options(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(respond))
+    )
+    await previous.close()
+
+
+async def _turn(provider, streaming):
+    if streaming:
+        return "".join([chunk async for chunk in provider.chat(MESSAGES)])
+    return (await provider.chat_complete(MESSAGES)).content
+
+
+def _error(status, message):
+    return httpx.Response(
+        status,
+        json={"error": {"message": message, "type": "provider_error", "code": status}},
+        headers={"retry-after-ms": "1"},
+    )
+
+
+def _success(streaming):
+    if streaming:
+        chunk = {
+            "id": "reply",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "test",
+            "choices": [
+                {"index": 0, "delta": {"content": "ok"}, "finish_reason": None}
+            ],
+        }
+        return httpx.Response(
+            200,
+            text=f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+    return httpx.Response(
+        200,
+        json={
+            "id": "reply",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+    )
+
+
+class TestOpenAIRetries:
+    @pytest.mark.parametrize("streaming", [False, True])
+    @pytest.mark.parametrize(
+        ("header", "expected_delay"),
+        [("10", 10.0), ("Thu, 01 Jan 10000 00:00:00 GMT", 1.0)],
+    )
+    async def test_retry_after_is_observed(
+        self, streaming, header, expected_delay, monkeypatch
+    ):
+        delays = []
+        requests = []
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        async def respond(request):
+            requests.append(request)
+            if len(requests) == 1:
+                return httpx.Response(
+                    429,
+                    json={"error": {"message": "busy"}},
+                    headers={"retry-after": header},
+                )
+            return _success(streaming)
+
+        monkeypatch.setattr(provider_module, "asyncio", SimpleNamespace(sleep=sleep))
+        async with OpenAIProvider(
+            api_key="test-key", model="test", retry_policy=RetryPolicy(jitter=0)
+        ) as provider:
+            await _attach_transport(provider, respond)
+            assert await _turn(provider, streaming) == "ok"
+            assert len(requests) == 2
+            assert delays == [expected_delay]
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    @pytest.mark.parametrize("local_media", [False, True])
+    async def test_positive_retry_hint_respects_local_media_errors(
+        self, streaming, local_media
+    ):
+        requests = []
+
+        async def respond(request):
+            requests.append(request)
+            if len(requests) == 1:
+                return httpx.Response(
+                    500 if local_media else 422,
+                    json={
+                        "error": {
+                            "message": LOCAL_MEDIA_ERROR if local_media else "busy"
+                        }
+                    },
+                    headers={"x-should-retry": "true", "retry-after-ms": "1"},
+                )
+            return _success(streaming)
+
+        async with OpenAIProvider(
+            api_key="test-key",
+            model="test",
+            retry_policy=RetryPolicy(max_retries=1, base_delay=0, jitter=0),
+        ) as provider:
+            await _attach_transport(provider, respond)
+            if local_media:
+                with pytest.raises(APIStatusError, match="allowed-local-media-path"):
+                    await _turn(provider, streaming)
+                assert len(requests) == 1
+            else:
+                assert await _turn(provider, streaming) == "ok"
+                assert len(requests) == 2
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    @pytest.mark.parametrize("variant", ["initial", "model", "credentials"])
+    async def test_local_media_failure_sends_once(
+        self, streaming, variant, monkeypatch
+    ):
+        requests = []
+
+        async def respond(request):
+            requests.append(request)
+            return _error(500, LOCAL_MEDIA_ERROR)
+
+        original = OpenAIProvider(api_key="test-key", model="test")
+        provider = original
+        try:
+            if variant == "model":
+                provider = original.with_model("other-model")
+            elif variant == "credentials":
+                monkeypatch.setenv("OPENAI_API_KEY", "rotated-test-key")
+                provider._credential_provider = "openai"
+                assert provider.reload_credentials()
+            await _attach_transport(provider, respond)
+            with pytest.raises(APIStatusError, match="allowed-local-media-path"):
+                await _turn(provider, streaming)
+            assert len(requests) == 1
+            if variant == "credentials":
+                assert requests[0].headers["authorization"] == "Bearer rotated-test-key"
+            if variant == "model":
+                assert json.loads(requests[0].content)["model"] == "other-model"
+        finally:
+            await provider.close()
+            if provider is not original:
+                await original.close()
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    @pytest.mark.parametrize("status", [408, 409, 429, 503])
+    @pytest.mark.parametrize("budget", [0, 2])
+    async def test_retry_policy_bounds_http_attempts(self, streaming, status, budget):
+        requests = []
+
+        async def respond(request):
+            requests.append(request.content)
+            return _error(status, "provider unavailable")
+
+        async with OpenAIProvider(
+            api_key="test-key",
+            model="test",
+            retry_policy=RetryPolicy(max_retries=budget, base_delay=0, jitter=0),
+        ) as provider:
+            await _attach_transport(provider, respond)
+            with pytest.raises(APIStatusError):
+                await _turn(provider, streaming)
+            assert len(requests) == budget + 1
+            assert len(set(requests)) == 1
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    @pytest.mark.parametrize("status", [408, 409, 503])
+    async def test_transient_failure_can_recover(self, streaming, status):
+        requests = []
+
+        async def respond(request):
+            requests.append(request.content)
+            return (
+                _error(status, "temporary outage")
+                if len(requests) == 1
+                else _success(streaming)
+            )
+
+        async with OpenAIProvider(
+            api_key="test-key",
+            model="test",
+            retry_policy=RetryPolicy(max_retries=1, base_delay=0, jitter=0),
+        ) as provider:
+            await _attach_transport(provider, respond)
+            assert await _turn(provider, streaming) == "ok"
+            assert len(requests) == 2
+
+    async def test_legacy_zero_retries_disables_retry(self):
+        requests = []
+
+        async def respond(request):
+            requests.append(request)
+            return _error(503, "temporary outage")
+
+        async with OpenAIProvider(
+            api_key="test-key", model="test", max_retries=0
+        ) as provider:
+            await _attach_transport(provider, respond)
+            with pytest.raises(APIStatusError):
+                await provider.chat_complete(MESSAGES)
+            assert len(requests) == 1
+
+    async def test_explicit_policy_overrides_legacy_zero_retries(self):
+        requests = []
+
+        async def respond(request):
+            requests.append(request)
+            return _error(503, "temporary outage")
+
+        async with OpenAIProvider(
+            api_key="test-key",
+            model="test",
+            max_retries=0,
+            retry_policy={"max_retries": 1, "base_delay": 0, "jitter": 0},
+        ) as provider:
+            await _attach_transport(provider, respond)
+            with pytest.raises(APIStatusError):
+                await provider.chat_complete(MESSAGES)
+            assert len(requests) == 2

--- a/tests/unit/llm/test_recovery.py
+++ b/tests/unit/llm/test_recovery.py
@@ -49,6 +49,18 @@ class TestClassifyOpenAIError:
     def test_5xx_status_is_server(self):
         assert classify_openai_error(_HTTPError(status_code=503)) == ErrorClass.SERVER
 
+    def test_local_media_500_is_user_error_not_retried(self):
+        exc = _HTTPError(
+            "Cannot load local files without --allowed-local-media-path",
+            status_code=500,
+        )
+        assert classify_openai_error(exc) == ErrorClass.USER_ERROR
+        assert ErrorClass.USER_ERROR not in RetryPolicy().retry_classes
+
+    def test_cannot_load_local_files_500_is_user_error(self):
+        exc = _HTTPError("cannot load local files from file://", status_code=500)
+        assert classify_openai_error(exc) == ErrorClass.USER_ERROR
+
     def test_4xx_user_status_is_user_error(self):
         assert (
             classify_openai_error(_HTTPError(status_code=401)) == ErrorClass.USER_ERROR

--- a/tests/unit/llm/test_recovery.py
+++ b/tests/unit/llm/test_recovery.py
@@ -7,6 +7,12 @@ backoff math, and the emergency context-drop reducer's splice result
 """
 
 import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from kohakuterrarium.llm import recovery
 
 from kohakuterrarium.llm.recovery import (
     ErrorClass,
@@ -153,6 +159,45 @@ class TestBackoffDelay:
         policy = RetryPolicy(base_delay=0.01, max_delay=100.0, jitter=10.0)
         for _ in range(50):
             assert backoff_delay(1, policy) >= 0.0
+
+
+class TestRetryDelay:
+    @pytest.mark.parametrize(
+        ("headers", "expected"),
+        [
+            ({"retry-after-ms": "1500", "retry-after": "10"}, 1.5),
+            ({"retry-after-ms": "invalid", "retry-after": "10"}, 10.0),
+            ({"retry-after": "0.5"}, 0.5),
+            ({"retry-after": "60"}, 60.0),
+            ({"retry-after": "invalid"}, 4.0),
+            ({"retry-after": "0"}, 4.0),
+            ({"retry-after": "-1"}, 4.0),
+            ({"retry-after": "61"}, 4.0),
+            ({"retry-after": "nan"}, 4.0),
+            ({"retry-after": "inf"}, 4.0),
+            ({"retry-after": "Thu, 01 Jan 10000 00:00:00 GMT"}, 4.0),
+            ({"retry-after": "Thu, 01 Jan 100000000000 00:00:00 GMT"}, 4.0),
+            ({"retry-after-ms": "61000"}, 4.0),
+            ({}, 4.0),
+        ],
+    )
+    def test_server_delay_and_backoff_fallback(self, headers, expected):
+        exc = _HTTPError(status_code=429)
+        exc.response = httpx.Response(429, headers=headers)
+        policy = RetryPolicy(base_delay=2, jitter=0)
+        assert recovery.retry_delay(exc, 2, policy) == expected
+
+    def test_retry_after_http_date(self, monkeypatch):
+        monkeypatch.setattr(recovery, "time", SimpleNamespace(time=lambda: 0))
+        exc = _HTTPError(status_code=503)
+        exc.response = httpx.Response(
+            503, headers={"Retry-After": "Thu, 01 Jan 1970 00:00:30 GMT"}
+        )
+        assert recovery.retry_delay(exc, 1, RetryPolicy(jitter=0)) == 30.0
+
+    def test_transport_error_uses_backoff(self):
+        policy = RetryPolicy(base_delay=2, jitter=0)
+        assert recovery.retry_delay(TimeoutError(), 2, policy) == 4.0
 
 
 class TestFormatDropPlaceholder:

--- a/tests/unit/studio/persistence/session_index/test_hooks.py
+++ b/tests/unit/studio/persistence/session_index/test_hooks.py
@@ -1,10 +1,12 @@
 """Unit tests for ``session_index.hooks`` — every code path."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from kohakuterrarium.session.store import SessionStore
+from kohakuterrarium.studio.persistence.session_index import hooks as hooks_mod
 from kohakuterrarium.studio.persistence.session_index.hooks import (
     SessionIndexHook,
     push_index_update,
@@ -115,20 +117,18 @@ class TestSessionIndexHook:
         assert row2["preview"] == "one"
 
     def test_event_flush_debounced_by_time(self, idx, tmp_path, monkeypatch):
-        # Use n=999 so count never fires; advance monotonic clock
-        # manually to trigger the time gate.
+        now = 100.0
+        monkeypatch.setattr(hooks_mod, "time", SimpleNamespace(monotonic=lambda: now))
         s = _make_store(tmp_path, "alice")
         try:
             hook = SessionIndexHook(
-                s, idx, flush_every_n_events=999, flush_every_seconds=0.001
+                s, idx, flush_every_n_events=999, flush_every_seconds=5
             )
-            # Default ``time.monotonic`` runs in real time; with our
-            # tiny ``flush_every_seconds``, the next ``append_event``
-            # almost certainly trips the gate.
-            import time as _time
-
-            _time.sleep(0.01)
+            now = 104.0
             s.append_event("alice", "user_input", {"content": "after gate"})
+            assert idx.get("alice.kohakutr")["preview"] == ""
+            now = 105.0
+            s.append_event("alice", "text", {"content": "gate reached"})
             hook.detach()
         finally:
             s.close()


### PR DESCRIPTION
## Summary

Unresolved local image references are omitted from outgoing OpenAI/LiteLLM requests while stored conversation references remain unchanged. Existing local images still inline as data URLs.

OpenAI-compatible local-media configuration errors now stop after one HTTP request with the default retry policy. Previously the OpenAI SDK retried the same 500 response four times before the framework classified it as non-retryable. The framework now owns the retry budget, including after model switches and credential reloads.

## PR Type

- [x] Bug fix
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / maintenance
- [ ] Feature / behavior change
- [ ] Breaking change

## Motivation / Context

vLLM can reject stale `file://` image history with `Cannot load local files without --allowed-local-media-path`. Re-uploading the same request cannot repair that configuration error, and nested SDK/framework retries made failed turns unnecessarily slow.

## Changes

- Omit unresolved local image parts at the send boundary; preserve existing files, remote URLs, and stored messages.
- Classify local-media configuration failures before generic server errors.
- Disable OpenAI SDK retries and apply the framework policy before retrying. A budget of N permits at most N+1 attempts for an ordinary retryable failure; context-overflow recovery remains separate.
- Preserve HTTP 408/409 recovery, positive server retry hints, and `retry-after-ms`/`Retry-After` delays up to the SDK's 60-second limit. Invalid dates fall back to normal backoff.
- Keep constructor `max_retries` as the framework budget when no explicit policy is supplied; explicit policies take precedence.
- Add real SDK/HTTP transport regressions for request counts, streaming and non-streaming recovery, policy precedence, model changes, credential rotation, and retry headers. Extend the existing multimodal integration workflow to verify outgoing payloads and unchanged history.
- Apply the same deterministic debounce-clock test correction as #310/#311. The original #312 Windows 3.12 job failed this existing timing-sensitive test.

## Validation

Local Python 3.12, macOS:

```bash
black src/ tests/
black --check src/ tests/
ruff check src/ tests/
pytest tests/unit/llm tests/integration/test_llm.py tests/unit/studio/persistence/session_index/test_hooks.py -q
ulimit -n 4096
pytest tests/unit/ -q --ignore=tests/unit/test_file_sizes.py --ignore=tests/unit/test_dep_graph_lint.py
pytest tests/integration/ -q
pytest tests/unit/test_file_sizes.py tests/unit/test_dep_graph_lint.py -q
cd src/kohakuterrarium-frontend
npm ci
npm run format:check
npm run build
```

- Focused regression suite: **915 passed**.
- Full integration tier: **175 passed**.
- File-size/dependency guards: **1,770 passed**.
- Python lint/format and frontend format/build: passed.
- Full unit tier: **13,084 passed, 1 skipped, 2 existing local log-capture failures**; see exceptions below. The final focused run also covers the subsequently added malformed-date regressions.
- Updated-head CI: **all 13 jobs passed** on `900266f7dc6cd9ca6cdb61ff8875a79aab3cdecc`: [run 34735568037](https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/34735568037), including Linux/macOS Python 3.12–3.14, Windows Python 3.12–3.13, lint, both guards, frontend, and wheel build/install.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] I linked the relevant issue(s) / discussion(s) below
- [ ] If this is a feature / behavior / API / architecture change, there was a pre-existing issue or discussion opened before this PR, and a maintainer explicitly approved it
- [x] If this is not a feature PR, the change is limited to a bug fix, docs, tests, or a small non-behavioral refactor
- [x] I kept this PR focused and did not include unrelated changes
- [x] I updated docs if this changes user-visible behavior, config, CLI, APIs, or developer workflow
- [x] I added or updated tests when needed
- [x] `ruff check src/ tests/` passes
- [x] `black --check src/ tests/` passes
- [x] `pytest tests/unit/` passes locally, or I explained below why I could not run the full suite
- [x] If frontend files changed, I ran `npm run format:check` and `npm run build` in `src/kohakuterrarium-frontend/`
- [x] CI on my fork is green, or I explained the exception below

## Related Issues / Discussions

Related media work: #310 and #311. This is a bug fix; no separate feature approval is required.

## Notes for Reviewers

Request-count tests use the actual OpenAI SDK with `httpx.MockTransport`, retaining client retry configuration so hidden SDK retries are observable. No live provider is required. Local-media classification takes precedence over a positive retry hint.

The retry-budget changes apply to `OpenAIProvider` and its subclass clients; LiteLLM's own retry policy is unchanged.

## Screenshots / Logs (if applicable)

Original Windows failure: [Run 34715758195, Windows 3.12](https://github.com/Kohaku-Lab/KohakuTerrarium/actions/runs/34715758195/job/103612589658), `test_event_flush_debounced_by_time`.

## Breaking Changes (if applicable)

The effective OpenAI request count is now bounded by one retry policy instead of multiplying SDK and framework budgets. `max_retries=0` disables ordinary retries unless an explicit policy overrides it.

## Exceptions / Not Run

- Full unit execution encountered the two macOS log-capture failures already reproduced on the unchanged baseline during #310/#311 work: `TestSaveDurability::test_dir_barrier_einval_reports_file_only_and_warns` and `TestAtomicWriteDirBarrier::test_dir_fsync_einval_is_tolerated_but_signalled`. The warnings are emitted, but the configured non-propagating logger does not reach pytest's root capture handler. Their source and tests are unchanged here.
- Live vLLM/manual conversation-resume testing was not run; deterministic SDK transport and multimodal workflow tests cover the error, request count, outgoing images, and history preservation.
- E2E was not rerun: this change does not modify multi-node, Studio, or serving behavior. Those journeys were already exercised during the related #310/#311 work.
- The repository workflow triggers on upstream pull requests and pushes to `main`; the upstream PR matrix validates this fork branch.

Original implementation made with [Cursor](https://cursor.com).
